### PR TITLE
chore: decommission SendGrid

### DIFF
--- a/infra/secrets/prod.enc.env
+++ b/infra/secrets/prod.enc.env
@@ -40,11 +40,10 @@ GRAFANA_ADMIN_PASSWORD=ENC[AES256_GCM,data:ewF0ZBWGaAOklAJm1RpOyinkbYWCy3hGmeaOD
 AUTH_KEYCLOAK_SECRET=ENC[AES256_GCM,data:LB8yVttwUHYF1xuDNUO5juxjZMgo8qo0DEF//9qoL40=,iv:B+lWG1FdmyFhejmXzRpFLnwfpuUFXjYE0tUr3tnR1dM=,tag:zldYVKoww8C3MxF8fGM8PA==,type:str]
 AUTH_SECRET=ENC[AES256_GCM,data:ZD1tEzAdwSXeXL810/sdXgzuUEx/kcJsFUDYjPvv2GaVZh19ZGaMu7y8KlQ=,iv:GU6kc1pbc49AXOc2b33IdFON9HQ07LppX8W06lJETUM=,tag:9QdyDEGyF0DMXeYqWhzQrg==,type:str]
 AUTH_KEYCLOAK_ID=ENC[AES256_GCM,data:GIDt4tSjVk4/,iv:cPXQLqCF2iEL2WQhew/x4WPednTrxTH5my3kSkt+WRI=,tag:asATpegxfLPGBvv0I9JOuw==,type:str]
-SENDGRID_API_KEY=ENC[AES256_GCM,data:oOeK3/Cwv0PEbhQUwPfCd36V2yYwtq8wkHGGdpv8rhu+LFPpbnnGrTsp90YNUJSK2lf26/5YYRFrw/lCoL32GTKRxKsK,iv:XGo1exMr5aPMgV/x1wl2q1itpnCSe50ZW7k5u+RtSFk=,tag:7MEyitWBFgH0QV/HmutrUQ==,type:str]
 SMTP_PASSWORD=ENC[AES256_GCM,data:F91MMBGGflfds3QTP/SK4Rugl4oGQR2lkmIlaj5B,iv:Hl1Emms8dy6b5uzDu4GjtCdLcGieZzwNfnKj1Rk0ViA=,tag:fpFFTA9hK0f9DqDQ85bUjQ==,type:str]
 sops_age__list_0__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA0Tk9jcWxubnBSdzYrVTh3\nUWljVFZrNFB2Tk8yaVdrYTZXZzZlSlNKM0dvCjMyd2NrL3RnUGpOMXlmZlBybWlD\nYnpLNFFtSnVNMnJ4SzBoZVFKcnU0aTQKLS0tIFZaYXlwRm1lQ3lwekI3NkdvQ04y\nQmhLM3dFSzc2NUlSeFFacFhoVEEvSGsKWtC/jJg4cVLm4upH51WbrwVDdNCm0/ut\ntu3ywZWs24JYbZd/6mKg52TdLleMsDO6xrIz3l5yLASJvDNm2Xictw==\n-----END AGE ENCRYPTED FILE-----\n
 sops_age__list_0__map_recipient=age1p30vk2qpvlkj5pzh72f0wwvlqgmedvr204nldmpskmptgy9ryg8qg9qd5v
-sops_lastmodified=2026-02-21T20:45:24Z
-sops_mac=ENC[AES256_GCM,data:3Zr4Xb7Xb/l/SYx+wsQJ8oioKxx1ZxFPLhrl4//nhI7JOnF5Z51CatBobMXgMgcMzmES3jRBmauWrUOjR+Q6NvGTybAueaTFAv4d/3Egai9Hd4AtCWvp7UU5E2Rh0M9gVKhqo59st7tc+IJeS8EypfKd2VycLZ1AGfuzvknOnj0=,iv:jjvrK/GjF1fVtGA5BAtkl8KVlYzsSqybmlEjD/0/K7E=,tag:AeRR1EgDYXWGzYmPfKLn6w==,type:str]
+sops_lastmodified=2026-02-21T21:16:31Z
+sops_mac=ENC[AES256_GCM,data:/CtPMVzmKJGDiCt/MrGfDjsHJ6nVyduIYmyADOr7bEaIrK6n7CapRtl47hoZSCzasVbC/f+vOko9l8JAwpxDZkKaKzFFzNH0/tZ48pvNl7WYoL/9osanQpEDHyCbNGGFdu/adUoEjyFZ0cAZBD1m6Etk6kXG11bGxMPduvImKjU=,iv:Cbi4lljmX4XbDSjqw8bQ5Gwbl5RJkfbYphTDVKAasZk=,tag:wpUFOefIHfWChh8LYBOwag==,type:str]
 sops_unencrypted_suffix=_unencrypted
 sops_version=3.11.0


### PR DESCRIPTION
## Summary
- Removed 5 SendGrid CNAME DNS records (s1._domainkey, s2._domainkey, url1667, em3163, 60009633) via Hostinger API
- Updated SPF TXT record to remove `include:sendgrid.net`
- Removed `SENDGRID_API_KEY` from SOPS (`infra/secrets/prod.enc.env`)

Follows PR #79 which migrated Keycloak SMTP from SendGrid to Hostinger.

## Test plan
- [x] DNS snapshot captured before changes (rollback ID: 111371953)
- [x] 5 SendGrid CNAME records deleted — confirmed absent via `dns get`
- [x] SPF validated then updated — `dig TXT hill90.com` returns `v=spf1 include:_spf.mail.hostinger.com ~all`
- [x] `dig CNAME s1._domainkey.hill90.com` returns empty (NXDOMAIN)
- [x] Keycloak SMTP "Test connection" — **Success! E-mail was sent!**
- [x] `grep -ri sendgrid` across codebase — no remaining references
- [x] SENDGRID_API_KEY backup saved to `~/.hill90/sendgrid-key-backup.txt` (delete after merge confirmed stable)

## Rollback
- DNS: `bash scripts/hostinger.sh dns snapshot restore 111371953`
- Secret: Restore from `~/.hill90/sendgrid-key-backup.txt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)