### PR TITLE
feat: add expandable Docs nav section with nested children

### DIFF
--- a/services/ui/src/__tests__/MobileDrawer.test.tsx
+++ b/services/ui/src/__tests__/MobileDrawer.test.tsx
@@ -139,6 +139,8 @@ describe('MobileDrawer', () => {
 
     render(<MobileDrawer open={true} onClose={vi.fn()} />)
 
+    fireEvent.click(screen.getByRole('button', { name: /docs/i }))
+
     expect(screen.getByRole('link', { name: /api docs/i })).toBeInTheDocument()
   })
 })

--- a/services/ui/src/__tests__/Sidebar.test.tsx
+++ b/services/ui/src/__tests__/Sidebar.test.tsx
@@ -69,6 +69,8 @@ describe('Sidebar', () => {
 
     render(<Sidebar />)
 
+    fireEvent.click(screen.getByRole('button', { name: /docs/i }))
+
     expect(screen.getByRole('link', { name: /api docs/i })).toBeInTheDocument()
   })
 

--- a/services/ui/src/__tests__/docs-nav.test.tsx
+++ b/services/ui/src/__tests__/docs-nav.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, screen, cleanup } from '@testing-library/react'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
 import '@testing-library/jest-dom/vitest'
 
 // Mock next-auth/react
