### PR TITLE
fix: broaden right peak and smooth dark hill in SVG logo

### DIFF
--- a/src/services/ui/src/components/HillLogo.tsx
+++ b/src/services/ui/src/components/HillLogo.tsx
@@ -26,7 +26,7 @@ export default function HillLogo({
       {/* Right peak (background, taller) — left edge follows gap boundary */}
       <path
         className="hill-right"
-        d="M 458,297 L 256,95 C 300,40 340,5 365,5 C 390,5 540,130 660,297 Z"
+        d="M 458,297 L 256,95 C 298,48 332,10 368,8 C 404,6 540,130 660,297 Z"
         fill={lightColor}
       />
       {/* Left peak (middle layer, shorter) — right edge follows gap boundary */}
@@ -38,7 +38,7 @@ export default function HillLogo({
       {/* Front hill (foreground, darker) — smooth concave curve */}
       <path
         className="hill-front"
-        d="M 240,297 C 340,200 430,110 465,105 C 510,100 600,200 660,297 Z"
+        d="M 240,297 C 330,205 420,118 462,108 C 508,98 598,200 660,297 Z"
         fill={darkColor}
       />
     </svg>


### PR DESCRIPTION
## Summary
- Widen Bezier control points at right peak summit for a rounder dome shape matching PNG original
- Adjust front dark hill curve control points for a smoother, wider concave shape
- Identified differences via Playwright screenshot comparison of /logo-test PNG vs SVG section

## Test plan
- [ ] CI gates pass
- [ ] Post-deploy: screenshot hill90.com/logo-test and verify SVG more closely matches PNG
- [ ] May need follow-up iteration if differences remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)