### PR TITLE
feat: add user dropdown menu with federated Keycloak logout

### DIFF
--- a/deploy/compose/dev/docker-compose.yml
+++ b/deploy/compose/dev/docker-compose.yml
@@ -91,7 +91,7 @@ services:
       - NODE_ENV=development
       - API_URL=http://api:3000
       - AI_URL=http://ai:8000
-      - AUTH_URL=http://auth:3001
+      - AUTH_URL=http://localhost:3002
       - MCP_URL=http://mcp:8001
     command: npm run dev
 

--- a/platform/auth/keycloak/hill90-realm.json
+++ b/platform/auth/keycloak/hill90-realm.json
@@ -45,6 +45,9 @@
       "webOrigins": ["https://hill90.com"],
       "standardFlowEnabled": true,
       "directAccessGrantsEnabled": false,
+      "attributes": {
+        "post.logout.redirect.uris": "https://hill90.com/"
+      },
       "protocolMappers": [
         {
           "name": "realm-roles",

--- a/src/services/ui/src/__tests__/AuthButtons.test.tsx
+++ b/src/services/ui/src/__tests__/AuthButtons.test.tsx
@@ -1,22 +1,33 @@
 import React from 'react'
-import { describe, it, expect, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
 import '@testing-library/jest-dom/vitest'
 
 // Mock next-auth/react
 const mockSignIn = vi.fn()
-const mockSignOut = vi.fn()
 let mockSession: any = { data: null, status: 'unauthenticated' }
 
 vi.mock('next-auth/react', () => ({
   useSession: () => mockSession,
   signIn: (...args: any[]) => mockSignIn(...args),
-  signOut: (...args: any[]) => mockSignOut(...args),
+}))
+
+// Mock next/link
+vi.mock('next/link', () => ({
+  default: ({ children, href, ...props }: any) => <a href={href} {...props}>{children}</a>,
 }))
 
 import AuthButtons from '@/components/AuthButtons'
 
 describe('AuthButtons', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
   it('renders sign-in avatar button when unauthenticated', () => {
     mockSession = { data: null, status: 'unauthenticated' }
 
@@ -25,7 +36,16 @@ describe('AuthButtons', () => {
     expect(screen.getByRole('button', { name: 'Sign in' })).toBeInTheDocument()
   })
 
-  it('renders initials circle and "Sign out" when authenticated', () => {
+  it('renders pulsing placeholder during loading', () => {
+    mockSession = { data: null, status: 'loading' }
+
+    render(<AuthButtons />)
+
+    expect(screen.getByRole('status')).toBeInTheDocument()
+    expect(screen.getByLabelText('Loading user information')).toBeInTheDocument()
+  })
+
+  it('renders avatar button with initials when authenticated', () => {
     mockSession = {
       data: { user: { name: 'Admin Hill90' } },
       status: 'authenticated',
@@ -34,8 +54,125 @@ describe('AuthButtons', () => {
     render(<AuthButtons />)
 
     expect(screen.getByText('AH')).toBeInTheDocument()
-    expect(screen.getByTitle('Admin Hill90')).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Sign out' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'User menu' })).toBeInTheDocument()
+  })
+
+  it('avatar button has aria-haspopup="menu" and aria-expanded toggles', () => {
+    mockSession = {
+      data: { user: { name: 'Admin Hill90' } },
+      status: 'authenticated',
+    }
+
+    render(<AuthButtons />)
+
+    const button = screen.getByRole('button', { name: 'User menu' })
+    expect(button).toHaveAttribute('aria-haspopup', 'menu')
+    expect(button).toHaveAttribute('aria-expanded', 'false')
+
+    fireEvent.click(button)
+    expect(button).toHaveAttribute('aria-expanded', 'true')
+  })
+
+  it('clicking avatar opens dropdown with Profile, Settings, Sign out', () => {
+    mockSession = {
+      data: { user: { name: 'Admin Hill90' } },
+      status: 'authenticated',
+    }
+
+    render(<AuthButtons />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'User menu' }))
+
+    const items = screen.getAllByRole('menuitem')
+    expect(items).toHaveLength(3)
+    expect(items[0]).toHaveTextContent('Profile')
+    expect(items[1]).toHaveTextContent('Settings')
+    expect(items[2]).toHaveTextContent('Sign out')
+  })
+
+  it('clicking avatar again closes dropdown', () => {
+    mockSession = {
+      data: { user: { name: 'Admin Hill90' } },
+      status: 'authenticated',
+    }
+
+    render(<AuthButtons />)
+
+    const button = screen.getByRole('button', { name: 'User menu' })
+    fireEvent.click(button)
+    expect(screen.getByRole('menu')).toBeInTheDocument()
+
+    fireEvent.click(button)
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+  })
+
+  it('Escape key closes dropdown', () => {
+    mockSession = {
+      data: { user: { name: 'Admin Hill90' } },
+      status: 'authenticated',
+    }
+
+    render(<AuthButtons />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'User menu' }))
+    expect(screen.getByRole('menu')).toBeInTheDocument()
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+  })
+
+  it('Sign out item links to /api/auth/federated-logout', () => {
+    mockSession = {
+      data: { user: { name: 'Admin Hill90' } },
+      status: 'authenticated',
+    }
+
+    render(<AuthButtons />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'User menu' }))
+
+    const signOutItem = screen.getByRole('menuitem', { name: 'Sign out' })
+    expect(signOutItem).toHaveAttribute('href', '/api/auth/federated-logout')
+  })
+
+  it('menu items have role="menuitem"', () => {
+    mockSession = {
+      data: { user: { name: 'Admin Hill90' } },
+      status: 'authenticated',
+    }
+
+    render(<AuthButtons />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'User menu' }))
+
+    const items = screen.getAllByRole('menuitem')
+    expect(items).toHaveLength(3)
+  })
+
+  it('Profile links to /profile', () => {
+    mockSession = {
+      data: { user: { name: 'Admin Hill90' } },
+      status: 'authenticated',
+    }
+
+    render(<AuthButtons />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'User menu' }))
+
+    expect(screen.getByRole('menuitem', { name: 'Profile' })).toHaveAttribute('href', '/profile')
+  })
+
+  it('Settings links to /settings', () => {
+    mockSession = {
+      data: { user: { name: 'Admin Hill90' } },
+      status: 'authenticated',
+    }
+
+    render(<AuthButtons />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'User menu' }))
+
+    expect(screen.getByRole('menuitem', { name: 'Settings' })).toHaveAttribute('href', '/settings')
   })
 
   it('renders single initial for single-word names', () => {
@@ -47,7 +184,6 @@ describe('AuthButtons', () => {
     render(<AuthButtons />)
 
     expect(screen.getByText('M')).toBeInTheDocument()
-    expect(screen.getByTitle('Madonna')).toBeInTheDocument()
   })
 
   it('renders initials from the first two words for multi-word names', () => {
@@ -59,15 +195,5 @@ describe('AuthButtons', () => {
     render(<AuthButtons />)
 
     expect(screen.getByText('JP')).toBeInTheDocument()
-    expect(screen.getByTitle('John Paul Jones')).toBeInTheDocument()
-  })
-
-  it('renders pulsing placeholder during loading', () => {
-    mockSession = { data: null, status: 'loading' }
-
-    render(<AuthButtons />)
-
-    expect(screen.getByRole('status')).toBeInTheDocument()
-    expect(screen.getByLabelText('Loading user information')).toBeInTheDocument()
   })
 })

--- a/src/services/ui/src/__tests__/auth-callbacks.test.ts
+++ b/src/services/ui/src/__tests__/auth-callbacks.test.ts
@@ -53,6 +53,19 @@ describe('jwt callback', () => {
     expect(result.accessTokenExpires).toBeGreaterThan(Date.now())
   })
 
+  it('stores idToken from account.id_token on initial sign-in', async () => {
+    const account = {
+      access_token: mockAccessToken(),
+      id_token: 'my-id-token-value',
+      refresh_token: 'refresh-123',
+      expires_at: Math.floor(Date.now() / 1000) + 300,
+    }
+
+    const result = await jwtCallback({ token: { name: 'Test' }, account })
+
+    expect(result.idToken).toBe('my-id-token-value')
+  })
+
   it('returns token as-is when not expired', async () => {
     const token = {
       accessToken: 'at-123',
@@ -132,5 +145,22 @@ describe('session callback', () => {
     expect(result.accessToken).toBe('at-123')
     expect(result.user.roles).toEqual(['admin', 'user'])
     expect(result.error).toBeUndefined()
+  })
+
+  it('exposes idToken on session from token', async () => {
+    const token = {
+      accessToken: 'at-123',
+      idToken: 'id-token-value',
+      roles: ['user'],
+      error: undefined,
+    }
+    const session = {
+      user: { name: 'Test', email: 'test@test.com' },
+      expires: '2099-01-01',
+    }
+
+    const result = await sessionCallback({ session, token })
+
+    expect(result.idToken).toBe('id-token-value')
   })
 })

--- a/src/services/ui/src/__tests__/federated-logout.test.ts
+++ b/src/services/ui/src/__tests__/federated-logout.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// Track what NextResponse.redirect receives
+let redirectUrl: URL | null = null
+let responseCookies: Map<string, { value: string; maxAge: number; path: string }>
+
+const mockResponseCookies = {
+  set: vi.fn((name: string, value: string, opts: any) => {
+    responseCookies.set(name, { value, maxAge: opts.maxAge, path: opts.path })
+  }),
+}
+
+vi.mock('next/server', () => ({
+  NextResponse: {
+    redirect: vi.fn((url: URL) => {
+      redirectUrl = url
+      return { cookies: mockResponseCookies }
+    }),
+  },
+}))
+
+// Mock session returned by auth()
+let mockSession: any = null
+
+vi.mock('@/auth', () => ({
+  auth: vi.fn(async () => mockSession),
+}))
+
+// Mock cookies()
+let mockCookieList: { name: string; value: string }[] = []
+
+vi.mock('next/headers', () => ({
+  cookies: vi.fn(async () => ({
+    getAll: () => mockCookieList,
+  })),
+}))
+
+// Import the route handler after mocks
+const { GET } = await import('@/app/api/auth/federated-logout/route')
+
+describe('federated-logout route', () => {
+  const originalEnv = process.env
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    redirectUrl = null
+    responseCookies = new Map()
+    process.env = {
+      ...originalEnv,
+      AUTH_KEYCLOAK_ISSUER: 'https://auth.hill90.com/realms/hill90',
+      AUTH_KEYCLOAK_ID: 'hill90-ui',
+      AUTH_KEYCLOAK_SECRET: 'test-secret',
+      AUTH_URL: 'https://hill90.com',
+    }
+    mockCookieList = [
+      { name: 'authjs.session-token', value: 'abc' },
+      { name: 'authjs.session-token.0', value: 'chunk0' },
+      { name: 'authjs.session-token.1', value: 'chunk1' },
+      { name: 'authjs.callback-url', value: 'https://hill90.com' },
+      { name: '__Secure-authjs.session-token', value: 'secure-abc' },
+      { name: 'other-cookie', value: 'keep-me' },
+    ]
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+  })
+
+  it('builds Keycloak logout URL with id_token_hint when session has idToken', async () => {
+    mockSession = { idToken: 'my-id-token', user: { name: 'Test' } }
+
+    await GET()
+
+    expect(redirectUrl).not.toBeNull()
+    expect(redirectUrl!.pathname).toBe('/realms/hill90/protocol/openid-connect/logout')
+    expect(redirectUrl!.searchParams.get('id_token_hint')).toBe('my-id-token')
+    expect(redirectUrl!.searchParams.has('client_id')).toBe(false)
+  })
+
+  it('falls back to client_id when idToken is missing', async () => {
+    mockSession = { user: { name: 'Test' } }
+
+    await GET()
+
+    expect(redirectUrl!.searchParams.get('client_id')).toBe('hill90-ui')
+    expect(redirectUrl!.searchParams.has('id_token_hint')).toBe(false)
+  })
+
+  it('falls back to client_id when session is null', async () => {
+    mockSession = null
+
+    await GET()
+
+    expect(redirectUrl!.searchParams.get('client_id')).toBe('hill90-ui')
+  })
+
+  it('post_logout_redirect_uri is derived from AUTH_URL env var', async () => {
+    mockSession = { idToken: 'tok', user: { name: 'Test' } }
+
+    await GET()
+
+    expect(redirectUrl!.searchParams.get('post_logout_redirect_uri')).toBe('https://hill90.com/')
+  })
+
+  it('clears all cookies with authjs. or __Secure-authjs. prefix', async () => {
+    mockSession = { idToken: 'tok', user: { name: 'Test' } }
+
+    await GET()
+
+    // Should clear 5 Auth.js cookies, not the 'other-cookie'
+    expect(mockResponseCookies.set).toHaveBeenCalledTimes(5)
+
+    const clearedNames = mockResponseCookies.set.mock.calls.map((c: any) => c[0])
+    expect(clearedNames).toContain('authjs.session-token')
+    expect(clearedNames).toContain('authjs.session-token.0')
+    expect(clearedNames).toContain('authjs.session-token.1')
+    expect(clearedNames).toContain('authjs.callback-url')
+    expect(clearedNames).toContain('__Secure-authjs.session-token')
+    expect(clearedNames).not.toContain('other-cookie')
+
+    // All cleared with maxAge: 0
+    for (const call of mockResponseCookies.set.mock.calls) {
+      expect(call[1]).toBe('')
+      expect(call[2]).toEqual({ maxAge: 0, path: '/' })
+    }
+  })
+
+  it('returns 302 redirect to Keycloak logout URL', async () => {
+    mockSession = { idToken: 'tok', user: { name: 'Test' } }
+    const { NextResponse } = await import('next/server')
+
+    await GET()
+
+    expect(NextResponse.redirect).toHaveBeenCalledOnce()
+    expect(redirectUrl!.origin).toBe('https://auth.hill90.com')
+  })
+})

--- a/src/services/ui/src/__tests__/middleware.test.ts
+++ b/src/services/ui/src/__tests__/middleware.test.ts
@@ -53,4 +53,46 @@ describe('middleware', () => {
     // When auth is present, handler returns undefined (no redirect)
     expect(result).toBeUndefined()
   })
+
+  it('redirects to /api/auth/signin for /profile when unauthenticated', () => {
+    mockSession = null
+    const req = makeRequest('/profile')
+
+    const result = middleware(req as any)
+
+    expect(NextResponse.redirect).toHaveBeenCalledWith(
+      new URL('/api/auth/signin', 'https://hill90.com/profile')
+    )
+    expect(result).toBeDefined()
+  })
+
+  it('redirects to /api/auth/signin for /settings when unauthenticated', () => {
+    mockSession = null
+    const req = makeRequest('/settings')
+
+    const result = middleware(req as any)
+
+    expect(NextResponse.redirect).toHaveBeenCalledWith(
+      new URL('/api/auth/signin', 'https://hill90.com/settings')
+    )
+    expect(result).toBeDefined()
+  })
+
+  it('passes through /profile when authenticated', () => {
+    mockSession = { user: { name: 'Test' } }
+    const req = makeRequest('/profile')
+
+    const result = middleware(req as any)
+
+    expect(result).toBeUndefined()
+  })
+
+  it('passes through /settings when authenticated', () => {
+    mockSession = { user: { name: 'Test' } }
+    const req = makeRequest('/settings')
+
+    const result = middleware(req as any)
+
+    expect(result).toBeUndefined()
+  })
 })

