### PR TITLE
enhance: add session-recovery rule and block local build commands

### DIFF
--- a/.claude/rules/session-recovery.md
+++ b/.claude/rules/session-recovery.md
@@ -1,0 +1,13 @@
+---
+description: Enforces context-collapse recovery protocol
+globs:
+alwaysApply: true
+---
+
+After any context compaction or collapse, you MUST:
+
+1. Restate the current task and active workflow from the most recent summary.
+2. Run primer (`/primer`) before making any changes or running commands.
+3. Do not assume prior tool results are still valid — re-read key files if needed.
+
+Never resume editing or running commands without completing steps 1-2 first.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,6 +100,7 @@ Don't:
 - Use TodoWrite as persistent task tracking.
 - Run deploy scripts locally on Mac.
 - Use `gh pr merge --admin` or `gh pr merge --force`.
-- Run local app servers (`npm run dev`, `npm start`, `pnpm dev`, `yarn dev`) unless explicitly asked in the current turn.
+- Run local app servers or builds (`npm run dev`, `npm start`, `npm run build`, `pnpm dev`, `yarn dev`) unless explicitly asked in the current turn.
 - Skip CI/review feedback.
 - Add speculative features outside request scope.
+- If a hook blocks an action, do not retry or work around it. Stop immediately and ask the user what to do next.

--- a/scripts/hooks/block-local-deploy.sh
+++ b/scripts/hooks/block-local-deploy.sh
@@ -48,6 +48,11 @@ check_segment() {
     return 1
   fi
 
+  # ALLOW: git commands (commit messages may contain blocked keywords)
+  if [[ "$seg" =~ ^git[[:space:]] ]]; then
+    return 1
+  fi
+
   # ALLOW: ssh-routed commands (non-deploy maintenance operations are valid)
   if [[ "$seg" =~ ^ssh[[:space:]] ]]; then
     return 1
@@ -60,8 +65,8 @@ check_segment() {
   fi
 
   # DENY: local app/dev servers (must be explicitly requested by user first)
-  if [[ "$seg" =~ (^|[[:space:]])(npm|pnpm|yarn)[[:space:]]+(run[[:space:]]+)?(dev|start)([[:space:]]|$) ]] || \
-     [[ "$seg" =~ (^|[[:space:]])next[[:space:]]+dev([[:space:]]|$) ]]; then
+  if [[ "$seg" =~ (^|[[:space:]])(npm|pnpm|yarn)[[:space:]]+(run[[:space:]]+)?(dev|start|build)([[:space:]]|$) ]] || \
+     [[ "$seg" =~ (^|[[:space:]])next[[:space:]]+(dev|build)([[:space:]]|$) ]]; then
     return 0
   fi
 
@@ -96,9 +101,9 @@ done <<< "$SEGMENTS"
 if [[ "$BLOCKED" == "true" ]]; then
   REASON="Blocked by Hill90 harness policy.
 - Never use gh pr merge with --admin or --force.
-- Do not run local app/dev servers unless the user explicitly asks in this turn.
+- Do not run local app/dev/build commands unless the user explicitly asks in this turn.
 - Do not run local deploy commands (make deploy-*, scripts/deploy.sh).
-Workflow: merge only after CI gates pass; deployment is automatic via GitHub Actions on push/merge to main."
+Deploys happen automatically via GitHub Actions on merge to main. Do nothing."
   jq -n --arg reason "$REASON" '{
     hookSpecificOutput: {
       hookEventName: "PreToolUse",

--- a/tests/scripts/hooks.bats
+++ b/tests/scripts/hooks.bats
@@ -174,6 +174,24 @@ SCRIPT
   [[ "$output" == *"deny"* ]]
 }
 
+@test "block-local-deploy: blocks npm run build" {
+  run bash -c 'echo "{\"tool_input\":{\"command\":\"npm run build\"}}" | bash scripts/hooks/block-local-deploy.sh'
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"deny"* ]]
+}
+
+@test "block-local-deploy: blocks next build" {
+  run bash -c 'echo "{\"tool_input\":{\"command\":\"next build\"}}" | bash scripts/hooks/block-local-deploy.sh'
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"deny"* ]]
+}
+
+@test "block-local-deploy: allows git commit with build keyword in message" {
+  run bash -c 'echo "{\"tool_input\":{\"command\":\"git commit -m \\\"block npm run build\\\"\"}}" | bash scripts/hooks/block-local-deploy.sh'
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
 @test "block-local-deploy: allows empty command" {
   run bash -c 'echo "{\"tool_input\":{}}" | bash scripts/hooks/block-local-deploy.sh'
   [ "$status" -eq 0 ]


### PR DESCRIPTION
## Summary
- Add `.claude/rules/session-recovery.md` enforcing context-collapse recovery protocol (restate task + run primer before acting)
- Block `npm run build` / `next build` in PreToolUse hook alongside existing dev/start blocks
- Fix false-positive: git commands now skip segment checking so commit messages containing "build" don't trigger denials
- Add "stop and ask" guardrail to AGENTS.md: if a hook blocks an action, stop immediately and ask the user
- Tighten hook deny message to say "Do nothing." instead of suggesting workflows

## Test plan
- [x] All 35 bats tests pass (2 new: `npm run build` blocked, `git commit` with build keyword allowed)
- [x] shellcheck clean on `block-local-deploy.sh`
- [ ] CI gates pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)