### PR TITLE
fix: clear __Host-authjs cookies and set secure flag on logout

### DIFF
--- a/src/services/ui/src/__tests__/federated-logout.test.ts
+++ b/src/services/ui/src/__tests__/federated-logout.test.ts
@@ -58,6 +58,7 @@ describe('federated-logout route', () => {
       { name: 'authjs.session-token.1', value: 'chunk1' },
       { name: 'authjs.callback-url', value: 'https://hill90.com' },
       { name: '__Secure-authjs.session-token', value: 'secure-abc' },
+      { name: '__Host-authjs.csrf-token', value: 'csrf-abc' },
       { name: 'other-cookie', value: 'keep-me' },
     ]
   })
@@ -102,13 +103,13 @@ describe('federated-logout route', () => {
     expect(redirectUrl!.searchParams.get('post_logout_redirect_uri')).toBe('https://hill90.com/')
   })
 
-  it('clears all cookies with authjs. or __Secure-authjs. prefix', async () => {
+  it('clears all cookies with authjs., __Secure-authjs., or __Host-authjs. prefix', async () => {
     mockSession = { idToken: 'tok', user: { name: 'Test' } }
 
     await GET()
 
-    // Should clear 5 Auth.js cookies, not the 'other-cookie'
-    expect(mockResponseCookies.set).toHaveBeenCalledTimes(5)
+    // Should clear 6 Auth.js cookies, not the 'other-cookie'
+    expect(mockResponseCookies.set).toHaveBeenCalledTimes(6)
 
     const clearedNames = mockResponseCookies.set.mock.calls.map((c: any) => c[0])
     expect(clearedNames).toContain('authjs.session-token')
@@ -116,13 +117,28 @@ describe('federated-logout route', () => {
     expect(clearedNames).toContain('authjs.session-token.1')
     expect(clearedNames).toContain('authjs.callback-url')
     expect(clearedNames).toContain('__Secure-authjs.session-token')
+    expect(clearedNames).toContain('__Host-authjs.csrf-token')
     expect(clearedNames).not.toContain('other-cookie')
 
-    // All cleared with maxAge: 0
+    // All cleared with maxAge: 0 and path /
     for (const call of mockResponseCookies.set.mock.calls) {
       expect(call[1]).toBe('')
-      expect(call[2]).toEqual({ maxAge: 0, path: '/' })
+      expect(call[2].maxAge).toBe(0)
+      expect(call[2].path).toBe('/')
     }
+  })
+
+  it('sets secure flag on __Secure- and __Host- prefixed cookies', async () => {
+    mockSession = { idToken: 'tok', user: { name: 'Test' } }
+
+    await GET()
+
+    const calls = mockResponseCookies.set.mock.calls
+    const byName = (name: string) => calls.find((c: any) => c[0] === name)
+
+    expect(byName('authjs.session-token')![2].secure).toBe(false)
+    expect(byName('__Secure-authjs.session-token')![2].secure).toBe(true)
+    expect(byName('__Host-authjs.csrf-token')![2].secure).toBe(true)
   })
 
   it('returns 302 redirect to Keycloak logout URL', async () => {

--- a/src/services/ui/src/app/api/auth/federated-logout/route.ts
+++ b/src/services/ui/src/app/api/auth/federated-logout/route.ts
@@ -27,8 +27,16 @@ export async function GET() {
   const response = NextResponse.redirect(logoutUrl)
   const cookieStore = await cookies()
   for (const cookie of cookieStore.getAll()) {
-    if (cookie.name.startsWith("authjs.") || cookie.name.startsWith("__Secure-authjs.")) {
-      response.cookies.set(cookie.name, "", { maxAge: 0, path: "/" })
+    if (
+      cookie.name.startsWith("authjs.") ||
+      cookie.name.startsWith("__Secure-authjs.") ||
+      cookie.name.startsWith("__Host-authjs.")
+    ) {
+      response.cookies.set(cookie.name, "", {
+        maxAge: 0,
+        path: "/",
+        secure: cookie.name.startsWith("__Secure-") || cookie.name.startsWith("__Host-"),
+      })
     }
   }
 


### PR DESCRIPTION
## Summary
- Add `__Host-authjs.*` prefix to cookie cleanup in federated logout route (was missing CSRF token)
- Set `secure: true` when clearing `__Secure-` and `__Host-` prefixed cookies (required for HTTPS cookie deletion)
- Without this fix, session cookies persist after logout and the user remains authenticated

## Linear
- Issue: N/A (discovered during browser verification of #90)

## Validation Evidence
- UI: `vitest run` — 33/33 tests pass, including new test for `secure` flag on prefixed cookies
- Browser: verified cookies `__Secure-authjs.session-token.0`, `__Secure-authjs.session-token.1`, `__Secure-authjs.callback-url`, `__Host-authjs.csrf-token` were present after logout attempt before this fix

## Test plan
- [x] Local checks run (`vitest run` — 33/33 pass)
- [ ] CI checks pass
- [ ] Manual browser: Sign in → Sign out → reload → verify Sign in button (not avatar)

## Notes
- Root cause: Auth.js uses `__Secure-` and `__Host-` cookie prefixes in production (HTTPS). These prefixes require `secure: true` in `Set-Cookie` to be accepted by the browser. The original route set cookies without the secure flag, so the browser ignored the deletion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)