### PR TITLE
feat: restore and enhance GitHub Copilot instructions

### DIFF
--- a/.github/agents/code-reviewer.md
+++ b/.github/agents/code-reviewer.md
@@ -9,13 +9,14 @@ tools:
 model: inherit
 ---
 
-You are a senior code reviewer ensuring high standards of code quality and security.
+You are a senior code reviewer for Hill90, a microservices platform on Hostinger VPS with Traefik edge proxy, Tailscale-secured SSH, and Docker Compose deployments.
 
 ## When Invoked
 
 1. Run `git diff` to see recent changes
 2. Focus on modified files
-3. Begin review immediately
+3. Identify which category of change this is (infra, app, scripts, docs)
+4. Apply the relevant checklist sections below
 
 ## Review Checklist
 
@@ -24,20 +25,38 @@ You are a senior code reviewer ensuring high standards of code quality and secur
 - Functions and variables are well-named
 - No duplicated code
 - Proper error handling
-- Consistent style
+- Consistent style with existing codebase
 
 ### Security
-- No exposed secrets or API keys
+- No exposed secrets, API keys, or password hashes
+- No plaintext credentials in compose files, configs, or scripts
 - Input validation implemented
-- No SQL injection vulnerabilities
-- No XSS vulnerabilities
+- No SQL injection, XSS, or command injection vulnerabilities
 - Authentication/authorization checks present
+- Tailscale-only services use `tailscale-only@file` middleware
 
-### Best Practices
-- Tests written first (Red-Green-Refactor followed for code changes)
+### Infrastructure (Traefik, Compose, Scripts)
+- Traefik YAML has no `${VAR}` — Traefik does not interpolate env vars
+- Email is hardcoded in `traefik.yml`, not `${ACME_EMAIL}`
+- `caServer` set via compose CLI args only (compose does interpolate)
+- Auth middleware uses `usersFile`, not inline `users`
+- `letsencrypt-dns` resolver exists for Tailscale-only services
+- Compose files reference correct networks (`hill90_edge`, `hill90_internal`)
+- Deploy scripts run on VPS via SSH, not locally
+- `--remove-orphans` only used in infra deploy, not per-service
+- All deploy workflows have `concurrency: group: deploy-prod`
+
+### Path Consistency
+- No stale `deployments/platform/edge/` paths (correct: `platform/edge/`)
+- File paths in docs match actual repo structure
+- Symlinks point to correct targets
+
+### Testing
+- Tests written first (Red-Green-Refactor for code changes)
 - Tests verify behavior, not implementation details
-- Triangulation used (multiple test cases prevent false positives)
-- Performance considerations addressed
+- Bats tests pass: `bats tests/scripts/`
+- Traefik validation passes: `bash scripts/validate.sh traefik`
+- Shell scripts pass: `shellcheck --severity=error scripts/*.sh`
 - No unnecessary complexity
 - Dependencies are appropriate
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,1 @@
+../AGENTS.md

--- a/.github/instructions/agent-authoring.instructions.md
+++ b/.github/instructions/agent-authoring.instructions.md
@@ -1,0 +1,50 @@
+---
+description: 'Guidelines for writing and editing agent definition files'
+applyTo: '.github/agents/**/*.md'
+---
+
+# Agent Authoring Rules
+
+When writing or editing subagent markdown files:
+
+## Structure
+- YAML frontmatter for configuration
+- Markdown body is the system prompt
+
+## Required Frontmatter
+- `name`: Unique identifier (lowercase, hyphens)
+- `description`: When the agent should be delegated to
+
+## Optional Frontmatter
+- `tools`: Allowlist of tools as a **YAML array** (inherits all if omitted)
+- `disallowedTools`: Denylist as a **YAML array**
+- `model`: `sonnet`, `opus`, `haiku`, or `inherit`
+- `permissionMode`: Permission handling
+- `skills`: Skills to preload into context
+- `hooks`: Lifecycle hooks
+
+## Tools Syntax
+
+The `tools` and `disallowedTools` fields **must be YAML arrays**, not comma-separated strings.
+
+```yaml
+# Correct
+tools:
+  - Read
+  - Grep
+  - Glob
+
+# Wrong — will error: "The 'tools' attribute must be an array"
+tools: Read, Grep, Glob
+```
+
+## System Prompt Guidelines
+- Be clear about agent's role and purpose
+- Include step-by-step workflow when applicable
+- Specify output format expectations
+- Keep focused on one specific task
+
+## Tool Restrictions
+- Grant only necessary permissions
+- Use `disallowedTools` for read-only agents
+- Common read-only set: `[Read, Grep, Glob, Bash]`

