### PR TITLE
fix: add statuses:write permission to sync workflow

### DIFF
--- a/.github/workflows/vault-sync-to-sops.yml
+++ b/.github/workflows/vault-sync-to-sops.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  statuses: write
 
 concurrency:
   group: vault-sync-to-sops


### PR DESCRIPTION
## Summary
- Add `statuses: write` to the vault-sync-to-sops workflow permissions
- Required for setting the "Run Tests" status check on sync PRs via the statuses API

## Validation Evidence
- Previous run returned `HTTP 403: Resource not accessible by integration` on the statuses API call
- PR #148 was created but the status check wasn't set

## Test plan
- [ ] CI passes
- [ ] Close PR #148, retrigger workflow, verify PR created with green "Run Tests" status

🤖 Generated with [Claude Code](https://claude.com/claude-code)