### PR TITLE
test: Playwright smoke tests for auth theme branding

### DIFF
--- a/.github/workflows/smoke-auth.yml
+++ b/.github/workflows/smoke-auth.yml
@@ -1,0 +1,49 @@
+name: Smoke — Auth Theme
+
+on:
+  workflow_dispatch:
+
+  workflow_run:
+    workflows: ["Deploy Keycloak"]
+    types: [completed]
+    branches: [main]
+
+jobs:
+  smoke:
+    name: Auth theme smoke tests
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: tests/e2e/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: tests/e2e
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+        working-directory: tests/e2e
+
+      - name: Run smoke tests
+        continue-on-error: true
+        run: npx playwright test
+        working-directory: tests/e2e
+
+      - name: Upload test report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: tests/e2e/playwright-report/
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -185,3 +185,5 @@ AGENTS.override.md
 # Playwright runtime output
 .playwright-cli/
 .playwright-mcp/
+tests/e2e/test-results/
+tests/e2e/playwright-report/

--- a/tests/e2e/auth-theme.spec.ts
+++ b/tests/e2e/auth-theme.spec.ts
@@ -1,0 +1,96 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Hill90 Auth Theme — Login Page", () => {
+  test.beforeEach(async ({ page }) => {
+    // Navigate to the account page which redirects to login
+    await page.goto("/realms/hill90/account");
+    // Wait for redirect to login page
+    await page.waitForURL(/\/realms\/hill90\/protocol\/openid-connect\//);
+  });
+
+  test("loads with correct title", async ({ page }) => {
+    await expect(page).toHaveTitle("Sign in to Hill90");
+  });
+
+  test("has Hill90 logo via header ::before background-image", async ({
+    page,
+  }) => {
+    const header = page.locator(".pf-v5-c-login__main-header");
+    await expect(header).toBeVisible();
+
+    const bgImage = await header.evaluate((el) => {
+      return getComputedStyle(el, "::before").backgroundImage;
+    });
+    expect(bgImage).toContain("data:image/svg+xml");
+  });
+
+  test("has branded colors", async ({ page }) => {
+    // Dark background on login page
+    const loginBg = await page
+      .locator(".pf-v5-c-login")
+      .evaluate((el) => getComputedStyle(el).backgroundColor);
+    // #0f1720 = rgb(15, 23, 32)
+    expect(loginBg).toBe("rgb(15, 23, 32)");
+
+    // Green primary button
+    const buttonBg = await page
+      .locator(".pf-v5-c-button.pf-m-primary")
+      .first()
+      .evaluate((el) => getComputedStyle(el).backgroundColor);
+    // #5b9a2f = rgb(91, 154, 47)
+    expect(buttonBg).toBe("rgb(91, 154, 47)");
+  });
+
+  test("has Hill90 favicon", async ({ page }) => {
+    const favicon = page.locator('link[rel="icon"]');
+    await expect(favicon).toHaveCount(1);
+  });
+
+  test("logo area hover triggers glow", async ({ page }) => {
+    const header = page.locator(".pf-v5-c-login__main-header");
+    await header.hover();
+
+    const filter = await header.evaluate((el) => {
+      return getComputedStyle(el, "::before").filter;
+    });
+    expect(filter).toContain("drop-shadow");
+  });
+
+  test("title hover does NOT trigger logo glow", async ({ page }) => {
+    const title = page.locator(
+      ".pf-v5-c-login__main-header .pf-v5-c-title"
+    );
+    await title.hover();
+
+    const filter = await page
+      .locator(".pf-v5-c-login__main-header")
+      .evaluate((el) => {
+        return getComputedStyle(el, "::before").filter;
+      });
+    expect(filter).not.toContain("drop-shadow");
+  });
+
+  test("Forgot Password link is present", async ({ page }) => {
+    const forgotLink = page.getByRole("link", { name: /forgot password/i });
+    await expect(forgotLink).toBeVisible();
+  });
+
+  test("login form has expected fields", async ({ page }) => {
+    await expect(page.getByLabel(/username or email/i)).toBeVisible();
+    await expect(
+      page.getByRole("textbox", { name: /password/i })
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /sign in/i })
+    ).toBeVisible();
+  });
+});
+
+test.describe("Hill90 Auth Theme — Admin Console", () => {
+  test("admin console redirects to branded login", async ({ page }) => {
+    await page.goto("/admin/hill90/console/");
+    // Wait for redirect to login
+    await page.waitForURL(/\/realms\/hill90\/protocol\/openid-connect\//);
+    await expect(page).toHaveTitle("Sign in to Hill90");
+  });
+});

--- a/tests/e2e/package-lock.json
+++ b/tests/e2e/package-lock.json
@@ -1,0 +1,76 @@
+{
+  "name": "hill90-e2e",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "hill90-e2e",
+      "devDependencies": {
+        "@playwright/test": "^1.50.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "hill90-e2e",
+  "private": true,
+  "description": "Playwright smoke tests for Hill90 auth infrastructure",
+  "scripts": {
+    "test": "playwright test",
+    "test:headed": "playwright test --headed"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.50.0"
+  }
+}

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: ".",
+  timeout: 30_000,
+  retries: process.env.CI ? 2 : 0,
+  reporter: process.env.CI ? "github" : "list",
+  use: {
+    baseURL: "https://auth.hill90.com",
+    ignoreHTTPSErrors: false,
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { browserName: "chromium" },
+    },
+  ],
+});


### PR DESCRIPTION
## Summary
- Adds 9 Playwright smoke tests verifying Hill90 Keycloak theme branding on `auth.hill90.com`
- Tests cover login page title, logo SVG, branded colors, favicon, hover glow effects, form fields, forgot password link, and admin console redirect
- Adds post-deploy `Smoke — Auth Theme` workflow triggered after `Deploy Keycloak` completes on main (non-blocking initially via `continue-on-error`)

## Test plan
- [x] `npx playwright test` — all 9 tests pass locally against live `auth.hill90.com`
- [ ] CI gates pass on PR
- [ ] After merge, `smoke-auth.yml` triggers automatically on next auth deploy

## Validation evidence
| Surface | Method | Result |
|---------|--------|--------|
| Login title | `toHaveTitle("Sign in to Hill90")` | Pass |
| Logo SVG | `::before` backgroundImage contains `data:image/svg+xml` | Pass |
| Background color | `rgb(15, 23, 32)` (#0f1720) | Pass |
| Button color | `rgb(91, 154, 47)` (#5b9a2f) | Pass |
| Favicon | `link[rel="icon"]` present | Pass |
| Logo hover glow | `drop-shadow` in `::before` filter on header hover | Pass |
| Title hover suppression | No `drop-shadow` when hovering `.pf-v5-c-title` | Pass |
| Forgot Password | Link visible | Pass |
| Form fields | Username, password, Sign In button | Pass |
| Admin redirect | `/admin/hill90/console/` → branded login | Pass |

🤖 Generated with [Claude Code](https://claude.com/claude-code)