### PR TITLE
fix: transparent favicon with full hill silhouette

### DIFF
--- a/docs/site/favicon.svg
+++ b/docs/site/favicon.svg
@@ -1,6 +1,15 @@
-<svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
-  <rect width="32" height="32" rx="6" fill="#5b9a2f"/>
-  <svg x="2" y="4" width="28" height="24" viewBox="0 0 660 297">
-    <path d="M4494 1625 c-214 -33 -406 -126 -609 -295 -44 -37 -305 -292 -580 -567 -526 -525 -575 -567 -752 -656 -64 -33 -187 -71 -252 -79 -14 -2 -26 -9 -29 -15 -3 -10 435 -13 2167 -13 l2171 0 0 80 0 80 -102 108 c-304 318 -1097 1112 -1111 1112 -9 0 -33 12 -54 26 -21 14 -92 52 -158 84 -268 130 -471 170 -691 135z" transform="translate(0 297) scale(0.1 -0.1)" fill="white"/>
-  </svg>
+<svg width="32" height="32" viewBox="0 0 660 297" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Hill90 favicon">
+  <defs>
+    <linearGradient id="fav-light-grad" x1="0" y1="0" x2="660" y2="297" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#7A8E96"/>
+      <stop offset="100%" stop-color="#60757D"/>
+    </linearGradient>
+    <linearGradient id="fav-front-grad" x1="240" y1="110" x2="660" y2="297" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#4C5A63"/>
+      <stop offset="100%" stop-color="#3C4A52"/>
+    </linearGradient>
+  </defs>
+  <path d="M1983 2022 c-77 -28 -132 -75 -439 -379 -155 -153 -565 -559 -913 -902 l-631 -624 0 -59 0 -58 1134 0 c999 0 1135 2 1140 15 3 8 16 15 29 15 91 0 262 72 412 173 89 60 695 647 695 672 0 6 -246 256 -547 556 -620 618 -600 602 -748 607 -58 2 -94 -3 -132 -16z" transform="translate(0 297) scale(0.1 -0.1)" fill="url(#fav-light-grad)"/>
+  <path d="M3524 2951 c-28 -10 -71 -31 -95 -46 -51 -31 -893 -869 -888 -883 6 -16 996 -1012 1006 -1012 4 0 64 57 133 126 69 69 161 156 205 193 348 292 713 377 1087 251 101 -35 310 -132 372 -175 124 -85 -1 50 -686 738 -730 733 -744 746 -822 783 -98 47 -224 57 -312 25z" transform="translate(0 297) scale(0.1 -0.1)" fill="url(#fav-light-grad)"/>
+  <path d="M4494 1625 c-214 -33 -406 -126 -609 -295 -44 -37 -305 -292 -580 -567 -526 -525 -575 -567 -752 -656 -64 -33 -187 -71 -252 -79 -14 -2 -26 -9 -29 -15 -3 -10 435 -13 2167 -13 l2171 0 0 80 0 80 -102 108 c-304 318 -1097 1112 -1111 1112 -9 0 -33 12 -54 26 -21 14 -92 52 -158 84 -268 130 -471 170 -691 135z" transform="translate(0 297) scale(0.1 -0.1)" fill="url(#fav-front-grad)"/>
 </svg>


### PR DESCRIPTION
## Summary
- Replace green-background single-hill favicon with transparent-background three-hill silhouette
- Matches the hill90.com dashboard favicon style
- Uses same gradients as `light.svg` logo

## Linear
- Issue: N/A (follow-up fix to #131)

## Validation Evidence
- `xmllint --noout` passes
- SVG uses same paths/gradients as proven `light.svg`
- Transparent background matches dashboard favicon

## Test plan
- [x] SVG well-formed (`xmllint`)
- [ ] Visual check: favicon renders in Mintlify docs browser tab
- [ ] CI checks pass

## Notes
- Follow-up to #131 (Mintlify branding)
- 1 file changed: `docs/site/favicon.svg`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- mintlify-editor-comments:start -->
Mintlify
---
0 threads from 0 users in Mintlify

- No unresolved comments
<!-- mintlify-editor-comments:end -->

<!-- mintlify-comment-->

<a href="https://dashboard.mintlify.com/hill90/hill90/editor/fix%2Fmintlify-favicon?source=pr_comment" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://d3gk2c5xim1je2.cloudfront.net/assets/open-mintlify-editor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://d3gk2c5xim1je2.cloudfront.net/assets/open-mintlify-editor-light.svg"><img src="https://d3gk2c5xim1je2.cloudfront.net/assets/open-mintlify-editor-light.svg" alt="Open in Mintlify Editor"></picture></a>

<!-- /mintlify-comment -->