### PR TITLE
fix: pass OIDC role config as JSON via stdin

### DIFF
--- a/scripts/vault.sh
+++ b/scripts/vault.sh
@@ -252,14 +252,13 @@ cmd_setup_oidc() {
     bao_exec_env policy write policy-oidc-admin "/openbao/policies/policy-oidc-admin.hcl"
 
     # Create admin-sso role (maps Keycloak admin role to vault policy)
+    # Uses JSON via stdin because bound_claims requires a map type that
+    # the CLI doesn't parse correctly from positional arguments.
     echo "Creating admin-sso OIDC role..."
-    bao_exec_env write auth/oidc/role/admin-sso \
-        role_type="oidc" \
-        user_claim="sub" \
-        policies="policy-oidc-admin" \
-        oidc_scopes="openid,profile,email" \
-        bound_claims='{"realm_roles":["admin"]}' \
-        allowed_redirect_uris="https://vault.hill90.com/v1/auth/oidc/callback,https://vault.hill90.com/ui/vault/auth/oidc/oidc/callback"
+    local role_json='{"role_type":"oidc","user_claim":"sub","policies":["policy-oidc-admin"],"oidc_scopes":["openid","profile","email"],"bound_claims":{"realm_roles":["admin"]},"allowed_redirect_uris":["https://vault.hill90.com/v1/auth/oidc/callback","https://vault.hill90.com/ui/vault/auth/oidc/oidc/callback"]}'
+    local token="${BAO_TOKEN:-}"
+    echo "$role_json" | docker exec -i -e "BAO_ADDR=http://127.0.0.1:8200" -e "BAO_TOKEN=${token}" "$CONTAINER_NAME" \
+        bao write auth/oidc/role/admin-sso -
 
     echo ""
     success "OIDC setup complete!"


### PR DESCRIPTION
## Summary

- Fixes `vault.sh setup-oidc` failing with `error converting input for field "bound_claims": '' expected type 'map[string]interface {}', got unconvertible type 'string'`
- The `bound_claims` parameter requires a JSON map type that the bao CLI doesn't parse correctly when passed as a positional argument through `docker exec`
- Solution: pipe the full role config as JSON to `bao write auth/oidc/role/admin-sso -` via stdin using `docker exec -i`

## Plan

Single-file fix to `scripts/vault.sh` — replace CLI positional arguments with JSON stdin for the OIDC role creation.

## Risks

| Risk | Likelihood | Impact | Mitigation |
|---|---|---|---|
| JSON stdin not parsed by older OpenBao | Very Low | Medium | Tested on deployed OpenBao 2.5.1; `bao write - ` is documented |

## Rollback

Revert this PR. OIDC role creation would need to use the HTTP API directly instead.

## Validation Evidence

- `shellcheck --severity=warning scripts/vault.sh` — clean
- `bats tests/scripts/vault.bats` — all 37 tests pass
- VPS: `vault.sh setup-oidc` completed successfully after this fix
- VPS: OIDC login tested end-to-end via Playwright (admin user authenticated through Keycloak, landed in vault UI with secrets access)

## Test plan

- [x] `shellcheck --severity=warning scripts/vault.sh` — clean
- [x] `bats tests/scripts/vault.bats` — all 37 pass
- [x] VPS: `vault.sh setup-oidc` succeeds (was failing before this fix)
- [x] VPS: Playwright confirms OIDC login works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)