### PR TITLE
feat: add closed-loop planning CI check and skill

### DIFF
--- a/.github/agents/planner.md
+++ b/.github/agents/planner.md
@@ -40,34 +40,57 @@ In Claude Code, you can also use built-in plan mode (EnterPlanMode) for the same
 
 ## Plan Output Format
 
+Use the closed-loop format with all 9 required sections:
+
 ```markdown
 # Plan: <title>
 
-## Objective
-<1-2 sentences describing what this plan achieves>
+## Goal / Signal
+<What does success look like? What observable signal confirms this landed correctly?>
 
-## Affected Files
-| File | Action | Purpose |
-|------|--------|---------|
-| `path/to/file` | create/edit/delete | What changes and why |
+## Scope
+**In scope:** ...
+**Out of scope:** ...
 
-## Approach
-1. <Step 1>
-2. <Step 2>
-3. ...
+## TDD Matrix
+| Requirement | Test | Type |
+|---|---|---|
+| ... | `test_...` | unit/integration |
+
+## Implementation Steps
+### Phase 1: Red — Write failing tests
+### Phase 2: Green — Minimum implementation
+### Phase 3: Refactor — Clean up
+
+## Verification Matrix
+| Check | Command | Expected Result |
+|---|---|---|
+| ... | `...` | ... |
+
+## CI / Drift Gates
+- New gates added
+- Existing gates preserved
+- Drift risks
 
 ## Risks & Mitigations
-| Risk | Mitigation |
-|------|-----------|
-| <what could go wrong> | <how to prevent or handle it> |
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| ... | ... | ... | ... |
 
-## Verification Checklist
-- [ ] <check 1>
-- [ ] <check 2>
+## Definition of Done
+- [ ] <condition 1>
+- [ ] <condition 2>
+
+## Stop Conditions
+**Stop if:** ...
+**Out of scope:** ...
 ```
+
+See `/closing-the-loop` skill for detailed guidance on each section.
 
 ## References
 
 - Testing conventions: `.github/instructions/testing.instructions.md`
 - Contribution workflow: `.github/docs/contribution-workflow.md`
 - Harness reference: `.github/docs/harness-reference.md`
+- Closed-loop planning skill: `.github/skills/closing-the-loop/SKILL.md`

--- a/.github/docs/best-practices.md
+++ b/.github/docs/best-practices.md
@@ -30,7 +30,7 @@ Separate research from implementation. Jumping straight to code solves the wrong
 5. **Refactor** — clean up while keeping tests green
 6. **Commit** — descriptive message, clean diff
 
-Skip steps 3-5 for non-code changes (docs, config). Skip planning for trivial changes. See `.github/docs/tdd-workflow.md` for TDD details.
+Skip steps 3-5 for non-code changes (docs, config). Skip planning for trivial changes. See `.github/docs/tdd-workflow.md` for TDD details. For the full planning template, use `/closing-the-loop`.
 
 ## 3. Specific Prompts Beat Vague Ones
 

--- a/.github/docs/contribution-workflow.md
+++ b/.github/docs/contribution-workflow.md
@@ -9,7 +9,8 @@ See also: `.github/docs/harness-reference.md` for platform parity, repository to
 1. **Orient**
    - Run `/primer` first.
 2. **Plan**
-   - Use plan mode to inspect code, write a decision-complete implementation plan, and get approval.
+   - Use plan mode to produce a closed-loop plan (`/closing-the-loop`), and get approval.
+   - Non-trivial changes require all 9 closed-loop sections.
 3. **Implement**
    - Code changes: Red -> Green -> Refactor.
    - Infra/docs changes: make direct surgical edits.

