### PR TITLE
feat: add change-class-aware rollback with schema-forward protection

### DIFF
--- a/.github/workflows/ci-deploy-scripts.yml
+++ b/.github/workflows/ci-deploy-scripts.yml
@@ -9,8 +9,10 @@ on:
       - 'scripts/agentbox.sh'
       - 'scripts/agentbox-compose-gen.py'
       - 'scripts/backup.sh'
+      - 'scripts/rollback.sh'
       - 'tests/scripts/deploy.bats'
       - 'tests/scripts/backup.bats'
+      - 'tests/scripts/rollback.bats'
   pull_request:
     paths:
       - 'scripts/deploy.sh'
@@ -18,8 +20,10 @@ on:
       - 'scripts/agentbox.sh'
       - 'scripts/agentbox-compose-gen.py'
       - 'scripts/backup.sh'
+      - 'scripts/rollback.sh'
       - 'tests/scripts/deploy.bats'
       - 'tests/scripts/backup.bats'
+      - 'tests/scripts/rollback.bats'
 
 jobs:
   validate:
@@ -28,13 +32,14 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Lint deploy scripts
-        run: shellcheck --severity=warning scripts/deploy.sh scripts/_common.sh scripts/agentbox.sh scripts/backup.sh
+        run: shellcheck --severity=warning scripts/deploy.sh scripts/_common.sh scripts/agentbox.sh scripts/backup.sh scripts/rollback.sh
 
       - name: Run deploy script tests
         run: |
           sudo apt-get install -y bats
           bats tests/scripts/deploy.bats
           bats tests/scripts/backup.bats
+          bats tests/scripts/rollback.bats
 
       - name: Validate all compose files
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,6 +99,8 @@ For manual VPS access, see `docs/runbooks/deployment.md`.
 | Backup service | `bash scripts/backup.sh backup <svc>` | `make backup-<svc>` |
 | List backups | `bash scripts/backup.sh list` | `make backup-list` |
 | Prune backups | `bash scripts/backup.sh prune [days]` | `make backup-prune` |
+| Rollback service | `bash scripts/rollback.sh rollback <svc> [ref]` | `make rollback SERVICE=<svc>` |
+| Classify changes | `bash scripts/rollback.sh classify <svc> [ref]` | `make rollback-classify SERVICE=<svc>` |
 | View secret | `bash scripts/secrets.sh view infra/secrets/prod.enc.env <key>` | `make secrets-view KEY=<key>` |
 | Update secret | `bash scripts/secrets.sh update infra/secrets/prod.enc.env <key> <val>` | `make secrets-update KEY=<key> VALUE=<v>` |
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help build deploy-infra deploy-infra-production deploy-db deploy-minio deploy-observability deploy-auth deploy-api deploy-ai deploy-mcp deploy-agentbox deploy-ui deploy-all agentbox-list agentbox-status agentbox-generate test logs health ssh secrets-edit secrets-init secrets-view secrets-update lint format ps snapshot recreate-vps config-vps validate dev dev-logs dev-down backup backup-list backup-prune backup-restore down dns-view dns-sync dns-snapshots dns-restore dns-verify
+.PHONY: help build deploy-infra deploy-infra-production deploy-db deploy-minio deploy-observability deploy-auth deploy-api deploy-ai deploy-mcp deploy-agentbox deploy-ui deploy-all agentbox-list agentbox-status agentbox-generate test logs health ssh secrets-edit secrets-init secrets-view secrets-update lint format ps snapshot recreate-vps config-vps validate dev dev-logs dev-down backup backup-list backup-prune backup-restore rollback rollback-classify down dns-view dns-sync dns-snapshots dns-restore dns-verify
 
 # Environment
 ENV ?= prod
@@ -286,3 +286,17 @@ backup-restore: ## Restore from backup (usage: make backup-restore SERVICE=db BA
 		exit 1; \
 	fi
 	bash scripts/backup.sh restore $(SERVICE) $(BACKUP_PATH)
