### PR TITLE
feat: add MinIO root credentials to SOPS secrets

### DIFF
--- a/infra/secrets/prod.enc.env
+++ b/infra/secrets/prod.enc.env
@@ -34,9 +34,11 @@ OPENCLAW_GATEWAY_TOKEN=ENC[AES256_GCM,data:50ljOL76+5SCYHdNPpU5pe6QDg4FiuL/DBmbB
 TRAEFIK_ADMIN_PASSWORD=ENC[AES256_GCM,data:K5tSWDd93N1x6O0oxjUcZN2tapk=,iv:uwwQZPSDei/s0FM/dD8mDhjkflLw9INO6/Z0/lPyolw=,tag:9cnLWwiHOhiMFu8BX7itCw==,type:str]
 KC_ADMIN_USERNAME=ENC[AES256_GCM,data:bVTKQLk=,iv:A0EPQLb98JXOkLgPn7C2jfMDJhvqS+c/Dk+3uC7Ls3s=,tag:Hcw0U7SUzLplg1bHfq1QYw==,type:str]
 KC_ADMIN_PASSWORD=ENC[AES256_GCM,data:fIlJA7Dci30OYjwe4qX797BiVMeJwBwcFp1Mq/W+rb/Fngrb6gV9MombZrw=,iv:9vq35jKlnyqfoqIWc/hUZqcWw7jPE+pGrMnbPa2zwcc=,tag:yPLVwwTjhEd4BHgMQR78EA==,type:str]
+MINIO_ROOT_USER=ENC[AES256_GCM,data:RGZYMrHlykT/7fs=,iv:CPc43cp5ls6iW9x16oxh3JxvVBZCk7Icc11LKvRyZPU=,tag:xPbJ0LQseNU28vYY00nNEA==,type:str]
+MINIO_ROOT_PASSWORD=ENC[AES256_GCM,data:zs5sNPfiR8IUf4ZZ7doiLTtJrLnJo+vXJ8a1epsN/mUoP6Q1xBYfbitQA/s=,iv:on5oPQQ2ItJ+NRq8fdLFVf2DnNUnHEXNq/Fur225Mtc=,tag:IawEjBvkuiAeu+C8r1sANQ==,type:str]
 sops_age__list_0__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA0Tk9jcWxubnBSdzYrVTh3\nUWljVFZrNFB2Tk8yaVdrYTZXZzZlSlNKM0dvCjMyd2NrL3RnUGpOMXlmZlBybWlD\nYnpLNFFtSnVNMnJ4SzBoZVFKcnU0aTQKLS0tIFZaYXlwRm1lQ3lwekI3NkdvQ04y\nQmhLM3dFSzc2NUlSeFFacFhoVEEvSGsKWtC/jJg4cVLm4upH51WbrwVDdNCm0/ut\ntu3ywZWs24JYbZd/6mKg52TdLleMsDO6xrIz3l5yLASJvDNm2Xictw==\n-----END AGE ENCRYPTED FILE-----\n
 sops_age__list_0__map_recipient=age1p30vk2qpvlkj5pzh72f0wwvlqgmedvr204nldmpskmptgy9ryg8qg9qd5v
-sops_lastmodified=2026-02-16T07:57:20Z
-sops_mac=ENC[AES256_GCM,data:eI98EBKwhkLPVZmn46/sXEoq5exWULvKQA9IljJ70q4R6UnjNB9MUcA/DENQg8anJcQS7P88OwCVH10d6SXGKPzLMcV1qdj/56f1PTEQpzGwNNcJemE/7vhoTW6X6EiOiRXb9anyL108znNVq0vhQfm3te010A7lsxZvgvbZlsg=,iv:E8a1URAMbRkaR4ALyZUl3pN2zS2g4a+jfCb//oGDSW4=,tag:y6DeA1jQ0zd5NsLD0WPnAA==,type:str]
+sops_lastmodified=2026-02-17T02:55:41Z
+sops_mac=ENC[AES256_GCM,data:9BrxTmpD2lQ+JmrtVRMyZATz/E9CCQdaSPTxt8Y9IuBTAhwxo6R5G0Xq0jqYAkRP/CXQ7SKD5qGFP57MJb67C5F+8e5st3MQPs9EPpz/WS1o8+Gd+WS+KDyaBZFwZiwGhtd2g537xi9UDSt23UvdezNjqtF98zmJQSFJmwcosvc=,iv:bSNinsSY1Yg93mRiDTEsYekya1SCPJ0751HPBdDlhXA=,tag:Tg6JqNXK5b9rOBputmTI0A==,type:str]
 sops_unencrypted_suffix=_unencrypted
 sops_version=3.11.0


### PR DESCRIPTION
## Summary

- Add MINIO_ROOT_USER and MINIO_ROOT_PASSWORD to SOPS-encrypted prod secrets
- Required before MinIO can be deployed on VPS

## Test plan

- [x] Secrets verified via `make secrets-view`
- [ ] CI passes

Generated with [Claude Code](https://claude.com/claude-code)
