### PR TITLE
docs: update documentation for Keycloak auth integration

### DIFF
--- a/.github/docs/deployment.md
+++ b/.github/docs/deployment.md
@@ -5,7 +5,8 @@
 **Infrastructure and applications are deployed separately:**
 
 1. **Infrastructure** (Traefik, dns-manager, Portainer) - Deploy once after VPS config
-2. **Application services** (auth, api, ai, mcp) - Deploy independently as needed
+2. **Database** (PostgreSQL) - Deploy before application services
+3. **Application services** (keycloak, api, ai, mcp, ui) - Deploy independently as needed
 
 ## Deployment Location
 
@@ -37,11 +38,12 @@ Deploy individual services without affecting others:
 
 ```bash
 make deploy-infra   # Traefik, dns-manager, Portainer
-make deploy-auth    # Auth + PostgreSQL
+make deploy-db      # PostgreSQL database
+make deploy-auth    # Keycloak identity provider
 make deploy-api     # API service
 make deploy-ai      # AI service
 make deploy-mcp     # MCP service
-make deploy-all     # All app services (not infra)
+make deploy-all     # All app services (not infra or db)
 ```
 
 ### Deprecated Aliases
@@ -60,10 +62,12 @@ Separate compose files in `deploy/compose/prod/`:
 | File | Services | Networks |
 |------|----------|----------|
 | `docker-compose.infra.yml` | traefik, dns-manager, portainer | Creates hill90_edge, hill90_internal |
-| `docker-compose.auth.yml` | auth, postgres | Uses external networks |
+| `docker-compose.auth.yml` | keycloak | Uses external networks |
+| `docker-compose.db.yml` | postgres | Uses external networks |
 | `docker-compose.api.yml` | api | Uses external networks |
 | `docker-compose.ai.yml` | ai | Uses external networks |
 | `docker-compose.mcp.yml` | mcp | Uses external networks |
+| `docker-compose.ui.yml` | ui | Uses external networks |
 | `docker-compose.yml` | All services (legacy) | Creates networks |
 
 ## GitHub Actions Deployment
@@ -73,19 +77,23 @@ Separate compose files in `deploy/compose/prod/`:
 | Workflow | Trigger | Services |
 |----------|---------|----------|
 | `deploy-infra.yml` | Manual only | traefik, dns-manager, portainer |
-| `deploy-auth.yml` | `src/services/auth/**` changes | auth, postgres |
+| `deploy-auth.yml` | `platform/auth/keycloak/**` changes | keycloak |
+| `deploy-db.yml` | `docker-compose.db.yml`, `platform/data/postgres/**` | postgres |
 | `deploy-api.yml` | `src/services/api/**` changes | api |
 | `deploy-ai.yml` | `src/services/ai/**` changes | ai |
 | `deploy-mcp.yml` | `src/services/mcp/**` changes | mcp |
+| `deploy-ui.yml` | `src/services/ui/**` changes | ui |
 | `deploy.yml` | Any `src/**` changes (legacy) | All services |
 
 ### Path-Based Auto-Deployment
 
 When you push changes to `main`:
-- Changes to `src/services/auth/**` → Only auth service deploys
+- Changes to `platform/auth/keycloak/**` → Only Keycloak deploys
+- Changes to `platform/data/postgres/**` → Only database deploys
 - Changes to `src/services/api/**` → Only API service deploys
 - Changes to `src/services/ai/**` → Only AI service deploys
 - Changes to `src/services/mcp/**` → Only MCP service deploys
+- Changes to `src/services/ui/**` → Only UI service deploys
 
 ## Let's Encrypt Configuration
 
@@ -105,7 +113,9 @@ When you push changes to `main`:
 - **portainer** - Container management (Tailscale-only)
 
 **Auth (deploy-auth):**
-- **auth** - Authentication service
+- **keycloak** - Keycloak identity provider (auth.hill90.com)
+
+**Database (deploy-db):**
 - **postgres** - PostgreSQL database
 
 **API (deploy-api):**
@@ -118,12 +128,11 @@ When you push changes to `main`:
 - **mcp** - MCP Gateway
 
 ### Networks
-- **hill90_edge** - Public-facing (traefik, api, ai, mcp)
-- **hill90_internal** - Private services (postgres, auth, all apps)
+- **hill90_edge** - Public-facing (traefik, api, ai, mcp, keycloak, ui)
+- **hill90_internal** - Private services (postgres, keycloak, all apps)
 
 ### Dependencies
