### PR TITLE
fix: widen right peak dome in SVG logo

### DIFF
--- a/src/services/ui/src/components/HillLogo.tsx
+++ b/src/services/ui/src/components/HillLogo.tsx
@@ -26,7 +26,7 @@ export default function HillLogo({
       {/* Right peak (background, taller) — left edge follows gap boundary */}
       <path
         className="hill-right"
-        d="M 458,297 L 256,95 C 298,48 332,10 368,8 C 404,6 540,130 660,297 Z"
+        d="M 458,297 L 256,95 C 290,52 315,12 368,10 C 420,12 540,130 660,297 Z"
         fill={lightColor}
       />
       {/* Left peak (middle layer, shorter) — right edge follows gap boundary */}


### PR DESCRIPTION
## Summary
- Spread Bezier control points at the right peak summit to create a wider/rounder dome
- Flat zone near peak now spans ~x=315 to x=420 at y≈10-12 (was too narrow before)
- Visual comparison at large scale showed peak was still too pointed vs PNG original

## Test plan
- [ ] CI gates pass
- [ ] Post-deploy: screenshot hill90.com/logo-test at large size and compare peak roundness

🤖 Generated with [Claude Code](https://claude.com/claude-code)