+
+rollback: ## Rollback a service (usage: make rollback SERVICE=api REF=HEAD~1)
+	@if [ -z "$(SERVICE)" ]; then \
+		echo "$(COLOR_YELLOW)Usage: make rollback SERVICE=<service> [REF=<git-ref>]$(COLOR_RESET)"; \
+		exit 1; \
+	fi
+	bash scripts/rollback.sh rollback $(SERVICE) $(REF)
+
+rollback-classify: ## Classify changes for a service (usage: make rollback-classify SERVICE=api REF=HEAD~1)
+	@if [ -z "$(SERVICE)" ]; then \
+		echo "$(COLOR_YELLOW)Usage: make rollback-classify SERVICE=<service> [REF=<git-ref>]$(COLOR_RESET)"; \
+		exit 1; \
+	fi
+	bash scripts/rollback.sh classify $(SERVICE) $(REF)

--- a/docs/runbooks/deployment.md
+++ b/docs/runbooks/deployment.md
@@ -168,11 +168,55 @@ make backup-restore SERVICE=db BACKUP_PATH=/opt/hill90/backups/db/20260222_12000
 
 For PostgreSQL, prefer the SQL dump restore (`database.sql`) over volume tar — it's portable and handles version differences.
 
-## Rollback Guidance
+## Rollback
 
-- If a service deploy fails, redeploy the last known good compose revision and rerun `make health`.
-- If infrastructure is unstable, rerun `make deploy-infra` before app redeploy.
-- For catastrophic failure, use the VPS rebuild flow in `docs/runbooks/vps-rebuild.md`.
+The rollback script classifies changes and applies the appropriate strategy.
+
+### Change Classes
+
+| Class | Services | Strategy | Automated? |
+|-------|----------|----------|------------|
+| **code-only** | api, ai, mcp, ui, agentbox | Checkout previous source, redeploy | Yes |
+| **config-only** | auth, infra, observability | Checkout previous config, redeploy | Yes |
+| **schema-forward** | db (when migrations change) | Restore from backup, then rollback code | Manual |
+| **mixed** | any | Review, then rollback | Yes (with review) |
+
+### Rollback Commands
+
+```bash
+# Classify changes before rolling back (read-only, safe)
+bash scripts/rollback.sh classify api HEAD~1
+make rollback-classify SERVICE=api REF=HEAD~1
+
+# Automated rollback (code-only or config-only)
+bash scripts/rollback.sh rollback api HEAD~1
+make rollback SERVICE=api REF=HEAD~1
+
+# After rollback, redeploy and verify
+bash scripts/deploy.sh api prod
+bash scripts/deploy.sh verify api
+```
+
+### Schema-Forward Rollback (Manual)
+
+When the rollback script detects migration files, it refuses automated rollback and prints manual restore instructions:
+
+1. Restore the database from the pre-deploy backup
+2. Checkout the previous code
+3. Redeploy both db and the app service
+4. Verify health
+
+### DB Migration Compatibility Policy
+
+- All DB migrations must be backward-compatible with the previous application version
+- Destructive schema changes (drop column, rename table) require two phases: deprecate first, remove in a subsequent release
+- Pre-deploy backup is mandatory before any schema migration (enforced by deploy script)
+
+### General Rollback Guidance
+
+- If a service deploy fails, use `rollback.sh classify` to understand the change, then `rollback.sh rollback` or manual restore
+- If infrastructure is unstable, rerun `make deploy-infra` before app redeploy
+- For catastrophic failure, use the VPS rebuild flow in `docs/runbooks/vps-rebuild.md`
 
 ## Failure Modes
 

