### PR TITLE
fix: add missing cd to verify readiness step in deploy workflow

### DIFF
--- a/.github/workflows/_deploy-service.yml
+++ b/.github/workflows/_deploy-service.yml
@@ -70,7 +70,7 @@ jobs:
         run: |
           ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
             deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
-            "bash scripts/deploy.sh verify ${{ inputs.service }}"
+            "cd /opt/hill90/app && bash scripts/deploy.sh verify ${{ inputs.service }}"
 
       - name: Notify deploy result
         if: always() && env.DEPLOY_WEBHOOK_URL != ''


### PR DESCRIPTION
## Summary
- Add missing `cd /opt/hill90/app` to the "Verify readiness" step in `_deploy-service.yml`
- The deploy step already included the `cd` but verify did not, causing exit code 127 ("No such file or directory") on every service verification

## Linear
- Issue: Deployment Hardening Closeout (discovered during runtime migration)

## Validation Evidence
- Infra/Deploy: `workflow_dispatch deploy.yml service=all` failed with exit 127 on all verify steps — logs show `bash: scripts/deploy.sh: No such file or directory` because SSH lands in home dir, not `/opt/hill90/app`

## Test plan
- [ ] CI checks pass
- [ ] `workflow_dispatch deploy.yml service=all` verify steps succeed after merge

## Notes
- Follow-up to PRs #105, #106 — discovered during runtime migration step

🤖 Generated with [Claude Code](https://claude.com/claude-code)