--- a/.github/instructions/documentation.instructions.md
+++ b/.github/instructions/documentation.instructions.md
@@ -1,0 +1,32 @@
+---
+description: 'Guidelines for writing and editing documentation and reference files'
+applyTo: '.github/docs/**/*.md'
+---
+
+# Documentation Rules
+
+When writing or editing documentation:
+
+## Content
+- Be comprehensive but concise
+- Use tables for structured information
+- Include code examples where helpful
+- Prefer specific examples over generic descriptions
+
+## Structure
+- Use clear headings hierarchy
+- Include quick reference tables
+- Organize from general to specific
+- Link to related documentation
+
+## Formatting
+- Use markdown properly
+- Code blocks with language hints
+- Tables for structured data
+- Lists for enumerable items
+
+## For Reference Files
+- Cover all features from official docs
+- Include practical examples
+- Cross-reference related guides
+- Keep up to date with official docs

--- a/.github/instructions/infrastructure.instructions.md
+++ b/.github/instructions/infrastructure.instructions.md
@@ -1,0 +1,48 @@
+---
+description: 'Rules for editing infrastructure, deployment, and platform configuration files'
+applyTo:
+  - 'infra/**'
+  - 'deployments/**'
+  - 'platform/**'
+  - 'scripts/**'
+---
+
+# Infrastructure Rules
+
+When editing infrastructure files (Ansible, Docker Compose, Traefik, deployment configs, scripts):
+
+## Principles
+
+- All operations use Makefile commands — don't bypass with raw commands
+- Ansible playbooks must be idempotent — safe to re-run
+- Docker Compose files are per-service — don't combine into monolithic files
+- Secrets are SOPS-encrypted — never commit plaintext secrets
+
+## Traefik Configuration
+
+- Traefik does NOT interpolate `${VAR}` in YAML config files — hardcode values
+- `caServer` is set via Docker Compose CLI args (Compose does interpolate)
+- `letsencrypt` resolver = HTTP-01 (public services)
+- `letsencrypt-dns` resolver = DNS-01 (Tailscale-only services)
+- `tailscale-only` middleware restricts access to CGNAT range (100.64.0.0/10)
+- Auth middleware uses `usersFile`, not inline `users`
+
+## Deployment
+
+- Infrastructure deploys before applications (creates Docker networks)
+- Deployments run on VPS via SSH, never locally on Mac
+- Use STAGING certificates for local testing, PRODUCTION via GitHub Actions
+- All deploy workflows share `concurrency: group: deploy-prod` for serialization
+
+## Testing
+
+- After infrastructure changes, verify with `make health`
+- After Traefik changes, run `bash scripts/validate.sh traefik`
+- After script changes, run `bats tests/scripts/` and `shellcheck --severity=error scripts/*.sh`
+- After deployment changes, test with per-service deploy commands
+
+## Secrets
+
+- Use `make secrets-view` / `make secrets-update` for safe operations
+- Never use `sops -d` to temp files (leaves unencrypted data on disk)
+- Age key: `infra/secrets/keys/age-prod.key` (local) or `/opt/hill90/secrets/keys/keys.txt` (VPS)

--- a/.github/instructions/reference-freshness.instructions.md
+++ b/.github/instructions/reference-freshness.instructions.md
@@ -1,0 +1,16 @@
+---
+description: 'Verify reference docs against source URLs before relying on local content'
+applyTo: '.github/docs/**/*.md'
+---
+
+# Reference Freshness
+
+Reference docs are distilled summaries of external sources. They may be stale.
+
+## Before Relying on Local Content
+
+1. Check the **source URLs** listed at the top of each reference doc
+2. Use MCP tools (context7, microsoft-learn, deepwiki) to fetch current documentation
+3. If the local summary contradicts the live source, trust the live source
+
+Local references are a starting point, not the final word.

