### PR TITLE
docs: add comprehensive LGTM observability documentation

### DIFF
--- a/.github/docs/vps-operations.md
+++ b/.github/docs/vps-operations.md
@@ -34,6 +34,9 @@ make deploy-db
 # Step 3c: Deploy MinIO storage (optional)
 make deploy-minio
 
+# Step 3d: Deploy observability stack
+make deploy-observability  # or: bash scripts/deploy.sh observability prod
+
 # Step 4: Deploy application services
 make deploy-all  # All services
 # OR deploy individually:
@@ -96,12 +99,15 @@ make deploy-mcp   # MCP service
 - ✅ Age key transferred to `/opt/hill90/secrets/keys/keys.txt`
 - ❌ **No containers running**
 
-**After Step 3 (Deploy Infra):**
+**After Step 3 (Deploy Infra + DB + MinIO + Observability):**
 - ✅ All above +
 - ✅ Traefik running (reverse proxy)
 - ✅ dns-manager running (DNS-01 challenges)
 - ✅ Portainer running (Tailscale-only access)
 - ✅ Docker networks created
+- ✅ PostgreSQL + postgres-exporter running
+- ✅ MinIO running (optional)
+- ✅ Observability stack running (Prometheus, Grafana, Loki, Tempo, collectors)
 - ❌ **No application services running**
 
 **After Step 4 (Deploy All):**
@@ -119,8 +125,9 @@ make deploy-auth    # Keycloak identity provider
 make deploy-api     # API service
 make deploy-ai      # AI service
 make deploy-mcp     # MCP service
-make deploy-minio   # MinIO object storage
-make deploy-all     # All app services (not infra or db)
+make deploy-minio          # MinIO object storage
+make deploy-observability  # Prometheus, Grafana, Loki, Tempo + collectors (or: bash scripts/deploy.sh observability prod)
+make deploy-all            # All app services (not infra or db)
 ```
 
 ## Safety Operations
@@ -235,6 +242,7 @@ make health    # Check all services
 - `scripts/deploy.sh ai` - AI service deployment
 - `scripts/deploy.sh mcp` - MCP service deployment
 - `scripts/deploy.sh minio` - MinIO storage deployment
+- `scripts/deploy.sh observability` - Observability stack deployment
 - `scripts/deploy.sh all` - All app services deployment
 - `scripts/hostinger.sh` - VPS API operations
 - `infra/ansible/playbooks/bootstrap.yml` - Master playbook

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -11,6 +11,7 @@ Hill90 is a Docker-based microservices platform hosted on a single Hostinger VPS
 - **Edge Layer**: Traefik reverse proxy with automatic HTTPS (dual certificate resolvers)
 - **Application Layer**: Microservices (API, AI, MCP, UI) with Keycloak identity provider
 - **Data Layer**: PostgreSQL database, MinIO S3-compatible object storage
+- **Observability Layer**: LGTM stack (Loki, Grafana, Tempo, Prometheus) with collectors and exporters
 - **Infrastructure Layer**:
   - Docker Compose orchestration
   - DNS Manager (Let's Encrypt DNS-01 challenge webhook)
@@ -37,6 +38,17 @@ Traefik (edge network)           ┌──────────────�
 │ Internal Services (internal)│  Hostinger DNS API
 │ - PostgreSQL                │  (TXT record management)
 │ - MinIO (S3 API)            │
+│ - postgres-exporter         │
+└─────────────────────────────┘
+   ↓
+┌─────────────────────────────┐
+│ Observability (internal)    │  ┌──────────────────────────┐
+│ - Prometheus (metrics)      │  │ Grafana Dashboard        │
+│ - Loki (logs)               │  │ (grafana.hill90.com,     │
+│ - Tempo (traces)            │  │  Tailscale-only)         │
+│ - Promtail (log collector)  │  └──────────────────────────┘
+│ - Node Exporter (host)      │
+│ - cAdvisor (containers)     │
 └─────────────────────────────┘
 ```
 
@@ -47,8 +59,8 @@ Traefik (edge network)           ┌──────────────�
 
 **Network Isolation:**
 - **edge network**: Public-facing services (Traefik → API, AI, MCP, Keycloak, UI)
