### PR TITLE
fix: sync VPS_HOST with TAILSCALE_IP during VPS config

### DIFF
--- a/infra/secrets/prod.enc.env
+++ b/infra/secrets/prod.enc.env
@@ -24,7 +24,7 @@ TRAEFIK_ADMIN_PASSWORD_HASH=ENC[AES256_GCM,data:F3YxVbklwKEdHFcafmX6Tohb5lKRL0hF
 OPENAI_API_KEY=ENC[AES256_GCM,data:uPputkhW4t9pCZE=,iv:79luwGo4O5yokVKE7ZgUi+VWVJCqdQMoyx1n4cdm7EQ=,tag:IMjTZVz9+agPTD0sxydjrg==,type:str]
 ANTHROPIC_API_KEY=ENC[AES256_GCM,data:HdVAh8597YDDkwo=,iv:B1qmf5rMmqaYiVzoNsuwkb0OegH2+QYzxar7zRTsm/k=,tag:I74zukyrELIqNPAmg/eDlw==,type:str]
 TAILSCALE_AUTH_KEY=ENC[AES256_GCM,data:iwpcGXSRGmsHkuiW8KVo3ieK9NUUPwUUiEgCSyFZbJKMb1F4nwrstCJoCBzjFkVZjoi20kc8TBoXwXh0OQ==,iv:TrczZUtjgmaQlmfCuSY+pQOxIJ7ZcRDaLRWE7iwnGgU=,tag:JHLBIeDPJBpNrMyhhRpoGw==,type:str]
-VPS_HOST=ENC[AES256_GCM,data:R4a1fsBrjYlnXKxUgeo=,iv:fR/zuAjyr1UvVu80KVBAjSkn55xfyQjX5/I/Rue+ZfM=,tag:ZHqczHSfNTktsC3NZHiDmw==,type:str]
+VPS_HOST=ENC[AES256_GCM,data:/ufHO7XGXdOM6XoX5w==,iv:1HXhI34yh6iSR5w0ToPa0d8VgURI9x4l1rSEl95qNr0=,tag:zJY8GebxoqqCko25jIupJQ==,type:str]
 ACME_CA_SERVER=ENC[AES256_GCM,data:Btfl6yGiK4dRHPpBjHl+hVMCzU8gpd/gM3VAlGu5Q4ZVwu0Fyhs4+qF3umNFHA==,iv:mWDCvUwa923HYc2e1GVxv9Fw8lds2inU2XtM7RfXcuY=,tag:8vPQYA9Ca2vys14hm+NFQA==,type:str]
 HOSTINGER_POST_INSTALL_SCRIPT_ID=ENC[AES256_GCM,data:ahZGcQ==,iv:cwC+D+hWf8PkIKltDp+fBq5/OfLpNcjQPFG+jlAhcJ4=,tag:k5GdQTMCx9UflkFD6T+OHw==,type:str]
 TAILSCALE_API_KEY=ENC[AES256_GCM,data:HOwQg3bjRFO2vAum5I2irS/FgKGc42S1acWtnI9xWxR5oSZbY/2ZkDLCSQdC9//5fbSUasNASQVKXHkz,iv:dMRybNmKr8vf+DCacjGTn7vX3IblW53KTKD+MX4/M/4=,tag:DNYTgc22gSNpbqytySh9gQ==,type:str]
@@ -38,7 +38,7 @@ MINIO_ROOT_USER=ENC[AES256_GCM,data:RGZYMrHlykT/7fs=,iv:CPc43cp5ls6iW9x16oxh3Jxv
 MINIO_ROOT_PASSWORD=ENC[AES256_GCM,data:zs5sNPfiR8IUf4ZZ7doiLTtJrLnJo+vXJ8a1epsN/mUoP6Q1xBYfbitQA/s=,iv:on5oPQQ2ItJ+NRq8fdLFVf2DnNUnHEXNq/Fur225Mtc=,tag:IawEjBvkuiAeu+C8r1sANQ==,type:str]
 sops_age__list_0__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA0Tk9jcWxubnBSdzYrVTh3\nUWljVFZrNFB2Tk8yaVdrYTZXZzZlSlNKM0dvCjMyd2NrL3RnUGpOMXlmZlBybWlD\nYnpLNFFtSnVNMnJ4SzBoZVFKcnU0aTQKLS0tIFZaYXlwRm1lQ3lwekI3NkdvQ04y\nQmhLM3dFSzc2NUlSeFFacFhoVEEvSGsKWtC/jJg4cVLm4upH51WbrwVDdNCm0/ut\ntu3ywZWs24JYbZd/6mKg52TdLleMsDO6xrIz3l5yLASJvDNm2Xictw==\n-----END AGE ENCRYPTED FILE-----\n
 sops_age__list_0__map_recipient=age1p30vk2qpvlkj5pzh72f0wwvlqgmedvr204nldmpskmptgy9ryg8qg9qd5v
-sops_lastmodified=2026-02-17T02:55:41Z
-sops_mac=ENC[AES256_GCM,data:9BrxTmpD2lQ+JmrtVRMyZATz/E9CCQdaSPTxt8Y9IuBTAhwxo6R5G0Xq0jqYAkRP/CXQ7SKD5qGFP57MJb67C5F+8e5st3MQPs9EPpz/WS1o8+Gd+WS+KDyaBZFwZiwGhtd2g537xi9UDSt23UvdezNjqtF98zmJQSFJmwcosvc=,iv:bSNinsSY1Yg93mRiDTEsYekya1SCPJ0751HPBdDlhXA=,tag:Tg6JqNXK5b9rOBputmTI0A==,type:str]
+sops_lastmodified=2026-02-17T03:00:21Z
+sops_mac=ENC[AES256_GCM,data:bhl94rj/6dKeIqm4ae6s8Aktz2k3jBqSbGfE4uJy1VUjnno3sjJx45BgCFxOQxbwL8IYAUkrz8v2q9wHktKMnXks/1rK9PH9zOAUDgYevHZY5w5pzv/CQV6bpcMT+3P6ld7jxgJiY9DGbJkY7MqzCUS+fNPbqU1UN+ff7osmt98=,iv:CKKE6uh9CHkXqOATXiMEEJT0GOFRUrixT6/r6/e1+Kc=,tag:srni5UmmykSQn4g++KbhNA==,type:str]
 sops_unencrypted_suffix=_unencrypted
 sops_version=3.11.0

--- a/scripts/vps.sh
+++ b/scripts/vps.sh
@@ -245,10 +245,12 @@ cmd_config() {
     echo ""
 
     # Step 3: Update TAILSCALE_IP in secrets
-    echo -e "${CYAN}[3/3] Updating TAILSCALE_IP in encrypted secrets...${NC}"
+    echo -e "${CYAN}[3/3] Updating TAILSCALE_IP and VPS_HOST in encrypted secrets...${NC}"
     cd "$PROJECT_ROOT"
     make secrets-update KEY=TAILSCALE_IP VALUE="$tailscale_ip" > /dev/null 2>&1
     success "   ✓ TAILSCALE_IP updated"
+    make secrets-update KEY=VPS_HOST VALUE="$tailscale_ip" > /dev/null 2>&1
+    success "   ✓ VPS_HOST updated (SSH via Tailscale)"
     echo ""
 
     echo ""


### PR DESCRIPTION
## Summary

- Fix stale VPS_HOST secret — was pointing to old Tailscale IP (100.109.231.52) instead of current (100.65.232.75)
- Add VPS_HOST update to `cmd_config()` in `scripts/vps.sh` so it stays in sync with TAILSCALE_IP on future rebuilds
- Root cause: `cmd_config()` updated TAILSCALE_IP but never VPS_HOST, so every VPS rebuild caused drift

## Test plan

- [x] `bats tests/scripts/` — 158/158 pass
- [x] `make secrets-view KEY=VPS_HOST` confirms corrected value
- [ ] `make ssh` connects successfully via Tailscale

Generated with [Claude Code](https://claude.com/claude-code)