--- a/.github/instructions/skill-authoring.instructions.md
+++ b/.github/instructions/skill-authoring.instructions.md
@@ -1,0 +1,35 @@
+---
+description: 'Guidelines for writing and editing SKILL.md files'
+applyTo: '.github/skills/**/*.md'
+---
+
+# Skill Authoring Rules
+
+When writing or editing SKILL.md files:
+
+## Structure
+- Keep SKILL.md under 500 lines
+- Move detailed content to reference files
+- Reference supporting files with relative links
+
+## Frontmatter
+- `name` and `description` are the only required fields
+- Description is the PRIMARY triggering mechanism - be clear and comprehensive
+- Include "when to use" context in description, not in body
+
+## Content
+- Use imperative/infinitive form ("Run tests" not "Running tests")
+- Prefer concise examples over verbose explanations
+- Only include what the agent doesn't already know
+
+## Progressive Disclosure
+- Core workflow in SKILL.md
+- Detailed reference material in separate files
+- Agent reads reference files on demand
+
+## Modern Features to Consider
+- `context: fork` for isolated execution
+- `allowed-tools` for restricted access
+- `disable-model-invocation: true` for manual-only skills
+- `$ARGUMENTS`, `$0`, `$1` for dynamic content
+- `` !`command` `` for dynamic context injection

--- a/.github/instructions/testing.instructions.md
+++ b/.github/instructions/testing.instructions.md
@@ -1,0 +1,62 @@
+---
+description: 'Use these guidelines when generating, updating, or reviewing code and tests.'
+applyTo:
+  - 'tests/**'
+  - '**/*.py'
+  - '**/*.sh'
+---
+
+# Testing Guidelines
+
+## Workflow: Red-Green-Refactor
+
+Follow test-driven development when writing new features or fixing bugs:
+
+1. **Red** — Write a failing test that defines the expected behavior
+2. **Green** — Write the minimum code to make the test pass
+3. **Refactor** — Clean up while keeping tests green
+
+Do not skip steps. Do not write implementation before the test exists.
+
+## Test Conventions
+
+- Write clear, focused tests that verify one behavior at a time
+- Use descriptive test names that explain what is being tested and the expected outcome
+- Follow Arrange-Act-Assert (AAA) pattern: set up test data, execute the code under test, verify results
+- Keep tests independent — each test should run in isolation without depending on other tests
+- Start with the simplest test case, then add edge cases and error conditions
+- Tests should fail for the right reason — verify they catch the bugs they're meant to catch
+- Mock external dependencies to keep tests fast and reliable
+
+## Hill90-Specific Testing
+
+- Use **bats** for shell script tests (`tests/scripts/`)
+- Run `bats tests/scripts/` to execute the full suite
+- Run `bash scripts/validate.sh traefik` after Traefik config changes
+- Run `shellcheck --severity=error scripts/*.sh` after script changes
+- Compose files must parse: `docker compose -f <file> config > /dev/null`
+
+## Triangulation
+
+Don't trust a single test case. Use multiple examples to prevent false positives from hardcoded or overly specific implementations. If one test could pass by accident, add another that forces a real implementation.
+
+## Test Doubles
+
+- Use stubs to replace external dependencies with controlled return values
+- Use spies to verify interactions without changing behavior
+- Be explicit about what kind of double you need — don't use vague terms
+- Keep test doubles minimal — only fake what's necessary for isolation
+
+## Quality Checks
+
+- Every test should fail before it passes (verify the Red step)
+- Run the full suite after each change, not just the new test
+- Match existing test style — naming, structure, assertion patterns
+- If refactoring, tests must stay green throughout
+
+## Do Not
+
+- Generate tests without running them
+- Write tests that pass trivially (testing nothing)
+- Couple tests to implementation details — test behavior, not internals
+- Skip edge cases: null, empty, boundary values, error paths

