### PR TITLE
fix: position logo above login form, disable theme cache

### DIFF
--- a/deploy/compose/prod/docker-compose.auth.yml
+++ b/deploy/compose/prod/docker-compose.auth.yml
@@ -40,7 +40,7 @@ services:
       - KC_TRACING_ENDPOINT=http://tempo:4317
       - KC_TRACING_PROTOCOL=grpc
       - KC_TELEMETRY_SERVICE_NAME=keycloak
-    command: start --import-realm
+    command: start --import-realm --spi-theme-cache-themes=false
     healthcheck:
       test: ["CMD", "bash", "-c", "exec 3<>/dev/tcp/localhost/9000"]
       interval: 30s

--- a/platform/auth/keycloak/themes/hill90/login/resources/css/styles.css
+++ b/platform/auth/keycloak/themes/hill90/login/resources/css/styles.css
@@ -16,21 +16,23 @@
   box-shadow: 0 4px 24px rgba(0, 0, 0, 0.4);
 }
 
-/* ── Card header accent ── */
+/* ── Hide side-panel header — logo moved into the card ── */
+.pf-v5-c-login__header {
+  display: none !important;
+}
+
+/* ── Card header accent + logo above title ── */
 .pf-v5-c-login__main-header {
   border-top: 3px solid #5b9a2f;
 }
 
-/* ── Logo ── */
-#kc-header-wrapper.pf-v5-c-brand {
-  font-size: 0;
-  color: transparent;
-  overflow: hidden;
+.pf-v5-c-login__main-header::before {
+  content: '';
   display: block;
   width: 180px;
   height: 80px;
   background: url('../img/logo.svg') center / contain no-repeat;
-  margin: 0 auto;
+  margin: 0 auto 1rem;
 }
 
 /* ── Form inputs ── */
@@ -122,6 +124,10 @@
   .pf-v5-c-login {
     background-color: #0f1720;
     background-image: none;
+  }
+
+  .pf-v5-c-login__header {
+    display: none !important;
   }
 
   .pf-v5-c-login__main {


### PR DESCRIPTION
## Summary
- Hide the Keycloak side-panel header where the logo text appeared to the right of the login card
- Show the Hill90 SVG logo inside the card header via a `::before` pseudo-element, centered above "Sign in to your account"
- Disable Keycloak theme caching (`--spi-theme-cache-themes=false`) so bind-mounted theme files are read fresh, preventing stale gzip cache after deploys

## Test plan
- [ ] Verify login page shows SVG hill logo centered above the form title
- [ ] Verify side-panel "Hill90" text is no longer visible
- [ ] Verify theme changes take effect immediately after deploy (no stale cache)
- [ ] Verify login/registration flow still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)