-- **internal network**: Private services (Keycloak, PostgreSQL)
-- **Tailscale network**: Admin-only services (Traefik dashboard, Portainer, MinIO console)
+- **internal network**: Private services (Keycloak, PostgreSQL, observability stack)
+- **Tailscale network**: Admin-only services (Traefik dashboard, Portainer, MinIO console, Grafana)
 - **IP Whitelist**: 100.64.0.0/10 (Tailscale CGNAT range) via middleware
 
 ## Service Responsibilities
@@ -84,6 +96,13 @@ Traefik (edge network)           ┌──────────────�
   - Portainer (container management)
   - PostgreSQL
   - MinIO (S3-compatible object storage)
+- **Observability**:
+  - Prometheus (metrics collection and alerting)
+  - Grafana (dashboards and exploration)
+  - Loki (log aggregation)
+  - Tempo (distributed tracing)
+  - OpenTelemetry (application tracing instrumentation)
+  - Promtail, Node Exporter, cAdvisor, postgres-exporter (collectors)
 - **Security**:
   - SOPS + age (secrets encryption)
   - Tailscale VPN (admin access)
@@ -110,5 +129,6 @@ Traefik (edge network)           ┌──────────────�
 
 - [Certificate Management](./certificates.md) - HTTP-01 vs DNS-01 challenges, DNS Manager implementation
 - [Security Architecture](./security.md)
+- [Observability Runbook](../runbooks/observability.md) - LGTM stack operations, dashboards, alerts
 - [Deployment Guide](../runbooks/deployment.md)
 - [VPS Rebuild Runbook](../runbooks/vps-rebuild.md)

--- a/docs/runbooks/deployment.md
+++ b/docs/runbooks/deployment.md
@@ -40,6 +40,18 @@ Expected outcome:
 - S3 API available at `http://minio:9000` from internal containers.
 - Console at `https://storage.hill90.com` (Tailscale-only).
 
+## Deploy Observability
+
+```bash
+bash scripts/deploy.sh observability prod   # canonical (VPS/CI)
+make deploy-observability                    # convenience (local Mac)
+```
+
+Expected outcome:
+- 7 containers healthy: `prometheus`, `grafana`, `loki`, `tempo`, `promtail`, `node-exporter`, `cadvisor`.
+- Grafana accessible at `https://grafana.hill90.com` (Tailscale-only).
+- Prometheus scrape targets all show `up`.
+
 ## Deploy Application Services
 
 ```bash
@@ -73,7 +85,7 @@ curl -f https://storage.hill90.com
 
 ```bash
 ssh -i ~/.ssh/remote.hill90.com deploy@remote.hill90.com \