-- Infrastructure must be deployed first (creates networks)
-- Auth (with postgres) should be deployed before api, ai, mcp
+- Deploy order: infra → db → auth (Keycloak) → remaining app services
 
 ## Traefik Dashboard Authentication
 

--- a/.github/docs/vps-operations.md
+++ b/.github/docs/vps-operations.md
@@ -28,10 +28,13 @@ make config-vps VPS_IP=<ip>
 # Step 3: Deploy infrastructure (Traefik, dns-manager, Portainer)
 make deploy-infra
 
+# Step 3b: Deploy database (required before app services)
+make deploy-db
+
 # Step 4: Deploy application services
 make deploy-all  # All services
 # OR deploy individually:
-make deploy-auth  # Auth + PostgreSQL
+make deploy-auth  # Keycloak identity provider
 make deploy-api   # API service
 make deploy-ai    # AI service
 make deploy-mcp   # MCP service
@@ -71,11 +74,12 @@ make deploy-mcp   # MCP service
 5. Deploys Portainer (container management)
 
 **Step 4: `make deploy-all`** (~2-3 minutes):
-1. Deploys auth + postgres
+1. Deploys keycloak
 2. Deploys api
 3. Deploys ai
 4. Deploys mcp
-5. Verifies all services running
+5. Deploys ui
+6. Verifies all services running
 
 ### Infrastructure After Each Step
 
@@ -107,11 +111,12 @@ Deploy individual services without affecting others:
 
 ```bash
 make deploy-infra   # Traefik, dns-manager, Portainer
-make deploy-auth    # Auth + PostgreSQL
+make deploy-db      # PostgreSQL database
+make deploy-auth    # Keycloak identity provider
 make deploy-api     # API service
 make deploy-ai      # AI service
 make deploy-mcp     # MCP service
-make deploy-all     # All app services (not infra)
+make deploy-all     # All app services (not infra or db)
 ```
 
 ## Safety Operations

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,7 @@ ssh -i ~/.ssh/remote.hill90.com deploy@remote.hill90.com \
 - `make recreate-vps`
 - `make config-vps VPS_IP=<ip>`
 - `make deploy-infra`
+- `make deploy-db`
 - `make deploy-all`
 - `make health`
 - `make secrets-view KEY=<key>`

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -9,7 +9,7 @@ Hill90 is a Docker-based microservices platform hosted on a single Hostinger VPS
 ### Components
 
 - **Edge Layer**: Traefik reverse proxy with automatic HTTPS (dual certificate resolvers)
-- **Application Layer**: Microservices (API, AI, MCP, Auth, UI)
+- **Application Layer**: Microservices (API, AI, MCP, UI) with Keycloak identity provider
 - **Data Layer**: PostgreSQL database
 - **Infrastructure Layer**:
   - Docker Compose orchestration
@@ -29,12 +29,12 @@ Traefik (edge network)           ┌──────────────�
 │ - API (HTTP-01 cert)        │  └──────────────────────────┘
 │ - AI (HTTP-01 cert)         │           ↓ (DNS-01 certs)
 │ - MCP (HTTP-01, auth)       │           ↓
