### PR TITLE
Fix nav logo hover glow after load flash

### DIFF
--- a/src/services/ui/src/app/globals.css
+++ b/src/services/ui/src/app/globals.css
@@ -14,13 +14,13 @@
 
 /* Top-nav logo animation + hover affordance */
 .logo-glow-hold {
-  animation: logoGlowHold 1.2s ease-out both;
+  animation: logoGlowHold 1.2s ease-out 1;
   filter: none;
   transition: filter 180ms ease;
 }
 
 .logo-link:hover .logo-glow-hold {
-  filter: drop-shadow(0 0 16px rgba(109, 179, 58, 0.9));
+  filter: drop-shadow(0 0 16px rgba(109, 179, 58, 0.9)) !important;
 }
 
 @keyframes logoGlowHold {


### PR DESCRIPTION
## Summary
- remove persistent animation fill behavior from nav logo flash
- keep one-time load flash only
- make hover glow reliably visible for the top logo link

## Test plan
- [ ] load / and verify logo flashes once then returns to neutral
- [ ] hover logo and verify green glow appears
- [ ] verify same behavior on /dashboard