### PR TITLE
fix: remove read_only from docker-proxy container

### DIFF
--- a/deploy/compose/prod/docker-compose.api.yml
+++ b/deploy/compose/prod/docker-compose.api.yml
@@ -55,10 +55,8 @@ services:
     pids_limit: 50
     security_opt:
       - no-new-privileges:true
-    read_only: true
     tmpfs:
       - /tmp
-      - /usr/local/etc/haproxy
     healthcheck:
       test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:2375/_ping"]
       interval: 30s


### PR DESCRIPTION
## Summary
- Remove `read_only: true` from docker-proxy container
- Previous fix (#111) added tmpfs for `/usr/local/etc/haproxy` but that wiped the `haproxy.cfg.template` that ships with the image, causing a new failure: `sed: haproxy.cfg.template: No such file or directory`

## Linear
- Issue: N/A (hotfix)

## Plan
1. Remove `read_only: true` from docker-proxy service definition
2. Remove the `/usr/local/etc/haproxy` tmpfs entry added in #111 (keep `/tmp`)
3. Merge — deploy triggers automatically

## Risks
- **Low:** docker-proxy already has `/var/run/docker.sock` mounted — rootfs write protection adds minimal incremental security
- **None:** No other services affected

## Rollback
- Revert this commit and merge — auto-deploy restores previous config
- Manual: `docker restart docker-proxy && docker restart api`

## Validation Evidence
- Infra/Deploy: `docker compose config` — valid
- Root cause chain: `read_only: true` blocked haproxy.cfg write -> #111 tmpfs fix wiped template -> `sed: haproxy.cfg.template: No such file or directory`
- Verified image contents: `docker run --rm --entrypoint ls tecnativa/docker-socket-proxy:0.3 /usr/local/etc/haproxy/` shows `haproxy.cfg.template` and `errors/` dir that tmpfs destroys

## Test plan
- [x] Compose file validates
- [ ] CI checks pass
- [ ] docker-proxy starts healthy after deploy
- [ ] API container starts and passes healthcheck
