### PR TITLE
fix: widen right peak dome and add convexity to right slope

### DIFF
--- a/src/services/ui/src/app/logo-test/page.tsx
+++ b/src/services/ui/src/app/logo-test/page.tsx
@@ -32,7 +32,7 @@ function Hill({
       {/* Right peak (background, taller) — left edge follows gap boundary */}
       <path
         className="hill-right"
-        d="M 458,297 L 256,95 C 290,52 315,12 368,10 C 420,12 540,130 660,297 Z"
+        d="M 458,297 L 256,95 C 286,54 308,14 368,12 C 428,14 548,125 660,297 Z"
         fill={lightColor}
       />
       {/* Left peak (middle layer, shorter) — right edge follows gap boundary */}
@@ -64,7 +64,7 @@ function HillOutline({ className = '' }: { className?: string }) {
     >
       <path
         className="draw-right"
-        d="M 458,297 L 256,95 C 290,52 315,12 368,10 C 420,12 540,130 660,297 Z"
+        d="M 458,297 L 256,95 C 286,54 308,14 368,12 C 428,14 548,125 660,297 Z"
         fill="none"
         stroke="#60757D"
         strokeWidth="3"

--- a/src/services/ui/src/components/HillLogo.tsx
+++ b/src/services/ui/src/components/HillLogo.tsx
@@ -26,7 +26,7 @@ export default function HillLogo({
       {/* Right peak (background, taller) — left edge follows gap boundary */}
       <path
         className="hill-right"
-        d="M 458,297 L 256,95 C 290,52 315,12 368,10 C 420,12 540,130 660,297 Z"
+        d="M 458,297 L 256,95 C 286,54 308,14 368,12 C 428,14 548,125 660,297 Z"
         fill={lightColor}
       />
       {/* Left peak (middle layer, shorter) — right edge follows gap boundary */}


### PR DESCRIPTION
## Summary
- Widen the right peak's Bezier flat zone (x=308 to x=428 at y≈14) for a broader dome
- Shift descent control point to (548,125) for subtle outward bow on right slope
- Paths synced across HillLogo.tsx, Hill, and HillOutline in logo-test page

## Test plan
- [ ] CI gates pass
- [ ] Post-deploy: screenshot hill90.com/logo-test and verify right peak matches PNG dome shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)