### PR TITLE
fix: add diagonal gap between SVG hill peaks

### DIFF
--- a/src/services/ui/src/app/logo-test/page.tsx
+++ b/src/services/ui/src/app/logo-test/page.tsx
@@ -29,7 +29,7 @@ function Hill({
       {/* Right peak (background, taller) — straight slopes, slight convex right edge */}
       <path
         className="hill-right"
-        d="M 55,297 L 340,18 Q 365,-2 390,18 Q 530,130 660,297 Z"
+        d="M 458,297 L 256,95 C 300,40 340,5 365,5 C 390,5 540,130 660,297 Z"
         fill={lightColor}
       />
       {/* Left peak (middle layer, shorter) — angular triangle, rounded peak */}
@@ -61,7 +61,7 @@ function HillOutline({ className = '' }: { className?: string }) {
     >
       <path
         className="draw-right"
-        d="M 55,297 L 340,18 Q 365,-2 390,18 Q 530,130 660,297 Z"
+        d="M 458,297 L 256,95 C 300,40 340,5 365,5 C 390,5 540,130 660,297 Z"
         fill="none"
         stroke="#60757D"
         strokeWidth="3"

--- a/src/services/ui/src/components/HillLogo.tsx
+++ b/src/services/ui/src/components/HillLogo.tsx
@@ -23,13 +23,13 @@ export default function HillLogo({
       role="img"
       aria-label="Hill90 logo"
     >
-      {/* Right peak (background, taller) — straight slopes, slight convex right edge */}
+      {/* Right peak (background, taller) — left edge follows gap boundary */}
       <path
         className="hill-right"
-        d="M 55,297 L 340,18 Q 365,-2 390,18 Q 530,130 660,297 Z"
+        d="M 458,297 L 256,95 C 300,40 340,5 365,5 C 390,5 540,130 660,297 Z"
         fill={lightColor}
       />
-      {/* Left peak (middle layer, shorter) — angular triangle, rounded peak */}
+      {/* Left peak (middle layer, shorter) — right edge follows gap boundary */}
       <path
         className="hill-left"
         d="M 0,297 L 180,100 Q 198,78 220,95 L 422,297 Z"


### PR DESCRIPTION
## Summary
- Fix the missing diagonal gap/slit between the two hill peaks
- Right peak's left edge was starting at x=55, extending under the left hill and covering the gap
- Rebuilt right peak path so its left edge follows the gap boundary (36px wide, parallel to left hill's right edge)

## Test plan
- [ ] Verify diagonal gap is visible on `/logo-test` between the two peaks
- [ ] Compare with PNG on landing page

🤖 Generated with [Claude Code](https://claude.com/claude-code)
