### PR TITLE
docs: add docs.hill90.com references across project docs

### DIFF
--- a/.github/docs/deployment.md
+++ b/.github/docs/deployment.md
@@ -1,5 +1,7 @@
 # Deployment Reference
 
+> **External users:** See [docs.hill90.com/getting-started/quickstart](https://docs.hill90.com/getting-started/quickstart) for the public deployment guide.
+
 ## Deployment Architecture
 
 **Infrastructure and applications are deployed separately:**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,7 +114,7 @@ For manual VPS access, see `docs/runbooks/deployment.md`.
 - VPS rebuild runbook: `docs/runbooks/vps-rebuild.md`
 - Architecture overview: `docs/architecture/overview.md`
 - Closed-loop planning skill: `.github/skills/closing-the-loop/SKILL.md`
-- Public documentation site (Mintlify): `docs/site/` — external-facing docs; `docs/` is internal
+- Public documentation site (Mintlify): `docs/site/` (source) — https://docs.hill90.com (live); `docs/` is internal
 
 ## Guardrails
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Production-ready Docker-based microservices platform hosted on Hostinger VPS.
 | MCP | Python | https://ai.hill90.com/mcp | MCP Gateway (authenticated) |
 | Keycloak | Java | https://auth.hill90.com | OIDC/OAuth2 identity provider |
 | UI | TypeScript | https://hill90.com | Frontend |
+| Docs | - | https://docs.hill90.com | Platform documentation (Mintlify) |
 
 **Note:** Traefik, Portainer, MinIO console, and Grafana are accessible only via Tailscale network (100.64.0.0/10).
 
@@ -555,6 +556,8 @@ make dns-sync
 ```
 
 ## Documentation
+
+- **[Hill90 Docs](https://docs.hill90.com)** - Platform documentation, API reference, and getting started guides
 
 ### Core Documentation
 - **[Claude Code Operating Manual](CLAUDE.md)** - How Claude Code manages this infrastructure


### PR DESCRIPTION
## Summary
- Add `Docs` service row in `README.md` pointing to `https://docs.hill90.com`
- Add public docs link in `README.md` Documentation section for discoverability
- Update `AGENTS.md` reference map to include Mintlify source path and live docs URL
- Add external-user quickstart pointer in `.github/docs/deployment.md`

## Linear
- Issue: AI-93

## Validation Evidence
- UI (if applicable): N/A
- API/MCP (if applicable): N/A
- Infra/Deploy (if applicable): N/A
- Docs-only:
  - Verified links inserted in expected files via `rg`
  - Verified symlink chain still resolves (`CLAUDE.md -> AGENTS.md`, `.github/copilot-instructions.md -> ../AGENTS.md`)
  - Manual accuracy review of wording and placement
  - External URL HEAD check attempted (`curl -sIL https://docs.hill90.com`) but blocked in sandbox (returned `000`)

## Test plan
- [x] Local checks run
- [ ] CI checks pass

## Notes
- This PR changes markdown/docs references only.
