### PR TITLE
fix: Keycloak deploy — hostname URLs, Traefik labels, DNS sync

### DIFF
--- a/deploy/compose/prod/docker-compose.auth.yml
+++ b/deploy/compose/prod/docker-compose.auth.yml
@@ -26,8 +26,8 @@ services:
       - KC_DB_URL=jdbc:postgresql://postgres:5432/keycloak
       - KC_DB_USERNAME=${DB_USER}
       - KC_DB_PASSWORD=${DB_PASSWORD}
-      - KC_HOSTNAME=auth.hill90.com
-      - KC_HOSTNAME_ADMIN=admin.hill90.com
+      - KC_HOSTNAME=https://auth.hill90.com
+      - KC_HOSTNAME_ADMIN=https://admin.hill90.com
       - KC_PROXY_HEADERS=xforwarded
       - KC_HTTP_ENABLED=true
       - KC_HEALTH_ENABLED=true
@@ -44,14 +44,16 @@ services:
       start_period: 90s
     labels:
       - "traefik.enable=true"
+      # Single service definition for both routers
+      - "traefik.http.services.keycloak.loadbalancer.server.port=8080"
       # Public OIDC/login (auth.hill90.com)
       - "traefik.http.routers.keycloak.rule=Host(`auth.hill90.com`)"
       - "traefik.http.routers.keycloak.entrypoints=websecure"
       - "traefik.http.routers.keycloak.tls.certresolver=letsencrypt"
-      - "traefik.http.services.keycloak.loadbalancer.server.port=8080"
+      - "traefik.http.routers.keycloak.service=keycloak"
       # Admin console (admin.hill90.com) — Tailscale only
       - "traefik.http.routers.keycloak-admin.rule=Host(`admin.hill90.com`)"
       - "traefik.http.routers.keycloak-admin.entrypoints=websecure"
       - "traefik.http.routers.keycloak-admin.tls.certresolver=letsencrypt-dns"
       - "traefik.http.routers.keycloak-admin.middlewares=tailscale-only@file"
-      - "traefik.http.services.keycloak-admin.loadbalancer.server.port=8080"
+      - "traefik.http.routers.keycloak-admin.service=keycloak"