--- a/scripts/rollback.sh
+++ b/scripts/rollback.sh
@@ -1,0 +1,276 @@
+#!/usr/bin/env bash
+# Rollback CLI — change-class-aware service rollback
+# Usage: rollback.sh <service> [git-ref]
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/_common.sh"
+
+# ---------------------------------------------------------------------------
+# Usage
+# ---------------------------------------------------------------------------
+
+usage() {
+    cat <<EOF
+Rollback CLI — Hill90 change-class-aware rollback
+
+Usage: rollback.sh <command> [args]
+
+Commands:
+  rollback <service> [ref]  Rollback a service to a previous git ref (default: HEAD~1)
+  classify <service> [ref]  Show what kind of change occurred (without rolling back)
+  help                      Show this help message
+
+Change classes:
+  code-only      App source changes only — auto-rollback via redeploy
+  config-only    Infrastructure/platform config — auto-rollback via redeploy
+  schema-forward DB migration files changed — MANUAL rollback required
+  mixed          Multiple change classes — requires review
+
+Supported services:
+  api, ai, mcp, ui, agentbox    Code-only rollback (checkout + redeploy)
+  auth, infra, observability    Config rollback (checkout + redeploy)
+  db                            Schema-aware (refuses if migrations detected)
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# Change classification
+# ---------------------------------------------------------------------------
+
+# Map service name to its source paths for git diff
+service_paths() {
+    local service="$1"
+    case "$service" in
+        api)           echo "src/services/api/ deploy/compose/prod/docker-compose.api.yml" ;;
+        ai)            echo "src/services/ai/ deploy/compose/prod/docker-compose.ai.yml" ;;
+        mcp)           echo "src/services/mcp/ deploy/compose/prod/docker-compose.mcp.yml" ;;
+        ui)            echo "src/services/ui/ deploy/compose/prod/docker-compose.ui.yml" ;;
+        agentbox)      echo "src/services/agentbox/ platform/agentbox/ deploy/compose/prod/docker-compose.agentbox.yml scripts/agentbox-compose-gen.py scripts/agentbox.sh" ;;
+        auth)          echo "platform/auth/keycloak/ deploy/compose/prod/docker-compose.auth.yml" ;;
+        db)            echo "platform/data/postgres/ deploy/compose/prod/docker-compose.db.yml src/services/api/src/db/migrations/" ;;
+        infra)         echo "platform/edge/ deploy/compose/prod/docker-compose.infra.yml" ;;
+        minio)         echo "deploy/compose/prod/docker-compose.minio.yml" ;;
+        observability) echo "platform/observability/ deploy/compose/prod/docker-compose.observability.yml" ;;
+        *)             die "Unknown service: $service" ;;
+    esac
+}
+
+# Classify changes between current HEAD and target ref for a service
+classify_changes() {
+    local service="$1"
+    local target_ref="$2"
+    local paths
+    paths="$(service_paths "$service")"
+
+    # Get list of changed files between target ref and HEAD for this service's paths
+    local changed_files
+    # shellcheck disable=SC2086  # Intentional word splitting of $paths
+    changed_files="$(git diff --name-only "$target_ref"..HEAD -- $paths 2>/dev/null)" || true
+
+    if [ -z "$changed_files" ]; then
+        echo "none"
+        return
+    fi
+
+    local has_migrations=false
+    local has_code=false
+    local has_config=false
+
+    while IFS= read -r file; do
+        if [[ "$file" == *"/migrations/"* ]]; then
+            has_migrations=true
+        elif [[ "$file" == "src/services/"* ]]; then
+            has_code=true
+        elif [[ "$file" == "platform/"* ]] || [[ "$file" == "deploy/"* ]] || [[ "$file" == "scripts/"* ]]; then
+            has_config=true
+        else
+            has_code=true
+        fi
+    done <<< "$changed_files"
+
+    if [ "$has_migrations" = true ]; then
+        echo "schema-forward"
+    elif [ "$has_code" = true ] && [ "$has_config" = true ]; then
+        echo "mixed"
+    elif [ "$has_code" = true ]; then
+        echo "code-only"
+    elif [ "$has_config" = true ]; then
+        echo "config-only"
+    else
+        echo "none"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Commands
+# ---------------------------------------------------------------------------
+
+cmd_classify() {
+    local service="$1"
+    local target_ref="${2:-HEAD~1}"
+
+    if [ -z "$service" ]; then
+        die "Usage: rollback.sh classify <service> [ref]"
+    fi
+
+    # Validate service
+    service_paths "$service" >/dev/null
+
+    local change_class
+    change_class="$(classify_changes "$service" "$target_ref")"
+
+    echo "================================"
+    echo "Change Classification: ${service}"
+    echo "================================"
+    echo "Current:  HEAD ($(git rev-parse --short HEAD))"
+    echo "Target:   ${target_ref} ($(git rev-parse --short "$target_ref" 2>/dev/null || echo 'unknown'))"
+    echo "Class:    ${change_class}"
+    echo ""
+
+    # Show changed files
+    local paths
+    paths="$(service_paths "$service")"
+    echo "Changed files:"
+    # shellcheck disable=SC2086  # Intentional word splitting of $paths
+    git diff --name-only "$target_ref"..HEAD -- $paths 2>/dev/null | while IFS= read -r f; do
+        echo "  $f"
+    done
+
+    echo ""
+    case "$change_class" in
+        none)
+            echo "No changes detected for ${service} between HEAD and ${target_ref}."
+            ;;
+        code-only)
+            echo "Safe for automated rollback (code-only change)."
+            ;;
+        config-only)
+            echo "Safe for automated rollback (config-only change)."
+            ;;
+        schema-forward)
+            echo "MANUAL ROLLBACK REQUIRED — migration files detected."
+            echo "Automated rollback cannot reverse database schema changes."
+            echo ""
+            echo "Steps:"
+            echo "  1. Restore database from pre-deploy backup:"
+            echo "     bash scripts/backup.sh list db"
+            echo "     bash scripts/backup.sh restore db <backup-dir>"
+            echo "  2. Then rollback code:"
+            echo "     git checkout ${target_ref} -- \$(service_paths ${service})"
+            echo "     bash scripts/deploy.sh ${service} prod"
+            ;;
+        mixed)
+            echo "Mixed changes detected — review before proceeding."
+            echo "Consider rolling back code and config separately."
+            ;;
+    esac
+}
+
+cmd_rollback() {
+    local service="$1"
+    local target_ref="${2:-HEAD~1}"
+
+    if [ -z "$service" ]; then
+        die "Usage: rollback.sh rollback <service> [ref]"
+    fi
+
+    # Validate service
+    service_paths "$service" >/dev/null
+
+    local change_class
+    change_class="$(classify_changes "$service" "$target_ref")"
+
+    echo "================================"
+    echo "Rollback: ${service}"
+    echo "================================"
+    echo "Current:  HEAD ($(git rev-parse --short HEAD))"
+    echo "Target:   ${target_ref} ($(git rev-parse --short "$target_ref" 2>/dev/null || echo 'unknown'))"
+    echo "Class:    ${change_class}"
+    echo ""
+
+    case "$change_class" in
+        none)
+            echo "No changes detected for ${service} between HEAD and ${target_ref}."
+            echo "Nothing to roll back."
+            return 0
+            ;;
+        schema-forward)
+            echo "ROLLBACK REFUSED — migration files detected."
+            echo ""
+            echo "Automated rollback cannot reverse database schema changes."
+            echo "A forward-only migration has been applied and rolling back"
+            echo "the code without restoring the database would leave the"
+            echo "application in an inconsistent state."
+            echo ""
+            echo "Manual restore procedure:"
+            echo "  1. List available backups:"
+            echo "     bash scripts/backup.sh list db"
+            echo ""
+            echo "  2. Restore from pre-deploy backup:"
+            echo "     bash scripts/backup.sh restore db <backup-dir>"
+            echo ""
+            echo "  3. Then rollback the code:"
+            echo "     git checkout ${target_ref} -- platform/data/postgres/ src/services/api/src/db/migrations/"
+            echo "     bash scripts/deploy.sh db prod"
+            echo "     bash scripts/deploy.sh api prod"
+            echo ""
+            echo "  4. Verify:"
+            echo "     bash scripts/deploy.sh verify db"
+            echo "     bash scripts/deploy.sh verify api"
+            exit 1
+            ;;
+        code-only|config-only|mixed)
+            ;;
+    esac
+
+    # Automated rollback for code-only, config-only, and mixed changes
+    warn "Rolling back ${service} to ${target_ref}. Press Ctrl+C within 5 seconds to abort."
+    sleep 5
+
+    echo "Checking out ${service} files from ${target_ref}..."
+    local paths
+    paths="$(service_paths "$service")"
+    # shellcheck disable=SC2086  # Intentional word splitting of $paths
+    git checkout "$target_ref" -- $paths
+
+    echo ""
+    echo "Files rolled back. Redeploying ${service}..."
+    echo ""
+    echo "To complete the rollback, run:"
+    echo "  bash scripts/deploy.sh ${service} prod"
+    echo "  bash scripts/deploy.sh verify ${service}"
+    echo ""
+    echo "To commit the rollback:"
+    echo "  git add -A && git commit -m 'rollback: revert ${service} to ${target_ref}'"
+    echo ""
+    echo "✓ Rollback files restored from ${target_ref}"
+}
+
+# ---------------------------------------------------------------------------
+# Main dispatcher
+# ---------------------------------------------------------------------------
+
+main() {
+    if [[ $# -lt 1 ]]; then
+        usage
+        exit 1
+    fi
+
+    local cmd="$1"
+    shift
+
+    case "$cmd" in
+        rollback)       cmd_rollback "$@" ;;
+        classify)       cmd_classify "$@" ;;
+        help|--help|-h) usage ;;
+        *)
+            echo "Unknown command: $cmd"
+            usage
+            exit 1
+            ;;
+    esac
+}
+
+main "$@"

