### PR TITLE
fix: update backup.sh volume names to match compose pinned names

### DIFF
--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -101,7 +101,7 @@ backup_db() {
     fi
 
     # Volume tar (full data directory backup)
-    backup_volume "postgres-data" "$backup_dir/postgres-data.tar.gz" || true
+    backup_volume "prod_postgres-data" "$backup_dir/postgres-data.tar.gz" || true
 }
 
 backup_minio() {
@@ -117,8 +117,8 @@ backup_infra() {
     mkdir -p "$backup_dir"
 
     echo "Backing up infrastructure volumes..."
-    backup_volume "traefik-certs" "$backup_dir/traefik-certs.tar.gz" || true
-    backup_volume "portainer-data" "$backup_dir/portainer-data.tar.gz" || true
+    backup_volume "prod_traefik-certs" "$backup_dir/traefik-certs.tar.gz" || true
+    backup_volume "prod_portainer-data" "$backup_dir/portainer-data.tar.gz" || true
 }
 
 backup_observability() {
@@ -206,7 +206,7 @@ cmd_restore() {
                 echo "  ✓ SQL dump restored"
             elif [ -f "$backup_dir/postgres-data.tar.gz" ]; then
                 warn "No SQL dump found — restoring from volume tar (requires postgres restart)"
-                restore_volume "postgres-data" "$backup_dir/postgres-data.tar.gz"
+                restore_volume "prod_postgres-data" "$backup_dir/postgres-data.tar.gz"
                 echo "  Restart postgres: docker restart postgres"
             else
                 die "No backup files found in $backup_dir"
@@ -219,9 +219,9 @@ cmd_restore() {
             ;;
         infra)
             [ -f "$backup_dir/traefik-certs.tar.gz" ] || die "traefik-certs.tar.gz not found in $backup_dir"
-            restore_volume "traefik-certs" "$backup_dir/traefik-certs.tar.gz"
+            restore_volume "prod_traefik-certs" "$backup_dir/traefik-certs.tar.gz"
             if [ -f "$backup_dir/portainer-data.tar.gz" ]; then
-                restore_volume "portainer-data" "$backup_dir/portainer-data.tar.gz"
+                restore_volume "prod_portainer-data" "$backup_dir/portainer-data.tar.gz"
             fi
             echo "  Restart services: docker restart traefik portainer"
             ;;


### PR DESCRIPTION
Linear: [AI-92](https://linear.app/jonhill90/issue/AI-92/fix-volume-safety-ci-checks-compose-name-pinning-and-infra-agent-loop)

## Summary

- Update 6 volume name references in `backup.sh` to match the pinned `name:` fields from PR #108
- Affects backup and restore for db (`prod_postgres-data`) and infra (`prod_traefik-certs`, `prod_portainer-data`)
- MinIO and observability volumes unchanged (they never had a `prod_` prefix)

## Plan

Update volume name strings in `backup_db`, `backup_infra`, and `cmd_restore` to use the `prod_` prefixed names that match the Docker volumes on VPS.

## Risks

- Existing backups created with old volume names still restore correctly (tar filenames unchanged, only the Docker volume target name changed)
- If this fix is reverted without also reverting #108, backups would reference non-existent unprefixed volumes

## Rollback

Revert this PR. If #108 is also reverted, the unprefixed names become correct again.

## Validation Evidence

- `bats tests/scripts/backup.bats` — 27/27 pass
- `shellcheck --severity=warning scripts/backup.sh` — clean
- VPS volume names confirmed via `docker volume ls`:
  - `prod_postgres-data` ✅
  - `prod_traefik-certs` ✅
  - `prod_portainer-data` ✅
  - `minio-data` (unchanged) ✅
  - `grafana-data`, `prometheus-data` (unchanged) ✅

## Test plan

- [x] `bats tests/scripts/backup.bats` — all 27 tests pass
- [x] `shellcheck` clean
- [ ] CI passes
- [ ] Post-merge: run `bash scripts/backup.sh backup db` and `bash scripts/backup.sh backup infra` on VPS to confirm volumes are found

🤖 Generated with [Claude Code](https://claude.com/claude-code)
