### PR TITLE
docs: SMTP architecture, troubleshooting, and test coverage

### DIFF
--- a/docs/architecture/security.md
+++ b/docs/architecture/security.md
@@ -22,6 +22,13 @@ Hill90 uses layered controls to keep public services reachable while restricting
 - The hill90 realm disables self-registration and enables brute force detection.
 - Keycloak admin console is credential-protected with MFA capability.
 
+## Email / SMTP
+
+- Keycloak sends transactional email (password resets, verification) via Hostinger SMTP relay (`smtp.hostinger.com:587`, STARTTLS).
+- Sender address: `noreply@hill90.com`.
+- `SMTP_PASSWORD` is stored in SOPS (`infra/secrets/prod.enc.env`) and injected into the Keycloak realm via the `setup-realm.sh` phase1 REST API call — it is not a Docker environment variable.
+- DNS email authentication: SPF (`v=spf1 include:_spf.hostinger.email ~all`), DKIM (hostingermail CNAME records), and DMARC (`v=DMARC1; p=none`).
+
 ## Network Segmentation
 
 - `hill90_edge`: ingress-facing network for Traefik and public app routes.

--- a/docs/runbooks/troubleshooting.md
+++ b/docs/runbooks/troubleshooting.md
@@ -399,6 +399,51 @@ echo | openssl s_client -connect api.hill90.com:443 -servername api.hill90.com 2
 
 ---
 
+## Email Delivery Issues
+
+### Keycloak Emails Not Sending
+
+**Problem**: Password reset or verification emails are not delivered
+
+**Solutions**:
+
+1. **Test connection from Keycloak admin console:**
+   - Navigate to Realm Settings → Email → Test connection
+   - A successful test confirms SMTP credentials and network path
+
+2. **Verify SMTP_PASSWORD in SOPS:**
+   ```bash
+   bash scripts/secrets.sh view infra/secrets/prod.enc.env SMTP_PASSWORD
+   ```
+
+3. **Re-apply SMTP config via deploy:**
+   ```bash
+   bash scripts/deploy.sh auth prod
+   ```
+   Phase1 of `setup-realm.sh` re-injects SMTP settings via the Keycloak REST API.
+
+4. **Check DNS email authentication records:**
+   ```bash
+   # SPF
+   dig TXT hill90.com +short
+   # Should include: "v=spf1 include:_spf.hostinger.email ~all"
+
+   # DKIM
+   dig CNAME hostingermail-a._domainkey.hill90.com +short
+   dig CNAME hostingermail-b._domainkey.hill90.com +short
+   dig CNAME hostingermail-c._domainkey.hill90.com +short
+
+   # DMARC
+   dig TXT _dmarc.hill90.com +short
+   ```
+
+5. **Verify Hostinger SMTP credentials:**
+   - Username: `noreply@hill90.com`
+   - Managed at the Hostinger email panel (hpanel.hostinger.com → Emails)
+   - SMTP host: `smtp.hostinger.com`, port `587`, STARTTLS
+
+---
+
 ## Secrets Decryption Failures
 
 ### Cannot Decrypt Secrets

--- a/tests/scripts/validate.bats
+++ b/tests/scripts/validate.bats
@@ -335,6 +335,20 @@
 }
 
 # ---------------------------------------------------------------------------
+# SMTP secrets
+# ---------------------------------------------------------------------------
+
+@test "prod.enc.env.example has SMTP_PASSWORD" {
+  run grep "SMTP_PASSWORD" infra/secrets/prod.enc.env.example
+  [ "$status" -eq 0 ]
+}
+
+@test "setup-realm.sh references SMTP_PASSWORD from SOPS" {
+  run grep "SMTP_PASSWORD" platform/auth/keycloak/setup-realm.sh
+  [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
 # GitHub Actions workflows
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Add **Email / SMTP** section to `docs/architecture/security.md` documenting Hostinger relay config, SMTP_PASSWORD injection via setup-realm.sh, and DNS email auth (SPF/DKIM/DMARC)
- Add **Email Delivery Issues** troubleshooting section to `docs/runbooks/troubleshooting.md` with 5 diagnostic steps (Keycloak console test, SOPS verification, redeploy, DNS checks, Hostinger credentials)
- Add 2 SMTP bats tests to `tests/scripts/validate.bats` verifying SMTP_PASSWORD in prod.enc.env.example and setup-realm.sh

Closes the documentation and test gap from PR1 (#79, SendGrid→Hostinger migration) and PR2 (#80, SendGrid decommission).

## Test plan

- [x] `bats tests/scripts/validate.bats` — 87/87 pass (85→87 with new SMTP tests)
- [x] `grep -ric sendgrid docs/` — 0 matches (no stale SendGrid references)
- [x] New doc sections match existing heading levels, code block style, and structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)