### PR TITLE
fix: infra reliability hardening

### DIFF
--- a/.github/docs/deployment.md
+++ b/.github/docs/deployment.md
@@ -132,7 +132,7 @@ The Traefik dashboard at `https://traefik.hill90.com` uses basic authentication.
 **Credentials are automatically generated during deployment:**
 
 1. Password hash stored in: `TRAEFIK_ADMIN_PASSWORD_HASH` (encrypted in secrets)
-2. Deploy script generates: `deployments/platform/edge/dynamic/.htpasswd`
+2. Deploy script generates: `platform/edge/dynamic/.htpasswd`
 
 **Access credentials:**
 - Username: `admin`

--- a/.github/docs/secrets.md
+++ b/.github/docs/secrets.md
@@ -72,7 +72,7 @@ sops -d --extract '["VPS_IP"]' infra/secrets/prod.enc.env
 Bcrypt password hash for Traefik dashboard authentication.
 
 **Usage:**
-- Deployed to: `deployments/platform/edge/dynamic/.htpasswd`
+- Deployed to: `platform/edge/dynamic/.htpasswd`
 - Format: `$2y$05$...` (bcrypt hash)
 - Username: `admin`
 - Generated during: Every deployment via deploy scripts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,3 +22,19 @@ jobs:
 
       - name: Run bats tests
         run: bats tests/scripts/
