### PR TITLE
fix: harden harness guardrails for merge and local run safety

### DIFF
--- a/.github/docs/contribution-workflow.md
+++ b/.github/docs/contribution-workflow.md
@@ -31,8 +31,10 @@ See also: `.github/docs/harness-reference.md` for platform parity, repository to
    - Resolve CI failures and Copilot review findings, then push updates.
 11. **Merge**
    - Squash merge and delete branch: `gh pr merge --squash --delete-branch`
+   - Never use `--admin` or `--force` to bypass branch protections.
 12. **Post-Merge Deployment**
    - Push-to-main triggers path-filtered deploy workflows (`deploy-api.yml`, `deploy-auth.yml`, etc.) over SSH/Tailscale.
+   - Do not run manual deploy commands after merge unless explicitly requested for incident recovery.
 
 ## Branch Naming Convention
 

--- a/.github/docs/harness-reference.md
+++ b/.github/docs/harness-reference.md
@@ -117,7 +117,7 @@ Hooks are configured in `.claude/settings.json` and run automatically during Cla
 | Hook | Event | Script | Behavior |
 |------|-------|--------|----------|
 | shellcheck-on-edit | PostToolUse (Edit\|Write) | `scripts/hooks/shellcheck-on-edit.sh` | Runs shellcheck on edited `.sh` files (informational) |
-| block-local-deploy | PreToolUse (Bash) | `scripts/hooks/block-local-deploy.sh` | Blocks `make deploy-*` and `scripts/deploy.sh` locally (blocking) |
+| block-local-deploy | PreToolUse (Bash) | `scripts/hooks/block-local-deploy.sh` | Blocks local deploy commands, privileged PR merges (`--admin`/`--force`), and local dev-server starts (blocking) |
 | stop-gate | Stop | `scripts/hooks/stop-gate.sh` | Verifies required checks ran during session (blocking) |
 
 ## TDD Agent Chain
@@ -139,6 +139,7 @@ Do:
 - Track real work in Linear (`todo` -> `doing` -> `review` -> `done`).
 - Validate locally before PR.
 - Use `make` wrappers and existing scripts.