--- a/.github/instructions/workflows.instructions.md
+++ b/.github/instructions/workflows.instructions.md
@@ -1,0 +1,46 @@
+---
+description: 'Rules for editing GitHub Actions workflow files'
+applyTo: '.github/workflows/**/*.yml'
+---
+
+# GitHub Actions Workflow Rules
+
+When editing GitHub Actions workflow files:
+
+## Principles
+
+- Workflows use the hybrid approach: local Mac scripts AND GitHub Actions
+- VPS recreate requires manual confirmation ("RECREATE" input)
+- Config VPS auto-triggers deploy-infra after completion
+- Deploy workflows use PRODUCTION certificates by default
+
+## Required Secrets
+
+All workflows depend on these GitHub repository secrets:
+- `HOSTINGER_API_KEY` — VPS management API
+- `TAILSCALE_API_KEY` — Device/key management API
+- `TS_OAUTH_CLIENT_ID` — GitHub runner network access
+- `TS_OAUTH_SECRET` — GitHub runner network access
+- `VPS_SSH_PRIVATE_KEY` — SSH access to VPS
+- `SOPS_AGE_KEY` — Secrets decryption
+
+## Patterns
+
+- Use Tailscale GitHub Action for SSH access to VPS
+- Ephemeral runner nodes join Tailscale network via OAuth
+- SSH to VPS uses Tailscale IP, not public IP
+- Always validate infrastructure before deployment
+- Include health checks after deployment
+- All deploy workflows must have `concurrency: group: deploy-prod`
+
+## Certificate Management
+
+- GitHub Actions: PRODUCTION Let's Encrypt (trusted, rate-limited)
+- Local development: STAGING Let's Encrypt (untrusted, unlimited)
+- Rate limits: 50 certs/week, 5 failures/hour
+
+## Post-Deploy Verification
+
+- Check containers are running (hard failure)
+- Check Traefik logs for config errors (hard failure)
+- Check TLS certificate issuers (warning — DNS-01 certs may take 2-5 min)


### PR DESCRIPTION
## Summary

- **Restore Copilot integration**: Add `.github/copilot-instructions.md` symlink to `AGENTS.md` — same single-source-of-truth pattern used in the vibes agent harness
- **Add 7 scoped instruction files**: Path-specific Copilot guidance in `.github/instructions/` using `applyTo:` frontmatter
- **Enhance code-reviewer agent**: Hill90-specific checks (Traefik config invariants, path consistency, deploy safety, Tailscale middleware)
- **Add VS Code MCP config**: `.vscode/mcp.json` for Copilot MCP server access (gitignored, local convenience)

## What Copilot Gets

| Instruction File | Scoped To | Purpose |
|-----------------|-----------|---------|
| `copilot-instructions.md` | All requests | Full AGENTS.md (project context, principles, structure) |
| `skill-authoring` | `.github/skills/**` | SKILL.md frontmatter, progressive disclosure |
| `agent-authoring` | `.github/agents/**` | Agent YAML frontmatter, tools syntax |
| `documentation` | `.github/docs/**` | Doc writing standards |
| `reference-freshness` | `.github/docs/**` | MCP-first, live docs over stale local |
| `infrastructure` | `infra/`, `deployments/`, `platform/`, `scripts/` | Traefik invariants, deploy rules, secrets safety |
| `workflows` | `.github/workflows/**` | GHA patterns, concurrency, cert management |
| `testing` | `tests/`, `**/*.py`, `**/*.sh` | TDD, bats, shellcheck, Hill90-specific test commands |

## Platform Parity

| Platform | Instruction Source | Scoped Rules | MCP Config |
|----------|-------------------|--------------|------------|
| Claude Code | `CLAUDE.md` → `AGENTS.md` | `.claude/rules/` | `.mcp.json` |
| GitHub Copilot | `.github/copilot-instructions.md` → `AGENTS.md` | `.github/instructions/` | `.vscode/mcp.json` |
| Codex CLI | `AGENTS.md` (direct) | `.codex/rules/` | `.codex/config.toml` |

## Test plan

- [x] Symlink resolves: `head .github/copilot-instructions.md` shows AGENTS.md content
- [x] All 7 instruction files have valid `description:` + `applyTo:` frontmatter
- [x] Code-reviewer agent has Hill90-specific infrastructure checks
- [ ] CI passes (no functional code changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)