### PR TITLE
test: add deploy.sh regression tests and CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    name: Run Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install bats
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y bats
+
+      - name: Run bats tests
+        run: bats tests/scripts/

--- a/tests/scripts/deploy.bats
+++ b/tests/scripts/deploy.bats
@@ -31,3 +31,54 @@
   run bash scripts/deploy.sh all nonexistent-env
   [ "$status" -eq 1 ]
 }
+
+# ---------------------------------------------------------------------------
+# Bug fix regression tests (post-merge fixes from e71c8e5, e72f93e)
+# ---------------------------------------------------------------------------
+
+@test "deploy.sh infra creates hill90_internal network if missing" {
+  # Bug: infra compose doesn't define hill90_internal, but app services need it.
+  # Fix (e71c8e5): cmd_infra creates the network after docker compose up.
+  run grep "docker network create.*hill90_internal" scripts/deploy.sh
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"hill90_internal"* ]]
+}
+
+@test "deploy.sh infra checks if hill90_internal already exists before creating" {
+  # The fix should be idempotent — check with docker network inspect first.
+  run grep "docker network inspect hill90_internal" scripts/deploy.sh
+  [ "$status" -eq 0 ]
+}
+
+@test "deploy.sh per-service deploy does not use --remove-orphans" {
+  # Bug: per-service down with --remove-orphans killed containers from other
+  # compose files (e.g. deploying auth would stop api).
+  # Fix (e72f93e): cmd_service uses plain 'docker compose down' without the flag.
+  #
+  # Extract cmd_service function body and verify no --remove-orphans.
+  run bash -c 'sed -n "/^cmd_service()/,/^}/p" scripts/deploy.sh | grep -- "--remove-orphans"'
+  [ "$status" -eq 1 ]  # grep should NOT find it
+}
+
+@test "deploy.sh infra DOES use --remove-orphans for full infra teardown" {
+  # Infra deploy owns the full infra stack, so --remove-orphans is correct there.
+  run bash -c 'sed -n "/^cmd_infra()/,/^}/p" scripts/deploy.sh | grep -- "--remove-orphans"'
+  [ "$status" -eq 0 ]
+}
+
+@test "deploy.sh all deploys auth api ai and mcp services" {
+  # cmd_all must iterate over all 4 app services.
+  run grep "for svc in" scripts/deploy.sh
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"auth"* ]]
+  [[ "$output" == *"api"* ]]
+  [[ "$output" == *"ai"* ]]
+  [[ "$output" == *"mcp"* ]]
+}
+
+@test "deploy.sh service checks hill90_internal network exists" {
+  # App services require hill90_internal — deploy should fail fast if missing.
+  run grep -A2 "hill90_internal" scripts/deploy.sh
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Deploy infrastructure first"* ]]
+}


### PR DESCRIPTION
## Summary
- Adds 6 bats regression tests for deploy.sh bug fixes (e71c8e5, e72f93e)
  - infra deploy creates `hill90_internal` network if missing
  - per-service deploy does NOT use `--remove-orphans`
  - deploy all iterates over all 4 app services
- Adds CI workflow (`.github/workflows/ci.yml`) that runs `bats tests/scripts/` on PRs and pushes to main
- Branch protection enabled: "Run Tests" status check required before merge

## Context
Post-merge fixes from refactor/simplify (#5) were pushed directly to main without TDD. This retroactively adds the tests that should have existed first.

## Test plan
- [x] `bats tests/scripts/deploy.bats` — all 11 tests pass locally
- [ ] CI workflow runs on this PR and passes
- [ ] After merge, future PRs require CI to pass before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)