### PR TITLE
feat: add profile UI — avatar, display name, and password forms

### DIFF
--- a/src/services/ui/src/app/api/profile/[...path]/route.ts
+++ b/src/services/ui/src/app/api/profile/[...path]/route.ts
@@ -1,0 +1,80 @@
+import { auth } from '@/auth'
+import { NextRequest, NextResponse } from 'next/server'
+
+const API_URL = process.env.API_URL || 'http://localhost:3000'
+
+async function proxyRequest(req: NextRequest, { params }: { params: Promise<{ path: string[] }> }) {
+  const session = await auth()
+  if (!session?.accessToken) {
+    return NextResponse.json({ error: 'Not authenticated' }, { status: 401 })
+  }
+
+  const { path } = await params
+  const pathStr = path.join('/')
+  const url = new URL(`${API_URL}/profile/${pathStr}`)
+
+  // Forward query params
+  req.nextUrl.searchParams.forEach((value, key) => {
+    url.searchParams.set(key, value)
+  })
+
+  const headers: Record<string, string> = {
+    'Authorization': `Bearer ${session.accessToken}`,
+  }
+
+  const contentType = req.headers.get('content-type')
+
+  // For multipart (avatar upload), forward raw body and content-type header
+  // For JSON requests, forward content-type normally
+  if (contentType) {
+    headers['Content-Type'] = contentType
+  }
+
+  const fetchOpts: RequestInit = {
+    method: req.method,
+    headers,
+    signal: AbortSignal.timeout(30000),
+  }
+
+  if (req.method !== 'GET' && req.method !== 'HEAD') {
+    // Forward raw body bytes (works for both multipart and JSON)
+    fetchOpts.body = await req.arrayBuffer()
+    // duplex required for streaming request bodies in Node fetch
+    ;(fetchOpts as any).duplex = 'half'
+  }
+
+  try {
+    const res = await fetch(url.toString(), fetchOpts)
+
+    // Binary response (avatar image) — stream through
+    const resContentType = res.headers.get('content-type') || ''
+    if (resContentType.startsWith('image/')) {
+      const responseHeaders: Record<string, string> = {
+        'Content-Type': resContentType,
+        'Cache-Control': res.headers.get('cache-control') || 'private, no-cache',
+      }
+      const etag = res.headers.get('etag')
+      if (etag) responseHeaders['ETag'] = etag
+
+      return new Response(res.body, {
+        status: res.status,
+        headers: responseHeaders,
+      })
+    }
+
+    // 304 Not Modified has no body
+    if (res.status === 304) {
+      return new Response(null, { status: 304 })
+    }
+
+    const data = await res.json()
+    return NextResponse.json(data, { status: res.status })
+  } catch (err) {
+    console.error('[profile-proxy] Error:', err)
+    return NextResponse.json({ error: 'API request failed' }, { status: 502 })
+  }
+}
+
+export const GET = proxyRequest
+export const POST = proxyRequest
+export const DELETE = proxyRequest

--- a/src/services/ui/src/app/api/profile/route.ts
+++ b/src/services/ui/src/app/api/profile/route.ts
@@ -1,0 +1,44 @@
+import { auth } from '@/auth'
+import { NextRequest, NextResponse } from 'next/server'
+
+const API_URL = process.env.API_URL || 'http://localhost:3000'
+
+async function proxyRequest(req: NextRequest) {
+  const session = await auth()
+  if (!session?.accessToken) {
+    return NextResponse.json({ error: 'Not authenticated' }, { status: 401 })
+  }
+
+  const url = new URL(`${API_URL}/profile`)
+
+  const headers: Record<string, string> = {
+    'Authorization': `Bearer ${session.accessToken}`,
+  }
+
+  const contentType = req.headers.get('content-type')
+  if (contentType) {
+    headers['Content-Type'] = contentType
+  }
+
+  const fetchOpts: RequestInit = {
+    method: req.method,
+    headers,
+    signal: AbortSignal.timeout(30000),
+  }
+
+  if (req.method !== 'GET' && req.method !== 'HEAD') {
+    fetchOpts.body = await req.text()
+  }
+
+  try {
+    const res = await fetch(url.toString(), fetchOpts)
+    const data = await res.json()
+    return NextResponse.json(data, { status: res.status })
+  } catch (err) {
+    console.error('[profile-proxy] Error:', err)
+    return NextResponse.json({ error: 'API request failed' }, { status: 502 })
+  }
+}
+
+export const GET = proxyRequest
+export const PATCH = proxyRequest

