### PR TITLE
fix: add tmpfs for haproxy config in docker-proxy

### DIFF
--- a/deploy/compose/prod/docker-compose.api.yml
+++ b/deploy/compose/prod/docker-compose.api.yml
@@ -58,6 +58,7 @@ services:
     read_only: true
     tmpfs:
       - /tmp
+      - /usr/local/etc/haproxy
     healthcheck:
       test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:2375/_ping"]
       interval: 30s


### PR DESCRIPTION
## Summary
- Add tmpfs mount for `/usr/local/etc/haproxy` on docker-proxy container
- The `read_only: true` rootfs prevents the entrypoint from writing `haproxy.cfg`, causing a crash loop that blocks the API container from starting

## Linear
- Issue: N/A (hotfix)

## Plan
1. Add `/usr/local/etc/haproxy` to the existing `tmpfs:` list for docker-proxy in `docker-compose.api.yml`
2. Merge to main — path-filtered deploy triggers automatically for `deploy/**` changes
3. Verify docker-proxy starts healthy and API container follows

## Risks
- **Low:** tmpfs mount is ephemeral and scoped — haproxy.cfg is regenerated from env vars on every container start, so no persistence needed
- **None:** No other services affected — only docker-proxy compose definition changed

## Rollback
- Revert this commit and merge revert PR — auto-deploy will restore previous compose config
- Manual recovery on VPS: `docker restart docker-proxy && docker restart api`

## Validation Evidence
- Infra/Deploy: `docker compose config` — valid
- Root cause: `docker logs docker-proxy` shows `can't create /usr/local/etc/haproxy/haproxy.cfg: Read-only file system`
- Cascade: docker-proxy unhealthy -> API depends_on blocks -> API never starts

## Test plan
- [x] Compose file validates
- [x] CI checks pass
- [ ] docker-proxy starts healthy after deploy
- [ ] API container starts and passes healthcheck

## Notes
- UI deploy failure was transient — container recovered and is healthy
- tempo and agentbox containers also restarting (pre-existing, separate issues)