-  'cd /opt/hill90/app && export SOPS_AGE_KEY_FILE=/opt/hill90/secrets/keys/keys.txt && bash scripts/deploy.sh infra prod && bash scripts/deploy.sh db prod && bash scripts/deploy.sh minio prod && bash scripts/deploy.sh all prod'
+  'cd /opt/hill90/app && export SOPS_AGE_KEY_FILE=/opt/hill90/secrets/keys/keys.txt && bash scripts/deploy.sh infra prod && bash scripts/deploy.sh db prod && bash scripts/deploy.sh minio prod && bash scripts/deploy.sh observability prod && bash scripts/deploy.sh all prod'
 ```
 
 ## Rollback Guidance

--- a/docs/runbooks/observability.md
+++ b/docs/runbooks/observability.md
@@ -1,0 +1,157 @@
+# Observability Runbook
+
+Operational guide for the Hill90 LGTM (Loki, Grafana, Tempo, Prometheus) observability stack.
+
+## Architecture
+
+### Components
+
+| Component | Role | Port | Signal |
+|-----------|------|------|--------|
+| **Prometheus** | Metrics collection and alerting | 9090 | Metrics |
+| **Loki** | Log aggregation | 3100 | Logs |
+| **Tempo** | Distributed tracing backend | 3200 (API), 4317 (gRPC), 4318 (HTTP) | Traces |
+| **Grafana** | Dashboards and exploration UI | 3000 | All |
+| **Promtail** | Log collector (Docker → Loki) | — | Logs |
+| **Node Exporter** | Host-level metrics | 9100 | Metrics |
+| **cAdvisor** | Container metrics | 8080 | Metrics |
+| **postgres-exporter** | PostgreSQL metrics | 9187 | Metrics |
+
+### Signal Flow
+
+```
+Application Services
+  ├── Metrics ──→ Prometheus (scrape every 15s)
+  ├── Logs ────→ Promtail → Loki (Docker JSON logs)
+  └── Traces ──→ Tempo (OTLP HTTP :4318 / gRPC :4317)
+
+Infrastructure
+  ├── Host metrics ──→ Node Exporter → Prometheus
+  ├── Container metrics ──→ cAdvisor → Prometheus
+  └── PostgreSQL metrics ──→ postgres-exporter → Prometheus
+
+All signals ──→ Grafana (query + visualize)
+```
+
+### Signal Coverage by Service
+
+| Service | Metrics | Logs | Traces |
+|---------|---------|------|--------|
+| API (Node.js) | Prometheus scrape* | Promtail | OTEL auto-instrumentation |
+| AI (Python) | Prometheus scrape* | Promtail | OTEL instrument CLI |
+| MCP (Python) | Prometheus scrape* | Promtail | OTEL instrument CLI |
+| Keycloak | Prometheus (:9000) | Promtail | Native KC_TRACING |
+| PostgreSQL | postgres-exporter | Promtail | — |
+| MinIO | Prometheus (/minio/v2/metrics/cluster) | Promtail | — |
+| Traefik | Prometheus (:8082) | Promtail | — |
+| UI (Next.js) | — | Promtail | — |
+| dns-manager | — | Promtail | — |
+
+*App services expose metrics if instrumented; current tracing config sets `OTEL_METRICS_EXPORTER=none`.
+
+## Deployment
+
+### Deploy / Update
+
+Canonical (VPS/CI):
+
+```bash
+bash scripts/deploy.sh observability prod
+```
+
+Local convenience:
+
+```bash
+make deploy-observability
+```
+
+Expected outcome: 7 containers healthy — `prometheus`, `grafana`, `loki`, `tempo`, `promtail`, `node-exporter`, `cadvisor`.
+
+The `postgres-exporter` deploys with the database stack (`bash scripts/deploy.sh db prod`).
+
+### Verification Checklist
+
+After deployment, verify in order:
+
+**1. Docker container health (binary liveness only):**
+
+```bash
+docker ps --filter name=prometheus --filter name=grafana --filter name=loki --filter name=tempo --filter name=promtail --filter name=node-exporter --filter name=cadvisor --format "table {{.Names}}\t{{.Status}}"
+```
+
+Or use `bash scripts/ops.sh health`.
+
+> **Caveat**: Docker healthchecks for `promtail` and `postgres-exporter` validate binary presence (`--version`), not endpoint readiness. A healthy Docker status does NOT guarantee the upstream connection is working.
+
+**2. Prometheus targets (connection truth — required for exporters):**
+
+```bash
+curl -s http://localhost:9090/api/v1/targets | jq '.data.activeTargets[] | {job: .labels.job, health: .health, lastError: .lastError}'
+```
+
+This is the authoritative source for whether scrape targets are actually reachable. Always check this for `postgres-exporter` and `promtail`.
+
+**3. Grafana datasource connectivity:**
+
+Open Grafana at `https://grafana.hill90.com` (Tailscale-only) → Settings → Data Sources → test each connection.
+
+**4. Alert rules loaded:**
+
+```bash
+curl -s http://localhost:9090/api/v1/rules | jq '.data.groups[].name'
+```
+
+## Incident Triage Flow
+
+When investigating an issue, follow this signal hierarchy:
+
+1. **Grafana dashboards** — check for anomalies in metrics (Node Exporter, cAdvisor, service-specific)
+2. **Loki logs** — search for error patterns around the incident timeframe
+3. **Tempo traces** — find slow or failed request traces for the affected service
+4. **Prometheus alerts** — check if any alerts fired before or during the incident
+
+## Dashboards
+
+| Dashboard | Source | Covers |
+|-----------|--------|--------|
+| Node Exporter | Provisioned | CPU, memory, disk, network (host) |
+| cAdvisor | Provisioned | Container CPU, memory, network |
+| Traefik | Provisioned | Request rates, latencies, errors |
+| PostgreSQL | Grafana ID 9628 rev 7 | Connections, transactions, cache hits |
+| MinIO | Grafana ID 13502 rev 2 | Bucket operations, storage usage |
+| Keycloak | Grafana ID 19659 rev 1 | Login events, active sessions |
+| Loki Logs | Provisioned | Log search and exploration |
+
+All dashboards are file-provisioned from `platform/observability/grafana/provisioning/dashboards/`.
+
+## Alert Rules
+
+Baseline alerts in `platform/observability/prometheus/alerts.yml`:
+
+| Alert | Condition | Severity |
+|-------|-----------|----------|
+| ServiceDown | Any scrape target down > 5m | critical |
+| HighMemoryUsage | Container memory > 90% of limit | warning |
+| DiskSpaceRunningLow | Root filesystem < 15% free | warning |
+| PostgresConnectionsHigh | Active connections > 80% max | warning |
+| LokiIngestionErrors | Ingestion error rate > 0 | warning |
+| TempoIngestionErrors | Ingestion failure rate > 0 | warning |
+
+## Backup and Retention
+
+| Component | Retention | Storage |
+|-----------|-----------|---------|
+| Prometheus | 7 days / 20 GB (whichever first) | `prometheus-data` volume |
+| Loki | 7 days (compactor) | `loki-data` volume |
+| Tempo | Default retention | `tempo-data` volume |
+| Grafana | Persistent | `grafana-data` volume |
+
+Volumes are backed up by `bash scripts/ops.sh backup` (Prometheus and Grafana volumes included).
+
+## Known Caveats
+
+- **Compose v2 `version` field warnings**: Cosmetic only, ignored by Docker Compose v2+.
+- **Healthcheck binary-only checks**: `promtail --version` and `postgres_exporter --version` validate binary presence, not endpoint readiness. Docker reports healthy even if upstream (Loki, PostgreSQL) is unreachable. Always cross-check Prometheus target status.
+- **Tailscale-only access**: Grafana at `grafana.hill90.com` requires Tailscale VPN connection (IP whitelist middleware).
+- **Promtail Docker socket**: Requires `/var/run/docker.sock` mount for container log discovery.
+- **MinIO metrics auth**: Set to `public` (no bearer token required). Safe because MinIO is on `hill90_internal` network only.