--- a/src/services/ui/src/app/profile/ProfileClient.tsx
+++ b/src/services/ui/src/app/profile/ProfileClient.tsx
@@ -1,0 +1,394 @@
+'use client'
+
+import { useState, useEffect, useCallback, useRef } from 'react'
+import type { Session } from 'next-auth'
+
+interface ProfileData {
+  firstName?: string
+  lastName?: string
+  email?: string
+  avatarUrl?: string
+}
+
+export default function ProfileClient({ session }: { session: Session }) {
+  // Profile data
+  const [profile, setProfile] = useState<ProfileData | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  // Name editing
+  const [firstName, setFirstName] = useState('')
+  const [lastName, setLastName] = useState('')
+  const [nameSaving, setNameSaving] = useState(false)
+  const [nameSuccess, setNameSuccess] = useState(false)
+  const [nameError, setNameError] = useState('')
+
+  // Avatar
+  const [avatarUrl, setAvatarUrl] = useState<string | null>(null)
+  const [avatarUploading, setAvatarUploading] = useState(false)
+  const [avatarError, setAvatarError] = useState('')
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  // Password
+  const [currentPassword, setCurrentPassword] = useState('')
+  const [newPassword, setNewPassword] = useState('')
+  const [confirmPassword, setConfirmPassword] = useState('')
+  const [passwordSaving, setPasswordSaving] = useState(false)
+  const [passwordError, setPasswordError] = useState('')
+  const [passwordNotAvailable, setPasswordNotAvailable] = useState(false)
+
+  const fetchProfile = useCallback(async () => {
+    try {
+      const res = await fetch('/api/profile')
+      if (res.ok) {
+        const data = await res.json()
+        setProfile(data)
+        setFirstName(data.firstName || '')
+        setLastName(data.lastName || '')
+      }
+    } catch (err) {
+      console.error('Failed to fetch profile:', err)
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  const fetchAvatar = useCallback(async () => {
+    try {
+      const res = await fetch('/api/profile/avatar')
+      if (res.ok) {
+        const blob = await res.blob()
+        setAvatarUrl((prev) => {
+          if (prev) URL.revokeObjectURL(prev)
+          return URL.createObjectURL(blob)
+        })
+      } else {
+        setAvatarUrl(null)
+      }
+    } catch {
+      setAvatarUrl(null)
+    }
+  }, [])
+
+  useEffect(() => {
+    fetchProfile()
+    fetchAvatar()
+  }, [fetchProfile, fetchAvatar])
+
+  // Cleanup blob URL on unmount
+  useEffect(() => {
+    return () => {
+      if (avatarUrl) URL.revokeObjectURL(avatarUrl)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const handleNameSave = async () => {
+    setNameError('')
+    setNameSuccess(false)
+
+    if (firstName.length > 100 || lastName.length > 100) {
+      setNameError('Name must be 100 characters or less')
+      return
+    }
+
+    setNameSaving(true)
+    try {
+      const res = await fetch('/api/profile', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ firstName, lastName }),
+      })
+      if (res.ok) {
+        setNameSuccess(true)
+        setTimeout(() => setNameSuccess(false), 3000)
+      } else {
+        const data = await res.json()
+        setNameError(data.error || 'Failed to update name')
+      }
+    } catch {
+      setNameError('Failed to update name')
+    } finally {
+      setNameSaving(false)
+    }
+  }
+
+  const handleAvatarUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+
+    setAvatarError('')
+
+    if (file.size > 5 * 1024 * 1024) {
+      setAvatarError('File must be under 5MB')
+      return
+    }
+
+    if (!file.type.startsWith('image/')) {
+      setAvatarError('File must be an image')
+      return
+    }
+
+    setAvatarUploading(true)
+    try {
+      const formData = new FormData()
+      formData.append('avatar', file)
+
+      const res = await fetch('/api/profile/avatar', {
+        method: 'POST',
+        body: formData,
+      })
+      if (res.ok) {
+        await fetchAvatar()
+        window.dispatchEvent(new Event('avatar-changed'))
+      } else {
+        const data = await res.json()
+        setAvatarError(data.error || 'Failed to upload avatar')
+      }
+    } catch {
+      setAvatarError('Failed to upload avatar')
+    } finally {
+      setAvatarUploading(false)
+      if (fileInputRef.current) fileInputRef.current.value = ''
+    }
+  }
+
+  const handleAvatarDelete = async () => {
+    setAvatarError('')
+    setAvatarUploading(true)
+    try {
+      const res = await fetch('/api/profile/avatar', { method: 'DELETE' })
+      if (res.ok) {
+        setAvatarUrl((prev) => {
+          if (prev) URL.revokeObjectURL(prev)
+          return null
+        })
+        window.dispatchEvent(new Event('avatar-changed'))
+      } else {
+        const data = await res.json()
+        setAvatarError(data.error || 'Failed to delete avatar')
+      }
+    } catch {
+      setAvatarError('Failed to delete avatar')
+    } finally {
+      setAvatarUploading(false)
+    }
+  }
+
+  const handlePasswordChange = async () => {
+    setPasswordError('')
+
+    if (newPassword.length < 8) {
+      setPasswordError('New password must be at least 8 characters')
+      return
+    }
+    if (newPassword !== confirmPassword) {
+      setPasswordError('Passwords do not match')
+      return
+    }
+
+    setPasswordSaving(true)
+    try {
+      const res = await fetch('/api/profile/password', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ currentPassword, newPassword }),
+      })
+      const data = await res.json()
+      if (data.code === 'NOT_IMPLEMENTED') {
+        setPasswordNotAvailable(true)
+      } else if (!res.ok) {
+        setPasswordError(data.error || 'Failed to change password')
+      }
+    } catch {
+      setPasswordError('Failed to change password')
+    } finally {
+      setPasswordSaving(false)
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-24">
+        <div className="h-8 w-8 rounded-full border-2 border-brand-500 border-t-transparent animate-spin" />
+      </div>
+    )
+  }
+
+  const initials = session.user?.name
+    ? session.user.name
+        .split(/\s+/)
+        .filter(Boolean)
+        .slice(0, 2)
+        .map((p) => p.charAt(0).toUpperCase())
+        .join('')
+    : ''
+
+  return (
+    <>
+      <h1 className="text-2xl font-bold text-white mb-8">Profile</h1>
+
+      {/* Avatar Section */}
+      <div className="rounded-lg border border-navy-700 bg-navy-800 p-6 mb-4">
+        <h2 className="text-lg font-semibold text-white mb-4">Profile Picture</h2>
+        <div className="flex items-center gap-6">
+          <div className="h-20 w-20 rounded-full bg-brand-500 flex items-center justify-center text-xl font-semibold text-white overflow-hidden flex-shrink-0">
+            {avatarUrl ? (
+              <img
+                src={avatarUrl}
+                alt="Avatar"
+                className="h-full w-full object-cover"
+                onError={() => setAvatarUrl(null)}
+              />
+            ) : (
+              initials || (
+                <svg className="h-10 w-10 text-white" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                  <path d="M12 12c2.7 0 4.8-2.1 4.8-4.8S14.7 2.4 12 2.4 7.2 4.5 7.2 7.2 9.3 12 12 12zm0 2.4c-3.2 0-9.6 1.6-9.6 4.8v1.2c0 .7.5 1.2 1.2 1.2h16.8c.7 0 1.2-.5 1.2-1.2v-1.2c0-3.2-6.4-4.8-9.6-4.8z" />
+                </svg>
+              )
+            )}
+          </div>
+          <div className="space-y-2">
+            <div className="flex items-center gap-2">
+              <button
+                onClick={() => fileInputRef.current?.click()}
+                disabled={avatarUploading}
+                className="px-4 py-2 text-sm font-medium rounded-lg bg-brand-600 hover:bg-brand-500 text-white transition-colors disabled:opacity-50 cursor-pointer disabled:cursor-not-allowed"
+              >
+                {avatarUploading ? 'Uploading...' : 'Upload'}
+              </button>
+              {avatarUrl && (
+                <button
+                  onClick={handleAvatarDelete}
+                  disabled={avatarUploading}
+                  className="px-4 py-2 text-sm font-medium rounded-lg border border-navy-600 text-mountain-400 hover:text-white hover:border-red-500 transition-colors disabled:opacity-50 cursor-pointer disabled:cursor-not-allowed"
+                >
+                  Remove
+                </button>
+              )}
+            </div>
+            <p className="text-xs text-mountain-500">Max 5MB. Will be resized to 256x256.</p>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="image/*"
+              className="hidden"
+              onChange={handleAvatarUpload}
+            />
+          </div>
+        </div>
+        {avatarError && <p className="mt-3 text-sm text-red-400">{avatarError}</p>}
+      </div>
+
+      {/* Display Name Section */}
+      <div className="rounded-lg border border-navy-700 bg-navy-800 p-6 mb-4">
+        <h2 className="text-lg font-semibold text-white mb-4">Display Name</h2>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-4">
+          <div>
+            <label htmlFor="firstName" className="block text-xs font-medium text-mountain-500 uppercase tracking-wide mb-1">
+              First Name
+            </label>
+            <input
+              id="firstName"
+              type="text"
+              value={firstName}
+              onChange={(e) => setFirstName(e.target.value)}
+              maxLength={100}
+              className="w-full px-3 py-2 rounded-lg bg-navy-900 border border-navy-600 text-white placeholder-mountain-500 focus:outline-none focus:border-brand-500 transition-colors"
+              placeholder="First name"
+            />
+          </div>
+          <div>
+            <label htmlFor="lastName" className="block text-xs font-medium text-mountain-500 uppercase tracking-wide mb-1">
+              Last Name
+            </label>
+            <input
+              id="lastName"
+              type="text"
+              value={lastName}
+              onChange={(e) => setLastName(e.target.value)}
+              maxLength={100}
+              className="w-full px-3 py-2 rounded-lg bg-navy-900 border border-navy-600 text-white placeholder-mountain-500 focus:outline-none focus:border-brand-500 transition-colors"
+              placeholder="Last name"
+            />
+          </div>
+        </div>
+        <div className="flex items-center gap-3">
+          <button
+            onClick={handleNameSave}
+            disabled={nameSaving}
+            className="px-4 py-2 text-sm font-medium rounded-lg bg-brand-600 hover:bg-brand-500 text-white transition-colors disabled:opacity-50 cursor-pointer disabled:cursor-not-allowed"
+          >
+            {nameSaving ? 'Saving...' : 'Save'}
+          </button>
+          {nameSuccess && <span className="text-sm text-brand-400">Saved</span>}
+          {nameError && <span className="text-sm text-red-400">{nameError}</span>}
+        </div>
+        <div className="mt-4">
+          <label className="block text-xs font-medium text-mountain-500 uppercase tracking-wide mb-1">Email</label>
+          <p className="text-white text-sm">{profile?.email || session.user?.email || 'Not set'}</p>
+        </div>
+      </div>
+
+      {/* Password Section */}
+      <div className="rounded-lg border border-navy-700 bg-navy-800 p-6">
+        <h2 className="text-lg font-semibold text-white mb-4">Change Password</h2>
+        {passwordNotAvailable ? (
+          <p className="text-sm text-mountain-400">
+            Password change is not yet available. Please use the Keycloak account console to change your password.
+          </p>
+        ) : (
+          <>
+            <div className="space-y-4 mb-4 max-w-sm">
+              <div>
+                <label htmlFor="currentPassword" className="block text-xs font-medium text-mountain-500 uppercase tracking-wide mb-1">
+                  Current Password
+                </label>
+                <input
+                  id="currentPassword"
+                  type="password"
+                  value={currentPassword}
+                  onChange={(e) => setCurrentPassword(e.target.value)}
+                  className="w-full px-3 py-2 rounded-lg bg-navy-900 border border-navy-600 text-white placeholder-mountain-500 focus:outline-none focus:border-brand-500 transition-colors"
+                />
+              </div>
+              <div>
+                <label htmlFor="newPassword" className="block text-xs font-medium text-mountain-500 uppercase tracking-wide mb-1">
+                  New Password
+                </label>
+                <input
+                  id="newPassword"
+                  type="password"
+                  value={newPassword}
+                  onChange={(e) => setNewPassword(e.target.value)}
+                  className="w-full px-3 py-2 rounded-lg bg-navy-900 border border-navy-600 text-white placeholder-mountain-500 focus:outline-none focus:border-brand-500 transition-colors"
+                />
+              </div>
+              <div>
+                <label htmlFor="confirmPassword" className="block text-xs font-medium text-mountain-500 uppercase tracking-wide mb-1">
+                  Confirm New Password
+                </label>
+                <input
+                  id="confirmPassword"
+                  type="password"
+                  value={confirmPassword}
+                  onChange={(e) => setConfirmPassword(e.target.value)}
+                  className="w-full px-3 py-2 rounded-lg bg-navy-900 border border-navy-600 text-white placeholder-mountain-500 focus:outline-none focus:border-brand-500 transition-colors"
+                />
+              </div>
+            </div>
+            <div className="flex items-center gap-3">
+              <button
+                onClick={handlePasswordChange}
+                disabled={passwordSaving || !currentPassword || !newPassword || !confirmPassword}
+                className="px-4 py-2 text-sm font-medium rounded-lg bg-brand-600 hover:bg-brand-500 text-white transition-colors disabled:opacity-50 cursor-pointer disabled:cursor-not-allowed"
+              >
+                {passwordSaving ? 'Changing...' : 'Change Password'}
+              </button>
+              {passwordError && <span className="text-sm text-red-400">{passwordError}</span>}
+            </div>
+          </>
+        )}
+      </div>
+    </>
+  )
+}

