### PR TITLE
Fix nav logo to flash on load and glow on hover

### DIFF
--- a/src/services/ui/src/app/globals.css
+++ b/src/services/ui/src/app/globals.css
@@ -15,7 +15,7 @@
 /* Top-nav logo animation + hover affordance */
 .logo-glow-hold {
   animation: logoGlowHold 1.2s ease-out both;
-  filter: drop-shadow(0 0 10px rgba(109, 179, 58, 0.45));
+  filter: none;
   transition: filter 180ms ease;
 }
 
@@ -26,5 +26,5 @@
 @keyframes logoGlowHold {
   0% { filter: drop-shadow(0 0 0 rgba(109, 179, 58, 0)); }
   40% { filter: drop-shadow(0 0 14px rgba(109, 179, 58, 0.65)); }
-  100% { filter: drop-shadow(0 0 10px rgba(109, 179, 58, 0.45)); }
+  100% { filter: drop-shadow(0 0 0 rgba(109, 179, 58, 0)); }
 }


### PR DESCRIPTION
## Summary
- keep a one-time green load flash for top nav logo
- remove persistent steady-state green glow
- keep stronger green hover glow so hover is the only persistent emphasis

## Test plan
- [ ] load / and confirm logo flashes once, then returns to no glow
- [ ] hover logo and confirm green glow appears
- [ ] verify same behavior on /dashboard