--- a/src/services/ui/src/app/api/auth/federated-logout/route.ts
+++ b/src/services/ui/src/app/api/auth/federated-logout/route.ts
@@ -1,0 +1,36 @@
+import { auth } from "@/auth"
+import { cookies } from "next/headers"
+import { NextResponse } from "next/server"
+
+function requireEnv(name: string): string {
+  const value = process.env[name]
+  if (!value) throw new Error(`Missing required env var: ${name}`)
+  return value
+}
+
+export async function GET() {
+  const session = await auth()
+
+  // Build Keycloak logout URL
+  const issuer = requireEnv("AUTH_KEYCLOAK_ISSUER")
+  const logoutUrl = new URL(`${issuer}/protocol/openid-connect/logout`)
+  const appRoot = new URL("/", requireEnv("AUTH_URL")).toString()
+
+  if (session?.idToken) {
+    logoutUrl.searchParams.set("id_token_hint", session.idToken)
+  } else {
+    logoutUrl.searchParams.set("client_id", requireEnv("AUTH_KEYCLOAK_ID"))
+  }
+  logoutUrl.searchParams.set("post_logout_redirect_uri", appRoot)
+
+  // Clear ALL Auth.js cookies (including chunked session cookies)
+  const response = NextResponse.redirect(logoutUrl)
+  const cookieStore = await cookies()
+  for (const cookie of cookieStore.getAll()) {
+    if (cookie.name.startsWith("authjs.") || cookie.name.startsWith("__Secure-authjs.")) {
+      response.cookies.set(cookie.name, "", { maxAge: 0, path: "/" })
+    }
+  }
+
+  return response
+}

