### PR TITLE
fix: isolate agentbox compose to prevent service outage

### DIFF
--- a/scripts/agentbox.sh
+++ b/scripts/agentbox.sh
@@ -78,10 +78,10 @@ cmd_start() {
 
     if [ -n "$agent_id" ]; then
         echo "Starting agentbox-${agent_id}..."
-        docker compose -f "$COMPOSE_FILE" up -d "agentbox-${agent_id}"
+        docker compose -p agentbox -f "$COMPOSE_FILE" up -d "agentbox-${agent_id}"
     else
         echo "Starting all agent containers..."
-        docker compose -f "$COMPOSE_FILE" up -d
+        docker compose -p agentbox -f "$COMPOSE_FILE" up -d
     fi
 }
 
@@ -90,16 +90,16 @@ cmd_stop() {
 
     if [ -n "$agent_id" ]; then
         echo "Stopping agentbox-${agent_id}..."
-        docker compose -f "$COMPOSE_FILE" stop "agentbox-${agent_id}"
+        docker compose -p agentbox -f "$COMPOSE_FILE" stop "agentbox-${agent_id}"
     else
         echo "Stopping all agent containers..."
-        docker compose -f "$COMPOSE_FILE" stop
+        docker compose -p agentbox -f "$COMPOSE_FILE" stop
     fi
 }
 
 cmd_status() {
     if [ -f "$COMPOSE_FILE" ]; then
-        docker compose -f "$COMPOSE_FILE" ps
+        docker compose -p agentbox -f "$COMPOSE_FILE" ps
     else
         echo "No compose file found. Run 'agentbox.sh generate' first."
     fi
@@ -109,9 +109,9 @@ cmd_logs() {
     local agent_id="${1:-}"
 
     if [ -n "$agent_id" ]; then
-        docker compose -f "$COMPOSE_FILE" logs -f "agentbox-${agent_id}"
+        docker compose -p agentbox -f "$COMPOSE_FILE" logs -f "agentbox-${agent_id}"
     else
-        docker compose -f "$COMPOSE_FILE" logs -f
+        docker compose -p agentbox -f "$COMPOSE_FILE" logs -f
     fi
 }
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -242,13 +242,13 @@ cmd_agentbox() {
     docker build -t hill90/agentbox:latest src/services/agentbox/
 
     echo "Deploying agent containers..."
-    docker compose -f "$compose_file" up -d --remove-orphans
+    docker compose -p agentbox -f "$compose_file" up -d
 
     echo ""
     echo "================================"
     echo "AgentBox Deployment Complete!"
     echo "================================"
-    docker compose -f "$compose_file" ps
+    docker compose -p agentbox -f "$compose_file" ps
 }
 
 # ---------------------------------------------------------------------------

--- a/src/services/agentbox/Dockerfile
+++ b/src/services/agentbox/Dockerfile
@@ -57,4 +57,4 @@ EXPOSE 8054
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
     CMD curl -sf http://localhost:8054/health || exit 1
 
-CMD ["python", "app/server.py"]
+CMD ["python", "-m", "app.server"]


### PR DESCRIPTION
## Summary

- Add `-p agentbox` to all docker compose commands in `deploy.sh`, `agentbox.sh` to isolate the agentbox compose project namespace from other Hill90 services
- Remove `--remove-orphans` from `cmd_agentbox()` — this flag caused a full service outage by treating all non-agentbox containers as orphans and removing them
- Fix Dockerfile CMD from `python app/server.py` to `python -m app.server` to resolve `ModuleNotFoundError: No module named 'app'` caused by WORKDIR `/app` creating a nested `/app/app/` path

## Root cause

`docker compose -f docker-compose.agentbox.yml up -d --remove-orphans` shared the default project namespace with all other Hill90 compose files. Docker treated every non-agentbox container (keycloak, postgres, traefik, api, ui, etc.) as an orphan and removed them.

## Test plan

- [x] All services recovered and healthy on VPS
- [ ] Agentbox deploy does not affect other services
- [ ] Agentbox containers start without ModuleNotFoundError