--- a/infra/secrets/prod.enc.env
+++ b/infra/secrets/prod.enc.env
@@ -32,9 +32,11 @@ TAILSCALE_TAILNET=ENC[AES256_GCM,data:IH2TPzjph4cgvYKG2D25r8c=,iv:Fv8nMP2Yo2vUp/
 HOSTINGER_API_KEY=ENC[AES256_GCM,data:tZdUW3WSURZ9ms8uoyoZ+QfMprrK7WvQgtp2uFxJpjuEi4Gce3Ap1WF9+j/YdhZO,iv:tBxowPI0dHXWwYscXYn/f/xWDDyrzpKUxHAWxf0GQ78=,tag:D0U+3IS6iqh+G1K+4EsB+g==,type:str]
 OPENCLAW_GATEWAY_TOKEN=ENC[AES256_GCM,data:50ljOL76+5SCYHdNPpU5pe6QDg4FiuL/DBmbBbkYWwZpbl+SBpvIA8v9fIWe3VJUDOwkWjaiesVLX3yQG/JEng==,iv:sjRW7153MFQaNCXe4ZARbMsi53x5ZnBYSS+iz60qBFI=,tag:Cy2MNbmT8psZKCFHhy6oXg==,type:str]
 TRAEFIK_ADMIN_PASSWORD=ENC[AES256_GCM,data:K5tSWDd93N1x6O0oxjUcZN2tapk=,iv:uwwQZPSDei/s0FM/dD8mDhjkflLw9INO6/Z0/lPyolw=,tag:9cnLWwiHOhiMFu8BX7itCw==,type:str]
+KC_ADMIN_USERNAME=ENC[AES256_GCM,data:bVTKQLk=,iv:A0EPQLb98JXOkLgPn7C2jfMDJhvqS+c/Dk+3uC7Ls3s=,tag:Hcw0U7SUzLplg1bHfq1QYw==,type:str]
+KC_ADMIN_PASSWORD=ENC[AES256_GCM,data:fIlJA7Dci30OYjwe4qX797BiVMeJwBwcFp1Mq/W+rb/Fngrb6gV9MombZrw=,iv:9vq35jKlnyqfoqIWc/hUZqcWw7jPE+pGrMnbPa2zwcc=,tag:yPLVwwTjhEd4BHgMQR78EA==,type:str]
 sops_age__list_0__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA0Tk9jcWxubnBSdzYrVTh3\nUWljVFZrNFB2Tk8yaVdrYTZXZzZlSlNKM0dvCjMyd2NrL3RnUGpOMXlmZlBybWlD\nYnpLNFFtSnVNMnJ4SzBoZVFKcnU0aTQKLS0tIFZaYXlwRm1lQ3lwekI3NkdvQ04y\nQmhLM3dFSzc2NUlSeFFacFhoVEEvSGsKWtC/jJg4cVLm4upH51WbrwVDdNCm0/ut\ntu3ywZWs24JYbZd/6mKg52TdLleMsDO6xrIz3l5yLASJvDNm2Xictw==\n-----END AGE ENCRYPTED FILE-----\n
 sops_age__list_0__map_recipient=age1p30vk2qpvlkj5pzh72f0wwvlqgmedvr204nldmpskmptgy9ryg8qg9qd5v
-sops_lastmodified=2026-02-14T22:39:27Z
-sops_mac=ENC[AES256_GCM,data:faj51cA8KKQ94VnyXeGZQWzEQOHENmo7QjA+AeDvyQ79nxrV3/vVP4nokksQRodAlIjkg+X1U2qSOG540TQw8j+NqXO/7GT1431tEhV3/Sj/6pY61Upl+YCVmeBcEZY3RmLc6if8xd9meCndHZwnVWjK1GubevPcDtggYqLrRAg=,iv:LfvhaiQEZLNLCLjI4r7gioHyxxrPsiGxa85p5kRUtyU=,tag:aL9MDSGI6zoOyyy8JOyEWA==,type:str]
+sops_lastmodified=2026-02-16T07:57:20Z
+sops_mac=ENC[AES256_GCM,data:eI98EBKwhkLPVZmn46/sXEoq5exWULvKQA9IljJ70q4R6UnjNB9MUcA/DENQg8anJcQS7P88OwCVH10d6SXGKPzLMcV1qdj/56f1PTEQpzGwNNcJemE/7vhoTW6X6EiOiRXb9anyL108znNVq0vhQfm3te010A7lsxZvgvbZlsg=,iv:E8a1URAMbRkaR4ALyZUl3pN2zS2g4a+jfCb//oGDSW4=,tag:y6DeA1jQ0zd5NsLD0WPnAA==,type:str]
 sops_unencrypted_suffix=_unencrypted
 sops_version=3.11.0

--- a/scripts/hostinger.sh
+++ b/scripts/hostinger.sh
@@ -353,7 +353,7 @@ dns_sync() {
     current_records=$(api_call GET "/api/dns/v1/zones/$DOMAIN")
 
     local needs_update=false
-    for pair in "@:$vps_ip" "api:$vps_ip" "ai:$vps_ip" "portainer:$tailscale_ip" "traefik:$tailscale_ip"; do
+    for pair in "@:$vps_ip" "api:$vps_ip" "ai:$vps_ip" "auth:$vps_ip" "admin:$tailscale_ip" "portainer:$tailscale_ip" "traefik:$tailscale_ip"; do
         local name="${pair%%:*}"
         local expected="${pair##*:}"
         local current
@@ -385,6 +385,8 @@ dns_sync() {
                 {name: "@",         type: "A", ttl: 3600, records: [{content: $vps}]},
                 {name: "api",       type: "A", ttl: 3600, records: [{content: $vps}]},
                 {name: "ai",        type: "A", ttl: 3600, records: [{content: $vps}]},
+                {name: "auth",      type: "A", ttl: 3600, records: [{content: $vps}]},
+                {name: "admin",     type: "A", ttl: 3600, records: [{content: $ts}]},
                 {name: "portainer", type: "A", ttl: 3600, records: [{content: $ts}]},
                 {name: "traefik",   type: "A", ttl: 3600, records: [{content: $ts}]}
             ]


### PR DESCRIPTION
## Summary

- **KC_HOSTNAME requires full URL** — Keycloak 26 rejects bare hostnames for `KC_HOSTNAME_ADMIN`, changed both to `https://` prefixed URLs
- **Traefik dual-router fix** — two routers on one container need explicit `service=keycloak` labels, otherwise Traefik errors with "cannot be linked automatically with multiple Services"
- **DNS sync updated** — added `auth` (public IP) and `admin` (Tailscale IP) A records to `dns_sync()` so they stay correct across VPS rebuilds
- **SOPS secrets** — added `KC_ADMIN_USERNAME` and `KC_ADMIN_PASSWORD` required for Keycloak bootstrap

## Test plan

- [x] `auth.hill90.com/realms/hill90` returns realm JSON
- [x] `admin.hill90.com` returns 302 (Keycloak login redirect)
- [x] Keycloak container healthy on VPS
- [x] All 140 bats tests pass
- [ ] CI gates pass
