### PR TITLE
fix: auto-unseal API wait accepts sealed status as ready

### DIFF
--- a/scripts/vault.sh
+++ b/scripts/vault.sh
@@ -597,10 +597,16 @@ cmd_auto_unseal() {
         waited=$((waited + 5))
     done
 
-    # Wait for API to respond
+    # Wait for API to respond (bao status exits 0=unsealed, 2=sealed, 1=error)
     waited=0
-    while ! bao_exec status >/dev/null 2>&1; do
-        if [ $waited -ge 30 ]; then
+    while true; do
+        local rc=0
+        bao_exec status >/dev/null 2>&1 || rc=$?
+        # Exit code 0 (unsealed) or 2 (sealed) both mean the API is responding
+        if [ "$rc" -eq 0 ] || [ "$rc" -eq 2 ]; then
+            break
+        fi
+        if [ $waited -ge 60 ]; then
             die "Timed out waiting for ${CONTAINER_NAME} API"
         fi
         sleep 2


### PR DESCRIPTION
## Summary

- `bao status` exits 2 when sealed, which the API wait loop treated as "not ready" — causing a 30s timeout before unseal was even attempted.
- Now accepts exit codes 0 (unsealed) and 2 (sealed) as valid API responses.
- Increased API wait timeout from 30s to 60s for slow container starts.

## Plan

Single fix in `cmd_auto_unseal()`: change the API readiness check to treat exit code 2 (sealed) as "API is responding".

## Risks

None — this only changes when the unseal attempt starts. The unseal logic itself is unchanged.

## Rollback

Revert the single commit.

## Validation Evidence

- [x] shellcheck clean
- [x] bats vault tests — all 67 pass (0 failures)

## Test plan

- [x] shellcheck clean
- [x] bats pass
- [ ] VPS: vault deploy verifies successfully after this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)