### PR TITLE
fix: add dispatch permissions and narrow deploy trigger scope

### DIFF
--- a/.github/workflows/deploy-auth.yml
+++ b/.github/workflows/deploy-auth.yml
@@ -3,6 +3,9 @@ name: Manual Deploy Auth (Prod)
 on:
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 concurrency:
   group: deploy-prod
   cancel-in-progress: false

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,9 +4,12 @@ on:
   push:
     branches: [main]
     paths:
-      - 'src/services/**'
-      - 'platform/auth/**'
-      - 'platform/data/**'
+      - 'src/services/api/**'
+      - 'src/services/ai/**'
+      - 'src/services/mcp/**'
+      - 'src/services/ui/**'
+      - 'platform/auth/keycloak/**'
+      - 'platform/data/postgres/**'
       - 'platform/observability/**'
       - 'deploy/compose/prod/docker-compose.db.yml'
       - 'deploy/compose/prod/docker-compose.minio.yml'
@@ -23,6 +26,9 @@ on:
         type: choice
         options: [all, db, minio, auth, api, ai, mcp, ui, observability]
         default: 'all'
+
+permissions:
+  contents: write
 
 concurrency:
   group: deploy-prod

--- a/.github/workflows/reusable-deploy-service.yml
+++ b/.github/workflows/reusable-deploy-service.yml
@@ -7,6 +7,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: write
+
 jobs:
   deploy:
     name: Deploy ${{ inputs.service }}

--- a/tests/checks/test_deploy_scope.py
+++ b/tests/checks/test_deploy_scope.py
@@ -157,6 +157,31 @@ class TestDornyFilters:
 class TestTriggerPaths:
     """L1: Verify trigger path inclusion and exclusion."""
 
+    def test_trigger_paths_exact_list(self, trigger_paths):
+        """Trigger paths must match the expected set exactly.
+
+        This is the strictest L1 gate: any addition or removal of trigger
+        paths must be reflected here, preventing silent scope creep.
+        """
+        expected = sorted([
+            "src/services/api/**",
+            "src/services/ai/**",
+            "src/services/mcp/**",
+            "src/services/ui/**",
+            "platform/auth/keycloak/**",
+            "platform/data/postgres/**",
+            "platform/observability/**",
+            "deploy/compose/prod/docker-compose.db.yml",
+            "deploy/compose/prod/docker-compose.minio.yml",
+            "deploy/compose/prod/docker-compose.auth.yml",
+            "deploy/compose/prod/docker-compose.api.yml",
+            "deploy/compose/prod/docker-compose.ai.yml",
+            "deploy/compose/prod/docker-compose.mcp.yml",
+            "deploy/compose/prod/docker-compose.ui.yml",
+            "deploy/compose/prod/docker-compose.observability.yml",
+        ])
+        assert sorted(trigger_paths) == expected
+
     def test_trigger_paths_include_api(self, trigger_paths):
         assert _matches_any("src/services/api/src/index.ts", trigger_paths)
 
@@ -164,6 +189,16 @@ class TestTriggerPaths:
         assert _matches_any(
             "platform/auth/keycloak/themes/hill90/login/theme.properties",
             trigger_paths,
+        )
+
+    def test_trigger_paths_exclude_unknown_service(self, trigger_paths):
+        assert not _matches_any(
+            "src/services/newsvc/src/main.ts", trigger_paths
+        )
+
+    def test_trigger_paths_exclude_unknown_platform_data(self, trigger_paths):
+        assert not _matches_any(
+            "platform/data/redis/redis.conf", trigger_paths
         )
 
     def test_trigger_paths_exclude_infra(self, trigger_paths):


### PR DESCRIPTION
## Summary
- Add `permissions: contents: write` to `deploy.yml`, `deploy-auth.yml`, and `reusable-deploy-service.yml` so `repository_dispatch` can fire auth smoke tests
- Narrow deploy orchestrator trigger paths from broad globs (`src/services/**`, `platform/data/**`, `platform/auth/**`) to explicit service subtrees, preventing zero-job noise runs from unknown subdirectories
- Add exact trigger-path contract test (set equality) and explicit negative tests for `src/services/newsvc/...` and `platform/data/redis/...` to catch future scope creep

## Test plan
- [x] `pytest tests/checks/test_deploy_scope.py -v` — 22 tests pass (19 existing + 3 new)
- [x] YAML validation passes for all 3 modified workflow files
- [ ] CI green

## Plan
Follows up on code review findings from #122. Fixes 3 of 4 identified issues (finding #4 is monitor-only).

## Risks
- Narrowing trigger paths is safe: all dorny filters are still covered (L3 invariant test verifies)
- `permissions: contents: write` is the minimum required for `repository_dispatch`

## Rollback
Revert this PR. Broad globs are safe (just noisy), and smoke tests already had a manual dispatch fallback.

## Validation Evidence
```
$ python3 -m pytest tests/checks/test_deploy_scope.py -v
22 passed in 0.03s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)