### PR TITLE
fix: add migration guard to cmd_infra for old project containers

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -115,6 +115,17 @@ cmd_infra() {
     echo "Running pre-deploy backup..."
     bash "$SCRIPT_DIR/backup.sh" backup infra || warn "Pre-deploy backup failed (continuing deploy)"
 
+    # One-time migration: remove old-project containers that would collide
+    local project_name="hill90-${env}-edge"
+    local old_project
+    for container in traefik dns-manager portainer; do
+        old_project=$(docker inspect "$container" --format '{{index .Config.Labels "com.docker.compose.project"}}' 2>/dev/null) || true
+        if [ -n "$old_project" ] && [ "$old_project" = "prod" ]; then
+            echo "Migrating $container from old project '$old_project' to $project_name..."
+            docker rm -f "$container" 2>/dev/null || true
+        fi
+    done
+
     echo "================================"
     echo "Edge Stack Deployment - ${env}"
     echo "================================"


### PR DESCRIPTION
## Summary
- Add one-time migration guard to `cmd_infra()` matching the existing pattern in `cmd_service()`
- Without this, infra containers (`traefik`, `dns-manager`, `portainer`) still labeled `com.docker.compose.project=prod` collide with the new `hill90-prod-edge` project name, failing the first post-migration deploy

## Linear
- Issue: Deployment Hardening Closeout (discovered during runtime migration)

## Validation Evidence
- Infra/Deploy: `workflow_dispatch deploy-infra.yml` failed with `container name "/dns-manager" is already in use` — this fix adds the same `docker inspect` + `docker rm -f` migration guard used by `cmd_service()`

## Test plan
- [ ] CI checks pass
- [ ] `workflow_dispatch deploy-infra.yml` succeeds after merge

## Notes
- Follow-up to PR #105 — discovered during runtime migration step

🤖 Generated with [Claude Code](https://claude.com/claude-code)
