### PR TITLE
fix: use relative paths in agentbox compose generator

### DIFF
--- a/deploy/compose/prod/docker-compose.agentbox.yml
+++ b/deploy/compose/prod/docker-compose.agentbox.yml
@@ -23,9 +23,9 @@ services:
     networks:
     - internal
     volumes:
-    - /Users/jon/source/repos/Personal/Hill90-agentbox/platform/agentbox/agents/coder/agent.yml:/etc/agentbox/agent.yml:ro
-    - /Users/jon/source/repos/Personal/Hill90-agentbox/platform/agentbox/agents/coder/SOUL.md:/etc/agentbox/SOUL.md:ro
-    - /Users/jon/source/repos/Personal/Hill90-agentbox/platform/agentbox/agents/coder/RULES.md:/etc/agentbox/RULES.md:ro
+    - ../../../platform/agentbox/agents/coder/agent.yml:/etc/agentbox/agent.yml:ro
+    - ../../../platform/agentbox/agents/coder/SOUL.md:/etc/agentbox/SOUL.md:ro
+    - ../../../platform/agentbox/agents/coder/RULES.md:/etc/agentbox/RULES.md:ro
     - agentbox-coder-workspace:/workspace
     - agentbox-coder-logs:/var/log/agentbox
     - agentbox-coder-data:/data
@@ -60,9 +60,9 @@ services:
     networks:
     - internal
     volumes:
-    - /Users/jon/source/repos/Personal/Hill90-agentbox/platform/agentbox/agents/ops/agent.yml:/etc/agentbox/agent.yml:ro
-    - /Users/jon/source/repos/Personal/Hill90-agentbox/platform/agentbox/agents/ops/SOUL.md:/etc/agentbox/SOUL.md:ro
-    - /Users/jon/source/repos/Personal/Hill90-agentbox/platform/agentbox/agents/ops/RULES.md:/etc/agentbox/RULES.md:ro
+    - ../../../platform/agentbox/agents/ops/agent.yml:/etc/agentbox/agent.yml:ro
+    - ../../../platform/agentbox/agents/ops/SOUL.md:/etc/agentbox/SOUL.md:ro
+    - ../../../platform/agentbox/agents/ops/RULES.md:/etc/agentbox/RULES.md:ro
     - agentbox-ops-workspace:/workspace
     - agentbox-ops-logs:/var/log/agentbox
     - agentbox-ops-data:/data
@@ -97,9 +97,9 @@ services:
     networks:
     - internal
     volumes:
-    - /Users/jon/source/repos/Personal/Hill90-agentbox/platform/agentbox/agents/researcher/agent.yml:/etc/agentbox/agent.yml:ro
-    - /Users/jon/source/repos/Personal/Hill90-agentbox/platform/agentbox/agents/researcher/SOUL.md:/etc/agentbox/SOUL.md:ro
-    - /Users/jon/source/repos/Personal/Hill90-agentbox/platform/agentbox/agents/researcher/RULES.md:/etc/agentbox/RULES.md:ro
+    - ../../../platform/agentbox/agents/researcher/agent.yml:/etc/agentbox/agent.yml:ro
+    - ../../../platform/agentbox/agents/researcher/SOUL.md:/etc/agentbox/SOUL.md:ro
+    - ../../../platform/agentbox/agents/researcher/RULES.md:/etc/agentbox/RULES.md:ro
     - agentbox-researcher-workspace:/workspace
     - agentbox-researcher-logs:/var/log/agentbox
     - agentbox-researcher-data:/data

--- a/scripts/agentbox-compose-gen.py
+++ b/scripts/agentbox-compose-gen.py
@@ -34,10 +34,11 @@ for agent_dir in sorted(AGENTS_DIR.iterdir()):
     compose["volumes"][vol_logs] = {}
     compose["volumes"][vol_data] = {}
 
-    # Absolute paths for bind mounts (repo-root anchored)
-    agent_config_path = str(agent_dir / "agent.yml")
-    soul_path = str(agent_dir / "SOUL.md")
-    rules_path = str(agent_dir / "RULES.md")
+    # Relative paths from compose file directory (deploy/compose/prod/)
+    rel_agent_dir = Path("../../../platform/agentbox/agents") / agent_dir.name
+    agent_config_path = str(rel_agent_dir / "agent.yml")
+    soul_path = str(rel_agent_dir / "SOUL.md")
+    rules_path = str(rel_agent_dir / "RULES.md")
 
     service = {
         "image": "hill90/agentbox:${VERSION:-latest}",


### PR DESCRIPTION
## Summary

- Switch agentbox-compose-gen.py from absolute Mac paths to relative paths from compose directory
- Update committed docker-compose.agentbox.yml to use relative paths
- No absolute /Users/ paths remain in any compose file

## Test plan

- [x] No `/Users/` paths in docker-compose.agentbox.yml
- [x] Generator uses `Path('../../../platform/agentbox/agents')` relative to compose dir
- [ ] CI passes
- [ ] Agentbox compose regenerated on VPS resolves paths correctly

Generated with [Claude Code](https://claude.com/claude-code)