--- a/.github/skills/closing-the-loop/SKILL.md
+++ b/.github/skills/closing-the-loop/SKILL.md
@@ -1,0 +1,213 @@
+---
+name: closing-the-loop
+description: Closed-loop planning discipline for non-trivial changes. Use when creating implementation plans, reviewing plan completeness, or preparing PRs that require structured planning evidence.
+---
+
+# Closed-Loop Planning
+
+Formalize implementation plans so every non-trivial change has a clear contract between planning and verification. The 9 required sections close the loop between "what we plan" and "what we enforce."
+
+## When to Use
+
+- Before implementing any non-trivial change (3+ files, new features, policy work)
+- When creating or reviewing implementation plans in plan mode
+- When preparing PR bodies that need structured planning evidence
+- Skip for trivial changes (< 3 files, docs-only, single-line fixes)
+
+## Required Plan Sections
+
+Every non-trivial plan must include all 9 sections. Order is flexible; names accept alternatives.
+
+### 1. Goal / Signal
+
+What does success look like? What observable signal confirms this work landed correctly?
+
+```markdown
+## Goal / Signal
+
+After this lands:
+- Observable signal: <what changes in the system>
+- User-facing impact: <what users see differently>
+```
+
+**Alternatives:** `Objective`
+
+### 2. Scope
+
+What is in scope and what is explicitly out of scope for this change?
+
+```markdown
+## Scope
+
+**In scope:**
+- Item A
+- Item B
+
+**Out of scope:**
+- Item C (future PR)
+```
+
+### 3. TDD Matrix
+
+Map each requirement to its test. This is the contract between what we build and how we verify it.
+
+```markdown
+## TDD Matrix
+
+| Requirement | Test | Type |
+|---|---|---|
+| Feature X works | `test_feature_x` | unit |
+| API returns 200 | `test_api_returns_200` | integration |
+```
+
+**Alternatives:** `Test Matrix`
+
+### 4. Implementation Steps
+
+Ordered steps with enough detail that another agent could execute them. Group by TDD phase (Red/Green/Refactor) when applicable.
+
+```markdown
+## Implementation Steps
+
+### Phase 1: Red
+1. Write failing test for X
+
+### Phase 2: Green
+2. Implement X to pass test
+
+### Phase 3: Refactor
+3. Clean up implementation
+```
+
+**Alternatives:** `Approach`
+
+### 5. Verification Matrix
+
+Concrete commands and expected results. Every claim in the plan maps to a verification step.
+
+```markdown
+## Verification Matrix
+
+| Check | Command | Expected Result |
+|---|---|---|
+| Tests pass | `pytest tests/ -v` | All green |
+| Lint clean | `shellcheck scripts/*.sh` | No errors |
+```
+
+**Alternatives:** `Verification Checklist`
+
+### 6. CI / Drift Gates
+
+What CI checks enforce this change? What drift could occur and how is it caught?
+
+```markdown
+## CI / Drift Gates
+
+- **New gate:** `check_foo.py` runs on PRs
+- **Existing gates preserved:** bats, compose, shellcheck
+- **Drift risk:** If X changes, Y catches it
+```
+
+**Alternatives:** `CI Gates`, `Drift Gates`
+
+### 7. Risks & Mitigations
+
+What could go wrong and how do we prevent or handle it?
+
+```markdown
+## Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| X breaks Y | Low | High | Guard with Z |
+```
+
+### 8. Definition of Done
+
+Checkbox list of all conditions that must be true before this work is complete.
+
+```markdown
+## Definition of Done
+
+- [ ] All tests pass
+- [ ] CI green
+- [ ] Docs updated
+- [ ] Line count constraints met
+```
+
+**Alternatives:** `Done Criteria`
+
+### 9. Stop Conditions / Out-of-Scope
+
+When should work stop? What explicit boundaries prevent scope creep?
+
+```markdown
+## Stop Conditions
+
+**Stop if:**
+- X exceeds threshold Y
+- Approach Z proves unviable
+
+**Out of scope:**
+- Future enhancement A
+- Unrelated refactor B
+```
+
+**Alternatives:** `Out of Scope`, `Out-of-Scope`
+
+## Plan Checklist
+
+Copy into your plan and check off as you complete each section:
+
+```markdown
+- [ ] Goal / Signal
+- [ ] Scope
+- [ ] TDD Matrix
+- [ ] Implementation Steps
+- [ ] Verification Matrix
+- [ ] CI / Drift Gates
+- [ ] Risks & Mitigations
+- [ ] Definition of Done
+- [ ] Stop Conditions
+```
+
+## Anti-Patterns
+
+| Anti-Pattern | Why It Fails | Fix |
+|---|---|---|
+| Vague goal ("improve things") | No observable signal to verify | State concrete before/after |
+| TDD matrix without test names | Can't verify tests were written | Name every test function |
+| Steps without phase grouping | Unclear when to test vs. implement | Group by Red/Green/Refactor |
+| Missing stop conditions | Scope creep goes unchecked | Define explicit boundaries |
+| Verification without commands | "It works" isn't evidence | Include exact commands + expected output |
+| Risks without mitigations | Identified but unaddressed | Every risk needs a mitigation |
+| DoD without checkboxes | Can't track completion | Use `- [ ]` for each condition |
+| Scope without "out of scope" | Boundaries are implicit | Explicitly list what you won't do |
+| CI section says "existing" only | Doesn't explain new enforcement | Document new gates + drift risks |
+
+## CI Enforcement
+
+The `check_plan_closed_loop.py` script validates plan sections:
+
+- **Advisory mode** (default): Warns on missing sections, exits 0
+- **Strict mode** (`PLAN_CLOSED_LOOP_STRICT=1`): Fails on missing sections, exits 1
+- **Skips:** docs-only PRs, trivial PRs (< 3 files)
+- **Sources:** checks PR body + changed `.claude/plans/*.md` files
+
+## Integration with PR Workflow
+
+This skill maps to step 2 of the Required PR Workflow in `AGENTS.md`:
+
+1. **Orient** — `/primer`
+2. **Plan** — `/closing-the-loop` (this skill)
+3. **Implement** — Red/Green/Refactor
+4. **Verify** — run commands from Verification Matrix
+
+## References
+
+- Policy: `AGENTS.md` (non-negotiable 6, PR workflow step 2)
+- CI check: `scripts/checks/check_plan_closed_loop.py`
+- Tests: `tests/checks/test_check_plan_closed_loop.py`
+- Best practices: `.github/docs/best-practices.md` (section 2)
+- Contribution workflow: `.github/docs/contribution-workflow.md`
+- Planner agent: `.github/agents/planner.md`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,13 @@ jobs:
       - name: Validate harness freshness
         run: python3 scripts/checks/check_harness_freshness.py
 
+      - name: Validate closed-loop plan evidence
+        if: github.event_name == 'pull_request'
+        env:
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+          PLAN_CLOSED_LOOP_STRICT: "0"
+        run: python3 scripts/checks/check_plan_closed_loop.py
+
       - name: Validate markdown links
         run: python3 scripts/checks/check_md_links.py
 
@@ -69,6 +76,9 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+
+      - name: Run check script tests
+        run: pip install pytest && pytest tests/checks/ -v
 
       - name: Run MCP tests
         working-directory: src/services/mcp

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,13 +22,16 @@ Chain: `AGENTS.md` (source) <- `CLAUDE.md` (symlink) <- `.github/copilot-instruc
    - Use `bash scripts/deploy.sh <service> prod` (canonical) or `make deploy-<service>` (convenience).
 5. **Context collapse recovery is mandatory**
    - After any context compaction/collapse, restate current task + active workflow from summary, then run primer before making changes or running commands.
+6. **Closed-loop planning for non-trivial changes**
+   - Non-trivial changes (3+ files, new features, policy work) require a closed-loop plan with all 9 sections.
+   - Use `/closing-the-loop` skill for the template and checklist.
 
 ## Required PR Workflow
 
 This is the required flow for Claude, Codex, and Copilot-assisted changes.
 
 1. **Orient** — run primer (`$primer` in Codex, `/primer` in Claude/Copilot).
-2. **Plan** — explore, produce plan, get approval.
+2. **Plan** — produce a closed-loop plan (`/closing-the-loop`), get approval. Non-trivial changes require all 9 sections. Trivial changes (< 3 files, docs-only) may skip.
 3. **Implement**
    - Code: Red -> Green -> Refactor
    - Infra/docs: direct surgical edits
@@ -110,6 +113,7 @@ For manual VPS access, see `docs/runbooks/deployment.md`.
 - Deployment architecture: `.github/docs/deployment.md`
 - VPS rebuild runbook: `docs/runbooks/vps-rebuild.md`
 - Architecture overview: `docs/architecture/overview.md`
+- Closed-loop planning skill: `.github/skills/closing-the-loop/SKILL.md`
 
 ## Guardrails
 
@@ -118,6 +122,7 @@ Do:
 - Track work in Linear and keep state current.
 - Use `bash scripts/*.sh` or `make` wrappers for operations.
 - Validate behavior locally before PR.
+- Complete closed-loop plan before implementing non-trivial changes.
 - Update `src/services/api/src/openapi/openapi.yaml` when adding or changing API routes. CI enforces spec-vs-route drift.
 
 Don't:

--- a/scripts/checks/check_plan_closed_loop.py
+++ b/scripts/checks/check_plan_closed_loop.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""Advisory closed-loop planning check for pull requests.
+
+Validates that non-trivial PRs include all 9 closed-loop plan sections,
+either in the PR body or in changed .claude/plans/*.md files.
+
+This check is intentionally non-blocking by default. Set
+PLAN_CLOSED_LOOP_STRICT=1 in the environment to fail on missing evidence.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+TRIVIAL_THRESHOLD = 3
+
+# Each entry: section key -> compiled regex pattern.
+# Patterns are anchored to heading start to avoid false passes from
+# headings like "Next steps", "CI workflow", "Done", etc.
+REQUIRED_SECTIONS: dict[str, re.Pattern[str]] = {
+    "goal": re.compile(
+        r"^#{2,3}\s+(?:goal|signal|goal\s*/\s*signal|objective)",
+        re.IGNORECASE | re.MULTILINE,
+    ),
+    "scope": re.compile(
+        r"^#{2,3}\s+scope",
+        re.IGNORECASE | re.MULTILINE,
+    ),
+    "tdd": re.compile(
+        r"^#{2,3}\s+(?:tdd|test\s+matrix)",
+        re.IGNORECASE | re.MULTILINE,
+    ),
+    "steps": re.compile(
+        r"^#{2,3}\s+(?:implementation\s+steps|approach)",
+        re.IGNORECASE | re.MULTILINE,
+    ),
+    "verification": re.compile(
+        r"^#{2,3}\s+(?:verification\s+matrix|verification\s+checklist|verification)",
+        re.IGNORECASE | re.MULTILINE,
+    ),
+    "ci-gates": re.compile(
+        r"^#{2,3}\s+(?:ci\s*/\s*drift|ci\s+gates|drift\s+gates)",
+        re.IGNORECASE | re.MULTILINE,
+    ),
+    "risks": re.compile(
+        r"^#{2,3}\s+(?:risks?(?:\s|$)|risks?\s*&|risks?\s+and\s+mitigations)",
+        re.IGNORECASE | re.MULTILINE,
+    ),
+    "definition-of-done": re.compile(
+        r"^#{2,3}\s+(?:definition\s+of\s+done|done\s+criteria)",
+        re.IGNORECASE | re.MULTILINE,
+    ),
+    "stop-conditions": re.compile(
+        r"^#{2,3}\s+(?:stop\s+conditions|out[- ]of[- ]scope)",
+        re.IGNORECASE | re.MULTILINE,
+    ),
+}
+
+
+def run(cmd: list[str]) -> str:
+    result = subprocess.run(cmd, cwd=ROOT, check=True, capture_output=True, text=True)
+    return result.stdout.strip()
+
+
+def changed_files(base_ref: str) -> list[str]:
+    """Get list of changed files, with test override support."""
+    override = os.environ.get("_CHANGED_FILES_OVERRIDE")
+    if override is not None:
+        if not override:
+            return []
+        path = Path(override)
+        if not path.exists() or path.stat().st_size == 0:
+            return []
+        return [line.strip() for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+    subprocess.run(
+        ["git", "fetch", "--no-tags", "origin", base_ref],
+        cwd=ROOT,
+        check=False,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        out = run(["git", "diff", "--name-only", f"origin/{base_ref}...HEAD"])
+    except subprocess.CalledProcessError:
+        out = run(["git", "diff", "--name-only", "HEAD"])
+    return [line.strip() for line in out.splitlines() if line.strip()]
+
+
+def read_pr_body() -> str:
+    event_path = os.environ.get("GITHUB_EVENT_PATH")
+    if not event_path:
+        return ""
+    try:
+        data = json.loads(Path(event_path).read_text(encoding="utf-8"))
+    except Exception:
+        return ""
+    pr = data.get("pull_request") or {}
+    body = pr.get("body")
+    return body or ""
+
+
+def classify(files: list[str]) -> dict[str, bool]:
+    docs_only = bool(files) and all(f.endswith(".md") for f in files)
+    return {"docs_only": docs_only}
+
+
+def get_plan_file_content(files: list[str]) -> str:
+    """Read changed plan file content, with test override support."""
+    override = os.environ.get("_PLAN_FILES_OVERRIDE")
+    if override is not None:
+        path = Path(override)
+        if path.exists():
+            return path.read_text(encoding="utf-8")
+        return ""
+
+    parts = []
+    for f in files:
+        if f.startswith(".claude/plans/") and f.endswith(".md"):
+            full = ROOT / f
+            if full.exists():
+                parts.append(full.read_text(encoding="utf-8"))
+    return "\n".join(parts)
+
+
+def check_sections(text: str) -> list[str]:
+    """Return list of missing section keys."""
+    missing = []
+    for key, pattern in REQUIRED_SECTIONS.items():
+        if not pattern.search(text):
+            missing.append(key)
+    return missing
+
+
+def main() -> int:
+    base_ref = os.environ.get("GITHUB_BASE_REF") or "main"
+    strict = os.environ.get("PLAN_CLOSED_LOOP_STRICT") == "1"
+
+    files = changed_files(base_ref)
+    body = read_pr_body()
+    types = classify(files)
+
+    # Skip for docs-only PRs.
+    if types["docs_only"]:
+        print("Closed-loop plan check: skipped (docs-only PR).")
+        _write_summary("Closed-loop plan check: skipped (docs-only PR).")
+        return 0
+
+    # Skip for trivial PRs (fewer than TRIVIAL_THRESHOLD files).
+    if len(files) < TRIVIAL_THRESHOLD:
+        print(f"Closed-loop plan check: skipped ({len(files)} files < {TRIVIAL_THRESHOLD} threshold).")
+        _write_summary(f"Closed-loop plan check: skipped ({len(files)} files < {TRIVIAL_THRESHOLD} threshold).")
+        return 0
+
+    # Collect text to check: PR body + changed plan file content.
+    plan_content = get_plan_file_content(files)
+    combined_text = body + "\n" + plan_content
+
+    missing = check_sections(combined_text)
+
+    warnings: list[str] = []
+    for key in missing:
+        warnings.append(f"[WARN] Missing closed-loop section: {key}")
+
+    # Build report.
+    header = "## Closed-Loop Plan Check (Advisory)"
+    lines = [header, "", f"- Changed files: `{len(files)}`"]
+
+    if warnings:
+        lines.append("")
+        lines.append("### Warnings")
+        for w in warnings:
+            lines.append(f"- {w}")
+            print(w)
+    else:
+        lines.append("")
+        lines.append("All 9 closed-loop plan sections found.")
+        print("Closed-loop plan check: all sections present.")
+
+    report = "\n".join(lines)
+    _write_summary(report)
+
+    if missing and strict:
+        return 1
+    return 0
+
+
+def _write_summary(text: str) -> None:
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_path:
+        with open(summary_path, "a", encoding="utf-8") as fh:
+            fh.write(text + "\n")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/checks/test_check_plan_closed_loop.py
+++ b/tests/checks/test_check_plan_closed_loop.py
@@ -1,0 +1,358 @@
+"""Tests for scripts/checks/check_plan_closed_loop.py
+
+Validates closed-loop planning evidence in PR bodies and plan files.
+Tests follow the subprocess pattern used by existing BATS tests.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "checks" / "check_plan_closed_loop.py"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+COMPLETE_PLAN = """
+## Goal / Signal
+We want to achieve X.
+
+## Scope
+In scope: A, B, C.
+
+## TDD Matrix
+| Requirement | Test |
+|---|---|
+| Foo | test_foo |
+
+## Implementation Steps
+1. Do this
+2. Do that
+
+## Verification Matrix
+- [ ] Check A
+- [ ] Check B
+
+## CI / Drift Gates
+Existing gates preserved.
+
+## Risks & Mitigations
+| Risk | Mitigation |
+|---|---|
+| X | Y |
+
+## Definition of Done
+- [ ] All tests pass
+
+## Stop Conditions
+Stop if X exceeds Y.
+"""
+
+
+def _run(
+    env_overrides: dict[str, str] | None = None,
+    pr_body: str = "",
+    changed_files: list[str] | None = None,
+    plan_file_content: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Run the check script with controlled environment."""
+    env = os.environ.copy()
+    # Clear CI env vars that might leak from real environment.
+    env.pop("GITHUB_EVENT_PATH", None)
+    env.pop("GITHUB_BASE_REF", None)
+    env.pop("GITHUB_STEP_SUMMARY", None)
+    env.pop("PLAN_CLOSED_LOOP_STRICT", None)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmpdir_path = Path(tmpdir)
+
+        # Write event.json with PR body.
+        event = {"pull_request": {"body": pr_body}}
+        event_path = tmpdir_path / "event.json"
+        event_path.write_text(json.dumps(event), encoding="utf-8")
+        env["GITHUB_EVENT_PATH"] = str(event_path)
+
+        # Write summary file path.
+        summary_path = tmpdir_path / "summary.md"
+        env["GITHUB_STEP_SUMMARY"] = str(summary_path)
+
+        # Create a fake changed-files list if provided.
+        if changed_files is not None:
+            files_path = tmpdir_path / "changed_files.txt"
+            files_path.write_text("\n".join(changed_files), encoding="utf-8")
+            env["_CHANGED_FILES_OVERRIDE"] = str(files_path)
+
+        # Write a plan file if provided.
+        if plan_file_content is not None:
+            plan_dir = tmpdir_path / "plans"
+            plan_dir.mkdir()
+            plan_file = plan_dir / "plan.md"
+            plan_file.write_text(plan_file_content, encoding="utf-8")
+            env["_PLAN_FILES_OVERRIDE"] = str(plan_file)
+
+        if env_overrides:
+            env.update(env_overrides)
+
+        return subprocess.run(
+            ["python3", str(SCRIPT)],
+            capture_output=True,
+            text=True,
+            env=env,
+            cwd=ROOT,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestAllSectionsPresent:
+    def test_all_sections_present_passes(self):
+        """Complete plan body with all 9 sections should pass with no warnings."""
+        result = _run(
+            pr_body=COMPLETE_PLAN,
+            changed_files=["src/foo.py", "src/bar.py", "tests/test_foo.py"],
+        )
+        assert result.returncode == 0
+        assert "[WARN]" not in result.stdout
+
+
+class TestMissingSections:
+    def test_missing_goal_warns(self):
+        """Missing Goal/Signal section should produce a warning."""
+        body = COMPLETE_PLAN.replace("## Goal / Signal", "## Removed")
+        result = _run(
+            pr_body=body,
+            changed_files=["src/foo.py", "src/bar.py", "tests/test_foo.py"],
+        )
+        assert result.returncode == 0
+        assert "[WARN]" in result.stdout
+        assert "goal" in result.stdout.lower()
+
+    def test_missing_tdd_warns(self):
+        """Missing TDD Matrix section should produce a warning."""
+        body = COMPLETE_PLAN.replace("## TDD Matrix", "## Removed2")
+        result = _run(
+            pr_body=body,
+            changed_files=["src/foo.py", "src/bar.py", "tests/test_foo.py"],
+        )
+        assert result.returncode == 0
+        assert "[WARN]" in result.stdout
+        assert "tdd" in result.stdout.lower()
+
+    def test_missing_scope_warns(self):
+        """Missing Scope section should produce a warning."""
+        body = COMPLETE_PLAN.replace("## Scope", "## Removed3")
+        result = _run(
+            pr_body=body,
+            changed_files=["src/foo.py", "src/bar.py", "tests/test_foo.py"],
+        )
+        assert result.returncode == 0
+        assert "[WARN]" in result.stdout
+        assert "scope" in result.stdout.lower()
+
+    def test_missing_stop_warns(self):
+        """Missing Stop Conditions section should produce a warning."""
+        body = COMPLETE_PLAN.replace("## Stop Conditions", "## Removed4")
+        result = _run(
+            pr_body=body,
+            changed_files=["src/foo.py", "src/bar.py", "tests/test_foo.py"],
+        )
+        assert result.returncode == 0
+        assert "[WARN]" in result.stdout
+        assert "stop" in result.stdout.lower()
+
+    def test_missing_dod_warns(self):
+        """Missing Definition of Done section should produce a warning."""
+        body = COMPLETE_PLAN.replace("## Definition of Done", "## Removed5")
+        result = _run(
+            pr_body=body,
+            changed_files=["src/foo.py", "src/bar.py", "tests/test_foo.py"],
+        )
+        assert result.returncode == 0
+        assert "[WARN]" in result.stdout
+        assert "definition" in result.stdout.lower() or "done" in result.stdout.lower()
+
+    def test_multiple_missing_warns_all(self):
+        """Multiple missing sections should produce a warning for each."""
+        body = (
+            COMPLETE_PLAN.replace("## Goal / Signal", "## Removed")
+            .replace("## TDD Matrix", "## Removed2")
+            .replace("## Risks & Mitigations", "## Removed3")
+        )
+        result = _run(
+            pr_body=body,
+            changed_files=["src/foo.py", "src/bar.py", "tests/test_foo.py"],
+        )
+        assert result.returncode == 0
+        warns = [line for line in result.stdout.splitlines() if "[WARN]" in line]
+        assert len(warns) >= 3
+
+
+class TestStrictMode:
+    def test_strict_mode_fails_on_missing(self):
+        """Strict mode should exit 1 when sections are missing."""
+        body = COMPLETE_PLAN.replace("## Goal / Signal", "## Removed")
+        result = _run(
+            pr_body=body,
+            changed_files=["src/foo.py", "src/bar.py", "tests/test_foo.py"],
+            env_overrides={"PLAN_CLOSED_LOOP_STRICT": "1"},
+        )
+        assert result.returncode == 1
+
+    def test_strict_mode_passes_when_complete(self):
+        """Strict mode should exit 0 when all sections are present."""
+        result = _run(
+            pr_body=COMPLETE_PLAN,
+            changed_files=["src/foo.py", "src/bar.py", "tests/test_foo.py"],
+            env_overrides={"PLAN_CLOSED_LOOP_STRICT": "1"},
+        )
+        assert result.returncode == 0
+
+
+class TestSkipConditions:
+    def test_docs_only_pr_skips(self):
+        """Docs-only PRs should skip the check entirely."""
+        result = _run(
+            pr_body="Just docs changes",
+            changed_files=["README.md", "docs/guide.md"],
+        )
+        assert result.returncode == 0
+        assert "[WARN]" not in result.stdout
+
+    def test_trivial_pr_skips(self):
+        """PRs with fewer than 3 changed files should skip."""
+        result = _run(
+            pr_body="Small fix",
+            changed_files=["src/foo.py", "src/bar.py"],
+        )
+        assert result.returncode == 0
+        assert "[WARN]" not in result.stdout
+
+
+class TestPlanFiles:
+    def test_changed_plan_file_validates(self):
+        """A changed plan file with all sections should pass."""
+        result = _run(
+            pr_body="",
+            changed_files=["src/foo.py", "src/bar.py", "tests/test_foo.py"],
+            plan_file_content=COMPLETE_PLAN,
+        )
+        assert result.returncode == 0
+        assert "[WARN]" not in result.stdout
+
+    def test_changed_plan_file_missing_sections_warns(self):
+        """A changed plan file missing sections should warn."""
+        result = _run(
+            pr_body="",
+            changed_files=["src/foo.py", "src/bar.py", "tests/test_foo.py"],
+            plan_file_content="## Goal / Signal\nSome goal.\n",
+        )
+        assert result.returncode == 0
+        assert "[WARN]" in result.stdout
+
+    def test_unchanged_plan_files_ignored(self):
+        """Historical plan files not in the diff should be ignored."""
+        # No plan file override + no plan content in body = warns about missing sections.
+        result = _run(
+            pr_body="No plan here",
+            changed_files=["src/foo.py", "src/bar.py", "tests/test_foo.py"],
+        )
+        assert result.returncode == 0
+        assert "[WARN]" in result.stdout
+
+
+class TestHeadingVariants:
+    def test_heading_case_insensitive(self):
+        """Headings should match case-insensitively."""
+        body = COMPLETE_PLAN.replace("## Goal / Signal", "## goal / signal")
+        result = _run(
+            pr_body=body,
+            changed_files=["src/foo.py", "src/bar.py", "tests/test_foo.py"],
+        )
+        assert result.returncode == 0
+        assert "[WARN]" not in result.stdout
+
+    def test_h2_and_h3_headings_accepted(self):
+        """Both ## and ### headings should be accepted."""
+        body = COMPLETE_PLAN.replace("## Goal / Signal", "### Goal / Signal").replace(
+            "## TDD Matrix", "### TDD Matrix"
+        )
+        result = _run(
+            pr_body=body,
+            changed_files=["src/foo.py", "src/bar.py", "tests/test_foo.py"],
+        )
+        assert result.returncode == 0
+        assert "[WARN]" not in result.stdout
+
+    def test_alternative_heading_names(self):
+        """Alternative heading names (Objective, Approach) should be accepted."""
+        body = (
+            COMPLETE_PLAN.replace("## Goal / Signal", "## Objective")
+            .replace("## Implementation Steps", "## Approach")
+            .replace("## Definition of Done", "## Done Criteria")
+            .replace("## Stop Conditions", "## Out of Scope")
+            .replace("## TDD Matrix", "## Test Matrix")
+        )
+        result = _run(
+            pr_body=body,
+            changed_files=["src/foo.py", "src/bar.py", "tests/test_foo.py"],
+        )
+        assert result.returncode == 0
+        assert "[WARN]" not in result.stdout
+
+
+class TestNoBodyNoPlanFiles:
+    def test_no_body_no_plan_files_warns(self):
+        """No PR body and no plan files should produce warnings."""
+        result = _run(
+            pr_body="",
+            changed_files=["src/foo.py", "src/bar.py", "tests/test_foo.py"],
+        )
+        assert result.returncode == 0
+        assert "[WARN]" in result.stdout
+
+
+class TestGitHubStepSummary:
+    def test_github_step_summary_written(self):
+        """GITHUB_STEP_SUMMARY file should be written to."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir_path = Path(tmpdir)
+            summary_path = tmpdir_path / "summary.md"
+            event = {"pull_request": {"body": COMPLETE_PLAN}}
+            event_path = tmpdir_path / "event.json"
+            event_path.write_text(json.dumps(event), encoding="utf-8")
+
+            env = os.environ.copy()
+            env.pop("GITHUB_EVENT_PATH", None)
+            env.pop("GITHUB_BASE_REF", None)
+            env.pop("PLAN_CLOSED_LOOP_STRICT", None)
+            env["GITHUB_EVENT_PATH"] = str(event_path)
+            env["GITHUB_STEP_SUMMARY"] = str(summary_path)
+            # Provide changed files so the check doesn't skip.
+            files_path = tmpdir_path / "changed_files.txt"
+            files_path.write_text(
+                "src/foo.py\nsrc/bar.py\ntests/test_foo.py", encoding="utf-8"
+            )
+            env["_CHANGED_FILES_OVERRIDE"] = str(files_path)
+
+            subprocess.run(
+                ["python3", str(SCRIPT)],
+                capture_output=True,
+                text=True,
+                env=env,
+                cwd=ROOT,
+            )
+
+            assert summary_path.exists()
+            content = summary_path.read_text(encoding="utf-8")
+            assert "Closed-Loop" in content or "closed-loop" in content.lower()


### PR DESCRIPTION
## Summary

- Add `/closing-the-loop` skill with all 9 required plan sections documented, checklist template, and anti-patterns table
- Add `check_plan_closed_loop.py` CI check that validates plan evidence in PR bodies and changed `.claude/plans/*.md` files
- Add 19 pytest unit tests for the check script covering sections, strict/advisory modes, skip conditions, heading variants, and plan files
- Update AGENTS.md with non-negotiable 6 (closed-loop planning), expanded PR workflow step 2, reference map entry, and guardrail
- Update planner agent output format to 9-section closed-loop template
- Add CI steps for the closed-loop check (advisory, PR-only) and check script tests

Phase 1 is advisory-only — warns on missing sections but does not block merges. Phase 2 (future PR) will add strict enforcement mirroring agent-loop-gate's two-job pattern.

## Test plan

- [x] 19/19 pytest tests pass (`pytest tests/checks/ -v`)
- [x] Advisory mode exits 0 with warnings when no PR body
- [x] Strict mode exits 1 when sections missing (`PLAN_CLOSED_LOOP_STRICT=1`)
- [x] AGENTS.md under 180 lines (135 lines)
- [x] SKILL.md under 500 lines (213 lines)
- [x] Harness freshness check passes
- [x] Markdown links check passes
- [x] 235/235 BATS tests pass
- [x] Shellcheck clean
- [x] CI YAML syntax valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)