### PR TITLE
refactor: move nav links to left side of navbar

### DIFF
--- a/services/ui/src/components/AppShell.tsx
+++ b/services/ui/src/components/AppShell.tsx
@@ -14,10 +14,10 @@ export default function AppShell({
     <div className="min-h-screen flex flex-col">
       {/* Nav */}
       <nav className="flex items-center justify-between px-6 py-4 border-b border-navy-700">
-        <Link href="/" aria-label="Go to homepage" className="logo-link inline-flex items-center">
-          <HillLogo width={96} className="logo-glow-hold" />
-        </Link>
         <div className="flex items-center gap-4">
+          <Link href="/" aria-label="Go to homepage" className="logo-link inline-flex items-center">
+            <HillLogo width={96} className="logo-glow-hold" />
+          </Link>
           <Link
             href="/dashboard"
             className="text-sm font-medium text-mountain-400 hover:text-white transition-colors"
@@ -32,8 +32,8 @@ export default function AppShell({
           </Link>
           <AdminDocsLink />
           {navExtra}
-          <AuthButtons />
         </div>
+        <AuthButtons />
       </nav>
 
       {/* Content */}


### PR DESCRIPTION
## Summary
- Move nav links (Dashboard, Agents, API Docs, navExtra) to sit alongside the logo on the left side of the navbar
- Keep AuthButtons (avatar/sign-in) on the far right via existing `justify-between`
- No functional changes — layout rearrangement only

## Test plan
- [ ] `npm run build` passes in `services/ui`
- [ ] `npm run lint` passes with no new warnings
- [ ] Nav links appear next to the logo on the left
- [ ] Avatar/sign-in button stays on the far right
- [ ] No extra gap when AdminDocsLink is hidden (non-admin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)