### PR TITLE
fix: target Keycloak logo hover without title-trigger glow

### DIFF
--- a/platform/auth/keycloak/themes/hill90/login/resources/css/styles.css
+++ b/platform/auth/keycloak/themes/hill90/login/resources/css/styles.css
@@ -58,6 +58,15 @@
   transition: filter 180ms ease;
 }
 
+.pf-v5-c-login__main-header:hover::before {
+  filter: drop-shadow(0 0 16px rgba(109, 179, 58, 0.9));
+}
+
+/* Keep logo hover glow, but suppress it when hovering header text (e.g. "Sign in to your account"). */
+.pf-v5-c-login__main-header:has(.pf-v5-c-title:hover)::before {
+  filter: none !important;
+}
+
 /* ── Title text ── */
 .pf-v5-c-login__main-header .pf-v5-c-title {
   color: #ffffff;


### PR DESCRIPTION
## Summary
- restore logo glow hover behavior for the login card header logo
- suppress logo glow when the cursor is over the header title text (`.pf-v5-c-title`)
- keep the initial one-time logo glow animation unchanged

## Linear
- AI-87

## Test plan
- [x] Verified CSS includes `.pf-v5-c-login__main-header:hover::before` glow rule
- [x] Verified CSS includes `.pf-v5-c-login__main-header:has(.pf-v5-c-title:hover)::before` suppression rule
- [ ] Validate in production after deploy: logo glows when hovering logo area, but not when hovering "Sign in to your account"