+- After context compaction/collapse, restate task/workflow and run primer before acting.
 
 Don't:
 - Rely on stale memory for changing APIs/tooling.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,8 @@ Chain: `AGENTS.md` (source) <- `CLAUDE.md` (symlink) <- `.github/copilot-instruc
    - Status flow: `todo` -> `doing` -> `review` -> `done`.
 4. **Deploy on VPS, not local Mac**
    - All deploy/rebuild actions run via `make` wrappers and VPS SSH.
+5. **Context collapse recovery is mandatory**
+   - After any context compaction/collapse, restate current task + active workflow from summary, then run primer before making changes or running commands.
 
 ## Required PR Workflow
 
@@ -37,7 +39,9 @@ This is the required flow for Claude, Codex, and Copilot-assisted changes.
 9. **CI gates** — tests, security scan, Copilot review.
 10. **Address feedback** — fix CI/review findings.
 11. **Merge** — `gh pr merge --squash --delete-branch`.
+   - Never use `--admin` or `--force` to bypass branch protections.
 12. **Post-merge deploy** — push-to-main triggers path-filtered deploy workflows.
+   - Do not run manual deploy commands after merge unless explicitly requested for incident recovery.
 
 ### Branch Naming
 
@@ -95,5 +99,7 @@ Do:
 Don't:
 - Use TodoWrite as persistent task tracking.
 - Run deploy scripts locally on Mac.
+- Use `gh pr merge --admin` or `gh pr merge --force`.
+- Run local app servers (`npm run dev`, `npm start`, `pnpm dev`, `yarn dev`) unless explicitly asked in the current turn.
 - Skip CI/review feedback.
 - Add speculative features outside request scope.

--- a/scripts/hooks/block-local-deploy.sh
+++ b/scripts/hooks/block-local-deploy.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# PreToolUse hook: block deploy commands that should only run on VPS.
+# PreToolUse hook: block risky local commands that violate Hill90 workflow.
 # Input: JSON via stdin with tool_input.command
 # Output: JSON permissionDecision deny/allow
 
@@ -19,7 +19,7 @@ NORMALIZED="$COMMAND"
 NORMALIZED="${NORMALIZED#"${NORMALIZED%%[![:space:]]*}"}"
 
 # Check each segment of chained commands (&&, ||, ;)
-# We need to check if ANY segment contains a deploy command
+# We need to check if ANY segment contains a blocked command.
 check_segment() {
   local seg="$1"
   # Strip leading whitespace
@@ -48,9 +48,21 @@ check_segment() {
     return 1
   fi
 
-  # ALLOW: ssh-routed commands
+  # ALLOW: ssh-routed commands (non-deploy maintenance operations are valid)
   if [[ "$seg" =~ ^ssh[[:space:]] ]]; then
     return 1
+  fi
+
+  # DENY: bypassing branch protections
+  if [[ "$seg" =~ gh[[:space:]]+pr[[:space:]]+merge ]] && \
+     [[ "$seg" =~ (--admin|--force) ]]; then
+    return 0
+  fi
+
+  # DENY: local app/dev servers (must be explicitly requested by user first)
+  if [[ "$seg" =~ (^|[[:space:]])(npm|pnpm|yarn)[[:space:]]+(run[[:space:]]+)?(dev|start)([[:space:]]|$) ]] || \
+     [[ "$seg" =~ (^|[[:space:]])next[[:space:]]+dev([[:space:]]|$) ]]; then
+    return 0
   fi
 
   # DENY: make deploy-*
@@ -82,9 +94,11 @@ while IFS= read -r segment; do
 done <<< "$SEGMENTS"
 
 if [[ "$BLOCKED" == "true" ]]; then
-  REASON="Deploy commands must run on VPS, not locally. Use SSH:
-  ssh -i ~/.ssh/remote.hill90.com deploy@remote.hill90.com 'cd /opt/hill90/app && bash scripts/deploy.sh all prod'
-Or use: make recreate-vps / make config-vps / make health (these are local-safe)"
+  REASON="Blocked by Hill90 harness policy.
+- Never use gh pr merge with --admin or --force.
+- Do not run local app/dev servers unless the user explicitly asks in this turn.
+- Do not run local deploy commands (make deploy-*, scripts/deploy.sh).
+Workflow: merge only after CI gates pass; deployment is automatic via GitHub Actions on push/merge to main."
   jq -n --arg reason "$REASON" '{
     hookSpecificOutput: {
       hookEventName: "PreToolUse",

--- a/tests/scripts/hooks.bats
+++ b/tests/scripts/hooks.bats
@@ -144,6 +144,36 @@ SCRIPT
   [[ "$output" == *"deny"* ]]
 }
 
+@test "block-local-deploy: blocks gh pr merge with --admin" {
+  run bash -c 'echo "{\"tool_input\":{\"command\":\"gh pr merge 23 --squash --delete-branch --admin\"}}" | bash scripts/hooks/block-local-deploy.sh'
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"deny"* ]]
+}
+
+@test "block-local-deploy: blocks gh pr merge with --force" {
+  run bash -c 'echo "{\"tool_input\":{\"command\":\"gh pr merge 23 --squash --delete-branch --force\"}}" | bash scripts/hooks/block-local-deploy.sh'
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"deny"* ]]
+}
+
+@test "block-local-deploy: allows gh pr merge without bypass flags" {
+  run bash -c 'echo "{\"tool_input\":{\"command\":\"gh pr merge 23 --squash --delete-branch\"}}" | bash scripts/hooks/block-local-deploy.sh'
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "block-local-deploy: blocks npm run dev" {
+  run bash -c 'echo "{\"tool_input\":{\"command\":\"cd src/services/ui && npm run dev\"}}" | bash scripts/hooks/block-local-deploy.sh'
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"deny"* ]]
+}
+
+@test "block-local-deploy: blocks pnpm dev" {
+  run bash -c 'echo "{\"tool_input\":{\"command\":\"pnpm dev\"}}" | bash scripts/hooks/block-local-deploy.sh'
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"deny"* ]]
+}
+
 @test "block-local-deploy: allows empty command" {
   run bash -c 'echo "{\"tool_input\":{}}" | bash scripts/hooks/block-local-deploy.sh'
   [ "$status" -eq 0 ]


### PR DESCRIPTION
## Summary
- Harden `block-local-deploy` hook to deny `gh pr merge` with `--admin` or `--force`
- Block unapproved local app-server starts (`npm/pnpm/yarn dev|start`, `next dev`) in PreToolUse
- Update policy/docs to codify no bypass merges, no manual post-merge deploys, and required context-collapse re-orientation
- Extend BATS coverage for new hook rules

## Test Plan
- [x] `shellcheck scripts/hooks/block-local-deploy.sh`
- [x] `bats tests/scripts/hooks.bats`

## Risk
- Low: scoped to harness policy/docs and hook behavior, with explicit tests
