### PR TITLE
chore: store vault sync token in SOPS

### DIFF
--- a/infra/secrets/prod.enc.env
+++ b/infra/secrets/prod.enc.env
@@ -41,9 +41,10 @@ AUTH_KEYCLOAK_SECRET=ENC[AES256_GCM,data:LB8yVttwUHYF1xuDNUO5juxjZMgo8qo0DEF//9q
 AUTH_SECRET=ENC[AES256_GCM,data:ZD1tEzAdwSXeXL810/sdXgzuUEx/kcJsFUDYjPvv2GaVZh19ZGaMu7y8KlQ=,iv:GU6kc1pbc49AXOc2b33IdFON9HQ07LppX8W06lJETUM=,tag:9QdyDEGyF0DMXeYqWhzQrg==,type:str]
 AUTH_KEYCLOAK_ID=ENC[AES256_GCM,data:GIDt4tSjVk4/,iv:cPXQLqCF2iEL2WQhew/x4WPednTrxTH5my3kSkt+WRI=,tag:asATpegxfLPGBvv0I9JOuw==,type:str]
 SMTP_PASSWORD=ENC[AES256_GCM,data:F91MMBGGflfds3QTP/SK4Rugl4oGQR2lkmIlaj5B,iv:Hl1Emms8dy6b5uzDu4GjtCdLcGieZzwNfnKj1Rk0ViA=,tag:fpFFTA9hK0f9DqDQ85bUjQ==,type:str]
+VAULT_SYNC_TOKEN=ENC[AES256_GCM,data:2X8kM3U8HaeV6w5wdKnXO9COwdIqUJ4blEs=,iv:ETHBbaItXEhPloobnplADe5/i8V5o8oNfTG9ADHz4yQ=,tag:1oJ9Q1P/oF6mttz+j4Yivg==,type:str]
 sops_age__list_0__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA0Tk9jcWxubnBSdzYrVTh3\nUWljVFZrNFB2Tk8yaVdrYTZXZzZlSlNKM0dvCjMyd2NrL3RnUGpOMXlmZlBybWlD\nYnpLNFFtSnVNMnJ4SzBoZVFKcnU0aTQKLS0tIFZaYXlwRm1lQ3lwekI3NkdvQ04y\nQmhLM3dFSzc2NUlSeFFacFhoVEEvSGsKWtC/jJg4cVLm4upH51WbrwVDdNCm0/ut\ntu3ywZWs24JYbZd/6mKg52TdLleMsDO6xrIz3l5yLASJvDNm2Xictw==\n-----END AGE ENCRYPTED FILE-----\n
 sops_age__list_0__map_recipient=age1p30vk2qpvlkj5pzh72f0wwvlqgmedvr204nldmpskmptgy9ryg8qg9qd5v
-sops_lastmodified=2026-02-21T21:16:31Z
-sops_mac=ENC[AES256_GCM,data:/CtPMVzmKJGDiCt/MrGfDjsHJ6nVyduIYmyADOr7bEaIrK6n7CapRtl47hoZSCzasVbC/f+vOko9l8JAwpxDZkKaKzFFzNH0/tZ48pvNl7WYoL/9osanQpEDHyCbNGGFdu/adUoEjyFZ0cAZBD1m6Etk6kXG11bGxMPduvImKjU=,iv:Cbi4lljmX4XbDSjqw8bQ5Gwbl5RJkfbYphTDVKAasZk=,tag:wpUFOefIHfWChh8LYBOwag==,type:str]
+sops_lastmodified=2026-02-26T05:16:42Z
+sops_mac=ENC[AES256_GCM,data:+TLGs9U/p2LJw3OdYTfUtA4JK4995nascQGW6an68Sv+0xlzWQE4FAOY3joskSr+mpo+ALqBCCmx3Dg0Ri84w588dq83jA24baIfKE1lUQsMbZ2rF4HxinJgnbW/nclAV2mnPsTpBvDIyEUQFqJ7HFe0BgN/H3Yv8hG1yyUHt+Y=,iv:UwB2sRSlC+PXtWYPNNAIODAZw6Qp6G1Hu12TKq0arZ8=,tag:730rwjwCJ0h5oyolMdWqLw==,type:str]
 sops_unencrypted_suffix=_unencrypted
 sops_version=3.11.0


### PR DESCRIPTION
## Summary
- One-time setup: stores `VAULT_SYNC_TOKEN` in SOPS for the automated vault-to-SOPS sync workflow
- Token has read-only KV access (`policy-sync`) — verified it can read but cannot write

## Validation Evidence
- `vault.sh setup-sync-token` ran successfully on VPS
- Sync token reads KV: confirmed
- Sync token write denied: `403 permission denied` confirmed
- Root token revoked after setup

## Test plan
- [x] Token stored in SOPS
- [x] Token can read KV secrets
- [x] Token cannot write KV secrets
- [x] Root token revoked
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)