### PR TITLE
feat: add Swagger UI, OpenAPI spec, and SSE proxy fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,10 @@ jobs:
         working-directory: src/services/api
         run: npm ci && npm test
 
+      - name: Validate OpenAPI spec
+        working-directory: src/services/api
+        run: npx --yes @redocly/cli lint src/openapi/openapi.yaml --skip-rule no-unused-components
+
       - name: Run UI tests
         working-directory: src/services/ui
         run: npm ci && npm test

--- a/src/services/api/package-lock.json
+++ b/src/services/api/package-lock.json
@@ -25,7 +25,8 @@
         "jwks-rsa": "^3.2.2",
         "pg": "^8.18.0",
         "pino": "^8.17.2",
-        "pino-http": "^9.0.0"
+        "pino-http": "^9.0.0",
+        "swagger-ui-express": "^5.0.1"
       },
       "devDependencies": {
         "@types/cors": "^2.8.17",
@@ -37,6 +38,7 @@
         "@types/node": "^20.11.0",
         "@types/pg": "^8.16.0",
         "@types/supertest": "^6.0.2",
+        "@types/swagger-ui-express": "^4.1.8",
         "@typescript-eslint/eslint-plugin": "^6.19.0",
         "@typescript-eslint/parser": "^6.19.0",
         "eslint": "^8.56.0",
@@ -3290,6 +3292,13 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -3728,6 +3737,17 @@
       "dependencies": {
         "@types/methods": "^1.1.4",
         "@types/superagent": "^8.1.0"
+      }
+    },
+    "node_modules/@types/swagger-ui-express": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@types/swagger-ui-express/-/swagger-ui-express-4.1.8.tgz",
+      "integrity": "sha512-AhZV8/EIreHFmBV5wAs0gzJUNq9JbbSXgJLQubCC0jtIo6prnI9MIRRxnU4MZX9RB9yXxF1V4R7jtLl/Wcj31g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*",
+        "@types/serve-static": "*"
       }
     },
     "node_modules/@types/tedious": {
@@ -5617,6 +5637,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
       "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -9476,6 +9497,30 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.31.2",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.31.2.tgz",
+      "integrity": "sha512-uIoesCjDcxnAKj/C/HG5pjHZMQs2K/qmqpUlwLxxaVryGKlgm8Ri+VOza5xywAqf//pgg/hW16RYa6dDuTCOSg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
+      }
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
+      "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
+      "license": "MIT",
+      "dependencies": {
+        "swagger-ui-dist": ">=5.0.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0 || >=5.0.0-beta"
       }
     },
     "node_modules/tar-fs": {

--- a/src/services/api/package.json
+++ b/src/services/api/package.json
@@ -4,7 +4,7 @@
   "description": "Hill90 API Gateway",
   "main": "dist/index.js",
   "scripts": {
-    "build": "tsc && cp -r src/db/migrations dist/db/migrations",
+    "build": "tsc && cp -r src/db/migrations dist/db/migrations && cp -r src/openapi dist/openapi",
     "dev": "tsx watch src/index.ts",
     "start": "node dist/index.js",
     "test": "jest",
@@ -29,7 +29,8 @@
     "jwks-rsa": "^3.2.2",
     "pg": "^8.18.0",
     "pino": "^8.17.2",
-    "pino-http": "^9.0.0"
+    "pino-http": "^9.0.0",
+    "swagger-ui-express": "^5.0.1"
   },
   "devDependencies": {
     "@types/cors": "^2.8.17",
@@ -41,6 +42,7 @@
     "@types/node": "^20.11.0",
     "@types/pg": "^8.16.0",
     "@types/supertest": "^6.0.2",
+    "@types/swagger-ui-express": "^4.1.8",
     "@typescript-eslint/eslint-plugin": "^6.19.0",
     "@typescript-eslint/parser": "^6.19.0",
     "eslint": "^8.56.0",

--- a/src/services/api/src/__tests__/docs.test.ts
+++ b/src/services/api/src/__tests__/docs.test.ts
@@ -1,0 +1,238 @@
+import request from 'supertest';
+import * as crypto from 'crypto';
+import * as jwt from 'jsonwebtoken';
+import { createApp } from '../app';
+
+// Generate a throwaway RSA keypair for test signing
+const { privateKey, publicKey } = crypto.generateKeyPairSync('rsa', {
+  modulusLength: 2048,
+  publicKeyEncoding: { type: 'spki', format: 'pem' },
+  privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+});
+
+const TEST_ISSUER = 'https://auth.hill90.com/realms/hill90';
+
+// Mock pg pool — docs routes don't use DB but agents router does at import time
+const mockQuery = jest.fn();
+jest.mock('../db/pool', () => ({
+  getPool: () => ({ query: mockQuery }),
+}));
+
+// Mock docker service — same reason
+jest.mock('../services/docker', () => ({
+  createAndStartContainer: jest.fn(),
+  stopAndRemoveContainer: jest.fn(),
+  inspectContainer: jest.fn(),
+  getContainerLogs: jest.fn(),
+  removeAgentVolumes: jest.fn(),
+  reconcileAgentStatuses: jest.fn(),
+}));
+
+// Mock agent-files service
+jest.mock('../services/agent-files', () => ({
+  writeAgentFiles: jest.fn(),
+  removeAgentFiles: jest.fn(),
+}));
+
+const app = createApp({
+  issuer: TEST_ISSUER,
+  getSigningKey: async () => publicKey,
+});
+
+function makeToken(sub: string, roles: string[]) {
+  return jwt.sign(
+    { sub, realm_roles: roles },
+    privateKey,
+    { algorithm: 'RS256', issuer: TEST_ISSUER, expiresIn: '5m' }
+  );
+}
+
+const adminToken = makeToken('admin-user', ['admin', 'user']);
+const userToken = makeToken('regular-user', ['user']);
+
+// ---------------------------------------------------------------------------
+// /openapi.json — auth + RBAC + schema shape
+// ---------------------------------------------------------------------------
+
+describe('GET /openapi.json', () => {
+  it('returns 401 without Authorization header', async () => {
+    const res = await request(app).get('/openapi.json');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 for user role (not admin)', async () => {
+    const res = await request(app)
+      .get('/openapi.json')
+      .set('Authorization', `Bearer ${userToken}`);
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 200 with admin token', async () => {
+    const res = await request(app)
+      .get('/openapi.json')
+      .set('Authorization', `Bearer ${adminToken}`);
+    expect(res.status).toBe(200);
+  });
+
+  it('returns valid OpenAPI 3.0 spec', async () => {
+    const res = await request(app)
+      .get('/openapi.json')
+      .set('Authorization', `Bearer ${adminToken}`);
+    expect(res.body.openapi).toMatch(/^3\.0/);
+    expect(res.body.info).toBeDefined();
+    expect(res.body.info.title).toBe('Hill90 API');
+    expect(res.body.paths).toBeDefined();
+    expect(res.body.components).toBeDefined();
+    expect(res.body.components.securitySchemes).toBeDefined();
+    expect(res.body.components.securitySchemes.bearerAuth).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// /docs — auth + RBAC + HTML response
+// ---------------------------------------------------------------------------
+
+describe('GET /docs/', () => {
+  it('returns 401 without Authorization header', async () => {
+    const res = await request(app).get('/docs/');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 for user role (not admin)', async () => {
+    const res = await request(app)
+      .get('/docs/')
+      .set('Authorization', `Bearer ${userToken}`);
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 200 with HTML for admin', async () => {
+    const res = await request(app)
+      .get('/docs/')
+      .set('Authorization', `Bearer ${adminToken}`);
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toMatch(/html/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Root route non-regression
+// ---------------------------------------------------------------------------
+
+describe('Root route non-regression', () => {
+  it('GET /health returns 200 without auth (still public)', async () => {
+    const res = await request(app).get('/health');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ status: 'healthy', service: 'api' });
+  });
+
+  it('GET /nonexistent returns 404, not 401 or 403', async () => {
+    const res = await request(app).get('/nonexistent');
+    expect(res.status).toBe(404);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// OpenAPI drift protection — spec contract enforcement
+// ---------------------------------------------------------------------------
+
+// Contract scope: runtime business endpoints only.
+// /docs and /openapi.json are infrastructure endpoints — intentionally excluded
+// from drift enforcement. They are tested for auth/RBAC above, not contract coverage.
+const EXPECTED_PATHS = [
+  '/health',
+  '/me',
+  '/agents',
+  '/agents/{id}',
+  '/agents/{id}/start',
+  '/agents/{id}/stop',
+  '/agents/{id}/status',
+  '/agents/{id}/logs',
+];
+
+const INFRA_PATHS = ['/docs', '/openapi.json'];
+
+/**
+ * Introspect Express app._router.stack to extract all registered route paths.
+ * Normalizes Express param syntax (:id) to OpenAPI syntax ({id}).
+ */
+function getRegisteredRoutes(expressApp: any): string[] {
+  const routes: string[] = [];
+  const stack = expressApp._router?.stack || [];
+
+  for (const layer of stack) {
+    // Direct routes (app.get, app.post, etc.)
+    if (layer.route) {
+      routes.push(layer.route.path);
+      continue;
+    }
+
+    // Sub-routers (app.use('/prefix', router))
+    if (layer.name === 'router' && layer.handle?.stack) {
+      // Extract base path from layer.regexp — handle escaped dots and slashes
+      const src = layer.regexp?.source || '';
+      const match = src.match(/^\^\\\/(.+?)(?:\\\/?(?:\?|$)|\?)/);
+      const base = match
+        ? '/' + match[1].replace(/\\\//g, '/').replace(/\\\./g, '.')
+        : '';
+
+      for (const subLayer of layer.handle.stack) {
+        if (subLayer.route) {
+          const subPath = subLayer.route.path === '/' ? '' : subLayer.route.path;
+          routes.push(base + subPath);
+        }
+      }
+    }
+    // Middleware-only layers (no .route, not a router): skip
+  }
+
+  // Normalize :param to {param} and deduplicate
+  return [...new Set(routes.map(r => r.replace(/:(\w+)/g, '{$1}')))];
+}
+
+describe('Spec contract enforcement', () => {
+  let spec: any;
+
+  beforeAll(async () => {
+    const res = await request(app)
+      .get('/openapi.json')
+      .set('Authorization', `Bearer ${adminToken}`);
+    spec = res.body;
+  });
+
+  it('spec documents all API routes', () => {
+    const specPaths = Object.keys(spec.paths || {});
+    for (const path of EXPECTED_PATHS) {
+      expect(specPaths).toContain(path);
+    }
+  });
+
+  it('spec does not contain phantom paths', () => {
+    const specPaths = Object.keys(spec.paths || {});
+    for (const path of specPaths) {
+      expect(EXPECTED_PATHS).toContain(path);
+    }
+  });
+
+  it('every registered Express route maps to EXPECTED_PATHS or INFRA_PATHS', () => {
+    const registered = getRegisteredRoutes(app);
+    const allKnown = [...EXPECTED_PATHS, ...INFRA_PATHS];
+    for (const route of registered) {
+      expect(allKnown).toContain(route);
+    }
+  });
+
+  it('every path except /health has security defined', () => {
+    for (const [pathKey, pathItem] of Object.entries((spec.paths || {}) as Record<string, any>)) {
+      for (const [method, operation] of Object.entries(pathItem)) {
+        if (method === 'parameters') continue;
+        const op = operation as any;
+        if (pathKey === '/health') {
+          expect(op.security).toEqual([]);
+        } else {
+          expect(op.security).toBeDefined();
+          expect(op.security.length).toBeGreaterThan(0);
+        }
+      }
+    }
+  });
+});

--- a/src/services/api/src/app.ts
+++ b/src/services/api/src/app.ts
@@ -2,6 +2,8 @@ import express, { Application } from 'express';
 import { createRequireAuth, createJwksKeyResolver } from './middleware/auth';
 import type { JwtHeader } from 'jsonwebtoken';
 import agentsRouter from './routes/agents';
+import { requireRole } from './middleware/role';
+import { docsRouter, specRouter } from './routes/docs';
 
 interface AppOptions {
   issuer?: string;
@@ -33,6 +35,10 @@ export function createApp(opts: AppOptions = {}): Application {
 
   // Agent management routes
   app.use('/agents', requireAuth, agentsRouter);
+
+  // API documentation (admin-only)
+  app.use('/docs', requireAuth, requireRole('admin'), docsRouter);
+  app.use('/openapi.json', requireAuth, requireRole('admin'), specRouter);
 
   return app;
 }

--- a/src/services/api/src/openapi/openapi.yaml
+++ b/src/services/api/src/openapi/openapi.yaml
@@ -1,0 +1,436 @@
+openapi: 3.0.3
+info:
+  title: Hill90 API
+  description: Hill90 platform API — agent management and lifecycle operations.
+  version: 0.1.0
+
+servers:
+  - url: /
+    description: Relative (behind Traefik reverse proxy)
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+
+  schemas:
+    Agent:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        agent_id:
+          type: string
+          description: Unique slug identifier (lowercase, alphanumeric, hyphens)
+          pattern: "^[a-z0-9][a-z0-9-]{0,61}[a-z0-9]$"
+        name:
+          type: string
+        description:
+          type: string
+        tools_config:
+          type: object
+        cpus:
+          type: string
+          default: "1.0"
+        mem_limit:
+          type: string
+          default: "1g"
+        pids_limit:
+          type: integer
+          default: 200
+        soul_md:
+          type: string
+        rules_md:
+          type: string
+        status:
+          type: string
+          enum: [stopped, running, error]
+        container_id:
+          type: string
+          nullable: true
+        error_message:
+          type: string
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        created_by:
+          type: string
+
+    AgentStatus:
+      type: object
+      properties:
+        db_status:
+          type: string
+        container:
+          type: object
+          nullable: true
+        error_message:
+          type: string
+          nullable: true
+
+    Error:
+      type: object
+      properties:
+        error:
+          type: string
+
+paths:
+  /health:
+    get:
+      summary: Health check
+      description: Returns service health status. Public — no authentication required.
+      security: []
+      responses:
+        "200":
+          description: Healthy
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: healthy
+                  service:
+                    type: string
+                    example: api
+
+  /me:
+    get:
+      summary: Get current user claims
+      description: Returns the JWT claims of the authenticated user.
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: JWT claims
+          content:
+            application/json:
+              schema:
+                type: object
+        "401":
+          description: Missing or invalid token
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /agents:
+    get:
+      summary: List agents
+      description: Returns agents scoped to the authenticated user (all agents for admin).
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Agent list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Agent"
+        "401":
+          description: Not authenticated
+        "403":
+          description: Requires user role
+
+    post:
+      summary: Create agent
+      description: Creates a new agent definition.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - agent_id
+                - name
+              properties:
+                agent_id:
+                  type: string
+                  pattern: "^[a-z0-9][a-z0-9-]{0,61}[a-z0-9]$"
+                name:
+                  type: string
+                description:
+                  type: string
+                tools_config:
+                  type: object
+                cpus:
+                  type: string
+                mem_limit:
+                  type: string
+                pids_limit:
+                  type: integer
+                soul_md:
+                  type: string
+                rules_md:
+                  type: string
+      responses:
+        "201":
+          description: Agent created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Agent"
+        "400":
+          description: Invalid input
+        "401":
+          description: Not authenticated
+        "403":
+          description: Requires user role
+        "409":
+          description: Duplicate agent_id
+
+  /agents/{id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+
+    get:
+      summary: Get agent detail
+      description: Returns a single agent, scoped to ownership.
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Agent detail
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Agent"
+        "401":
+          description: Not authenticated
+        "403":
+          description: Requires user role
+        "404":
+          description: Agent not found
+
+    put:
+      summary: Update agent
+      description: Updates agent configuration. Agent must be stopped.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                description:
+                  type: string
+                tools_config:
+                  type: object
+                cpus:
+                  type: string
+                mem_limit:
+                  type: string
+                pids_limit:
+                  type: integer
+                soul_md:
+                  type: string
+                rules_md:
+                  type: string
+      responses:
+        "200":
+          description: Agent updated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Agent"
+        "401":
+          description: Not authenticated
+        "403":
+          description: Requires user role
+        "404":
+          description: Agent not found
+        "409":
+          description: Agent is running
+
+    delete:
+      summary: Delete agent
+      description: Deletes an agent. Requires admin role. Optionally purges volumes.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: purge
+          in: query
+          schema:
+            type: string
+            enum: ["true", "false"]
+          description: If "true", also remove agent volumes
+      responses:
+        "200":
+          description: Agent deleted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  deleted:
+                    type: boolean
+        "401":
+          description: Not authenticated
+        "403":
+          description: Requires admin role
+        "404":
+          description: Agent not found
+
+  /agents/{id}/start:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    post:
+      summary: Start agent
+      description: Creates and starts the agent container. Requires admin role.
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Agent started
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: running
+                  container_id:
+                    type: string
+        "401":
+          description: Not authenticated
+        "403":
+          description: Requires admin role
+        "404":
+          description: Agent not found
+        "503":
+          description: AGENTBOX_CONFIG_HOST_PATH not configured
+
+  /agents/{id}/stop:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    post:
+      summary: Stop agent
+      description: Stops and removes the agent container. Requires admin role.
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Agent stopped
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: stopped
+        "401":
+          description: Not authenticated
+        "403":
+          description: Requires admin role
+        "404":
+          description: Agent not found
+
+  /agents/{id}/status:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    get:
+      summary: Get agent status
+      description: Returns agent status from DB and live container inspection. Scoped to ownership.
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Agent status
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AgentStatus"
+        "401":
+          description: Not authenticated
+        "403":
+          description: Requires user role
+        "404":
+          description: Agent not found
+
+  /agents/{id}/logs:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    get:
+      summary: Get agent logs
+      description: >
+        Returns container logs. Requires admin role.
+        With follow=true, returns an SSE stream (text/event-stream).
+        Without follow, returns JSON with log text.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: tail
+          in: query
+          schema:
+            type: integer
+            default: 200
+          description: Number of tail lines
+        - name: follow
+          in: query
+          schema:
+            type: string
+            enum: ["true", "false"]
+          description: If "true", stream logs via SSE
+      responses:
+        "200":
+          description: Log output (JSON or SSE stream)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  logs:
+                    type: string
+            text/event-stream:
+              schema:
+                type: string
+        "401":
+          description: Not authenticated
+        "403":
+          description: Requires admin role
+        "404":
+          description: Agent not found

--- a/src/services/api/src/routes/docs.ts
+++ b/src/services/api/src/routes/docs.ts
@@ -1,0 +1,17 @@
+import { Router } from 'express';
+import swaggerUi from 'swagger-ui-express';
+import * as yaml from 'js-yaml';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const specPath = path.resolve(__dirname, '../openapi/openapi.yaml');
+const specYaml = fs.readFileSync(specPath, 'utf-8');
+export const spec = yaml.load(specYaml) as Record<string, unknown>;
+
+export const docsRouter = Router();
+docsRouter.use('/', swaggerUi.serve, swaggerUi.setup(spec as any, { customSiteTitle: 'Hill90 API Docs' }));
+
+export const specRouter = Router();
+specRouter.get('/', (_req, res) => {
+  res.json(spec);
+});

--- a/src/services/ui/src/__tests__/agents-proxy.test.ts
+++ b/src/services/ui/src/__tests__/agents-proxy.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+let mockSession: any = null
+
+vi.mock('@/auth', () => ({
+  auth: vi.fn(() => Promise.resolve(mockSession)),
+}))
+
+// Mock NextResponse.json
+vi.mock('next/server', () => ({
+  NextResponse: {
+    json: vi.fn((data: any, init?: { status?: number }) => ({
+      _type: 'NextResponse.json',
+      _data: data,
+      _status: init?.status ?? 200,
+    })),
+  },
+}))
+
+// Mock global fetch
+const mockFetch = vi.fn()
+vi.stubGlobal('fetch', mockFetch)
+
+// Import after mocks
+const { GET } = await import('@/app/api/agents/[...path]/route')
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeRequest(pathSegments: string[], query: Record<string, string> = {}) {
+  const searchParams = new URLSearchParams(query)
+  return {
+    method: 'GET',
+    headers: {
+      get: vi.fn(() => null),
+    },
+    nextUrl: {
+      searchParams,
+    },
+  }
+}
+
+function makeParams(pathSegments: string[]) {
+  return { params: Promise.resolve({ path: pathSegments }) }
+}
+
+// ---------------------------------------------------------------------------
+// SSE proxy pass-through for text/event-stream
+// ---------------------------------------------------------------------------
+
+describe('SSE proxy pass-through', () => {
+  beforeEach(() => {
+    mockFetch.mockReset()
+    mockSession = { accessToken: 'test-jwt-token' }
+  })
+
+  it('returns raw Response with text/event-stream headers when upstream is SSE', async () => {
+    const mockStream = new ReadableStream()
+    mockFetch.mockResolvedValue({
+      status: 200,
+      headers: {
+        get: (name: string) => name === 'content-type' ? 'text/event-stream' : null,
+      },
+      body: mockStream,
+    })
+
+    const req = makeRequest(['some-id', 'logs'], { follow: 'true', tail: '100' })
+    const res = await GET(req as any, makeParams(['some-id', 'logs']))
+
+    // Must be a raw Response, NOT NextResponse.json
+    expect(res).toBeInstanceOf(Response)
+    expect(res.headers.get('Content-Type')).toBe('text/event-stream')
+    expect(res.headers.get('Cache-Control')).toBe('no-cache')
+  })
+
+  it('does not set AbortSignal timeout for follow=true requests', async () => {
+    const mockStream = new ReadableStream()
+    mockFetch.mockResolvedValue({
+      status: 200,
+      headers: {
+        get: (name: string) => name === 'content-type' ? 'text/event-stream' : null,
+      },
+      body: mockStream,
+    })
+
+    const req = makeRequest(['some-id', 'logs'], { follow: 'true' })
+    await GET(req as any, makeParams(['some-id', 'logs']))
+
+    // Verify fetch was called without a signal
+    const fetchOpts = mockFetch.mock.calls[0][1]
+    expect(fetchOpts.signal).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Non-SSE JSON proxy behavior unchanged
+// ---------------------------------------------------------------------------
+
+describe('JSON proxy pass-through', () => {
+  beforeEach(() => {
+    mockFetch.mockReset()
+    mockSession = { accessToken: 'test-jwt-token' }
+  })
+
+  it('parses JSON and returns NextResponse.json for non-SSE responses', async () => {
+    const { NextResponse } = await import('next/server')
+    mockFetch.mockResolvedValue({
+      status: 200,
+      headers: {
+        get: (name: string) => name === 'content-type' ? 'application/json' : null,
+      },
+      json: () => Promise.resolve({ id: '123', name: 'test-agent' }),
+    })
+
+    const req = makeRequest(['some-id'])
+    const res = await GET(req as any, makeParams(['some-id']))
+
+    expect(NextResponse.json).toHaveBeenCalledWith(
+      { id: '123', name: 'test-agent' },
+      { status: 200 }
+    )
+  })
+
+  it('sets AbortSignal timeout for non-SSE requests', async () => {
+    mockFetch.mockResolvedValue({
+      status: 200,
+      headers: {
+        get: () => 'application/json',
+      },
+      json: () => Promise.resolve({}),
+    })
+
+    const req = makeRequest(['some-id'])
+    await GET(req as any, makeParams(['some-id']))
+
+    const fetchOpts = mockFetch.mock.calls[0][1]
+    expect(fetchOpts.signal).toBeDefined()
+  })
+
+  it('returns 401 when session has no accessToken', async () => {
+    const { NextResponse } = await import('next/server')
+    mockSession = null
+
+    const req = makeRequest(['some-id'])
+    await GET(req as any, makeParams(['some-id']))
+
+    expect(NextResponse.json).toHaveBeenCalledWith(
+      { error: 'Not authenticated' },
+      { status: 401 }
+    )
+  })
+})

--- a/src/services/ui/src/app/api/agents/[...path]/route.ts
+++ b/src/services/ui/src/app/api/agents/[...path]/route.ts
@@ -28,10 +28,13 @@ async function proxyRequest(req: NextRequest, { params }: { params: Promise<{ pa
     headers['Content-Type'] = contentType
   }
 
+  // follow=true is reserved for SSE streaming routes — no timeout for long-lived streams
+  const isSSE = req.nextUrl.searchParams.get('follow') === 'true'
+
   const fetchOpts: RequestInit = {
     method: req.method,
     headers,
-    signal: AbortSignal.timeout(30000),
+    ...(isSSE ? {} : { signal: AbortSignal.timeout(30000) }),
   }
 
   if (req.method !== 'GET' && req.method !== 'HEAD') {
@@ -40,6 +43,20 @@ async function proxyRequest(req: NextRequest, { params }: { params: Promise<{ pa
 
   try {
     const res = await fetch(url.toString(), fetchOpts)
+
+    // SSE: pass the stream through without JSON parsing
+    const resContentType = res.headers.get('content-type') || ''
+    if (resContentType.includes('text/event-stream')) {
+      return new Response(res.body, {
+        status: res.status,
+        headers: {
+          'Content-Type': 'text/event-stream',
+          'Cache-Control': 'no-cache',
+          'Connection': 'keep-alive',
+        },
+      })
+    }
+
     const data = await res.json()
     return NextResponse.json(data, { status: res.status })
   } catch (err) {


### PR DESCRIPTION
## Summary
- Add JWT-protected `/docs` (Swagger UI) and `/openapi.json` endpoints, admin-only
- Create OpenAPI 3.0.3 spec covering all 8 business routes with security definitions
- Fix UI SSE proxy to pass `text/event-stream` responses through without JSON parsing or 30s timeout
- Add three-way drift enforcement: EXPECTED_PATHS <-> spec.paths <-> Express routes
- Add CI OpenAPI structural lint gate via `@redocly/cli`

## Linear
- Issue: N/A (standalone feature)

## Validation Evidence
- API: `npm test` — 44 passed, 0 failures (includes 13 new docs/drift tests)
- API: `npm run build && ls dist/openapi/openapi.yaml` — artifact exists
- API: OpenAPI lint — valid, 0 errors
- UI: `npm test` — 38 passed, 0 failures (includes 5 SSE proxy tests)

## Test plan
- [x] API tests pass (44/44)
- [x] UI tests pass (38/38)
- [x] Build artifact includes dist/openapi/openapi.yaml
- [x] OpenAPI lint — 0 errors
- [x] /health stays public (non-regression)
- [x] Unknown paths return 404, not 401/403 (non-regression)
- [x] /docs/ returns 401->403->200 for no-auth->user->admin
- [x] /openapi.json returns 401->403->200 for no-auth->user->admin
- [x] Spec contains exactly 8 EXPECTED_PATHS, no phantoms
- [x] Express route introspection matches EXPECTED_PATHS + INFRA_PATHS
- [x] SSE proxy confirms stream pass-through without 30s timeout
- [ ] CI checks pass

## Notes
- Access model: /docs and /openapi.json are JWT-authenticated API endpoints. Direct browser navigation returns 401 by design.
- @scarf/scarf telemetry is a transitive dep of swagger-ui-dist. Can disable with SCARF_ANALYTICS=false.