--- a/tests/scripts/rollback.bats
+++ b/tests/scripts/rollback.bats
@@ -1,0 +1,107 @@
+#!/usr/bin/env bats
+
+# Tests for scripts/rollback.sh CLI
+
+@test "rollback.sh with no args shows usage" {
+  run bash scripts/rollback.sh
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Usage"* ]]
+}
+
+@test "rollback.sh help shows usage" {
+  run bash scripts/rollback.sh help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Usage"* ]]
+}
+
+@test "rollback.sh invalid subcommand fails" {
+  run bash scripts/rollback.sh bogus
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Unknown"* ]]
+}
+
+@test "rollback.sh classify with invalid service fails" {
+  run bash scripts/rollback.sh classify bogus
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Unknown service"* ]]
+}
+
+@test "rollback.sh rollback with no service fails" {
+  run bash scripts/rollback.sh rollback
+  [ "$status" -eq 1 ]
+}
+
+@test "rollback.sh classify with no service fails" {
+  run bash scripts/rollback.sh classify
+  [ "$status" -eq 1 ]
+}
+
+# ---------------------------------------------------------------------------
+# Structure tests
+# ---------------------------------------------------------------------------
+
+@test "rollback.sh sources _common.sh" {
+  run grep "source.*_common.sh" scripts/rollback.sh
+  [ "$status" -eq 0 ]
+}
+
+@test "rollback.sh has classify_changes function" {
+  run grep "^classify_changes()" scripts/rollback.sh
+  [ "$status" -eq 0 ]
+}
+
+@test "rollback.sh has service_paths function" {
+  run grep "^service_paths()" scripts/rollback.sh
+  [ "$status" -eq 0 ]
+}
+
+@test "rollback.sh service_paths covers all services" {
+  for svc in api ai mcp ui agentbox auth db infra minio observability; do
+    run bash -c "sed -n '/^service_paths/,/^}/p' scripts/rollback.sh | grep '${svc})'"
+    [ "$status" -eq 0 ]
+  done
+}
+
+@test "rollback.sh detects migration files in change classification" {
+  run grep "migrations" scripts/rollback.sh
+  [ "$status" -eq 0 ]
+}
+
+@test "rollback.sh refuses rollback for schema-forward changes" {
+  run grep "ROLLBACK REFUSED" scripts/rollback.sh
+  [ "$status" -eq 0 ]
+}
+
+@test "rollback.sh provides manual restore instructions for schema-forward" {
+  run bash -c 'sed -n "/schema-forward/,/;;/p" scripts/rollback.sh | grep "backup.sh"'
+  [ "$status" -eq 0 ]
+}
+
+@test "rollback.sh has 5-second abort window for automated rollbacks" {
+  run grep "sleep 5" scripts/rollback.sh
+  [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Classify behavior tests (using real git history)
+# ---------------------------------------------------------------------------
+
+@test "rollback.sh classify reports 'none' when no service files changed" {
+  # HEAD vs HEAD should always be 'none'
+  run bash scripts/rollback.sh classify api HEAD
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"none"* ]]
+}
+
+@test "rollback.sh classify outputs change class field" {
+  run bash scripts/rollback.sh classify api HEAD~1
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Class:"* ]]
+}
+
+@test "rollback.sh classify shows current and target refs" {
+  run bash scripts/rollback.sh classify api HEAD~1
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Current:"* ]]
+  [[ "$output" == *"Target:"* ]]
+}


### PR DESCRIPTION
## Summary
- Add `scripts/rollback.sh` with change-class-aware rollback (code-only, config-only, schema-forward, mixed)
- Schema-forward changes (migration files detected) refuse automated rollback and print manual restore instructions
- 5-second abort window before automated rollbacks execute
- 17 bats tests covering CLI, structure, and behavioral validation with real git history
- Updated CI workflow, Makefile, AGENTS.md command map, and deployment runbook

## Test plan
- [x] `bats tests/scripts/rollback.bats` — 17/17 pass
- [x] `bats tests/scripts/backup.bats` — 27/27 pass
- [x] `bats tests/scripts/deploy.bats` — 31/31 pass (75 total)
- [x] `shellcheck scripts/rollback.sh` — clean
- [ ] CI passes (deploy script validation, bats, shellcheck)

🤖 Generated with [Claude Code](https://claude.com/claude-code)