### PR TITLE
feat: migrate Keycloak SMTP from SendGrid to Hostinger

### DIFF
--- a/infra/secrets/prod.enc.env
+++ b/infra/secrets/prod.enc.env
@@ -41,9 +41,10 @@ AUTH_KEYCLOAK_SECRET=ENC[AES256_GCM,data:LB8yVttwUHYF1xuDNUO5juxjZMgo8qo0DEF//9q
 AUTH_SECRET=ENC[AES256_GCM,data:ZD1tEzAdwSXeXL810/sdXgzuUEx/kcJsFUDYjPvv2GaVZh19ZGaMu7y8KlQ=,iv:GU6kc1pbc49AXOc2b33IdFON9HQ07LppX8W06lJETUM=,tag:9QdyDEGyF0DMXeYqWhzQrg==,type:str]
 AUTH_KEYCLOAK_ID=ENC[AES256_GCM,data:GIDt4tSjVk4/,iv:cPXQLqCF2iEL2WQhew/x4WPednTrxTH5my3kSkt+WRI=,tag:asATpegxfLPGBvv0I9JOuw==,type:str]
 SENDGRID_API_KEY=ENC[AES256_GCM,data:oOeK3/Cwv0PEbhQUwPfCd36V2yYwtq8wkHGGdpv8rhu+LFPpbnnGrTsp90YNUJSK2lf26/5YYRFrw/lCoL32GTKRxKsK,iv:XGo1exMr5aPMgV/x1wl2q1itpnCSe50ZW7k5u+RtSFk=,tag:7MEyitWBFgH0QV/HmutrUQ==,type:str]
+SMTP_PASSWORD=ENC[AES256_GCM,data:91Q+XYayMCG869LdrLMt35dE1bP7mP80qPNpqo/QM4c=,iv:T3bCLy8y4FCBXL09rpXCzqVsa9aAmnCqqD9k4bn46W4=,tag:MsZtdcHw2C7O8tCTOi2Oxw==,type:str]
 sops_age__list_0__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA0Tk9jcWxubnBSdzYrVTh3\nUWljVFZrNFB2Tk8yaVdrYTZXZzZlSlNKM0dvCjMyd2NrL3RnUGpOMXlmZlBybWlD\nYnpLNFFtSnVNMnJ4SzBoZVFKcnU0aTQKLS0tIFZaYXlwRm1lQ3lwekI3NkdvQ04y\nQmhLM3dFSzc2NUlSeFFacFhoVEEvSGsKWtC/jJg4cVLm4upH51WbrwVDdNCm0/ut\ntu3ywZWs24JYbZd/6mKg52TdLleMsDO6xrIz3l5yLASJvDNm2Xictw==\n-----END AGE ENCRYPTED FILE-----\n
 sops_age__list_0__map_recipient=age1p30vk2qpvlkj5pzh72f0wwvlqgmedvr204nldmpskmptgy9ryg8qg9qd5v
-sops_lastmodified=2026-02-19T06:24:35Z
-sops_mac=ENC[AES256_GCM,data:dhGafi2Dxbq7HSzfufO6Xb6b5atif4wA6HIi/HGpLPWrlYdFI1uIA299dj/s9g7C5C8hF3RvQ2aHs4XpCoM4XVGFC9GxAs1ColEmesPbn3yXk1gLu379e7wAtU9Nbq11LoPFLMs1ApSv2bkXeIVIUTRbzKSYzT0aeEgDVTNzQv8=,iv:pTKsXzz5EXYVgfuFyF6yzWfY5s0D2nDzvfYEZiwKnRU=,tag:/vY89CtmvF/BmduPFmgutw==,type:str]
+sops_lastmodified=2026-02-21T20:19:46Z
+sops_mac=ENC[AES256_GCM,data:324yde3hybJt4RN+ikMdZuz3iK9XTe94lKRsNAJg7Wq1xnchE3eT0vcPfQdEgE1fgsVhmfwvtMghERZlkXYSUeWjB0TbbBZ+u99ccmtzjnIYxGbFv1jFHJoVCnUhPhrXGukbw51Nxwoxf2xOM4M5KW4A84gDPvhZPZWWowgezAI=,iv:8B+kxG6eBjVFisJfOht+R6JrE7OD7LphKy5CJjtzFow=,tag:Tbz3xY1EbsAGXfFy9YTuhA==,type:str]
 sops_unencrypted_suffix=_unencrypted
 sops_version=3.11.0

--- a/infra/secrets/prod.enc.env.example
+++ b/infra/secrets/prod.enc.env.example
@@ -31,5 +31,8 @@ ACME_CA_SERVER=https://acme-staging-v02.api.letsencrypt.org/directory
 # Traefik Dashboard
 TRAEFIK_ADMIN_PASSWORD_HASH=REPLACE_WITH_HTPASSWD_HASH
 
+# SMTP (Hostinger)
+SMTP_PASSWORD=REPLACE_WITH_SMTP_PASSWORD
+
 # GitHub Container Registry
 GHCR_TOKEN=ghp_REPLACE

--- a/platform/auth/keycloak/hill90-realm.json
+++ b/platform/auth/keycloak/hill90-realm.json
@@ -21,7 +21,7 @@
     ]
   },
   "smtpServer": {
-    "host": "smtp.sendgrid.net",
+    "host": "smtp.hostinger.com",
     "port": "587",
     "from": "noreply@hill90.com",
     "fromDisplayName": "Hill90",
@@ -29,7 +29,7 @@
     "ssl": "false",
     "starttls": "true",
     "auth": "true",
-    "user": "apikey",
+    "user": "noreply@hill90.com",
     "password": ""
   },
   "clients": [

--- a/platform/auth/keycloak/setup-realm.sh
+++ b/platform/auth/keycloak/setup-realm.sh
@@ -109,17 +109,17 @@ if [ "$PHASE" = "phase1" ]; then
   echo ""
   echo "3. Applying login theme + SMTP configuration..."
 
-  SENDGRID_KEY=$(sops -d --extract '["SENDGRID_API_KEY"]' infra/secrets/prod.enc.env) \
-    || die "Failed to retrieve SENDGRID_API_KEY from SOPS."
-  [ -n "$SENDGRID_KEY" ] || die "SENDGRID_API_KEY is empty."
+  SMTP_PASS=$(sops -d --extract '["SMTP_PASSWORD"]' infra/secrets/prod.enc.env) \
+    || die "Failed to retrieve SMTP_PASSWORD from SOPS."
+  [ -n "$SMTP_PASS" ] || die "SMTP_PASSWORD is empty."
 
   REALM_JSON=$(curl -sf "${KC_BASE_URL}/admin/realms/${REALM}" "${AUTH[@]}") \
     || die "Failed to fetch realm config."
 
-  UPDATED=$(echo "$REALM_JSON" | jq --arg sgkey "$SENDGRID_KEY" '. + {
+  UPDATED=$(echo "$REALM_JSON" | jq --arg smtppw "$SMTP_PASS" '. + {
     loginTheme: "hill90",
     smtpServer: {
-      host: "smtp.sendgrid.net",
+      host: "smtp.hostinger.com",
       port: "587",
       from: "noreply@hill90.com",
       fromDisplayName: "Hill90",
@@ -127,8 +127,8 @@ if [ "$PHASE" = "phase1" ]; then
       ssl: "false",
       starttls: "true",
       auth: "true",
-      user: "apikey",
-      password: $sgkey
+      user: "noreply@hill90.com",
+      password: $smtppw
     }
   }')
 


### PR DESCRIPTION
## Summary

- Switches Keycloak SMTP from SendGrid (`smtp.sendgrid.net`) to Hostinger (`smtp.hostinger.com`) using `noreply@hill90.com` mailbox
- Adds `SMTP_PASSWORD` to SOPS encrypted secrets and example file
- Retains `SENDGRID_API_KEY` and DNS records for rollback safety — decommission deferred to PR2

**Why**: Microsoft (Outlook/Live.com) blocks SendGrid shared IPs with S3140 error, causing ~50% email delivery failure for password resets and verification emails.

## Changes

| File | Change |
|------|--------|
| `platform/auth/keycloak/setup-realm.sh` | SOPS key `SENDGRID_API_KEY` → `SMTP_PASSWORD`, host/user updated |
| `platform/auth/keycloak/hill90-realm.json` | `smtpServer` host/user updated to Hostinger |
| `infra/secrets/prod.enc.env` | Added `SMTP_PASSWORD` (encrypted) |
| `infra/secrets/prod.enc.env.example` | Added `SMTP_PASSWORD` placeholder |

## Test plan

- [ ] `shellcheck platform/auth/keycloak/setup-realm.sh` — passes
- [ ] `jq . platform/auth/keycloak/hill90-realm.json` — valid JSON
- [ ] Post-merge: run `setup-realm.sh phase1` on VPS
- [ ] Gate 1: Keycloak SMTP test connection returns HTTP 204
- [ ] Gate 2: Password reset email arrives at Gmail inbox
- [ ] Gate 3: Password reset email arrives at Outlook/Live.com inbox (critical gate)
- [ ] Gate 4: Received email shows SPF: pass, DKIM: pass in raw headers

## Rollback

`SENDGRID_API_KEY` remains in SOPS and SendGrid DNS records are untouched. Instant rollback via Keycloak Admin API (no redeploy needed) or full git revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)