### PR TITLE
fix: remove unsupported -self flag from bao token renew

### DIFF
--- a/.github/workflows/vault-sync-to-sops.yml
+++ b/.github/workflows/vault-sync-to-sops.yml
@@ -94,7 +94,7 @@ jobs:
             "docker exec \
               -e BAO_ADDR=http://127.0.0.1:8200 \
               -e BAO_TOKEN='${{ steps.sync-token.outputs.token }}' \
-              openbao bao token renew -self" || {
+              openbao bao token renew" || {
             echo "::error::Token renewal failed — token may be expired or revoked. Re-run 'vault.sh setup-sync-token'."
             exit 1
           }


### PR DESCRIPTION
## Summary
- OpenBao's `bao token renew` without args renews the authenticated token via `BAO_TOKEN` env
- The `-self` flag doesn't exist in OpenBao — it was a HashiCorp Vault CLI convention
- This caused the vault-sync-to-sops workflow to fail at the token renewal step

## Plan
One-line fix in `.github/workflows/vault-sync-to-sops.yml`: remove `-self` from `bao token renew -self`.

## Risks
None — this is a bug fix for a non-functional flag.

## Rollback
Revert the one-line change.

## Validation Evidence
- `bao token renew --help` confirms no `-self` flag exists
- Workflow error log: `flag provided but not defined: -self`

## Test plan
- [ ] CI passes
- [ ] Re-trigger vault-sync-to-sops workflow after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)