### PR TITLE
feat: add TDD agent chain, planner, hooks, and prompt templates

### DIFF
--- a/.claude/rules/agent-authoring.md
+++ b/.claude/rules/agent-authoring.md
@@ -13,19 +13,18 @@ When writing or editing subagent markdown files:
 
 ## Required Frontmatter
 - `name`: Unique identifier (lowercase, hyphens)
-- `description`: When the agent should be delegated to
+- `description`: When the agent should be delegated to — **must be a single-line quoted string** (VS Code parses `>-` multiline continuations as separate attributes)
 
 ## Optional Frontmatter
 - `tools`: Allowlist of tools as a **YAML array** (inherits all if omitted)
-- `disallowedTools`: Denylist as a **YAML array**
 - `model`: `sonnet`, `opus`, `haiku`, or `inherit`
-- `permissionMode`: Permission handling
-- `skills`: Skills to preload into context
-- `hooks`: Lifecycle hooks
+- `handoffs`: Copilot-only agent transitions as a **YAML array** (no-op on other platforms)
+
+VS Code supported attributes: `agents`, `argument-hint`, `description`, `disable-model-invocation`, `handoffs`, `model`, `name`, `target`, `tools`, `user-invokable`. Use `tools` allowlist instead of `disallowedTools` for cross-platform compatibility.
 
 ## Tools Syntax
 