--- a/docs/runbooks/troubleshooting.md
+++ b/docs/runbooks/troubleshooting.md
@@ -439,6 +439,130 @@ echo | openssl s_client -connect api.hill90.com:443 -servername api.hill90.com 2
 
 ---
 
+## Observability Issues
+
+### Grafana Not Accessible
+
+**Problem**: Cannot reach `grafana.hill90.com`
+
+**Solutions**:
+
+1. **Verify Tailscale connection** — Grafana is Tailscale-only:
+   ```bash
+   tailscale status
+   ```
+
+2. **Check DNS points to Tailscale IP:**
+   ```bash
+   dig +short grafana.hill90.com
+   # Should return 100.x.x.x (Tailscale IP)
+   ```
+
+3. **Check Grafana container:**
+   ```bash
+   ssh deploy@<tailscale-ip> 'docker ps | grep grafana'
+   ssh deploy@<tailscale-ip> 'docker logs grafana --tail 20'
+   ```
+
+### Prometheus Targets Down
+
+**Problem**: Scrape targets show `down` in Prometheus
+
+**Solutions**:
+
+1. **Check target status:**
+   ```bash
+   curl -s http://localhost:9090/api/v1/targets | jq '.data.activeTargets[] | select(.health != "up") | {job: .labels.job, health: .health, lastError: .lastError}'
+   ```
+
+2. **Verify network connectivity** — all targets must be on `hill90_internal`:
+   ```bash
+   docker network inspect hill90_internal --format '{{range .Containers}}{{.Name}} {{end}}'
+   ```
+
+3. **Check scrape config** — verify job exists in `platform/observability/prometheus/prometheus.yml`.
+
+### No Traces in Tempo
+
+**Problem**: Grafana Explore → Tempo shows no traces
+
+**Solutions**:
+
+1. **Verify OTEL env vars** in service compose files:
+   - `OTEL_EXPORTER_OTLP_ENDPOINT` should point to `http://tempo:4318` (HTTP) or `http://tempo:4317` (gRPC)
+   - `OTEL_TRACES_EXPORTER=otlp`
+
+2. **Check Tempo receiver health:**
+   ```bash
+   curl -s http://localhost:3200/ready
+   ```
+
+3. **Check service logs for OTEL errors:**
+   ```bash
+   ssh deploy@<tailscale-ip> 'docker logs api --tail 50 | grep -i otel'
+   ```
+
+4. **Verify Tempo distributor is receiving traces:**
+   ```bash
+   curl -s http://localhost:3200/metrics | grep tempo_distributor
+   ```
+
+### No Logs in Loki
+
+**Problem**: Grafana Explore → Loki shows no logs
+
+**Solutions**:
+
+1. **Check Promtail is running and connected:**
+   ```bash
+   ssh deploy@<tailscale-ip> 'docker ps | grep promtail'
+   ssh deploy@<tailscale-ip> 'docker logs promtail --tail 20'
+   ```
+
+2. **Verify Docker socket mount** — Promtail needs `/var/run/docker.sock`.
+
+3. **Check Promtail positions** — if positions file is corrupted, delete the `promtail-positions` volume and redeploy.
+
+### Alert Rules Not Loading
+
+**Problem**: Prometheus Alerts page shows no rules
+
+**Solutions**:
+
+1. **Verify `rule_files` in prometheus.yml** includes `/etc/prometheus/alerts.yml`.
+
+2. **Check alerts.yml is mounted** in `docker-compose.observability.yml`.
+
+3. **Validate syntax:**
+   ```bash
+   docker exec prometheus promtool check rules /etc/prometheus/alerts.yml
+   ```
+
+### Dashboard Not Showing Data
+
+**Problem**: Grafana dashboard panels show "No data"
+
+**Solutions**:
+
+1. **Check datasource configuration** — Settings → Data Sources → test connection.
+
+2. **Verify time range** — default dashboards may expect recent data. Expand the time range.
+
+3. **Check Prometheus has the expected metrics:**
+   ```bash
+   curl -s 'http://localhost:9090/api/v1/query?query=up' | jq '.data.result[] | {job: .metric.job, value: .value[1]}'
+   ```
+
+### Exporter Healthcheck Caveats
+
+Docker healthchecks for `promtail` and `postgres-exporter` use `--version` flags, which only validate binary presence. This means:
+
+- Docker reports `healthy` even if the upstream connection (Loki, PostgreSQL) is broken.
+- `ops.sh health` relies on Docker health state and will show green for these exporters regardless.
+- **Always verify Prometheus target status** for connection truth, especially after infrastructure changes.
+
+---
+
 ## For More Help
 
 - **Check service logs:** `make logs` or `make logs-<service>`