-│ - UI (HTTP-01 cert)         │  ┌──────────────────────────┐
-└─────────────────────────────┘  │ DNS Manager              │
-   ↓                             │ (Webhook for ACME)       │
-┌─────────────────────────────┐  └──────────────────────────┘
-│ Internal Services (internal)│           ↓
-│ - Auth                      │  Hostinger DNS API
+│ - Keycloak (HTTP-01 cert)   │  ┌──────────────────────────┐
+│ - UI (HTTP-01 cert)         │  │ DNS Manager              │
+└─────────────────────────────┘  │ (Webhook for ACME)       │
+   ↓                             └──────────────────────────┘
+┌─────────────────────────────┐           ↓
+│ Internal Services (internal)│  Hostinger DNS API
 │ - PostgreSQL                │  (TXT record management)
 └─────────────────────────────┘
 ```
@@ -45,8 +45,8 @@ Traefik (edge network)           ┌──────────────�
 - DNS Manager translates Traefik ACME requests to Hostinger DNS API calls
 
 **Network Isolation:**
-- **edge network**: Public-facing services (Traefik → API, AI, MCP, UI)
-- **internal network**: Private services (Auth, PostgreSQL)
+- **edge network**: Public-facing services (Traefik → API, AI, MCP, Keycloak, UI)
+- **internal network**: Private services (Keycloak, PostgreSQL)
 - **Tailscale network**: Admin-only services (Traefik dashboard, Portainer)
 - **IP Whitelist**: 100.64.0.0/10 (Tailscale CGNAT range) via middleware
 
@@ -56,8 +56,8 @@ Traefik (edge network)           ┌──────────────�
 
 - **API**: REST API gateway, orchestrates requests
 - **AI**: LangChain/LangGraph agents, AI operations
-- **MCP**: Model Context Protocol gateway (JWT authenticated)
-- **Auth**: JWT-based authentication service
+- **MCP**: Model Context Protocol gateway (Keycloak JWT authenticated)
+- **Keycloak**: Identity provider (OIDC/OAuth2) at auth.hill90.com
 - **UI**: Next.js frontend application
 
 ### Infrastructure Services
@@ -70,7 +70,7 @@ Traefik (edge network)           ┌──────────────�
 - **DNS Manager**: HTTP webhook for Let's Encrypt DNS-01 challenges
   - Translates Lego httpreq provider format to Hostinger DNS API
   - Creates/deletes DNS TXT records for ACME validation
-- **PostgreSQL**: Relational database for persistent storage
+- **PostgreSQL**: Relational database for persistent storage (separate deploy: `make deploy-db`)
 
 ## Technology Stack
 
@@ -87,6 +87,8 @@ Traefik (edge network)           ┌──────────────�
   - Let's Encrypt (automatic HTTPS)
   - IP whitelist middleware (Tailscale CGNAT range)
   - bcrypt (password hashing for Traefik auth)
+  - Keycloak 26.4 (identity provider, OIDC/OAuth2)
+  - Auth.js v5 (session management)
 - **DNS**: Hostinger DNS API (automated via MCP tools)
 - **APIs**:
   - Hostinger VPS API (infrastructure automation)

--- a/docs/architecture/security.md
+++ b/docs/architecture/security.md
@@ -14,10 +14,19 @@ Hill90 uses layered controls to keep public services reachable while restricting
 - Runtime secrets are stored in `infra/secrets/prod.enc.env` and encrypted with SOPS + age.
 - Secrets are decrypted only at deploy/runtime (`sops exec-env`) and not committed in plaintext.
 
+## Application Authentication
+
+- Keycloak 26.4 serves as the identity provider at auth.hill90.com (OIDC/OAuth2).
+- Auth.js v5 manages browser sessions in the UI and handles the authorization code flow.
+- API (Express) and MCP (FastAPI) validate Keycloak-issued JWTs on protected routes.
+- The hill90 realm disables self-registration and enables brute force detection.
+- Keycloak admin console is credential-protected with MFA capability.
+
 ## Network Segmentation
 
 - `hill90_edge`: ingress-facing network for Traefik and public app routes.
 - `hill90_internal`: internal-only network for private service communication.
+- Keycloak bridges both edge (public OIDC) and internal (database) networks.
 - Tailscale-only routes are protected with Traefik middleware and IP allowlists.
 
 ## TLS And Certificate Controls

--- a/docs/development/local-setup.md
+++ b/docs/development/local-setup.md
@@ -30,7 +30,7 @@ This starts all services in development mode with hot reload.
 
 - API: http://localhost:3000
 - AI: http://localhost:8000
-- Auth: http://localhost:3001
+- Keycloak: http://localhost:8080 (when running locally)
 - PostgreSQL: localhost:5432
 
 ## Service Development
@@ -51,13 +51,15 @@ poetry install
 poetry run uvicorn app.main:app --reload
 ```
 
-### Auth Service (TypeScript)
+### Keycloak (Identity Provider)
 
+Keycloak runs as a Docker container — no local build needed:
 ```bash
-cd src/services/auth
-npm install
-npm run dev
+make deploy-db   # Start PostgreSQL first
+make deploy-auth # Start Keycloak
 ```
+
+Admin console: http://localhost:8080/admin/master/console/
 
 ## Testing
 

--- a/docs/runbooks/bootstrap.md
+++ b/docs/runbooks/bootstrap.md
@@ -102,7 +102,7 @@ This single command:
 - DNS records updated to new VPS IP
 
 ❌ **Application services NOT running:**
-- API, AI, MCP, Auth, UI services require deployment (Step 3)
+- Database (PostgreSQL), Keycloak, API, AI, MCP, UI services require deployment
 
 ## Next Steps
 