@@ -52,6 +52,8 @@ describe('Admin docs nav filtering (Sidebar)', () => {
     }
 
     render(<Sidebar />)
+
+    fireEvent.click(screen.getByRole('button', { name: /docs/i }))
 
     const link = screen.getByRole('link', { name: /api docs/i })
     expect(link).toBeInTheDocument()

--- a/services/ui/src/__tests__/expandable-nav.test.tsx
+++ b/services/ui/src/__tests__/expandable-nav.test.tsx
@@ -1,0 +1,301 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+
+// Mock next-auth/react
+let mockSession: any = { data: null, status: 'unauthenticated' }
+
+vi.mock('next-auth/react', () => ({
+  useSession: () => mockSession,
+}))
+
+// Mock next/link
+vi.mock('next/link', () => ({
+  default: ({ children, href, ...props }: any) => <a href={href} {...props}>{children}</a>,
+}))
+
+// Mock next/navigation
+let mockPathname = '/'
+vi.mock('next/navigation', () => ({
+  usePathname: () => mockPathname,
+}))
+
+// Mock localStorage
+let localStore: Record<string, string> = {}
+const localStorageMock = {
+  getItem: vi.fn((key: string) => localStore[key] ?? null),
+  setItem: vi.fn((key: string, value: string) => { localStore[key] = value }),
+  removeItem: vi.fn((key: string) => { delete localStore[key] }),
+  clear: vi.fn(() => { localStore = {} }),
+}
+
+Object.defineProperty(window, 'localStorage', { value: localStorageMock })
+
+import Sidebar from '@/components/Sidebar'
+import MobileDrawer from '@/components/MobileDrawer'
+
+// ---------- Sidebar expand/collapse tests ----------
+
+describe('Expandable docs nav (Sidebar)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStore = {}
+    localStorageMock.getItem.mockImplementation((key: string) => localStore[key] ?? null)
+    localStorageMock.setItem.mockImplementation((key: string, value: string) => { localStore[key] = value })
+    mockPathname = '/'
+    mockSession = {
+      data: { user: { roles: ['admin'] } },
+      status: 'authenticated',
+    }
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('renders Docs parent for all users', () => {
+    mockSession = {
+      data: { user: { roles: ['user'] } },
+      status: 'authenticated',
+    }
+
+    render(<Sidebar />)
+
+    expect(screen.getByRole('button', { name: /docs/i })).toBeInTheDocument()
+  })
+
+  it('does not show children when Docs is collapsed', () => {
+    render(<Sidebar />)
+
+    expect(screen.queryByRole('link', { name: /api docs/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: /platform docs/i })).not.toBeInTheDocument()
+  })
+
+  it('shows children after clicking Docs', () => {
+    render(<Sidebar />)
+
+    fireEvent.click(screen.getByRole('button', { name: /docs/i }))
+
+    expect(screen.getByRole('link', { name: /api docs/i })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /platform docs/i })).toBeInTheDocument()
+  })
+
+  it('hides children after clicking Docs again', () => {
+    render(<Sidebar />)
+
+    const docsButton = screen.getByRole('button', { name: /docs/i })
+    fireEvent.click(docsButton)
+    fireEvent.click(docsButton)
+
+    expect(screen.queryByRole('link', { name: /api docs/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: /platform docs/i })).not.toBeInTheDocument()
+  })
+
+  it('persists expand state to localStorage', () => {
+    render(<Sidebar />)
+
+    fireEvent.click(screen.getByRole('button', { name: /docs/i }))
+
+    expect(localStorageMock.setItem).toHaveBeenCalledWith('nav-expanded-docs', 'true')
+  })
+
+  it('reads expand state from localStorage on mount', () => {
+    localStore['nav-expanded-docs'] = 'true'
+
+    render(<Sidebar />)
+
+    expect(screen.getByRole('link', { name: /api docs/i })).toBeInTheDocument()
+  })
+
+  it('shows API Docs child for admin', () => {
+    mockSession = {
+      data: { user: { roles: ['admin'] } },
+      status: 'authenticated',
+    }
+
+    render(<Sidebar />)
+    fireEvent.click(screen.getByRole('button', { name: /docs/i }))
+
+    expect(screen.getByRole('link', { name: /api docs/i })).toBeInTheDocument()
+  })
+
+  it('hides API Docs child for non-admin', () => {
+    mockSession = {
+      data: { user: { roles: ['user'] } },
+      status: 'authenticated',
+    }
+
+    render(<Sidebar />)
+    fireEvent.click(screen.getByRole('button', { name: /docs/i }))
+
+    expect(screen.queryByRole('link', { name: /api docs/i })).not.toBeInTheDocument()
+  })
+
+  it('shows Platform Docs child for all users', () => {
+    mockSession = {
+      data: { user: { roles: ['user'] } },
+      status: 'authenticated',
+    }
+
+    render(<Sidebar />)
+    fireEvent.click(screen.getByRole('button', { name: /docs/i }))
+
+    expect(screen.getByRole('link', { name: /platform docs/i })).toBeInTheDocument()
+  })
+
+  it('Platform Docs has target=_blank and rel=noopener', () => {
+    render(<Sidebar />)
+    fireEvent.click(screen.getByRole('button', { name: /docs/i }))
+
+    const platformLink = screen.getByRole('link', { name: /platform docs/i })
+    expect(platformLink).toHaveAttribute('target', '_blank')
+    expect(platformLink).toHaveAttribute('rel', 'noopener noreferrer')
+  })
+
+  it('Docs parent shows active when on /docs/api', () => {
+    mockPathname = '/docs/api'
+
+    render(<Sidebar />)
+
+    const docsButton = screen.getByRole('button', { name: /docs/i })
+    expect(docsButton.className).toContain('brand')
+  })
+
+  it('shows ChevronRight when collapsed, ChevronDown when expanded', () => {
+    render(<Sidebar />)
+
+    const docsButton = screen.getByRole('button', { name: /docs/i })
+
+    // When collapsed, should not have ChevronDown indicator
+    expect(docsButton.querySelector('[data-chevron="down"]')).not.toBeInTheDocument()
+    expect(docsButton.querySelector('[data-chevron="right"]')).toBeInTheDocument()
+
+    // Expand
+    fireEvent.click(docsButton)
+
+    expect(docsButton.querySelector('[data-chevron="down"]')).toBeInTheDocument()
+    expect(docsButton.querySelector('[data-chevron="right"]')).not.toBeInTheDocument()
+  })
+
+  it('auto-expands sidebar when clicking Docs while collapsed', () => {
+    localStore['sidebar-collapsed'] = 'true'
+
+    render(<Sidebar />)
+
+    // Sidebar should be collapsed
+    const aside = screen.getByRole('complementary')
+    expect(aside.className).toContain('w-[60px]')
+
+    // Click the Docs button
+    fireEvent.click(screen.getByRole('button', { name: /docs/i }))
+
+    // Sidebar should now be expanded
+    expect(aside.className).toContain('w-[220px]')
+  })
+
+  it('Docs button has aria-expanded=false then true after click', () => {
+    render(<Sidebar />)
+
+    const docsButton = screen.getByRole('button', { name: /docs/i })
+    expect(docsButton).toHaveAttribute('aria-expanded', 'false')
+
+    fireEvent.click(docsButton)
+
+    expect(docsButton).toHaveAttribute('aria-expanded', 'true')
+  })
+
+  it('Docs button aria-controls matches children container id', () => {
+    render(<Sidebar />)
+
+    const docsButton = screen.getByRole('button', { name: /docs/i })
+    const controlsId = docsButton.getAttribute('aria-controls')
+    expect(controlsId).toBe('docs-submenu')
+
+    // Expand to reveal the container
+    fireEvent.click(docsButton)
+
+    const submenu = document.getElementById('docs-submenu')
+    expect(submenu).toBeInTheDocument()
+  })
+
+  it('expands Docs children on Enter key', () => {
+    render(<Sidebar />)
+
+    const docsButton = screen.getByRole('button', { name: /docs/i })
+    fireEvent.keyDown(docsButton, { key: 'Enter' })
+
+    // Button should trigger via native behavior, but let's also test click
+    fireEvent.click(docsButton)
+
+    expect(screen.getByRole('link', { name: /platform docs/i })).toBeInTheDocument()
+  })
+
+  it('expands Docs children on Space key', () => {
+    render(<Sidebar />)
+
+    const docsButton = screen.getByRole('button', { name: /docs/i })
+    fireEvent.keyDown(docsButton, { key: ' ' })
+
+    // Button should trigger via native behavior, but let's also test click
+    fireEvent.click(docsButton)
+
+    expect(screen.getByRole('link', { name: /platform docs/i })).toBeInTheDocument()
+  })
+
+  it('does not crash when localStorage throws', () => {
+    localStorageMock.getItem.mockImplementation(() => { throw new Error('access denied') })
+    localStorageMock.setItem.mockImplementation(() => { throw new Error('access denied') })
+
+    // Should not throw
+    expect(() => {
+      render(<Sidebar />)
+    }).not.toThrow()
+
+    // Should still be able to click Docs
+    const docsButton = screen.getByRole('button', { name: /docs/i })
+    expect(() => {
+      fireEvent.click(docsButton)
+    }).not.toThrow()
+  })
+})
+
+// ---------- MobileDrawer expand/collapse tests ----------
+
+describe('Expandable docs nav (MobileDrawer)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStore = {}
+    localStorageMock.getItem.mockImplementation((key: string) => localStore[key] ?? null)
+    localStorageMock.setItem.mockImplementation((key: string, value: string) => { localStore[key] = value })
+    mockPathname = '/'
+    mockSession = {
+      data: { user: { roles: ['admin'] } },
+      status: 'authenticated',
+    }
+    document.body.style.overflow = ''
+  })
+
+  afterEach(() => {
+    cleanup()
+    document.body.style.overflow = ''
+  })
+
+  it('expands Docs children in mobile drawer', () => {
+    render(<MobileDrawer open={true} onClose={vi.fn()} />)
+
+    // Docs parent should be visible
+    const docsButton = screen.getByRole('button', { name: /docs/i })
+    expect(docsButton).toBeInTheDocument()
+
+    // Children hidden by default
+    expect(screen.queryByRole('link', { name: /api docs/i })).not.toBeInTheDocument()
+
+    // Click to expand
+    fireEvent.click(docsButton)
+
+    // Children now visible
+    expect(screen.getByRole('link', { name: /api docs/i })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /platform docs/i })).toBeInTheDocument()
+  })
+})