--- a/src/services/ui/src/app/dashboard/page.tsx
+++ b/src/services/ui/src/app/dashboard/page.tsx
@@ -1,8 +1,6 @@
 import { redirect } from 'next/navigation';
-import Link from 'next/link';
 import { auth } from '@/auth';
-import HillLogo from '@/components/HillLogo';
-import AuthButtons from '@/components/AuthButtons';
+import AppShell from '@/components/AppShell';
 import DashboardClient from './DashboardClient';
 
 export default async function Dashboard() {
@@ -13,27 +11,10 @@ export default async function Dashboard() {
   }
 
   return (
-    <div className="min-h-screen flex flex-col">
-      {/* Nav */}
-      <nav className="flex items-center justify-between px-6 py-4 border-b border-navy-700">
-        <Link href="/" aria-label="Go to homepage" className="logo-link inline-flex items-center">
-          <HillLogo width={96} className="logo-glow-hold" />
-        </Link>
-        <div className="flex items-center gap-4">
-          <span className="text-sm font-medium text-white">Dashboard</span>
-          <AuthButtons />
-        </div>
-      </nav>
-
-      {/* Content */}
+    <AppShell navExtra={<span className="text-sm font-medium text-white">Dashboard</span>}>
       <main className="flex-1 px-6 py-12 max-w-4xl mx-auto w-full">
         <DashboardClient session={session} />
       </main>
-
-      {/* Footer */}
-      <footer className="px-6 py-6 border-t border-navy-700 text-center text-sm text-mountain-500">
-        &copy; {new Date().getFullYear()} Hill90
-      </footer>
-    </div>
+    </AppShell>
   );
 }