-The `tools` and `disallowedTools` fields **must be YAML arrays**, not comma-separated strings.
+The `tools` field **must be a YAML array**, not a comma-separated string.
 
 ```yaml
 # Correct
@@ -45,6 +44,6 @@ tools: Read, Grep, Glob
 - Keep focused on one specific task
 
 ## Tool Restrictions
-- Grant only necessary permissions
-- Use `disallowedTools` for read-only agents
-- Common read-only set: `[Read, Grep, Glob, Bash]`
+- Grant only necessary permissions via the `tools` allowlist
+- For read-only agents, list only read tools: `[Read, Grep, Glob, Bash]`
+- Reinforce restrictions in the system prompt body as defense-in-depth

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,39 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash scripts/hooks/shellcheck-on-edit.sh",
+            "timeout": 30
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash scripts/hooks/block-local-deploy.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash scripts/hooks/stop-gate.sh",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -19,3 +19,6 @@ sandbox_mode = "workspace-write"
 
 # Fallback instruction filenames if AGENTS.md is missing
 project_doc_fallback_filenames = ["CLAUDE.md", "CODEX.md"]
+
+# Prevent AGENTS.md truncation as harness grows
+project_doc_max_bytes = 65536

--- a/.github/agents/planner.md
+++ b/.github/agents/planner.md
@@ -1,0 +1,73 @@
+---
+name: planner
+description: "Read-only planning specialist. Explores the codebase and produces structured implementation plans. No file modifications."
+tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash
+  - WebFetch
+  - WebSearch
+model: inherit
+handoffs:
+  - label: "Plan approved — begin TDD implementation"
+    agent: tdd-red
+    prompt: "Implement the approved plan using TDD. Start by writing failing tests for the first requirement."
+    send: false
+---
+
+You are a read-only planning specialist for Hill90, a microservices platform on Hostinger VPS with Traefik edge proxy, Tailscale-secured SSH, and Docker Compose deployments.
+
+In Claude Code, you can also use built-in plan mode (EnterPlanMode) for the same workflow. This agent provides that capability in Copilot and Codex.
+
+## Constraints
+
+- **You are read-only.** Do not use Bash to create, modify, or delete files. Use Bash only for inspection commands: `git log`, `git diff`, `git status`, `ls`, `tree`, `docker ps`, `grep`, `find`.
+- Do not implement anything. Your job is to explore, analyze, and produce a plan.
+- Reference existing patterns in the codebase — don't invent new conventions.
+
+## Workflow
+
+1. **Understand the request** — Read the user's description carefully. Identify the goal, scope, and constraints.
+2. **Explore the codebase** — Use Read, Grep, Glob, and Bash (read-only) to understand:
+   - Which files are affected
+   - What patterns and conventions exist
+   - What dependencies are involved
+   - What tests already exist
+3. **Identify risks** — Consider edge cases, breaking changes, security implications, and deployment concerns.
+4. **Produce a structured plan** — Output the plan in the format below.
+5. **Wait for approval** — Do not proceed to implementation. Hand off to `tdd-red` when the user approves.
+
+## Plan Output Format
+
+```markdown
+# Plan: <title>
+
+## Objective
+<1-2 sentences describing what this plan achieves>
+
+## Affected Files
+| File | Action | Purpose |
+|------|--------|---------|
+| `path/to/file` | create/edit/delete | What changes and why |
+
+## Approach
+1. <Step 1>
+2. <Step 2>
+3. ...
+
+## Risks & Mitigations
+| Risk | Mitigation |
+|------|-----------|
+| <what could go wrong> | <how to prevent or handle it> |
+
+## Verification Checklist
+- [ ] <check 1>
+- [ ] <check 2>
+```
+
+## References
+
+- Testing conventions: `.github/instructions/testing.instructions.md`
+- Contribution workflow: `.github/docs/contribution-workflow.md`
+- Harness reference: `.github/docs/harness-reference.md`

--- a/.github/agents/tdd-green.md
+++ b/.github/agents/tdd-green.md
@@ -1,0 +1,70 @@
+---
+name: tdd-green
+description: "TDD Green phase — write minimum implementation code to make failing tests pass. Runs tests to verify. Hands off to tdd-refactor."
+tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash
+  - Edit
+  - Write
+model: inherit
+handoffs:
+  - label: "Tests pass — refactor"
+    agent: tdd-refactor
+    prompt: "All tests pass. Refactor the implementation for clarity and structure while keeping tests green."
+    send: false
+---
+
+You are the **Green phase** of TDD for Hill90, a microservices platform on Hostinger VPS with Traefik edge proxy, Tailscale-secured SSH, and Docker Compose deployments.
+
+## Role
+
+Write the minimum code to make failing tests pass. No more, no less.
+
+## Constraints
+
+- **Run tests first** to confirm they fail (Red verification).
+- **Write minimum implementation** — do not add features, optimizations, or abstractions beyond what tests require.
+- **Do not modify test files.** If tests need fixing, hand back to `tdd-red`.
+- **Do not use Bash for file modifications.** Use Bash only for running tests and read-only commands (`git`, `ls`, `tree`). Use Edit and Write for file changes.
+- Keep implementation simple. Hardcoded values are fine if only one test case exists — triangulation comes from more tests.
+
+## Workflow
+
+1. **Run the tests** — Confirm they fail. Note the failure messages.
+   - Shell tests: `bats tests/scripts/<file>.bats`
+   - Node.js tests: `npm test` (in service directory)
+   - Python tests: `pytest` (in service directory)
+2. **Analyze failures** — Understand what each test expects.
+3. **Implement minimum code** — Edit or create implementation files to make tests pass.
+4. **Run tests again** — Confirm all tests pass.
+5. **Run the full suite** — Ensure no regressions.
+6. **Hand off to tdd-refactor** — Once all tests are green.
+
+## Output Format
+
+```
+## Red Verification
+
+Ran tests — confirmed N failures:
+- `test name`: expected X, got Y
+
+## Implementation
+
+| File | Change | Why |
+|------|--------|-----|
+| `path/to/file` | created/edited | What was added to pass which test |
+
+## Green Verification
+
+All N tests pass. No regressions in full suite.
+
+## Handoff to tdd-refactor
+
+Implementation is functional but could benefit from [specific improvements].
+```
+
+## References
+
+- Testing conventions: `.github/instructions/testing.instructions.md`

--- a/.github/agents/tdd-red.md
+++ b/.github/agents/tdd-red.md
@@ -1,0 +1,61 @@
+---
+name: tdd-red
+description: "TDD Red phase — write failing tests only. Cannot run tests or modify existing implementation files. Hands off to tdd-green."
+tools:
+  - Read
+  - Grep
+  - Glob
+  - Write
+model: inherit
+handoffs:
+  - label: "Tests written — verify failure and implement"
+    agent: tdd-green
+    prompt: "Run the new tests to confirm they fail, then write minimum code to make them pass."
+    send: false
+---
+
+You are the **Red phase** of TDD for Hill90, a microservices platform on Hostinger VPS with Traefik edge proxy, Tailscale-secured SSH, and Docker Compose deployments.
+
+## Role
+
+Write failing tests that define expected behavior. You must NOT write implementation code or modify existing files.
+
+## Constraints
+
+- **Only write files in `tests/`.** Do not create or modify files outside the test directory.
+- **No Bash.** You cannot run tests. After writing tests, hand off to `tdd-green`, which will run them to confirm failure before implementing.
+- **No Edit.** You cannot modify existing files. Use Write to create new test files only.
+- Write one test file per logical unit of behavior.
+- Follow existing test conventions in the codebase.
+
+## Workflow
+
+1. **Read the plan or requirements** — Understand what behavior needs to be tested.
+2. **Explore existing tests** — Use Read, Grep, Glob to find existing test patterns, naming conventions, and helpers.
+3. **Write failing tests** — Create test files in `tests/` that:
+   - Define the expected behavior clearly
+   - Use descriptive test names explaining what is tested and the expected outcome
+   - Follow Arrange-Act-Assert pattern
+   - Cover the happy path first, then edge cases
+   - Would fail because the implementation doesn't exist yet
+4. **List what you wrote** — Output a summary of test files created.
+5. **Hand off to tdd-green** — You cannot verify the tests fail. tdd-green will run them to confirm failure, then implement.
+
+## Output Format
+
+```
+## Tests Written
+
+| File | Tests | What they verify |
+|------|-------|-----------------|
+| `tests/path/file.bats` | 3 | Description of behavior tested |
+
+## Handoff to tdd-green
+
+The following tests should fail because [reason]. Implement [what] to make them pass.
+```
+
+## References
+
+- Testing conventions: `.github/instructions/testing.instructions.md`
+- Existing bats tests: `tests/scripts/*.bats`

--- a/.github/agents/tdd-refactor.md
+++ b/.github/agents/tdd-refactor.md
@@ -1,0 +1,71 @@
+---
+name: tdd-refactor
+description: "TDD Refactor phase — improve code structure and clarity while keeping all tests green. Hands off to tdd-red for the next cycle."
+tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash
+  - Edit
+  - Write
+model: inherit
+handoffs:
+  - label: "Refactoring complete — next TDD cycle"
+    agent: tdd-red
+    prompt: "Refactoring is done. Start the next TDD cycle by writing failing tests for the next requirement."
+    send: false
+---
+
+You are the **Refactor phase** of TDD for Hill90, a microservices platform on Hostinger VPS with Traefik edge proxy, Tailscale-secured SSH, and Docker Compose deployments.
+
+## Role
+
+Improve code structure, clarity, and maintainability without changing behavior. All tests must stay green throughout.
+
+## Constraints
+
+- **Don't create or modify test files.** Refactoring changes implementation only.
+- **Tests must stay green.** Run the full suite after every change. If a test breaks, undo the change immediately.
+- **Do not use Bash for file modifications.** Use Bash only for running tests and read-only commands. Use Edit and Write for file changes.
+- Write is available because refactoring sometimes requires extracting code into new files (splitting large modules).
+- Don't add new behavior. If you see missing functionality, note it for the next Red phase.
+
+## Workflow
+
+1. **Run tests** — Confirm everything is green before starting.
+2. **Identify improvements** — Look for:
+   - Duplicated code that can be extracted
+   - Long functions that should be split
+   - Unclear names that should be renamed
+   - Dead code that should be removed
+   - Inconsistent patterns that should be aligned
+3. **Make one change at a time** — Small, incremental refactors.
+4. **Run tests after each change** — Verify nothing broke.
+5. **Summarize changes** — Output what was improved and why.
+6. **Hand off to tdd-red** — For the next cycle of requirements.
+
+## Output Format
+
+```
+## Pre-Refactor Check
+
+All N tests green.
+
+## Refactoring Changes
+
+| File | Change | Rationale |
+|------|--------|-----------|
+| `path/to/file` | Extracted helper | Reduce duplication between X and Y |
+
+## Post-Refactor Check
+
+All N tests still green. No regressions.
+
+## Notes for Next Cycle
+
+- [Any observations about missing behavior or future improvements]
+```
+
+## References
+
+- Testing conventions: `.github/instructions/testing.instructions.md`

--- a/.github/docs/harness-reference.md
+++ b/.github/docs/harness-reference.md
@@ -23,8 +23,15 @@ Hill90/
 │   ├── docs/
 │   ├── skills/
 │   ├── agents/
+│   │   ├── code-reviewer.md
+│   │   ├── researcher.md
+│   │   ├── planner.md
+│   │   ├── tdd-red.md
+│   │   ├── tdd-green.md
+│   │   └── tdd-refactor.md
 │   └── workflows/
 ├── .claude/
+│   ├── settings.json
 │   ├── skills -> ../.github/skills
 │   ├── agents -> ../.github/agents
 │   ├── references/
@@ -49,7 +56,11 @@ Hill90/
 │   ├── hostinger.sh
 │   ├── vps.sh
 │   ├── ops.sh
-│   └── checks/
+│   ├── checks/
+│   └── hooks/
+│       ├── shellcheck-on-edit.sh
+│       ├── block-local-deploy.sh
+│       └── stop-gate.sh
 ├── tests/scripts/
 ├── src/services/
 └── docs/
@@ -98,6 +109,28 @@ ssh -i ~/.ssh/remote.hill90.com deploy@remote.hill90.com \
 | deepwiki | MCP tools | GitHub repo docs/wiki answers |
 | Hostinger MCP | `/hostinger` | VPS lifecycle + DNS management |
 | Linear MCP | `/linear` | Issue tracking and lifecycle |
+
+## Active Hooks (Claude Code Only)
+
+Hooks are configured in `.claude/settings.json` and run automatically during Claude Code sessions. Copilot and Codex enforce equivalent guardrails via CI workflows and scoped instructions.
+
+| Hook | Event | Script | Behavior |
+|------|-------|--------|----------|
+| shellcheck-on-edit | PostToolUse (Edit\|Write) | `scripts/hooks/shellcheck-on-edit.sh` | Runs shellcheck on edited `.sh` files (informational) |
+| block-local-deploy | PreToolUse (Bash) | `scripts/hooks/block-local-deploy.sh` | Blocks `make deploy-*` and `scripts/deploy.sh` locally (blocking) |
+| stop-gate | Stop | `scripts/hooks/stop-gate.sh` | Verifies required checks ran during session (blocking) |
+
+## TDD Agent Chain
+
+Three agents enforce Red-Green-Refactor phase separation:
+
+| Agent | Phase | Can Run Tests | Can Edit Files | Hands Off To |
+|-------|-------|---------------|---------------|-------------|
+| `tdd-red` | Write failing tests | No | No (Write only, in `tests/`) | `tdd-green` |
+| `tdd-green` | Minimum implementation | Yes | Yes | `tdd-refactor` |
+| `tdd-refactor` | Improve structure | Yes | Yes | `tdd-red` |
+
+Handoffs are Copilot-native (frontmatter `handoffs` key). Claude Code and Codex ignore unrecognized frontmatter.
 
 ## Guardrails
 

--- a/.github/instructions/agent-authoring.instructions.md
+++ b/.github/instructions/agent-authoring.instructions.md
@@ -13,19 +13,41 @@ When writing or editing subagent markdown files:
 
 ## Required Frontmatter
 - `name`: Unique identifier (lowercase, hyphens)
-- `description`: When the agent should be delegated to
+- `description`: When the agent should be delegated to — **must be a single-line quoted string** (VS Code parses `>-` multiline continuations as separate attributes)
 
 ## Optional Frontmatter
 - `tools`: Allowlist of tools as a **YAML array** (inherits all if omitted)
-- `disallowedTools`: Denylist as a **YAML array**
 - `model`: `sonnet`, `opus`, `haiku`, or `inherit`
 - `permissionMode`: Permission handling
 - `skills`: Skills to preload into context
-- `hooks`: Lifecycle hooks
+- `hooks`: Lifecycle hooks (Claude Code only)
+- `handoffs`: Copilot-only agent transitions as a **YAML array** (Claude Code and Codex silently ignore this key)
+
+### VS Code Compatibility
+
+VS Code agent files support only these attributes: `agents`, `argument-hint`, `description`, `disable-model-invocation`, `handoffs`, `model`, `name`, `target`, `tools`, `user-invokable`.
+
+**Not supported by VS Code** (Claude Code / Codex only):
+- `disallowedTools` — use `tools` allowlist instead to restrict available tools
+- `permissionMode`
+- `skills`
+- `hooks`
+
+### Handoffs Syntax
+
+The `handoffs` field enables one-click agent transitions in Copilot. It is a no-op on other platforms.
+
+```yaml
+handoffs:
+  - label: "Descriptive button text"
+    agent: target-agent-name
+    prompt: "Context passed to the target agent"
+    send: false
+```
 
 ## Tools Syntax
 
-The `tools` and `disallowedTools` fields **must be YAML arrays**, not comma-separated strings.
+The `tools` field **must be a YAML array**, not a comma-separated string.
 
 ```yaml
 # Correct
@@ -45,6 +67,6 @@ tools: Read, Grep, Glob
 - Keep focused on one specific task
 
 ## Tool Restrictions
-- Grant only necessary permissions
-- Use `disallowedTools` for read-only agents
-- Common read-only set: `[Read, Grep, Glob, Bash]`
+- Grant only necessary permissions via the `tools` allowlist
+- For read-only agents, list only read tools: `[Read, Grep, Glob, Bash]`
+- Reinforce restrictions in the system prompt body as defense-in-depth

--- a/.github/prompts/README.md
+++ b/.github/prompts/README.md
@@ -1,20 +1,31 @@
-# Prompt Evaluation
+# Prompts
 
-Use this directory to regression-test prompt and context-engineering changes before merging.
+This directory contains prompt templates and evaluation tools for Hill90 AI workflows.
 
-## Goal
+## Workflow Prompts
 
-Ensure prompt changes improve outputs without breaking known good behavior.
+| File | Purpose |
+|------|---------|
+| `new-feature.prompt.md` | Full PR workflow: orient, plan, TDD, verify, PR |
+| `fix-bug.prompt.md` | Bug fix workflow: reproduce, failing test, fix, verify, PR |
 
-## Workflow
+Use `$DESCRIPTION` in prompts — it is replaced by user input when invoked.
+
+## Evaluation
+
+| File | Purpose |
+|------|---------|
+| `eval-checklist.prompt.md` | Score prompt/agent outputs for quality |
+
+### Evaluation Workflow
 
 1. Add or update fixtures in `fixtures/`
 2. Run the prompt/agent with each fixture input
-3. Score results with `eval-checklist.md`
+3. Score results with `eval-checklist.prompt.md`
 4. Record failures and adjust prompt/context
 5. Re-run until all required checks pass
 
-## Minimum Gate
+### Minimum Gate
 
 - No critical checklist failures
 - No regressions on previously passing fixtures

--- a/.github/prompts/fix-bug.prompt.md
+++ b/.github/prompts/fix-bug.prompt.md
@@ -1,0 +1,58 @@
+---
+description: "Bug fix workflow: reproduce, failing test, fix, verify, PR"
+---
+
+# Fix Bug: $DESCRIPTION
+
+## Workflow
+
+### 1. Reproduce
+
+Understand the bug by:
+- Reading the bug report or description
+- Exploring the affected code with Read, Grep, Glob
+- Identifying the root cause (not just symptoms)
+
+### 2. Write a Failing Test
+
+Use `tdd-red` (or write directly) to create a test that:
+- Reproduces the exact bug condition
+- Fails with the current code
+- Will pass when the bug is fixed
+- Lives in `tests/` following existing conventions
+
+### 3. Fix the Bug
+
+Use `tdd-green` (or fix directly) to:
+- Make the minimum change to fix the bug
+- Run the failing test to confirm it passes
+- Run the full test suite to ensure no regressions
+
+### 4. Refactor (if needed)
+
+Use `tdd-refactor` if the fix reveals code that should be cleaned up. Keep tests green throughout.
+
+### 5. Verify Locally
+
+Run all relevant checks:
+- `shellcheck --severity=error scripts/*.sh` (if shell scripts changed)
+- `bats tests/scripts/` (if bats tests exist)
+- `npm test` (if Node.js services changed)
+- `pytest` (if Python services changed)
+
+### 6. Create Branch and PR
+
+```bash
+git checkout -b fix/<bug-name>
+git add <files>
+git commit -m "fix: <description>"
+git push -u origin fix/<bug-name>
+gh pr create --title "fix: <description>" --body "..."
+```
+
+## Constraints
+
+- Always write a regression test before fixing the bug
+- Fix the root cause, not the symptom
+- Do not add unrelated changes to the fix
+- Do not deploy locally — deployments run on VPS via SSH

--- a/.github/prompts/new-feature.prompt.md
+++ b/.github/prompts/new-feature.prompt.md
@@ -1,0 +1,56 @@
+---
+description: "Full PR workflow for adding a new feature: orient, plan, TDD, verify, PR"
+---
+
+# New Feature: $DESCRIPTION
+
+## Workflow
+
+Follow the required PR workflow from `AGENTS.md`:
+
+### 1. Orient
+
+Run `/primer` to understand current project state and conventions.
+
+### 2. Plan
+
+Use the `planner` agent (or Claude Code's built-in plan mode) to:
+- Explore affected files and existing patterns
+- Produce a structured implementation plan
+- Identify risks and verification steps
+- Get user approval before proceeding
+
+### 3. Implement with TDD
+
+Follow Red-Green-Refactor using the TDD agent chain:
+
+1. **Red** (`tdd-red`): Write failing tests in `tests/` that define the expected behavior for $DESCRIPTION
+2. **Green** (`tdd-green`): Run the tests to confirm failure, then write minimum code to make them pass
+3. **Refactor** (`tdd-refactor`): Improve structure while keeping tests green
+4. Repeat for each requirement
+
+### 4. Verify Locally
+
+Run all relevant checks before creating a PR:
+- `shellcheck --severity=error scripts/*.sh` (if shell scripts changed)
+- `bats tests/scripts/` (if bats tests exist)
+- `npm test` (if Node.js services changed)
+- `pytest` (if Python services changed)
+- `docker compose config` or `bash scripts/validate.sh` (if compose/edge config changed)
+
+### 5. Create Branch and PR
+
+```bash
+git checkout -b feat/<feature-name>
+git add <files>
+git commit -m "feat: <description>"
+git push -u origin feat/<feature-name>
+gh pr create --title "feat: <description>" --body "..."
+```
+
+## Constraints
+
+- Do not skip TDD steps — write tests before implementation
+- Do not deploy locally — deployments run on VPS via SSH
+- Do not add speculative features outside the described scope
+- Use MCP docs tools (`context7`, `microsoft-learn`, `deepwiki`) for fresh API references

--- a/scripts/hooks/block-local-deploy.sh
+++ b/scripts/hooks/block-local-deploy.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# PreToolUse hook: block deploy commands that should only run on VPS.
+# Input: JSON via stdin with tool_input.command
+# Output: JSON permissionDecision deny/allow
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+
+# No command — allow
+if [[ -z "$COMMAND" ]]; then
+  exit 0
+fi
+
+# Normalize: strip leading whitespace, handle chained commands and subshells
+NORMALIZED="$COMMAND"
+# Strip leading whitespace
+NORMALIZED="${NORMALIZED#"${NORMALIZED%%[![:space:]]*}"}"
+
+# Check each segment of chained commands (&&, ||, ;)
+# We need to check if ANY segment contains a deploy command
+check_segment() {
+  local seg="$1"
+  # Strip leading whitespace
+  seg="${seg#"${seg%%[![:space:]]*}"}"
+  # Strip common prefixes: env VAR=val, bash -c/-lc with quotes
+  # env prefix
+  while [[ "$seg" =~ ^env[[:space:]]+[A-Za-z_][A-Za-z0-9_]*= ]]; do
+    seg="${seg#env }"
+    seg="${seg#*= }"
+    seg="${seg#"${seg%%[![:space:]]*}"}"
+  done
+  # bash -c or bash -lc prefix (with quoted content)
+  if [[ "$seg" =~ ^bash[[:space:]]+-[a-z]*c[[:space:]]+ ]]; then
+    seg="${seg#bash }"
+    seg="${seg#-* }"
+    # Strip surrounding quotes
+    seg="${seg#\"}"
+    seg="${seg%\"}"
+    seg="${seg#\'}"
+    seg="${seg%\'}"
+    seg="${seg#"${seg%%[![:space:]]*}"}"
+  fi
+  # cd prefix
+  if [[ "$seg" =~ ^cd[[:space:]] ]]; then
+    # cd is just changing directory — not a deploy command itself
+    return 1
+  fi
+
+  # ALLOW: ssh-routed commands
+  if [[ "$seg" =~ ^ssh[[:space:]] ]]; then
+    return 1
+  fi
+
+  # DENY: make deploy-*
+  if [[ "$seg" =~ make[[:space:]]+deploy- ]]; then
+    return 0
+  fi
+
+  # DENY: direct deploy.sh invocations
+  if [[ "$seg" =~ (bash[[:space:]]+)?scripts/deploy\.sh ]] || \
+     [[ "$seg" =~ \./scripts/deploy\.sh ]]; then
+    return 0
+  fi
+
+  return 1
+}
+
+# Split on && || ; and check each segment
+NL=$'\n'
+SEGMENTS="${NORMALIZED//&&/$NL}"
+SEGMENTS="${SEGMENTS//||/$NL}"
+SEGMENTS="${SEGMENTS//;/$NL}"
+BLOCKED=false
+
+while IFS= read -r segment; do
+  if check_segment "$segment"; then
+    BLOCKED=true
+    break
+  fi
+done <<< "$SEGMENTS"
+
+if [[ "$BLOCKED" == "true" ]]; then
+  REASON="Deploy commands must run on VPS, not locally. Use SSH:
+  ssh -i ~/.ssh/remote.hill90.com deploy@remote.hill90.com 'cd /opt/hill90/app && bash scripts/deploy.sh all prod'
+Or use: make recreate-vps / make config-vps / make health (these are local-safe)"
+  jq -n --arg reason "$REASON" '{
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: $reason
+    }
+  }'
+  exit 0
+fi
+
+# Allow everything else
+exit 0

--- a/scripts/hooks/shellcheck-on-edit.sh
+++ b/scripts/hooks/shellcheck-on-edit.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# PostToolUse hook: run shellcheck on .sh files after Edit/Write.
+# Input: JSON via stdin with tool_input.file_path
+# Output: JSON systemMessage with findings (non-blocking, exit 0)
+
+INPUT=$(cat)
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+
+# No file path — nothing to check
+if [[ -z "$FILE_PATH" ]]; then
+  exit 0
+fi
+
+# Only check shell scripts
+if [[ "$FILE_PATH" != *.sh ]]; then
+  exit 0
+fi
+
+# Skip if file doesn't exist (e.g. deleted)
+if [[ ! -f "$FILE_PATH" ]]; then
+  exit 0
+fi
+
+# Skip if shellcheck not installed
+if ! command -v shellcheck &>/dev/null; then
+  jq -n '{systemMessage: "shellcheck not installed — skipping lint"}'
+  exit 0
+fi
+
+# Run shellcheck (error severity only)
+RESULT=$(shellcheck --severity=error "$FILE_PATH" 2>&1) || true
+
+if [[ -n "$RESULT" ]]; then
+  jq -n --arg findings "$RESULT" --arg file "$FILE_PATH" \
+    '{systemMessage: "shellcheck findings in \($file):\n\($findings)"}'
+else
+  exit 0
+fi

--- a/scripts/hooks/stop-gate.sh
+++ b/scripts/hooks/stop-gate.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Stop hook: verify that required verification commands ran during the session.
+# Input: JSON via stdin with transcript_path
+# Output: exit 2 (blocking) if required checks are missing, exit 0 otherwise
+
+INPUT=$(cat)
+TRANSCRIPT_PATH=$(echo "$INPUT" | jq -r '.transcript_path // empty')
+CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
+
+# Fail-open if no transcript path
+if [[ -z "$TRANSCRIPT_PATH" ]]; then
+  jq -n '{systemMessage: "stop-gate: no transcript path provided — skipping verification check"}'
+  exit 0
+fi
+
+# Fail-open if transcript file missing or empty
+if [[ ! -f "$TRANSCRIPT_PATH" ]]; then
+  jq -n '{systemMessage: "stop-gate: transcript file not found — skipping verification check"}'
+  exit 0
+fi
+
+if [[ ! -s "$TRANSCRIPT_PATH" ]]; then
+  jq -n '{systemMessage: "stop-gate: transcript file is empty — skipping verification check"}'
+  exit 0
+fi
+
+# Read transcript content (best-effort, fail-open on read errors)
+TRANSCRIPT=$(cat "$TRANSCRIPT_PATH" 2>/dev/null) || {
+  jq -n '{systemMessage: "stop-gate: could not read transcript — skipping verification check"}'
+  exit 0
+}
+
+# Extract modified file paths from the transcript
+# Look for tool_input.file_path in Edit/Write calls and tool_input.command in Bash
+MODIFIED_FILES=$(echo "$TRANSCRIPT" | jq -r '
+  select(.tool_name == "Edit" or .tool_name == "Write") |
+  .tool_input.file_path // empty
+' 2>/dev/null || true)
+
+MISSING_CHECKS=()
+
+# Helper: check if a command pattern appears in transcript Bash commands
+transcript_has_command() {
+  local pattern="$1"
+  echo "$TRANSCRIPT" | grep -qE "$pattern" 2>/dev/null
+}
+
+# Helper: check if any modified file matches a path pattern
+has_modified_path() {
+  local pattern="$1"
+  echo "$MODIFIED_FILES" | grep -qE "$pattern" 2>/dev/null
+}
+
+# Rule: scripts/*.sh or scripts/hooks/*.sh -> shellcheck
+if has_modified_path 'scripts/.*\.sh'; then
+  if ! transcript_has_command 'shellcheck'; then
+    MISSING_CHECKS+=("shellcheck (modified shell scripts in scripts/)")
+  fi
+fi
+
+# Rule: tests/scripts/** -> bats
+if has_modified_path 'tests/scripts/'; then
+  if ! transcript_has_command 'bats'; then
+    MISSING_CHECKS+=("bats (modified test files in tests/scripts/)")
+  fi
+fi
+
+# Rule: src/services/api/** or src/services/auth/** -> npm test
+if has_modified_path 'src/services/(api|auth)/'; then
+  if ! transcript_has_command 'npm test'; then
+    MISSING_CHECKS+=("npm test (modified Node.js service files)")
+  fi
+fi
+
+# Rule: src/services/ai/** -> pytest
+if has_modified_path 'src/services/ai/'; then
+  if ! transcript_has_command 'pytest'; then
+    MISSING_CHECKS+=("pytest (modified Python service files)")
+  fi
+fi
+
+# Rule: deploy/compose/** or platform/edge/** -> docker compose config or validate.sh
+if has_modified_path '(deploy/compose|platform/edge)/'; then
+  if ! transcript_has_command '(docker compose config|validate\.sh)'; then
+    MISSING_CHECKS+=("docker compose config or validate.sh (modified compose/edge config)")
+  fi
+fi
+
+if [[ ${#MISSING_CHECKS[@]} -gt 0 ]]; then
+  MISSING_LIST=$(printf '  - %s\n' "${MISSING_CHECKS[@]}")
+  echo "stop-gate: required verification commands were not found in this session:" >&2
+  echo "$MISSING_LIST" >&2
+  echo "Please run these checks before finishing." >&2
+  exit 2
+fi
+
+exit 0

--- a/tests/scripts/hooks.bats
+++ b/tests/scripts/hooks.bats
@@ -1,0 +1,229 @@
+#!/usr/bin/env bats
+
+# Tests for scripts/hooks/*.sh
+
+# ---------------------------------------------------------------------------
+# shellcheck-on-edit.sh
+# ---------------------------------------------------------------------------
+
+@test "shellcheck-on-edit: passes through non-.sh files" {
+  run bash -c 'echo "{\"tool_input\":{\"file_path\":\"src/app.py\"}}" | bash scripts/hooks/shellcheck-on-edit.sh'
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "shellcheck-on-edit: passes through missing file_path" {
+  run bash -c 'echo "{\"tool_input\":{}}" | bash scripts/hooks/shellcheck-on-edit.sh'
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "shellcheck-on-edit: reports errors in .sh files" {
+  # Create a script with a shellcheck error-severity issue (SC2045)
+  tmp="$(mktemp /tmp/hook-test-bad-XXXXXX.sh)"
+  cat > "$tmp" << 'SCRIPT'
+#!/bin/bash
+for f in $(ls); do echo "$f"; done
+SCRIPT
+
+  run bash -c "echo '{\"tool_input\":{\"file_path\":\"$tmp\"}}' | bash scripts/hooks/shellcheck-on-edit.sh"
+  [ "$status" -eq 0 ]
+  # Should return a systemMessage with shellcheck findings
+  echo "$output" | jq -e '.systemMessage' >/dev/null
+  [[ "$output" == *"shellcheck"* ]]
+
+  rm -f "$tmp"
+}
+
+@test "shellcheck-on-edit: clean .sh file produces no output" {
+  tmp="$(mktemp /tmp/good-script-XXXXXX.sh)"
+  cat > "$tmp" << 'SCRIPT'
+#!/bin/bash
+echo "hello"
+SCRIPT
+
+  run bash -c "echo '{\"tool_input\":{\"file_path\":\"$tmp\"}}' | bash scripts/hooks/shellcheck-on-edit.sh"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+
+  rm -f "$tmp"
+}
+
+@test "shellcheck-on-edit: handles nonexistent .sh file" {
+  run bash -c 'echo "{\"tool_input\":{\"file_path\":\"/tmp/does-not-exist.sh\"}}" | bash scripts/hooks/shellcheck-on-edit.sh'
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+# ---------------------------------------------------------------------------
+# block-local-deploy.sh
+# ---------------------------------------------------------------------------
+
+@test "block-local-deploy: allows ssh-routed commands" {
+  run bash -c 'echo "{\"tool_input\":{\"command\":\"ssh -i ~/.ssh/remote.hill90.com deploy@remote.hill90.com bash scripts/deploy.sh all prod\"}}" | bash scripts/hooks/block-local-deploy.sh'
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "block-local-deploy: allows make recreate-vps" {
+  run bash -c 'echo "{\"tool_input\":{\"command\":\"make recreate-vps\"}}" | bash scripts/hooks/block-local-deploy.sh'
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "block-local-deploy: allows make health" {
+  run bash -c 'echo "{\"tool_input\":{\"command\":\"make health\"}}" | bash scripts/hooks/block-local-deploy.sh'
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "block-local-deploy: allows make config-vps VPS_IP=1.2.3.4" {
+  run bash -c 'echo "{\"tool_input\":{\"command\":\"make config-vps VPS_IP=1.2.3.4\"}}" | bash scripts/hooks/block-local-deploy.sh'
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "block-local-deploy: allows make test" {
+  run bash -c 'echo "{\"tool_input\":{\"command\":\"make test\"}}" | bash scripts/hooks/block-local-deploy.sh'
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "block-local-deploy: allows make lint" {
+  run bash -c 'echo "{\"tool_input\":{\"command\":\"make lint\"}}" | bash scripts/hooks/block-local-deploy.sh'
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "block-local-deploy: allows make secrets-view" {
+  run bash -c 'echo "{\"tool_input\":{\"command\":\"make secrets-view KEY=foo\"}}" | bash scripts/hooks/block-local-deploy.sh'
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "block-local-deploy: blocks make deploy-all" {
+  run bash -c 'echo "{\"tool_input\":{\"command\":\"make deploy-all\"}}" | bash scripts/hooks/block-local-deploy.sh'
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.hookSpecificOutput.permissionDecision' >/dev/null
+  [[ "$output" == *"deny"* ]]
+}
+
+@test "block-local-deploy: blocks make deploy-infra" {
+  run bash -c 'echo "{\"tool_input\":{\"command\":\"make deploy-infra\"}}" | bash scripts/hooks/block-local-deploy.sh'
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"deny"* ]]
+}
+
+@test "block-local-deploy: blocks bash scripts/deploy.sh infra prod" {
+  run bash -c 'echo "{\"tool_input\":{\"command\":\"bash scripts/deploy.sh infra prod\"}}" | bash scripts/hooks/block-local-deploy.sh'
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"deny"* ]]
+}
+
+@test "block-local-deploy: blocks ./scripts/deploy.sh" {
+  run bash -c 'echo "{\"tool_input\":{\"command\":\"./scripts/deploy.sh all prod\"}}" | bash scripts/hooks/block-local-deploy.sh'
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"deny"* ]]
+}
+
+@test "block-local-deploy: blocks env FOO=bar make deploy-all (normalization)" {
+  run bash -c 'echo "{\"tool_input\":{\"command\":\"env FOO=bar make deploy-all\"}}" | bash scripts/hooks/block-local-deploy.sh'
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"deny"* ]]
+}
+
+@test "block-local-deploy: blocks cd /tmp && make deploy-all (chained)" {
+  run bash -c 'echo "{\"tool_input\":{\"command\":\"cd /tmp && make deploy-all\"}}" | bash scripts/hooks/block-local-deploy.sh'
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"deny"* ]]
+}
+
+@test "block-local-deploy: blocks bash -lc make deploy-all (quoted subshell)" {
+  run bash -c 'echo "{\"tool_input\":{\"command\":\"bash -lc \\\"make deploy-all\\\"\"}}" | bash scripts/hooks/block-local-deploy.sh'
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"deny"* ]]
+}
+
+@test "block-local-deploy: allows empty command" {
+  run bash -c 'echo "{\"tool_input\":{}}" | bash scripts/hooks/block-local-deploy.sh'
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+# ---------------------------------------------------------------------------
+# stop-gate.sh
+# ---------------------------------------------------------------------------
+
+@test "stop-gate: blocks when .sh edited but shellcheck not in transcript" {
+  transcript="$(mktemp /tmp/transcript-XXXXXX.jsonl)"
+  cat > "$transcript" << 'JSONL'
+{"tool_name":"Edit","tool_input":{"file_path":"scripts/deploy.sh"}}
+{"tool_name":"Bash","tool_input":{"command":"bats tests/scripts/"}}
+JSONL
+
+  run bash -c "echo '{\"transcript_path\":\"$transcript\",\"cwd\":\"/tmp\"}' | bash scripts/hooks/stop-gate.sh"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"shellcheck"* ]]
+
+  rm -f "$transcript"
+}
+
+@test "stop-gate: blocks when src/services/api edited but npm test not in transcript" {
+  transcript="$(mktemp /tmp/transcript-XXXXXX.jsonl)"
+  cat > "$transcript" << 'JSONL'
+{"tool_name":"Write","tool_input":{"file_path":"src/services/api/index.ts"}}
+JSONL
+
+  run bash -c "echo '{\"transcript_path\":\"$transcript\",\"cwd\":\"/tmp\"}' | bash scripts/hooks/stop-gate.sh"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"npm test"* ]]
+
+  rm -f "$transcript"
+}
+
+@test "stop-gate: allows when all required checks present" {
+  transcript="$(mktemp /tmp/transcript-XXXXXX.jsonl)"
+  cat > "$transcript" << 'JSONL'
+{"tool_name":"Edit","tool_input":{"file_path":"scripts/deploy.sh"}}
+{"tool_name":"Bash","tool_input":{"command":"shellcheck --severity=error scripts/deploy.sh"}}
+JSONL
+
+  run bash -c "echo '{\"transcript_path\":\"$transcript\",\"cwd\":\"/tmp\"}' | bash scripts/hooks/stop-gate.sh"
+  [ "$status" -eq 0 ]
+
+  rm -f "$transcript"
+}
+
+@test "stop-gate: allows when no checkable files were modified" {
+  transcript="$(mktemp /tmp/transcript-XXXXXX.jsonl)"
+  cat > "$transcript" << 'JSONL'
+{"tool_name":"Edit","tool_input":{"file_path":"README.md"}}
+JSONL
+
+  run bash -c "echo '{\"transcript_path\":\"$transcript\",\"cwd\":\"/tmp\"}' | bash scripts/hooks/stop-gate.sh"
+  [ "$status" -eq 0 ]
+
+  rm -f "$transcript"
+}
+
+@test "stop-gate: fails open with warning when transcript missing" {
+  run bash -c "echo '{\"transcript_path\":\"/tmp/nonexistent-transcript.jsonl\",\"cwd\":\"/tmp\"}' | bash scripts/hooks/stop-gate.sh"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"not found"* ]]
+}
+
+@test "stop-gate: fails open with warning when transcript path empty" {
+  run bash -c "echo '{\"cwd\":\"/tmp\"}' | bash scripts/hooks/stop-gate.sh"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"skipping"* ]]
+}
+
+@test "stop-gate: fails open with warning when transcript file is empty" {
+  transcript="$(mktemp /tmp/transcript-XXXXXX.jsonl)"
+
+  run bash -c "echo '{\"transcript_path\":\"$transcript\",\"cwd\":\"/tmp\"}' | bash scripts/hooks/stop-gate.sh"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"empty"* ]]
+
+  rm -f "$transcript"
+}


### PR DESCRIPTION
## Summary

- **TDD agent chain** — `tdd-red`, `tdd-green`, `tdd-refactor` agents with tool restrictions and Copilot handoffs enforcing Red-Green-Refactor phase separation
- **Planner agent** — read-only codebase exploration producing structured implementation plans, with handoff to `tdd-red`
- **Active hooks** (Claude Code only) — `shellcheck-on-edit` (PostToolUse), `block-local-deploy` (PreToolUse), `stop-gate` (Stop) configured in `.claude/settings.json`
- **Prompt templates** — `new-feature.prompt.md` and `fix-bug.prompt.md` for workflow-starter prompts
- **Doc/config updates** — VS Code compatibility rules for agent authoring (single-line descriptions, `tools` allowlist over `disallowedTools`), harness reference topology, Codex `project_doc_max_bytes`

## Test plan

- [x] `shellcheck --severity=error scripts/hooks/*.sh` — all clean
- [x] `bats tests/scripts/hooks.bats` — 27/27 pass
- [x] Agent lint validation — all 6 agents pass (no VS Code attribute errors)
- [ ] Copilot: verify handoff buttons appear on TDD agents
- [ ] Claude Code: verify hooks fire (shellcheck-on-edit, block-local-deploy, stop-gate)
- [ ] Codex: verify no parse errors from `handoffs` frontmatter

🤖 Generated with [Claude Code](https://claude.com/claude-code)