### PR TITLE
fix: move useAvatar hook before early return (React error #310)

### DIFF
--- a/src/services/ui/src/components/AuthButtons.tsx
+++ b/src/services/ui/src/components/AuthButtons.tsx
@@ -73,6 +73,7 @@ export default function AuthButtons() {
   const [open, setOpen] = useState(false)
   const menuRef = useRef<HTMLDivElement>(null)
   const itemsRef = useRef<(HTMLAnchorElement | null)[]>([])
+  const { avatarUrl, loaded: avatarLoaded } = useAvatar()
 
   const close = useCallback(() => setOpen(false), [])
 
@@ -147,8 +148,6 @@ export default function AuthButtons() {
       />
     )
   }
-
-  const { avatarUrl, loaded: avatarLoaded } = useAvatar()
 
   if (session) {
     const name = session.user?.name || ''


### PR DESCRIPTION
## Summary
- Site is down — React error #310 ("Rendered more hooks than during the previous render")
- Root cause: `useAvatar()` was called after the `if (status === "loading") return ...` early return in AuthButtons
- When session status transitions from "loading" to "authenticated", the hook count changes, crashing React
- Fix: move `useAvatar()` to the top of the component alongside all other hooks

## Test plan
- [ ] Site loads without client-side errors
- [ ] Navigate to homepage — no React error in console
- [ ] Sign in — avatar button renders correctly
- [ ] Profile page loads without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)