--- a/src/services/ui/src/app/page.tsx
+++ b/src/services/ui/src/app/page.tsx
@@ -1,6 +1,5 @@
 import Link from 'next/link';
-import HillLogo from '@/components/HillLogo';
-import AuthButtons from '@/components/AuthButtons';
+import AppShell from '@/components/AppShell';
 
 const services = [
   {
@@ -27,23 +26,16 @@ const services = [
 
 export default function Home() {
   return (
-    <div className="min-h-screen flex flex-col">
-      {/* Nav */}
-      <nav className="flex items-center justify-between px-6 py-4 border-b border-navy-700">
-        <Link href="/" aria-label="Go to homepage" className="logo-link inline-flex items-center">
-          <HillLogo width={96} className="logo-glow-hold" />
+    <AppShell
+      navExtra={
+        <Link
+          href="/dashboard"
+          className="text-sm font-medium text-mountain-400 hover:text-white transition-colors"
+        >
+          Dashboard
         </Link>
-        <div className="flex items-center gap-4">
-          <Link
-            href="/dashboard"
-            className="text-sm font-medium text-mountain-400 hover:text-white transition-colors"
-          >
-            Dashboard
-          </Link>
-          <AuthButtons />
-        </div>
-      </nav>
-
+      }
+    >
       {/* Hero */}
       <main className="flex-1 flex flex-col items-center justify-center px-6 py-24 text-center">
         <h1 className="text-4xl sm:text-5xl font-bold tracking-tight mb-4">
@@ -68,11 +60,6 @@ export default function Home() {
           ))}
         </div>
       </main>
-
-      {/* Footer */}
-      <footer className="px-6 py-6 border-t border-navy-700 text-center text-sm text-mountain-500">
-        &copy; {new Date().getFullYear()} Hill90
-      </footer>
-    </div>
+    </AppShell>
   );
 }

--- a/src/services/ui/src/app/profile/page.tsx
+++ b/src/services/ui/src/app/profile/page.tsx
@@ -1,0 +1,40 @@
+import { redirect } from 'next/navigation';
+import { auth } from '@/auth';
+import AppShell from '@/components/AppShell';
+
+export default async function Profile() {
+  const session = await auth();
+
+  if (!session) {
+    redirect('/api/auth/signin');
+  }
+
+  return (
+    <AppShell navExtra={<span className="text-sm font-medium text-white">Profile</span>}>
+      <main className="flex-1 px-6 py-12 max-w-2xl mx-auto w-full">
+        <h1 className="text-2xl font-bold text-white mb-8">Profile</h1>
+
+        <div className="rounded-lg border border-navy-700 bg-navy-800 p-6 space-y-4">
+          <div>
+            <label className="text-xs font-medium text-mountain-500 uppercase tracking-wide">Name</label>
+            <p className="text-white mt-1">{session.user?.name || 'Not set'}</p>
+          </div>
+          <div>
+            <label className="text-xs font-medium text-mountain-500 uppercase tracking-wide">Email</label>
+            <p className="text-white mt-1">{session.user?.email || 'Not set'}</p>
+          </div>
+        </div>
+
+        <div className="mt-8 rounded-lg border border-navy-700 bg-navy-800 p-6">
+          <h2 className="text-lg font-semibold text-white mb-2">Profile Picture</h2>
+          <p className="text-sm text-mountain-400">Coming soon.</p>
+        </div>
+
+        <div className="mt-4 rounded-lg border border-navy-700 bg-navy-800 p-6">
+          <h2 className="text-lg font-semibold text-white mb-2">Change Password</h2>
+          <p className="text-sm text-mountain-400">Coming soon.</p>
+        </div>
+      </main>
+    </AppShell>
+  );
+}

--- a/src/services/ui/src/app/settings/page.tsx
+++ b/src/services/ui/src/app/settings/page.tsx
@@ -1,0 +1,23 @@
+import { redirect } from 'next/navigation';
+import { auth } from '@/auth';
+import AppShell from '@/components/AppShell';
+
+export default async function Settings() {
+  const session = await auth();
+
+  if (!session) {
+    redirect('/api/auth/signin');
+  }
+
+  return (
+    <AppShell navExtra={<span className="text-sm font-medium text-white">Settings</span>}>
+      <main className="flex-1 px-6 py-12 max-w-2xl mx-auto w-full">
+        <h1 className="text-2xl font-bold text-white mb-8">Settings</h1>
+
+        <div className="rounded-lg border border-navy-700 bg-navy-800 p-6">
+          <p className="text-sm text-mountain-400">Settings options coming soon.</p>
+        </div>
+      </main>
+    </AppShell>
+  );
+}

--- a/src/services/ui/src/auth.ts
+++ b/src/services/ui/src/auth.ts
@@ -50,7 +50,11 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
   ],
   callbacks: {
     authorized({ auth, request }) {
-      const isProtected = request.nextUrl.pathname.startsWith("/dashboard")
+      const path = request.nextUrl.pathname
+      const isProtected =
+        path.startsWith("/dashboard") ||
+        path.startsWith("/profile") ||
+        path.startsWith("/settings")
       if (isProtected && !auth) return false
       return true
     },
@@ -64,6 +68,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
         return {
           ...token,
           accessToken: account.access_token,
+          idToken: account.id_token,
           refreshToken: account.refresh_token,
           accessTokenExpires: account.expires_at ? account.expires_at * 1000 : Date.now() + 300_000,
           roles: decoded.realm_roles ?? [],
@@ -80,6 +85,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
     },
     async session({ session, token }) {
       session.accessToken = token.accessToken
+      session.idToken = token.idToken
       session.error = token.error
       if (session.user) {
         session.user.roles = token.roles

--- a/src/services/ui/src/components/AppShell.tsx
+++ b/src/services/ui/src/components/AppShell.tsx
@@ -1,0 +1,34 @@
+import Link from 'next/link'
+import HillLogo from '@/components/HillLogo'
+import AuthButtons from '@/components/AuthButtons'
+
+export default function AppShell({
+  children,
+  navExtra,
+}: {
+  children: React.ReactNode
+  navExtra?: React.ReactNode
+}) {
+  return (
+    <div className="min-h-screen flex flex-col">
+      {/* Nav */}
+      <nav className="flex items-center justify-between px-6 py-4 border-b border-navy-700">
+        <Link href="/" aria-label="Go to homepage" className="logo-link inline-flex items-center">
+          <HillLogo width={96} className="logo-glow-hold" />
+        </Link>
+        <div className="flex items-center gap-4">
+          {navExtra}
+          <AuthButtons />
+        </div>
+      </nav>
+
+      {/* Content */}
+      {children}
+
+      {/* Footer */}
+      <footer className="px-6 py-6 border-t border-navy-700 text-center text-sm text-mountain-500">
+        &copy; {new Date().getFullYear()} Hill90
+      </footer>
+    </div>
+  )
+}

--- a/src/services/ui/src/components/AuthButtons.tsx
+++ b/src/services/ui/src/components/AuthButtons.tsx
@@ -1,6 +1,8 @@
 'use client'
 
-import { useSession, signIn, signOut } from "next-auth/react"
+import { useState, useRef, useEffect, useCallback } from 'react'
+import { useSession, signIn } from "next-auth/react"
+import Link from 'next/link'
 
 function getInitials(name: string): string {
   return name
@@ -13,6 +15,73 @@ function getInitials(name: string): string {
 
 export default function AuthButtons() {
   const { data: session, status } = useSession()
+  const [open, setOpen] = useState(false)
+  const menuRef = useRef<HTMLDivElement>(null)
+  const itemsRef = useRef<(HTMLAnchorElement | null)[]>([])
+
+  const close = useCallback(() => setOpen(false), [])
+
+  // Close on outside click or Escape
+  useEffect(() => {
+    if (!open) return
+
+    function handleMouseDown(e: MouseEvent) {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        close()
+      }
+    }
+
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        close()
+      }
+    }
+
+    document.addEventListener('mousedown', handleMouseDown)
+    document.addEventListener('keydown', handleKeyDown)
+    return () => {
+      document.removeEventListener('mousedown', handleMouseDown)
+      document.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [open, close])
+
+  // Focus first item when menu opens
+  useEffect(() => {
+    if (open) {
+      itemsRef.current[0]?.focus()
+    }
+  }, [open])
+
+  function handleMenuKeyDown(e: React.KeyboardEvent) {
+    const items = itemsRef.current.filter(Boolean) as HTMLAnchorElement[]
+    const currentIndex = items.indexOf(document.activeElement as HTMLAnchorElement)
+
+    switch (e.key) {
+      case 'ArrowDown': {
+        e.preventDefault()
+        const next = currentIndex < items.length - 1 ? currentIndex + 1 : 0
+        items[next]?.focus()
+        break
+      }
+      case 'ArrowUp': {
+        e.preventDefault()
+        const prev = currentIndex > 0 ? currentIndex - 1 : items.length - 1
+        items[prev]?.focus()
+        break
+      }
+      case 'Home':
+        e.preventDefault()
+        items[0]?.focus()
+        break
+      case 'End':
+        e.preventDefault()
+        items[items.length - 1]?.focus()
+        break
+      case 'Tab':
+        close()
+        break
+    }
+  }
 
   if (status === "loading") {
     return (
@@ -29,11 +98,13 @@ export default function AuthButtons() {
     const initials = getInitials(name)
 
     return (
-      <div className="flex items-center gap-3">
-        <div
-          className="h-9 w-9 rounded-full bg-brand-500 flex items-center justify-center text-sm font-semibold text-white select-none"
-          role="img"
-          aria-label={`User avatar: ${name}`}
+      <div className="relative" ref={menuRef}>
+        <button
+          onClick={() => setOpen(prev => !prev)}
+          className="h-9 w-9 rounded-full bg-brand-500 flex items-center justify-center text-sm font-semibold text-white select-none cursor-pointer"
+          aria-haspopup="menu"
+          aria-expanded={open}
+          aria-label="User menu"
           title={name}
         >
           {initials || (
@@ -41,13 +112,46 @@ export default function AuthButtons() {
               <path d="M12 12c2.7 0 4.8-2.1 4.8-4.8S14.7 2.4 12 2.4 7.2 4.5 7.2 7.2 9.3 12 12 12zm0 2.4c-3.2 0-9.6 1.6-9.6 4.8v1.2c0 .7.5 1.2 1.2 1.2h16.8c.7 0 1.2-.5 1.2-1.2v-1.2c0-3.2-6.4-4.8-9.6-4.8z" />
             </svg>
           )}
-        </div>
-        <button
-          onClick={() => signOut()}
-          className="text-sm font-medium text-mountain-400 hover:text-white transition-colors"
-        >
-          Sign out
         </button>
+
+        {open && (
+          <div
+            role="menu"
+            className="absolute right-0 top-full mt-2 z-50 bg-navy-800 border border-navy-700 rounded-lg shadow-lg py-1 min-w-[160px]"
+            onKeyDown={handleMenuKeyDown}
+          >
+            <Link
+              href="/profile"
+              role="menuitem"
+              tabIndex={-1}
+              ref={el => { itemsRef.current[0] = el }}
+              className="block px-4 py-2 text-sm text-mountain-400 hover:bg-navy-700 hover:text-white transition-colors"
+              onClick={close}
+            >
+              Profile
+            </Link>
+            <Link
+              href="/settings"
+              role="menuitem"
+              tabIndex={-1}
+              ref={el => { itemsRef.current[1] = el }}
+              className="block px-4 py-2 text-sm text-mountain-400 hover:bg-navy-700 hover:text-white transition-colors"
+              onClick={close}
+            >
+              Settings
+            </Link>
+            <div role="separator" className="border-t border-navy-700 my-1" />
+            <a
+              href="/api/auth/federated-logout"
+              role="menuitem"
+              tabIndex={-1}
+              ref={el => { itemsRef.current[2] = el }}
+              className="block px-4 py-2 text-sm text-mountain-400 hover:bg-navy-700 hover:text-white transition-colors"
+            >
+              Sign out
+            </a>
+          </div>
+        )}
       </div>
     )
   }

--- a/src/services/ui/src/middleware.ts
+++ b/src/services/ui/src/middleware.ts
@@ -8,5 +8,5 @@ export default auth((req) => {
 })
 
 export const config = {
-  matcher: ["/dashboard/:path*"],
+  matcher: ["/dashboard/:path*", "/profile/:path*", "/settings/:path*"],
 }

--- a/src/services/ui/src/types/next-auth.d.ts
+++ b/src/services/ui/src/types/next-auth.d.ts
@@ -4,6 +4,7 @@ import "next-auth/jwt"
 declare module "next-auth" {
   interface Session {
     accessToken?: string
+    idToken?: string
     error?: string
     user: {
       name?: string | null
@@ -17,6 +18,7 @@ declare module "next-auth" {
 declare module "next-auth/jwt" {
   interface JWT {
     accessToken?: string
+    idToken?: string
     refreshToken?: string
     accessTokenExpires?: number
     roles?: string[]


### PR DESCRIPTION
## Summary
- Replace inline sign-out button with accessible dropdown menu (Profile, Settings, Sign out) on user avatar
- Implement federated logout: clear Auth.js cookies + redirect to Keycloak RP-initiated logout for full re-authentication
- Extract shared `AppShell` layout component; create protected `/profile` and `/settings` pages
- Fix dev compose `AUTH_URL` from internal container address to `http://localhost:3002`

## Linear
- Issue: N/A (tracked in session)

## Validation Evidence
- UI (if applicable): `vitest run` — 32/32 tests pass (AuthButtons dropdown behavior, federated-logout route, auth callbacks idToken, middleware protection for /profile and /settings)
- Infra/Deploy (if applicable): Keycloak `post.logout.redirect.uris` added to `hill90-realm.json` for prod (`https://hill90.com/`). Dev realm requires manual registration of `http://localhost:3002/` in Keycloak admin.

## Test plan
- [x] Local checks run (`vitest run` — 32/32 pass)
- [ ] CI checks pass
- [ ] Manual browser: avatar click → dropdown with Profile, Settings, Sign out
- [ ] Sign out → cookies cleared → Keycloak logout → redirect to homepage → re-auth required
- [ ] `/profile` and `/settings` redirect to sign-in when unauthenticated
- [ ] Post-deploy: verify `post.logout.redirect.uris` in Keycloak admin console

## Notes
- Auth.js does not support federated logout out of the box — implemented manually via `/api/auth/federated-logout` route
- Cookie cleanup iterates all cookies by prefix (`authjs.`, `__Secure-authjs.`) to handle chunked JWT payloads
- Dev compose `AUTH_URL` fix (`http://auth:3001` → `http://localhost:3002`) is a pre-existing config issue corrected here — requires manual dev-environment validation
- Keycloak dev realm `post.logout.redirect.uris` is a manual admin step, not in this PR's realm export

🤖 Generated with [Claude Code](https://claude.com/claude-code)