@@ -446,6 +570,7 @@ echo | openssl s_client -connect api.hill90.com:443 -servername api.hill90.com 2
 - **Consult documentation:**
   - [Architecture Overview](../architecture/overview.md)
   - [Certificate Management](../architecture/certificates.md)
+  - [Observability Runbook](./observability.md)
   - [VPS Rebuild Runbook](./vps-rebuild.md)
   - [Bootstrap Runbook](./bootstrap.md)
 - **GitHub Actions logs:** Repository → Actions → Recent workflow runs


### PR DESCRIPTION
## Summary
- Create dedicated **observability runbook** (`docs/runbooks/observability.md`): architecture, signal flow, deployment, verification checklist, incident triage, dashboards, alert rules, retention, known caveats
- Update **architecture overview** with observability layer, network topology diagram, technology stack
- Add **observability deploy step** to deployment runbook (between Storage and Application Services) and SSH command sequence
- Add **observability troubleshooting** section: Grafana access, Prometheus targets, Tempo traces, Loki logs, alert rules, dashboard data, healthcheck caveats
- Update **VPS operations** with observability in deploy sequence, per-service commands, and key files

## Test plan
- [ ] All internal doc links resolve (no broken cross-references)
- [ ] Deploy commands use `bash scripts/deploy.sh` as canonical, `make` as convenience
- [ ] Signal coverage table matches actual implementation from PRs 1-3
- [ ] Verification checklist commands are accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)