@@ -111,6 +111,9 @@ After bootstrap completes, deploy infrastructure and application services:
 ```bash
 # Deploy infrastructure (Traefik, dns-manager, Portainer)
 make deploy-infra
+
+# Deploy database (required before app services)
+make deploy-db
 
 # Deploy application services
 make deploy-all
@@ -157,6 +160,7 @@ On first setup, point these domains to your VPS:
 - `@` (hill90.com)
 - `api.hill90.com`
 - `ai.hill90.com`
+- `auth.hill90.com`
 
 **Tailscale-only services (Tailscale IP):**
 - `traefik.hill90.com`

--- a/docs/runbooks/deployment.md
+++ b/docs/runbooks/deployment.md
@@ -19,6 +19,16 @@ Expected outcome:
 - `hill90_edge` and `hill90_internal` Docker networks exist.
 - DNS-01 certificate flow is functional for Tailscale-only routes.
 
+## Deploy Database
+
+```bash
+make deploy-db
+```
+
+Expected outcome:
+- `postgres` container is healthy on the internal network.
+- Required before `make deploy-all` (Keycloak depends on PostgreSQL).
+
 ## Deploy Application Services
 
 ```bash
@@ -26,7 +36,7 @@ make deploy-all
 ```
 
 Expected outcome:
-- `api`, `ai`, `mcp`, `auth`, `postgres` (and `ui` when enabled in compose) are running.
+- `keycloak`, `api`, `ai`, `mcp`, `ui` are running.
 - Public routes respond through Traefik with valid certificates.
 
 ## Validate Deployment
@@ -42,13 +52,14 @@ Optional targeted checks:
 make logs-traefik
 curl -f https://api.hill90.com/health
 curl -f https://ai.hill90.com/health
+curl -f https://auth.hill90.com/realms/hill90/.well-known/openid-configuration
 ```
 
 ## SSH-Based Deployment (On VPS)
 
 ```bash
 ssh -i ~/.ssh/remote.hill90.com deploy@remote.hill90.com \
-  'cd /opt/hill90/app && export SOPS_AGE_KEY_FILE=/opt/hill90/secrets/keys/keys.txt && bash scripts/deploy.sh infra prod && bash scripts/deploy.sh all prod'
+  'cd /opt/hill90/app && export SOPS_AGE_KEY_FILE=/opt/hill90/secrets/keys/keys.txt && bash scripts/deploy.sh infra prod && bash scripts/deploy.sh db prod && bash scripts/deploy.sh all prod'
 ```
 
 ## Rollback Guidance

--- a/docs/runbooks/troubleshooting.md
+++ b/docs/runbooks/troubleshooting.md
@@ -328,8 +328,8 @@ echo | openssl s_client -connect api.hill90.com:443 -servername api.hill90.com 2
 
 2. **Verify credentials in secrets:**
    ```bash
-   make secrets-view KEY=POSTGRES_PASSWORD
-   make secrets-view KEY=POSTGRES_USER
+   make secrets-view KEY=DB_PASSWORD
+   make secrets-view KEY=DB_USER
    make secrets-view KEY=POSTGRES_DB
    ```
 
@@ -346,6 +346,55 @@ echo | openssl s_client -connect api.hill90.com:443 -servername api.hill90.com 2
 5. **Test database connection:**
    ```bash
    ssh deploy@<tailscale-ip> 'docker exec -it postgres psql -U <user> -d <database> -c "\l"'
+   ```
+
+---
+
+## Keycloak Issues
+
+### Keycloak Not Starting
+
+**Problem**: Keycloak container exits or fails health check
+
+**Solutions**:
+
+1. **Verify PostgreSQL is running:**
+   ```bash
+   ssh deploy@<tailscale-ip> 'docker ps | grep postgres'
+   ```
+   Keycloak requires PostgreSQL. Deploy it first: `make deploy-db`
+
+2. **Check Keycloak logs:**
+   ```bash
+   ssh deploy@<tailscale-ip> 'docker logs keycloak --tail 50'
+   ```
+
+3. **Verify OIDC endpoint:**
+   ```bash
+   curl -f https://auth.hill90.com/realms/hill90/.well-known/openid-configuration
+   ```
+
+### Authentication Flow Not Working
+
+**Problem**: Users cannot log in via the UI
+
+**Solutions**:
+
+1. **Check Keycloak is accessible:**
+   ```bash
+   curl -f https://auth.hill90.com/realms/hill90
+   ```
+
+2. **Verify secrets:**
+   ```bash
+   make secrets-view KEY=AUTH_KEYCLOAK_ID
+   make secrets-view KEY=AUTH_KEYCLOAK_SECRET
+   make secrets-view KEY=AUTH_SECRET
+   ```
+
+3. **Check UI logs:**
+   ```bash
+   ssh deploy@<tailscale-ip> 'docker logs ui --tail 50'
    ```
 
 ---

--- a/docs/runbooks/vps-rebuild.md
+++ b/docs/runbooks/vps-rebuild.md
@@ -123,6 +123,16 @@ make deploy-infra
 
 ---
 