--- a/src/services/ui/src/app/profile/page.tsx
+++ b/src/services/ui/src/app/profile/page.tsx
@@ -1,40 +1,20 @@
-import { redirect } from 'next/navigation';
-import { auth } from '@/auth';
-import AppShell from '@/components/AppShell';
+import { redirect } from 'next/navigation'
+import { auth } from '@/auth'
+import AppShell from '@/components/AppShell'
+import ProfileClient from './ProfileClient'
 
 export default async function Profile() {
-  const session = await auth();
+  const session = await auth()
 
   if (!session) {
-    redirect('/api/auth/signin');
+    redirect('/api/auth/signin')
   }
 
   return (
     <AppShell navExtra={<span className="text-sm font-medium text-white">Profile</span>}>
       <main className="flex-1 px-6 py-12 max-w-2xl mx-auto w-full">
-        <h1 className="text-2xl font-bold text-white mb-8">Profile</h1>
-
-        <div className="rounded-lg border border-navy-700 bg-navy-800 p-6 space-y-4">
-          <div>
-            <label className="text-xs font-medium text-mountain-500 uppercase tracking-wide">Name</label>
-            <p className="text-white mt-1">{session.user?.name || 'Not set'}</p>
-          </div>
-          <div>
-            <label className="text-xs font-medium text-mountain-500 uppercase tracking-wide">Email</label>
-            <p className="text-white mt-1">{session.user?.email || 'Not set'}</p>
-          </div>
-        </div>
-
-        <div className="mt-8 rounded-lg border border-navy-700 bg-navy-800 p-6">
-          <h2 className="text-lg font-semibold text-white mb-2">Profile Picture</h2>
-          <p className="text-sm text-mountain-400">Coming soon.</p>
-        </div>
-
-        <div className="mt-4 rounded-lg border border-navy-700 bg-navy-800 p-6">
-          <h2 className="text-lg font-semibold text-white mb-2">Change Password</h2>
-          <p className="text-sm text-mountain-400">Coming soon.</p>
-        </div>
+        <ProfileClient session={session} />
       </main>
     </AppShell>
-  );
+  )
 }

