### PR TITLE
enhance: add Docker socket proxy to restrict API Docker access

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -217,7 +217,7 @@ logs-%: ## Show logs for a service (e.g., make logs-api)
 	docker logs -f $*
 
 ps: ## Show running containers
-	docker ps --format "table {{.Names}}\t{{.Status}}\t{{.Ports}}" | grep -E "(NAMES|traefik|dns-manager|portainer|postgres|keycloak|api|ai|mcp|ui|minio|grafana|agentbox)" || true
+	docker ps --format "table {{.Names}}\t{{.Status}}\t{{.Ports}}" | grep -E "(NAMES|traefik|dns-manager|portainer|postgres|keycloak|api|docker-proxy|ai|mcp|ui|minio|grafana|agentbox)" || true
 
 ssh: ## SSH into VPS
 	@if [ -z "$(VPS_HOST)" ]; then \

--- a/deploy/compose/prod/docker-compose.api.yml
+++ b/deploy/compose/prod/docker-compose.api.yml
@@ -15,6 +15,56 @@ networks:
     name: hill90_agent_internal
 
 services:
+  # Docker Socket Proxy — limits API surface for agentbox container management
+  docker-proxy:
+    image: tecnativa/docker-socket-proxy:0.3
+    container_name: docker-proxy
+    restart: unless-stopped
+    networks:
+      - agent_internal
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    environment:
+      # Allow container lifecycle operations (create, start, stop, remove, inspect, logs)
+      - CONTAINERS=1
+      # Allow volume operations (create, remove for agentbox workspace/logs/data volumes)
+      - VOLUMES=1
+      # POST required for container create/start/stop/remove
+      - POST=1
+      # Deny everything else
+      - EVENTS=0
+      - IMAGES=0
+      - NETWORKS=0
+      - VERSION=0
+      - SERVICES=0
+      - TASKS=0
+      - NODES=0
+      - BUILD=0
+      - COMMIT=0
+      - CONFIGS=0
+      - DISTRIBUTION=0
+      - EXEC=0
+      - GRPC=0
+      - PLUGINS=0
+      - SECRETS=0
+      - SESSION=0
+      - SWARM=0
+      - SYSTEM=0
+    mem_limit: 128m
+    cpus: 0.25
+    pids_limit: 50
+    security_opt:
+      - no-new-privileges:true
+    read_only: true
+    tmpfs:
+      - /tmp
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:2375/_ping"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+
   # API Gateway (TypeScript/Express)
   api:
     build:
@@ -27,8 +77,10 @@ services:
       - edge
       - internal
       - agent_internal
+    depends_on:
+      docker-proxy:
+        condition: service_healthy
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
       - /opt/hill90/agentbox-configs:/data/agentbox
     environment:
       - NODE_ENV=production
@@ -37,6 +89,7 @@ services:
       - KEYCLOAK_ISSUER=https://auth.hill90.com/realms/hill90
       - KEYCLOAK_JWKS_URI=https://auth.hill90.com/realms/hill90/protocol/openid-connect/certs
       - DATABASE_URL=postgresql://${DB_USER}:${DB_PASSWORD}@postgres:5432/hill90_api
+      - DOCKER_HOST=tcp://docker-proxy:2375
       - AGENTBOX_CONFIG_HOST_PATH=/opt/hill90/agentbox-configs
       - ENVIRONMENT=production
       - OTEL_SERVICE_NAME=api
@@ -45,8 +98,6 @@ services:
       - OTEL_TRACES_EXPORTER=otlp
       - OTEL_METRICS_EXPORTER=none
       - OTEL_LOGS_EXPORTER=none
-    group_add:
-      - "${DOCKER_GID:-999}"
     healthcheck:
       test: ["CMD", "node", "-e", "require('http').get('http://localhost:3000/health', (r) => {process.exit(r.statusCode === 200 ? 0 : 1)})"]
       interval: 30s

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -189,12 +189,13 @@ cmd_service() {
             ;;
         api)
             compose_file="deploy/compose/${env}/docker-compose.api.yml"
-            containers="api"
+            containers="api docker-proxy"
             banner="API Service Deployment"
             stack="apps"
             stateful=false
-            summary="Service deployed:
-  - api (API Gateway at api.hill90.com)"
+            summary="Services deployed:
+  - api (API Gateway at api.hill90.com)
+  - docker-proxy (Docker socket proxy for agentbox management)"
             ;;
         ai)
             compose_file="deploy/compose/${env}/docker-compose.ai.yml"
@@ -261,9 +262,6 @@ cmd_service() {
         # Ensure agentbox config directory exists
         mkdir -p /opt/hill90/agentbox-configs
         chown 1000:1000 /opt/hill90/agentbox-configs 2>/dev/null || true
-        # Resolve Docker GID for socket access
-        export DOCKER_GID
-        DOCKER_GID="$(getent group docker | cut -d: -f3 2>/dev/null || echo 999)"
     fi
     if [[ "$service" == "minio" ]]; then
         sops exec-env "$secrets_file" 'test -n "$MINIO_ROOT_USER" && test -n "$MINIO_ROOT_PASSWORD"' \

--- a/src/services/api/src/services/docker.ts
+++ b/src/services/api/src/services/docker.ts
@@ -1,6 +1,19 @@
 import Docker from 'dockerode';
 
-const docker = new Docker({ socketPath: '/var/run/docker.sock' });
+function createDockerClient(): Docker {
+  const dockerHost = process.env.DOCKER_HOST;
+  if (!dockerHost) {
+    return new Docker({ socketPath: '/var/run/docker.sock' });
+  }
+  try {
+    const url = new URL(dockerHost);
+    return new Docker({ host: url.hostname, port: Number(url.port) });
+  } catch {
+    throw new Error(`Invalid DOCKER_HOST: "${dockerHost}" — expected format: tcp://host:port`);
+  }
+}
+
+const docker = createDockerClient();
 
 const CONTAINER_PREFIX = 'agentbox-';
 const MANAGED_LABEL = 'managed-by';


### PR DESCRIPTION
## Summary
- Add `tecnativa/docker-socket-proxy:0.3` sidecar to API compose, replacing raw Docker socket mount
- API now connects via `DOCKER_HOST=tcp://docker-proxy:2375` with access limited to container and volume ops
- Explicit deny for 18 Docker API categories (images, networks, exec, swarm, events, etc.)
- Proxy hardened with `read_only`, `no-new-privileges`, resource limits (128m/0.25 CPU)
- Removed `DOCKER_GID` preflight from deploy script (no longer needed)

## Test plan
- [x] `bats tests/scripts/deploy.bats` — 31/31 pass
- [x] `docker compose -f docker-compose.api.yml config` validates
- [x] Code review: all critical and warning findings addressed
- [ ] CI passes
- [ ] VPS deploy: API can still manage agentbox containers through proxy

🤖 Generated with [Claude Code](https://claude.com/claude-code)