### PR TITLE
fix: OpenBao healthcheck, policy loading, and JSON parsing

### DIFF
--- a/deploy/compose/prod/docker-compose.vault.yml
+++ b/deploy/compose/prod/docker-compose.vault.yml
@@ -34,7 +34,7 @@ services:
       - BAO_ADDR=http://127.0.0.1:8200
       - BAO_LOCAL_CONFIG=
     healthcheck:
-      test: ["CMD", "wget", "--spider", "-q", "http://localhost:8200/v1/sys/health"]
+      test: ["CMD", "wget", "--spider", "-q", "http://127.0.0.1:8200/v1/sys/health"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/scripts/vault.sh
+++ b/scripts/vault.sh
@@ -89,9 +89,9 @@ cmd_init() {
     init_output=$(bao_exec operator init -key-shares=1 -key-threshold=1 -format=json)
 
     local unseal_key
-    unseal_key=$(echo "$init_output" | grep -o '"unseal_keys_b64":\[\"[^"]*\"' | sed 's/.*\["//' | sed 's/"//')
+    unseal_key=$(echo "$init_output" | python3 -c "import sys,json; print(json.load(sys.stdin)['unseal_keys_b64'][0])")
     local root_token
-    root_token=$(echo "$init_output" | grep -o '"root_token":"[^"]*"' | sed 's/"root_token":"//' | sed 's/"//')
+    root_token=$(echo "$init_output" | python3 -c "import sys,json; print(json.load(sys.stdin)['root_token'])")
 
     echo ""
     echo "================================"
@@ -314,7 +314,7 @@ cmd_policy_apply() {
         local policy_name
         policy_name=$(basename "$policy_file" .hcl)
         echo "  Applying policy: ${policy_name}"
-        bao_exec_env policy write "$policy_name" - < "$policy_file"
+        bao_exec_env policy write "$policy_name" "/openbao/policies/$(basename "$policy_file")"
     done
     success "All policies applied"
 }


### PR DESCRIPTION
## Summary
Three fixes discovered during Phase 1 VPS runbook execution:
1. **Healthcheck**: `localhost` doesn't resolve inside the Alpine-based OpenBao container — changed to `127.0.0.1`
2. **Policy apply**: stdin redirection (`< file`) fails through `docker exec` — use container-mounted path `/openbao/policies/` instead
3. **JSON parsing**: `grep -o` regex for init output was fragile — use `python3 -c json.load()` for reliable parsing

## Plan
Three targeted single-line fixes in compose and vault.sh.

## Risks
None — fixes runtime issues only, no behavior changes for other services.

## Rollback
`git revert` — vault was already manually initialized on VPS.

## Validation Evidence
- `shellcheck --severity=warning scripts/vault.sh` — clean
- `bats tests/scripts/vault.bats` — 27/27 pass
- `docker compose config` — valid
- VPS: vault initialized, unsealed, all secrets seeded, policies applied, AppRoles created

## Test Plan
- [x] shellcheck clean
- [x] 27/27 BATS pass
- [x] Compose valid
- [x] VPS Phase 1 runbook completed successfully with these fixes applied