--- a/src/services/ui/src/components/AuthButtons.tsx
+++ b/src/services/ui/src/components/AuthButtons.tsx
@@ -4,6 +4,61 @@ import { useState, useRef, useEffect, useCallback } from 'react'
 import { useSession, signIn } from "next-auth/react"
 import Link from 'next/link'
 
+function useAvatar() {
+  const [avatarUrl, setAvatarUrl] = useState<string | null>(null)
+  const [loaded, setLoaded] = useState(false)
+
+  const fetchAvatar = useCallback(async () => {
+    try {
+      const res = await fetch('/api/profile/avatar')
+      if (res.ok) {
+        const blob = await res.blob()
+        setAvatarUrl((prev) => {
+          if (prev) URL.revokeObjectURL(prev)
+          return URL.createObjectURL(blob)
+        })
+      } else {
+        setAvatarUrl((prev) => {
+          if (prev) URL.revokeObjectURL(prev)
+          return null
+        })
+      }
+    } catch {
+      setAvatarUrl((prev) => {
+        if (prev) URL.revokeObjectURL(prev)
+        return null
+      })
+    } finally {
+      setLoaded(true)
+    }
+  }, [])
+
+  useEffect(() => {
+    fetchAvatar()
+
+    function onAvatarChanged() {
+      fetchAvatar()
+    }
+    window.addEventListener('avatar-changed', onAvatarChanged)
+
+    return () => {
+      window.removeEventListener('avatar-changed', onAvatarChanged)
+    }
+  }, [fetchAvatar])
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      setAvatarUrl((prev) => {
+        if (prev) URL.revokeObjectURL(prev)
+        return null
+      })
+    }
+  }, [])
+
+  return { avatarUrl, loaded }
+}
+
 function getInitials(name: string): string {
   return name
     .split(/\s+/)
@@ -93,6 +148,8 @@ export default function AuthButtons() {
     )
   }
 
