### PR TITLE
Use Glow Hold SVG logo in top navigation

### DIFF
--- a/src/services/ui/src/app/dashboard/page.tsx
+++ b/src/services/ui/src/app/dashboard/page.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import Image from 'next/image';
 import Link from 'next/link';
 import { useState, useEffect, useCallback } from 'react';
+import HillLogo from '@/components/HillLogo';
 
 interface ServiceHealth {
   name: string;
@@ -44,14 +44,8 @@ export default function Dashboard() {
     <div className="min-h-screen flex flex-col">
       {/* Nav */}
       <nav className="flex items-center justify-between px-6 py-4 border-b border-navy-700">
-        <Link href="/">
-          <Image
-            src="/Hill90-logo10-notext.png"
-            alt="Hill90"
-            width={120}
-            height={54}
-            priority
-          />
+        <Link href="/" aria-label="Go to homepage" className="logo-link inline-flex items-center">
+          <HillLogo width={120} className="logo-glow-hold" />
         </Link>
         <span className="text-sm font-medium text-white">Dashboard</span>
       </nav>

--- a/src/services/ui/src/app/globals.css
+++ b/src/services/ui/src/app/globals.css
@@ -11,3 +11,20 @@
   --color-brand-500: #5b9a2f;
   --color-brand-400: #6db33a;
 }
+
+/* Top-nav logo animation + hover affordance */
+.logo-glow-hold {
+  animation: logoGlowHold 1.2s ease-out both;
+  filter: drop-shadow(0 0 10px rgba(109, 179, 58, 0.45));
+  transition: filter 180ms ease;
+}
+
+.logo-link:hover .logo-glow-hold {
+  filter: drop-shadow(0 0 16px rgba(109, 179, 58, 0.9));
+}
+
+@keyframes logoGlowHold {
+  0% { filter: drop-shadow(0 0 0 rgba(109, 179, 58, 0)); }
+  40% { filter: drop-shadow(0 0 14px rgba(109, 179, 58, 0.65)); }
+  100% { filter: drop-shadow(0 0 10px rgba(109, 179, 58, 0.45)); }
+}

--- a/src/services/ui/src/app/page.tsx
+++ b/src/services/ui/src/app/page.tsx
@@ -1,5 +1,5 @@
-import Image from 'next/image';
 import Link from 'next/link';
+import HillLogo from '@/components/HillLogo';
 
 const services = [
   {
@@ -29,13 +29,9 @@ export default function Home() {
     <div className="min-h-screen flex flex-col">
       {/* Nav */}
       <nav className="flex items-center justify-between px-6 py-4 border-b border-navy-700">
-        <Image
-          src="/Hill90-logo10-notext.png"
-          alt="Hill90"
-          width={120}
-          height={54}
-          priority
-        />
+        <Link href="/" aria-label="Go to homepage" className="logo-link inline-flex items-center">
+          <HillLogo width={120} className="logo-glow-hold" />
+        </Link>
         <Link
           href="/dashboard"
           className="text-sm font-medium text-mountain-400 hover:text-white transition-colors"


### PR DESCRIPTION
## Summary
- replace PNG top-nav logos with reusable SVG HillLogo on home and dashboard
- apply green glow-hold animation to top-nav logo by default
- make the logo a homepage link and add stronger green hover glow affordance

## Test plan
- [ ] open / and verify nav logo uses green glow-hold animation
- [ ] hover nav logo and verify glow intensifies in green
- [ ] click nav logo from /dashboard and verify it navigates to /