+### Step 3b: Deploy Database
+
+```bash
+make deploy-db
+```
+
+Deploys PostgreSQL to the internal network. Required before application services.
+
+---
+
 ### Step 4: Deploy Application Services (~2-3 minutes)
 
 Deploy application services:
@@ -135,7 +145,7 @@ make deploy-all
 1. Validates infrastructure configuration
 2. Decrypts secrets with SOPS
 3. Generates Traefik `.htpasswd` file for authentication
-4. Deploys application services (api, ai, mcp, auth, ui)
+4. Deploys application services (keycloak, api, ai, mcp, ui)
 5. Requests Let's Encrypt certificates
 6. Waits for services to start
 7. Verifies service health
@@ -145,8 +155,7 @@ make deploy-all
 - `ai.hill90.com` - LangChain/LangGraph agents
 - `ai.hill90.com/mcp` - MCP Gateway (authenticated)
 - `hill90.com` - Frontend UI
-- `auth` - JWT authentication (internal)
-- `postgres` - PostgreSQL database (internal)
+- `keycloak` - Keycloak identity provider (auth.hill90.com)
 
 **Result:**
 - ✅ All services running
@@ -169,6 +178,7 @@ make health
 - ✅ Portainer accessible (https://portainer.hill90.com via Tailscale)
 - ✅ API service responding (https://api.hill90.com/health)
 - ✅ AI service responding (https://ai.hill90.com/health)
+- ✅ Keycloak OIDC responding (https://auth.hill90.com/realms/hill90)
 - ✅ DNS resolution correct for all domains
 - ✅ SSL certificates valid
 
@@ -184,6 +194,7 @@ DNS records are **automatically updated** during Step 2 (config-vps).
 - `@` (hill90.com) → A record to new VPS IP
 - `api.hill90.com` → A record to new VPS IP
 - `ai.hill90.com` → A record to new VPS IP
+- `auth.hill90.com` → A record to new VPS IP
 - `portainer.hill90.com` → A record to new Tailscale IP
 - `traefik.hill90.com` → A record to new Tailscale IP
 
@@ -309,8 +320,9 @@ ssh deploy@<vps-ip> "cd /opt/hill90/app && docker compose logs"
 2. Recreate VPS: `make recreate-vps`
 3. Bootstrap infrastructure: `make config-vps VPS_IP=<ip>`
 4. Deploy infrastructure: `make deploy-infra`
-5. Deploy applications: `make deploy-all`
-6. Verify health: `make health`
+5. Deploy database: `make deploy-db`
+6. Deploy applications: `make deploy-all`
+7. Verify health: `make health`
 
 **Fully automated (no intervention):**
 - ✅ Tailscale auth key generation and rotation


### PR DESCRIPTION
## Summary

- Replaced all references to the old auth stub with Keycloak identity provider across 10 documentation files
- Added deploy-db step to all deployment/rebuild workflows (infra, db, auth, app services)
- Added Keycloak troubleshooting section, OIDC validation checks, and auth.hill90.com DNS entries
- Updated compose file tables, GitHub Actions triggers, path-based deploy paths, and network diagrams

## Files Changed (10)

- `docs/architecture/overview.md` — Components, network diagram, service responsibilities, tech stack
- `docs/architecture/security.md` — New Application Authentication section, network segmentation
- `docs/runbooks/deployment.md` — Deploy Database section, OIDC validation, SSH command
- `docs/runbooks/vps-rebuild.md` — Step 3b (deploy-db), service lists, health checks, DNS, automation summary
- `docs/runbooks/bootstrap.md` — Service list, deploy-db in next steps, auth.hill90.com DNS
- `docs/runbooks/troubleshooting.md` — DB credential refs (DB_PASSWORD/DB_USER), Keycloak Issues section
- `docs/development/local-setup.md` — Replaced Auth service with Keycloak
- `.github/docs/deployment.md` — Per-service commands, compose/Actions tables, path triggers, dependencies
- `.github/docs/vps-operations.md` — Deploy commands, service lists (caught by verification sweep)
- `AGENTS.md` — Added deploy-db to Quick Command Map

## Deploy Impact

**No deploy workflows will trigger.** All 7 deploy workflows use positive path filters scoped to their service directories. None match docs, .github/docs, or AGENTS.md. CI will run (harness/markdown checks) — expected.

## Test plan

- [x] Markdown link check — passes, no broken links
- [x] Grep for stale auth stub references — zero results across all 6 patterns
- [ ] CI passes on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
