### PR TITLE
fix: add curl to UI container for deploy readiness check

### DIFF
--- a/src/services/ui/Dockerfile
+++ b/src/services/ui/Dockerfile
@@ -6,6 +6,7 @@ COPY . .
 RUN npm run build
 
 FROM node:20-alpine
+RUN apk add --no-cache curl
 WORKDIR /app
 COPY --from=builder /build/.next/standalone ./
 COPY --from=builder /build/.next/static ./.next/static


### PR DESCRIPTION
## Summary
- The deploy script's readiness check runs `docker exec ui curl -sf http://localhost:3000/api/health`
- The `node:20-alpine` base image does not include `curl`, so this check always fails
- Adds `apk add --no-cache curl` to the runtime stage of the UI Dockerfile
- This was the root cause of every UI deploy failing at the "Verify readiness" step

## Test plan
- [ ] UI container builds successfully with curl installed
- [ ] Deploy readiness check passes after deploy
- [ ] Container health check continues to work (uses `node`, not `curl`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)