+
+      - name: Validate compose files
+        run: |
+          for f in deployments/compose/prod/docker-compose*.yml; do
+            echo "Validating $f..."
+            docker compose -f "$f" config > /dev/null
+          done
+
+      - name: Validate Traefik config
+        run: bash scripts/validate.sh traefik
+
+      - name: Install shellcheck
+        run: sudo apt-get install -y shellcheck
+
+      - name: Lint scripts
+        run: shellcheck --severity=error scripts/*.sh

--- a/.github/workflows/config-vps.yml
+++ b/.github/workflows/config-vps.yml
@@ -11,6 +11,10 @@ on:
         required: true
         type: string
 
+concurrency:
+  group: deploy-prod
+  cancel-in-progress: false
+
 jobs:
   validate:
     name: Validate Prerequisites

--- a/.github/workflows/deploy-ai.yml
+++ b/.github/workflows/deploy-ai.yml
@@ -20,6 +20,10 @@ on:
           - prod
         default: 'prod'
 
+concurrency:
+  group: deploy-prod
+  cancel-in-progress: false
+
 jobs:
   deploy:
     name: Deploy AI Service

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -20,6 +20,10 @@ on:
           - prod
         default: 'prod'
 
+concurrency:
+  group: deploy-prod
+  cancel-in-progress: false
+
 jobs:
   deploy:
     name: Deploy API Service

--- a/.github/workflows/deploy-auth.yml
+++ b/.github/workflows/deploy-auth.yml
@@ -20,6 +20,10 @@ on:
           - prod
         default: 'prod'
 
+concurrency:
+  group: deploy-prod
+  cancel-in-progress: false
+
 jobs:
   deploy:
     name: Deploy Auth Service

--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -11,6 +11,10 @@ on:
           - prod
         default: 'prod'
 
+concurrency:
+  group: deploy-prod
+  cancel-in-progress: false
+
 jobs:
   deploy:
     name: Deploy Infrastructure Services
@@ -71,11 +75,50 @@ jobs:
       - name: Wait for services to start
         run: sleep 30
 
-      - name: Verify services
+      - name: Verify containers running
         run: |
-          ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
+          echo "Checking required containers..."
+          for svc in traefik dns-manager portainer; do
+            STATUS=$(ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
+              deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
+              "docker inspect -f '{{.State.Status}}' $svc 2>/dev/null || echo missing")
+            echo "$svc: $STATUS"
+            if [ "$STATUS" != "running" ]; then
+              echo "::error::Container $svc is not running (status: $STATUS)"
+              exit 1
+            fi
+          done
+
+      - name: Check Traefik logs for config errors
+        run: |
+          echo "Checking Traefik logs for errors..."
+          ERRORS=$(ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
             deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
-            'docker ps --format "table {{.Names}}\t{{.Status}}" | grep -E "(traefik|dns-manager|portainer)"'
+            'docker logs traefik 2>&1 | grep -iE "nonexistent resolver|does not exist|error parsing" || true')
+          if [ -n "$ERRORS" ]; then
+            echo "::error::Traefik config errors detected:"
+            echo "$ERRORS"
+            exit 1
+          fi
+          echo "No config errors found"
+
+      - name: Verify TLS certificates
+        run: |
+          echo "Checking TLS certificate issuers..."
+          FAIL=0
+          for domain in api.hill90.com traefik.hill90.com portainer.hill90.com; do
+            ISSUER=$(ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
+              deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
+              "echo | openssl s_client -connect localhost:443 -servername $domain 2>/dev/null | openssl x509 -noout -issuer 2>/dev/null || echo 'issuer=NONE'")
+            echo "$domain: $ISSUER"
+            if echo "$ISSUER" | grep -qiE "TRAEFIK DEFAULT|FAKE|NONE"; then
+              echo "::warning::$domain does not have a valid Let's Encrypt certificate"
+              FAIL=1
+            fi
+          done
+          if [ "$FAIL" -eq 1 ]; then
+            echo "::warning::Some certificates are not yet issued. DNS-01 certs may take 2-5 minutes."
+          fi
 
       - name: Summary
         if: success()

--- a/.github/workflows/deploy-mcp.yml
+++ b/.github/workflows/deploy-mcp.yml
@@ -20,6 +20,10 @@ on:
           - prod
         default: 'prod'
 
+concurrency:
+  group: deploy-prod
+  cancel-in-progress: false
+
 jobs:
   deploy:
     name: Deploy MCP Service

--- a/deployments/compose/prod/docker-compose.infra.yml
+++ b/deployments/compose/prod/docker-compose.infra.yml
@@ -55,12 +55,12 @@ services:
       - ../../../platform/edge/dynamic:/etc/traefik/dynamic:ro
       - traefik-certs:/letsencrypt
     environment:
-      - ACME_EMAIL=${ACME_EMAIL:-jonhill90@live.com}
       - ACME_CA_SERVER=${ACME_CA_SERVER:-https://acme-staging-v02.api.letsencrypt.org/directory}
-      - TRAEFIK_ADMIN_PASSWORD_HASH=${TRAEFIK_ADMIN_PASSWORD_HASH}
       # DNS-01 challenge via dns-manager service (httpreq provider)
       - HTTPREQ_ENDPOINT=http://dns-manager:8080
       - HTTPREQ_MODE=RAW
+      - HTTPREQ_POLLING_INTERVAL=30s
+      - HTTPREQ_PROPAGATION_TIMEOUT=300s
     depends_on:
       - dns-manager
     labels:
@@ -69,7 +69,7 @@ services:
       - "traefik.http.routers.traefik.entrypoints=websecure"
       - "traefik.http.routers.traefik.tls.certresolver=letsencrypt-dns"
       - "traefik.http.routers.traefik.service=api@internal"
-      - "traefik.http.routers.traefik.middlewares=auth@file"
+      - "traefik.http.routers.traefik.middlewares=auth@file,tailscale-only@file"
 
   # Portainer Container Management (Tailscale-only access)
   portainer:

--- a/docs/architecture/certificates.md
+++ b/docs/architecture/certificates.md
@@ -127,10 +127,10 @@ Hill90 uses Let's Encrypt for SSL/TLS certificates with two different challenge 
 **Certificate Resolvers:**
 
 ```yaml
-# deployments/platform/edge/traefik.yml
+# platform/edge/traefik.yml
 
 certificatesResolvers:
-  # HTTP-01 for public services
+  # HTTP-01 for public services (api, ai, mcp)
   letsencrypt:
     acme:
       email: admin@hill90.com
@@ -138,7 +138,7 @@ certificatesResolvers:
       httpChallenge:
         entryPoint: web
 
-  # DNS-01 for Tailscale-only services
+  # DNS-01 for Tailscale-only services (traefik, portainer)
   letsencrypt-dns:
     acme:
       email: admin@hill90.com
@@ -150,6 +150,11 @@ certificatesResolvers:
           - 1.1.1.1:53
           - 8.8.8.8:53
 ```
+
+> **Important:** Traefik does NOT interpolate `${VAR}` in its YAML config files.
+> Email must be hardcoded in `traefik.yml`. The `caServer` is set via Docker Compose
+> CLI args (`command:` in the compose file), because Docker Compose does interpolate
+> environment variables.
 
 **Environment Variables:**
 

--- a/docs/runbooks/troubleshooting.md
+++ b/docs/runbooks/troubleshooting.md
@@ -167,7 +167,7 @@ Common issues and solutions for Hill90 VPS infrastructure.
 
 5. **Verify Traefik DNS-01 configuration:**
    ```bash
-   ssh deploy@<tailscale-ip> 'cat /opt/hill90/app/deployments/platform/edge/traefik.yml | grep -A5 dnsChallenge'
+   ssh deploy@<tailscale-ip> 'cat /opt/hill90/app/platform/edge/traefik.yml | grep -A5 dnsChallenge'
    ```
 
 6. **Rate limiting:**
@@ -269,7 +269,7 @@ echo | openssl s_client -connect api.hill90.com:443 -servername api.hill90.com 2
 
 2. **Check .htpasswd file:**
    ```bash
-   ssh deploy@<tailscale-ip> 'cat /opt/hill90/app/deployments/platform/edge/dynamic/.htpasswd'
+   ssh deploy@<tailscale-ip> 'cat /opt/hill90/app/platform/edge/dynamic/.htpasswd'
    # Should show: admin:$2y$05$...
    ```
 
@@ -287,7 +287,7 @@ echo | openssl s_client -connect api.hill90.com:443 -servername api.hill90.com 2
 
 5. **Check middleware configuration:**
    ```bash
-   ssh deploy@<tailscale-ip> 'cat /opt/hill90/app/deployments/platform/edge/dynamic/middlewares.yml'
+   ssh deploy@<tailscale-ip> 'cat /opt/hill90/app/platform/edge/dynamic/middlewares.yml'
    ```
 
 ### Traefik Dashboard Not Accessible

--- a/platform/edge/dynamic/middlewares.yml
+++ b/platform/edge/dynamic/middlewares.yml
@@ -28,8 +28,14 @@ http:
     # Basic Auth for Traefik Dashboard
     auth:
       basicAuth:
-        users:
-          - "${TRAEFIK_ADMIN_PASSWORD_HASH}"
+        usersFile: /etc/traefik/dynamic/.htpasswd
+
+    # Tailscale-only access (CGNAT range)
+    # NOTE: ipWhiteList is Traefik v2. If upgrading to v3, use ipAllowList.
+    tailscale-only:
+      ipWhiteList:
+        sourceRange:
+          - "100.64.0.0/10"
 
     # MCP Authentication (forward to auth service)
     mcp-auth:

--- a/platform/edge/traefik.yml
+++ b/platform/edge/traefik.yml
@@ -55,12 +55,25 @@ providers:
 
 # Certificate Resolvers
 certificatesResolvers:
+  # HTTP-01 for public services (api, ai, mcp)
   letsencrypt:
     acme:
-      email: "${ACME_EMAIL}"
+      email: admin@hill90.com
       storage: /letsencrypt/acme.json
       httpChallenge:
         entryPoint: web
+
+  # DNS-01 for Tailscale-only services (traefik, portainer)
+  letsencrypt-dns:
+    acme:
+      email: admin@hill90.com
+      storage: /letsencrypt/acme-dns.json
+      dnsChallenge:
+        provider: httpreq
+        delayBeforeCheck: 30s
+        resolvers:
+          - 1.1.1.1:53
+          - 8.8.8.8:53
 
 # Metrics (optional)
 # metrics:

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Validate CLI — validate infrastructure configuration
 # Usage: validate.sh {all|compose|secrets|traefik} [env]
+# shellcheck source=_common.sh
 
 set -e
 
@@ -106,6 +107,22 @@ cmd_traefik() {
             echo "✗ Docker provider not configured"
             all_valid=false
         fi
+
+        echo -n "Checking letsencrypt-dns resolver... "
+        if grep -q "^  letsencrypt-dns:" "$traefik_config"; then
+            echo "✓"
+        else
+            echo "✗ Missing letsencrypt-dns resolver (required for Tailscale-only services)"
+            all_valid=false
+        fi
+
+        echo -n "Checking for uninterpolated env vars in traefik.yml... "
+        if grep -q '\${' "$traefik_config"; then
+            echo "✗ Found \${...} — Traefik does not interpolate env vars in YAML"
+            all_valid=false
+        else
+            echo "✓"
+        fi
     fi
 
     echo -n "Checking dynamic config directory... "
@@ -134,6 +151,30 @@ cmd_traefik() {
             fi
         else
             echo "⊘ Skipped (PyYAML not installed)"
+        fi
+
+        echo -n "Checking tailscale-only middleware... "
+        if grep -q "tailscale-only:" "$dynamic_dir/middlewares.yml" 2>/dev/null; then
+            echo "✓"
+        else
+            echo "✗ Missing tailscale-only middleware (required for Portainer)"
+            all_valid=false
+        fi
+
+        echo -n "Checking auth uses usersFile... "
+        if grep -q "usersFile:" "$dynamic_dir/middlewares.yml" 2>/dev/null; then
+            echo "✓"
+        else
+            echo "✗ auth middleware should use usersFile, not inline users"
+            all_valid=false
+        fi
+
+        echo -n "Checking for uninterpolated env vars in middlewares... "
+        if grep -q '\${' "$dynamic_dir/middlewares.yml" 2>/dev/null; then
+            echo "✗ Found \${...} — Traefik does not interpolate env vars"
+            all_valid=false
+        else
+            echo "✓"
         fi
     fi
 

--- a/tests/scripts/validate.bats
+++ b/tests/scripts/validate.bats
@@ -30,3 +30,35 @@
   run bash scripts/validate.sh compose
   [[ "$output" == *"Compose"* ]]
 }
+
+# Traefik config regression tests
+
+@test "traefik.yml has letsencrypt-dns resolver" {
+  run grep "^  letsencrypt-dns:" platform/edge/traefik.yml
+  [ "$status" -eq 0 ]
+}
+
+@test "traefik.yml has no uninterpolated env vars" {
+  run grep -c '\${' platform/edge/traefik.yml
+  [ "$status" -eq 1 ]
+}
+
+@test "middlewares.yml has tailscale-only middleware" {
+  run grep "tailscale-only:" platform/edge/dynamic/middlewares.yml
+  [ "$status" -eq 0 ]
+}
+
+@test "middlewares.yml auth uses usersFile not inline users" {
+  run grep "usersFile:" platform/edge/dynamic/middlewares.yml
+  [ "$status" -eq 0 ]
+}
+
+@test "middlewares.yml has no uninterpolated env vars" {
+  run grep -c '\${' platform/edge/dynamic/middlewares.yml
+  [ "$status" -eq 1 ]
+}
+
+@test "docker-compose.infra.yml traefik has tailscale-only middleware" {
+  run grep "traefik.http.routers.traefik.middlewares" deployments/compose/prod/docker-compose.infra.yml
+  [[ "$output" == *"tailscale-only@file"* ]]
+}


### PR DESCRIPTION
## Summary

- **Fix Traefik config drift**: Add `letsencrypt-dns` resolver for Tailscale-only services, hardcode email (Traefik can't interpolate `${VAR}` in YAML), add `tailscale-only` IP whitelist middleware, switch auth to `usersFile`
- **CI quality gates**: Add compose render checks, `validate.sh traefik`, and shellcheck to CI pipeline
- **Deploy safety**: Add concurrency serialization to all 6 deploy workflows, add post-deploy smoke checks (container status, Traefik log errors, TLS cert verification) to `deploy-infra.yml`
- **Fix doc path drift**: 7 stale `deployments/platform/edge/` → `platform/edge/` references

## Changes (16 files)

| Category | Files |
|----------|-------|
| Traefik config | `platform/edge/traefik.yml`, `platform/edge/dynamic/middlewares.yml` |
| Compose | `deployments/compose/prod/docker-compose.infra.yml` |
| Tests | `tests/scripts/validate.bats` (6 new regression tests) |
| Validation | `scripts/validate.sh` (5 new checks) |
| CI | `.github/workflows/ci.yml` |
| Deploy workflows | `deploy-infra.yml`, `deploy-auth.yml`, `deploy-api.yml`, `deploy-ai.yml`, `deploy-mcp.yml`, `config-vps.yml` |
| Docs | `docs/architecture/certificates.md`, `docs/runbooks/troubleshooting.md`, `.github/docs/secrets.md`, `.github/docs/deployment.md` |

## Test plan

- [x] All 37 bats tests pass (including 6 new regression tests)
- [x] `bash scripts/validate.sh traefik` passes with new checks
- [x] `shellcheck --severity=error scripts/*.sh` clean
- [x] No stale `deployments/platform/edge` references remain
- [ ] CI passes on PR (compose render, bats, validate.sh, shellcheck)
- [ ] After merge + deploy-infra: containers running, no Traefik config errors, TLS certs issued

🤖 Generated with [Claude Code](https://claude.com/claude-code)