### PR TITLE
fix: use scalar() in PostgreSQL connection gauge query

### DIFF
--- a/platform/observability/grafana/provisioning/dashboards/postgres.json
+++ b/platform/observability/grafana/provisioning/dashboards/postgres.json
@@ -100,7 +100,7 @@
       },
       "targets": [
         {
-          "expr": "sum(pg_stat_activity_count{job=\"postgres-exporter\"}) / pg_settings_max_connections{job=\"postgres-exporter\"}",
+          "expr": "sum(pg_stat_activity_count{job=\"postgres-exporter\"}) / scalar(pg_settings_max_connections{job=\"postgres-exporter\"})",
           "legendFormat": "Connection Usage",
           "refId": "A"
         }


### PR DESCRIPTION
## Summary
- Fix PostgreSQL Connection Usage gauge showing "No data"
- `sum(pg_stat_activity_count)` strips labels, but `pg_settings_max_connections` retains them (instance, job, server) — PromQL binary division returns empty when labels don't match
- Wrap denominator in `scalar()` to convert to label-free scalar value

## Test plan
- [ ] PostgreSQL dashboard Connection Usage gauge shows percentage (e.g., 3%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
