### PR TITLE
docs: align AGENTS policy with advisory agent-loop workflow

### DIFF
--- a/.github/docs/harness-reference.md
+++ b/.github/docs/harness-reference.md
@@ -76,6 +76,13 @@ Hill90/
 
 Copilot code review reads both `copilot-instructions.md` and matching `.github/instructions/*.instructions.md` based on changed paths.
 
+## Agent Loop Signal
+
+- PRs run `.github/workflows/agent-loop-gate.yml` (`Agent Loop (Advisory)`).
+- The check is non-blocking by default and surfaces missing process evidence in PR summaries.
+- Evidence expectations are defined in `.github/docs/validation-matrix.md`.
+- PR authors should use `.github/pull_request_template.md` so all three agent platforms emit consistent evidence.
+
 ## Deployment Location And Access
 
 - Deployments run on VPS over SSH/Tailscale, not locally on Mac.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,9 @@ This is the required flow for Claude, Codex, and Copilot-assisted changes.
 6. **Commit** — required format below.
 7. **Push** — `git push -u origin <branch>`.
 8. **Create PR** — `gh pr create` with summary bullets + test plan checklist.
+   - Use `.github/pull_request_template.md` and include validation evidence per `.github/docs/validation-matrix.md`.
 9. **CI gates** — tests, security scan, Copilot review.
+   - Advisory process signal: `Agent Loop (Advisory)` workflow warns on missing Linear/validation evidence.
 10. **Address feedback** — fix CI/review findings.
 11. **Merge** — `gh pr merge --squash --delete-branch`.
    - Never use `--admin` or `--force` to bypass branch protections.
@@ -92,6 +94,7 @@ For manual VPS access, see `docs/runbooks/deployment.md`.
 
 - Harness details and platform parity: `.github/docs/harness-reference.md`
 - Contribution/PR operations: `.github/docs/contribution-workflow.md`
+- Validation evidence expectations: `.github/docs/validation-matrix.md`
 - Linear task lifecycle details: `.claude/references/task-management.md`
 - VPS rebuild runbook: `docs/runbooks/vps-rebuild.md`
 - Architecture overview: `docs/architecture/overview.md`


### PR DESCRIPTION
## Summary
- update `AGENTS.md` to explicitly require PR template + validation-matrix evidence
- document advisory `Agent Loop (Advisory)` CI signal in required PR workflow section
- update harness reference to describe how the advisory gate fits cross-platform agent behavior

## Linear
- AI-89

## Validation Evidence
- Local: `python3 scripts/checks/check_harness_freshness.py`
- Local: `python3 scripts/checks/check_md_links.py`

## Test plan
- [x] AGENTS line count remains under freshness cap
- [x] Harness freshness check passes
- [x] Markdown link check passes

## Notes
- This PR only aligns prompt/policy docs with already-shipped advisory CI behavior.