--- a/services/ui/src/components/MobileDrawer.tsx
+++ b/services/ui/src/components/MobileDrawer.tsx
@@ -1,11 +1,12 @@
 'use client'
 
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { useSession } from 'next-auth/react'
-import { X } from 'lucide-react'
+import { X, ChevronDown, ChevronRight } from 'lucide-react'
 import { NAV_ITEMS } from '@/components/nav-items'
+import type { NavItem, NavLink, NavGroup } from '@/components/nav-items'
 
 interface MobileDrawerProps {
   open: boolean
@@ -16,10 +17,27 @@ export default function MobileDrawer({ open, onClose }: MobileDrawerProps) {
   const pathname = usePathname()
   const { data: session } = useSession()
   const prevPathname = useRef(pathname)
+  const [expanded, setExpanded] = useState<Record<string, boolean>>({})
 
-  const roles: string[] = session?.user?.roles ?? []
+  const roles: string[] = (session?.user as any)?.roles ?? []
   const isAdmin = roles.includes('admin')
-  const items = NAV_ITEMS.filter((item) => !item.adminOnly || isAdmin)
+
+  function toggleExpand(id: string) {
+    setExpanded((prev) => ({ ...prev, [id]: !prev[id] }))
+  }
+
+  function isLinkActive(href: string): boolean {
+    if (href === '/') return pathname === '/'
+    return pathname === href || pathname.startsWith(href + '/')
+  }
+
+  function isGroupActive(group: NavGroup): boolean {
+    return group.children.some((child) => !child.external && isLinkActive(child.href))
+  }
+
+  function filterChildren(children: NavLink[]): NavLink[] {
+    return children.filter((child) => !child.adminOnly || isAdmin)
+  }
 
   // Close on route change
   useEffect(() => {
@@ -53,6 +71,86 @@ export default function MobileDrawer({ open, onClose }: MobileDrawerProps) {
 
   if (!open) return null
 
+  function renderLink(item: NavLink, indented: boolean) {
+    const isActive = isLinkActive(item.href)
+    const Icon = item.icon
+
+    if (item.external) {
+      return (
+        <a
+          key={item.id}
+          href={item.href}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={`flex items-center gap-3 rounded-lg px-3 py-2 ${indented ? 'pl-10' : ''} text-sm font-medium transition-colors text-mountain-400 hover:bg-navy-800 hover:text-white`}
+        >
+          <Icon size={indented ? 18 : 20} aria-hidden="true" />
+          {item.label}
+        </a>
+      )
+    }
+
+    return (
+      <Link
+        key={item.id}
+        href={item.href}
+        aria-current={isActive ? 'page' : undefined}
+        className={`flex items-center gap-3 rounded-lg px-3 py-2 ${indented ? 'pl-10' : ''} text-sm font-medium transition-colors ${
+          isActive
+            ? 'bg-brand-500/15 text-brand-400'
+            : 'text-mountain-400 hover:bg-navy-800 hover:text-white'
+        }`}
+      >
+        <Icon size={indented ? 18 : 20} aria-hidden="true" />
+        {item.label}
+      </Link>
+    )
+  }
+
+  function renderGroup(item: NavGroup) {
+    const isActive = isGroupActive(item)
+    const isExpanded = !!expanded[item.id]
+    const Icon = item.icon
+    const visibleChildren = filterChildren(item.children)
+
+    return (
+      <div key={item.id}>
+        <button
+          onClick={() => toggleExpand(item.id)}
+          aria-expanded={isExpanded}
+          aria-controls={`${item.id}-submenu`}
+          className={`flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors w-full ${
+            isActive
+              ? 'bg-brand-500/15 text-brand-400'
+              : 'text-mountain-400 hover:bg-navy-800 hover:text-white'
+          }`}
+        >
+          <Icon size={20} aria-hidden="true" />
+          {item.label}
+          {isExpanded
+            ? <ChevronDown size={16} aria-hidden="true" data-chevron="down" className="ml-auto" />
+            : <ChevronRight size={16} aria-hidden="true" data-chevron="right" className="ml-auto" />
+          }
+        </button>
+        {isExpanded && (
+          <div id={`${item.id}-submenu`} role="group">
+            {visibleChildren.map((child) => renderLink(child, true))}
+          </div>
+        )}
+      </div>
+    )
+  }
+
+  function renderItem(item: NavItem) {
+    if (item.type === 'group') {
+      return renderGroup(item)
+    }
+
+    if (item.adminOnly && !isAdmin) return null
+
+    return renderLink(item, false)
+  }
+
   return (
     <div
       className="md:hidden fixed inset-0 z-40"
@@ -81,28 +179,7 @@ export default function MobileDrawer({ open, onClose }: MobileDrawerProps) {
         </div>
 
         <div className="flex-1 flex flex-col gap-1 px-2 py-4">
-          {items.map((item) => {
-            const isActive =
-              item.href === '/'
-                ? pathname === '/'
-                : pathname === item.href || pathname.startsWith(item.href + '/')
-            const Icon = item.icon
-            return (
-              <Link
-                key={item.href}
-                href={item.href}
-                aria-current={isActive ? 'page' : undefined}
-                className={`flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors ${
-                  isActive
-                    ? 'bg-brand-500/15 text-brand-400'
-                    : 'text-mountain-400 hover:bg-navy-800 hover:text-white'
-                }`}
-              >
-                <Icon size={20} aria-hidden="true" />
-                {item.label}
-              </Link>
-            )
-          })}
+          {NAV_ITEMS.map(renderItem)}
         </div>
       </nav>
     </div>

--- a/services/ui/src/components/Sidebar.tsx
+++ b/services/ui/src/components/Sidebar.tsx
@@ -4,8 +4,9 @@ import { useState } from 'react'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { useSession } from 'next-auth/react'
-import { ChevronsLeft, ChevronsRight } from 'lucide-react'
+import { ChevronsLeft, ChevronsRight, ChevronDown, ChevronRight } from 'lucide-react'
 import { NAV_ITEMS } from '@/components/nav-items'
+import type { NavItem, NavLink, NavGroup } from '@/components/nav-items'
 
 function readCollapsed(): boolean {
   try {
@@ -15,15 +16,27 @@ function readCollapsed(): boolean {
   }
 }
 
+function readExpandState(): Record<string, boolean> {
+  const state: Record<string, boolean> = {}
+  for (const item of NAV_ITEMS) {
+    if (item.type === 'group') {
+      try {
+        const val = localStorage.getItem(`nav-expanded-${item.id}`)
+        if (val === 'true') state[item.id] = true
+      } catch { /* SSR / privacy mode */ }
+    }
+  }
+  return state
+}
+
 export default function Sidebar() {
   const pathname = usePathname()
   const { data: session } = useSession()
   const [collapsed, setCollapsed] = useState(readCollapsed)
+  const [expanded, setExpanded] = useState(readExpandState)
 
-  const roles: string[] = session?.user?.roles ?? []
+  const roles: string[] = (session?.user as any)?.roles ?? []
   const isAdmin = roles.includes('admin')
-
-  const items = NAV_ITEMS.filter((item) => !item.adminOnly || isAdmin)
 
   function toggleCollapse() {
     setCollapsed((prev) => {
@@ -35,6 +48,144 @@ export default function Sidebar() {
     })
   }
 
+  function toggleExpand(id: string) {
+    if (collapsed) {
+      setCollapsed(false)
+      try {
+        localStorage.setItem('sidebar-collapsed', 'false')
+      } catch { /* SSR / privacy mode */ }
+    }
+    setExpanded((prev) => {
+      const next = { ...prev, [id]: !prev[id] }
+      try {
+        localStorage.setItem(`nav-expanded-${id}`, String(next[id]))
+      } catch { /* SSR / privacy mode */ }
+      return next
+    })
+  }
+
+  function isLinkActive(href: string): boolean {
+    if (href === '/') return pathname === '/'
+    return pathname === href || pathname.startsWith(href + '/')
+  }
+
+  function isGroupActive(group: NavGroup): boolean {
+    return group.children.some((child) => !child.external && isLinkActive(child.href))
+  }
+
+  function filterChildren(children: NavLink[]): NavLink[] {
+    return children.filter((child) => !child.adminOnly || isAdmin)
+  }
+
+  function renderLink(item: NavLink) {
+    const isActive = isLinkActive(item.href)
+    const Icon = item.icon
+
+    if (item.external) {
+      return (
+        <a
+          key={item.id}
+          href={item.href}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={`flex items-center gap-3 rounded-lg px-3 py-2 pl-10 text-sm font-medium transition-colors text-mountain-400 hover:bg-navy-800 hover:text-white`}
+        >
+          <Icon size={18} aria-hidden="true" />
+          <span data-sidebar-label className={collapsed ? 'sr-only' : ''}>
+            {item.label}
+          </span>
+        </a>
+      )
+    }
+
+    return (
+      <Link
+        key={item.id}
+        href={item.href}
+        aria-current={isActive ? 'page' : undefined}
+        title={collapsed ? item.label : undefined}
+        className={`flex items-center gap-3 rounded-lg px-3 py-2 pl-10 text-sm font-medium transition-colors ${
+          isActive
+            ? 'bg-brand-500/15 text-brand-400'
+            : 'text-mountain-400 hover:bg-navy-800 hover:text-white'
+        }`}
+      >
+        <Icon size={18} aria-hidden="true" />
+        <span data-sidebar-label className={collapsed ? 'sr-only' : ''}>
+          {item.label}
+        </span>
+      </Link>
+    )
+  }
+
+  function renderGroup(item: NavGroup) {
+    const isActive = isGroupActive(item)
+    const isExpanded = !!expanded[item.id]
+    const Icon = item.icon
+    const visibleChildren = filterChildren(item.children)
+
+    return (
+      <div key={item.id}>
+        <button
+          onClick={() => toggleExpand(item.id)}
+          aria-expanded={isExpanded}
+          aria-controls={`${item.id}-submenu`}
+          title={collapsed ? item.label : undefined}
+          className={`flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors w-full ${
+            isActive
+              ? 'bg-brand-500/15 text-brand-400'
+              : 'text-mountain-400 hover:bg-navy-800 hover:text-white'
+          }`}
+        >
+          <Icon size={20} aria-hidden="true" />
+          <span data-sidebar-label className={collapsed ? 'sr-only' : ''}>
+            {item.label}
+          </span>
+          {!collapsed && (
+            isExpanded
+              ? <ChevronDown size={16} aria-hidden="true" data-chevron="down" className="ml-auto" />
+              : <ChevronRight size={16} aria-hidden="true" data-chevron="right" className="ml-auto" />
+          )}
+        </button>
+        {isExpanded && (
+          <div id={`${item.id}-submenu`} role="group">
+            {visibleChildren.map(renderLink)}
+          </div>
+        )}
+      </div>
+    )
+  }
+
+  function renderItem(item: NavItem) {
+    if (item.type === 'group') {
+      return renderGroup(item)
+    }
+
+    if (item.adminOnly && !isAdmin) return null
+
+    const isActive = isLinkActive(item.href)
+    const Icon = item.icon
+
+    return (
+      <Link
+        key={item.id}
+        href={item.href}
+        aria-current={isActive ? 'page' : undefined}
+        title={collapsed ? item.label : undefined}
+        className={`flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors ${
+          isActive
+            ? 'bg-brand-500/15 text-brand-400'
+            : 'text-mountain-400 hover:bg-navy-800 hover:text-white'
+        }`}
+      >
+        <Icon size={20} aria-hidden="true" />
+        <span data-sidebar-label className={collapsed ? 'sr-only' : ''}>
+          {item.label}
+        </span>
+      </Link>
+    )
+  }
+
   return (
     <aside
       className={`hidden md:flex flex-col border-r border-navy-700 bg-navy-900 transition-[width] duration-200 ${
@@ -42,31 +193,7 @@ export default function Sidebar() {
       }`}
     >
       <nav className="flex-1 flex flex-col gap-1 px-2 py-4">
-        {items.map((item) => {
-          const isActive =
-            item.href === '/'
-              ? pathname === '/'
-              : pathname === item.href || pathname.startsWith(item.href + '/')
-          const Icon = item.icon
-          return (
-            <Link
-              key={item.href}
-              href={item.href}
-              aria-current={isActive ? 'page' : undefined}
-              title={collapsed ? item.label : undefined}
-              className={`flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors ${
-                isActive
-                  ? 'bg-brand-500/15 text-brand-400'
-                  : 'text-mountain-400 hover:bg-navy-800 hover:text-white'
-              }`}
-            >
-              <Icon size={20} aria-hidden="true" />
-              <span data-sidebar-label className={collapsed ? 'sr-only' : ''}>
-                {item.label}
-              </span>
-            </Link>
-          )
-        })}
+        {NAV_ITEMS.map(renderItem)}
       </nav>
 
       <button

--- a/services/ui/src/components/nav-items.ts
+++ b/services/ui/src/components/nav-items.ts
@@ -1,16 +1,38 @@
-import { Home, LayoutDashboard, Bot, FileText } from 'lucide-react'
+import { Home, LayoutDashboard, Bot, FileText, Book, ExternalLink } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
 
-export interface NavItem {
+export interface NavLink {
+  type: 'link'
+  id: string
   label: string
   href: string
   icon: LucideIcon
   adminOnly?: boolean
+  external?: boolean
 }
 
+export interface NavGroup {
+  type: 'group'
+  id: string
+  label: string
+  icon: LucideIcon
+  children: NavLink[]
+}
+
+export type NavItem = NavLink | NavGroup
+
 export const NAV_ITEMS: NavItem[] = [
-  { label: 'Home', href: '/', icon: Home },
-  { label: 'Dashboard', href: '/dashboard', icon: LayoutDashboard },
-  { label: 'Agents', href: '/agents', icon: Bot },
-  { label: 'API Docs', href: '/docs/api', icon: FileText, adminOnly: true },
+  { type: 'link', id: 'home', label: 'Home', href: '/', icon: Home },
+  { type: 'link', id: 'dashboard', label: 'Dashboard', href: '/dashboard', icon: LayoutDashboard },
+  { type: 'link', id: 'agents', label: 'Agents', href: '/agents', icon: Bot },
+  {
+    type: 'group',
+    id: 'docs',
+    label: 'Docs',
+    icon: Book,
+    children: [
+      { type: 'link', id: 'api-docs', label: 'API Docs', href: '/docs/api', icon: FileText, adminOnly: true },
+      { type: 'link', id: 'platform-docs', label: 'Platform Docs', href: 'https://docs.hill90.com', icon: ExternalLink, external: true },
+    ],
+  },
 ]


### PR DESCRIPTION
## Summary
- Refactor `NavItem` to a discriminated union (`NavLink | NavGroup`) with stable `id` keys
- Replace flat "API Docs" nav entry with expandable "Docs" parent containing "API Docs" (admin-only) and "Platform Docs" (external link to `https://docs.hill90.com`, all users)
- Expand/collapse in both desktop Sidebar and MobileDrawer with chevron indicators
- localStorage persistence for expand state with try/catch guards (SSR-safe, private-mode-safe)
- External links open with `target="_blank"` and `rel="noopener noreferrer"`
- Collapsed sidebar auto-expands when clicking a group parent
- Parent shows active state when any child route matches
- Full ARIA support (`aria-expanded`, `aria-controls`, keyboard-accessible `<button>` elements)

## Linear
- Issue: N/A

## Validation Evidence
- UI (if applicable):
  - 106/106 Vitest tests pass (14 test files), including 19 new tests in `expandable-nav.test.tsx`
  - `npx tsc --noEmit` clean (no new errors; pre-existing middleware.test.ts errors unchanged)
  - Existing Sidebar, MobileDrawer, and docs-nav tests updated and passing

## Test plan
- [x] Local checks run
  - [x] `npx vitest run` — 106/106 pass
  - [x] `npx tsc --noEmit` — clean
  - [x] New test file: `expandable-nav.test.tsx` (19 tests covering expand/collapse, localStorage persistence, admin filtering, external links, ARIA attributes, auto-expand, localStorage error resilience)
  - [x] Existing tests updated: `Sidebar.test.tsx`, `MobileDrawer.test.tsx`, `docs-nav.test.tsx` (expand Docs parent before asserting API Docs)
- [ ] CI checks pass

## Notes
- ESLint has a pre-existing circular structure config issue unrelated to this change
- NavItem discriminated union: only Sidebar and MobileDrawer consume `NavItem` — both updated in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)