### PR TITLE
fix: allow SSH-routed deploy commands in harness hook

### DIFF
--- a/scripts/hooks/block-local-deploy.sh
+++ b/scripts/hooks/block-local-deploy.sh
@@ -18,6 +18,13 @@ NORMALIZED="$COMMAND"
 # Strip leading whitespace
 NORMALIZED="${NORMALIZED#"${NORMALIZED%%[![:space:]]*}"}"
 
+# ALLOW: entire command is SSH-routed (deploy runs on VPS, not locally).
+# Must check before &&/;/|| splitting, since the remote command string
+# contains those operators inside the ssh quoted argument.
+if [[ "$NORMALIZED" =~ ^ssh[[:space:]] ]]; then
+  exit 0
+fi
+
 # Check each segment of chained commands (&&, ||, ;)
 # We need to check if ANY segment contains a blocked command.
 check_segment() {


### PR DESCRIPTION
## Summary
- Fix false positive in `block-local-deploy.sh` hook that blocked SSH-routed VPS deploy commands
- The hook naively splits on `&&` before checking segments, so `ssh host 'cd ... && bash scripts/deploy.sh ...'` gets split and the inner deploy segment is checked without the `ssh` prefix
- Fix: check if the entire command starts with `ssh` before splitting — SSH-routed deploys run on VPS, not locally

## Test plan
- [ ] `ssh deploy@host '... && bash scripts/deploy.sh auth prod'` → allowed
- [ ] `bash scripts/deploy.sh auth prod` (local) → still blocked
- [ ] `make deploy-auth` (local) → still blocked
- [ ] `gh pr merge --admin` → still blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)