+  const { avatarUrl, loaded: avatarLoaded } = useAvatar()
+
   if (session) {
     const name = session.user?.name || ''
     const initials = getInitials(name)
@@ -101,16 +158,25 @@ export default function AuthButtons() {
       <div className="relative" ref={menuRef}>
         <button
           onClick={() => setOpen(prev => !prev)}
-          className="h-9 w-9 rounded-full bg-brand-500 flex items-center justify-center text-sm font-semibold text-white select-none cursor-pointer"
+          className="h-9 w-9 rounded-full bg-brand-500 flex items-center justify-center text-sm font-semibold text-white select-none cursor-pointer overflow-hidden"
           aria-haspopup="menu"
           aria-expanded={open}
           aria-label="User menu"
           title={name}
         >
-          {initials || (
-            <svg className="h-5 w-5 text-white" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-              <path d="M12 12c2.7 0 4.8-2.1 4.8-4.8S14.7 2.4 12 2.4 7.2 4.5 7.2 7.2 9.3 12 12 12zm0 2.4c-3.2 0-9.6 1.6-9.6 4.8v1.2c0 .7.5 1.2 1.2 1.2h16.8c.7 0 1.2-.5 1.2-1.2v-1.2c0-3.2-6.4-4.8-9.6-4.8z" />
-            </svg>
+          {avatarLoaded && avatarUrl ? (
+            <img
+              src={avatarUrl}
+              alt=""
+              className="h-full w-full object-cover"
+              onError={() => {/* fallback handled by useAvatar */}}
+            />
+          ) : (
+            initials || (
+              <svg className="h-5 w-5 text-white" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                <path d="M12 12c2.7 0 4.8-2.1 4.8-4.8S14.7 2.4 12 2.4 7.2 4.5 7.2 7.2 9.3 12 12 12zm0 2.4c-3.2 0-9.6 1.6-9.6 4.8v1.2c0 .7.5 1.2 1.2 1.2h16.8c.7 0 1.2-.5 1.2-1.2v-1.2c0-3.2-6.4-4.8-9.6-4.8z" />
+              </svg>
+            )
           )}
         </button>
 


### PR DESCRIPTION
## Summary
- **Profile page rewrite**: Replaced placeholder "Coming soon" sections with interactive client component (ProfileClient.tsx)
- **Avatar management**: Upload (multipart), delete, preview with 256x256 resize. Avatar displays in navbar via cross-component refresh (window event bus)
- **Display name editing**: First/last name inputs with validation (max 100 chars), saved via Keycloak Account API
- **Password change form**: Full form with current/new/confirm fields. Gracefully handles API 501 (not yet available) with informative message
- **API proxy routes**: Base proxy (GET/PATCH `/profile`) and catch-all proxy (`/avatar`, `/password`) with multipart forwarding and binary stream-through for avatar images

## Test plan
- [ ] Profile page loads and fetches profile data from API
- [ ] Avatar upload works (file picker, multipart forwarded, image displayed)
- [ ] Avatar delete works (removes image, falls back to initials)
- [ ] Avatar appears in navbar button after upload, disappears after delete
- [ ] Display name save updates first/last name via Keycloak
- [ ] Password form shows "not yet available" message (API returns 501)
- [ ] Unauthenticated users redirected to sign-in
- [ ] Proxy routes return 401 without session

🤖 Generated with [Claude Code](https://claude.com/claude-code)