### PR TITLE
feat: add vault.sh bootstrap-approles command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,6 +112,7 @@ For manual VPS access, see `docs/runbooks/deployment.md`.
 | Vault sync to SOPS | `bash scripts/vault.sh sync-to-sops` | `make vault-sync-to-sops` |
 | Vault auto-unseal | `bash scripts/vault.sh auto-unseal` | `make vault-auto-unseal` |
 | Vault setup sync token | `bash scripts/vault.sh setup-sync-token` | `make vault-setup-sync-token` |
+| Vault bootstrap AppRoles | `bash scripts/vault.sh bootstrap-approles` | `make vault-bootstrap-approles` |
 | Vault sync (automated) | GitHub Actions: `vault-sync-to-sops` workflow | Manual trigger or weekly schedule |
 | Check secrets schema | `python3 scripts/checks/check_secrets_schema.py` | `make check-secrets-schema` |
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help build deploy-infra deploy-infra-production deploy-db deploy-minio deploy-vault deploy-observability deploy-auth deploy-api deploy-ai deploy-mcp deploy-ui deploy-all test logs health ssh secrets-edit secrets-init secrets-view secrets-update lint format ps snapshot recreate-vps config-vps validate dev dev-logs dev-down docs-dev backup backup-list backup-prune backup-restore rollback rollback-classify down dns-view dns-sync dns-snapshots dns-restore dns-verify vault-init vault-unseal vault-auto-unseal vault-status vault-setup vault-seed vault-sync-to-sops vault-setup-sync-token check-secrets-schema
+.PHONY: help build deploy-infra deploy-infra-production deploy-db deploy-minio deploy-vault deploy-observability deploy-auth deploy-api deploy-ai deploy-mcp deploy-ui deploy-all test logs health ssh secrets-edit secrets-init secrets-view secrets-update lint format ps snapshot recreate-vps config-vps validate dev dev-logs dev-down docs-dev backup backup-list backup-prune backup-restore rollback rollback-classify down dns-view dns-sync dns-snapshots dns-restore dns-verify vault-init vault-unseal vault-auto-unseal vault-status vault-setup vault-seed vault-sync-to-sops vault-setup-sync-token vault-bootstrap-approles check-secrets-schema
 
 # Environment
 ENV ?= prod
@@ -319,6 +319,9 @@ vault-sync-to-sops: ## Sync vault secrets back to SOPS backup
 
 vault-auto-unseal: ## Wait for vault container + unseal (for deploy/systemd hooks)
 	bash scripts/vault.sh auto-unseal
+
+vault-bootstrap-approles: ## Generate AppRole credentials for all services and store in SOPS
+	bash scripts/vault.sh bootstrap-approles
 
 vault-setup-sync-token: ## Create read-only sync token and store in SOPS
 	bash scripts/vault.sh setup-sync-token

--- a/scripts/vault.sh
+++ b/scripts/vault.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Vault CLI — OpenBao secrets management lifecycle
-# Usage: vault.sh {init|unseal|auto-unseal|status|setup|seed|policy-apply|backup|export|sync-to-sops|setup-sync-token|help}
+# Usage: vault.sh {init|unseal|auto-unseal|status|setup|seed|policy-apply|backup|export|sync-to-sops|setup-sync-token|bootstrap-approles|help}
 
 set -e
 
@@ -38,6 +38,7 @@ Commands:
   auto-unseal         Wait for container + unseal (for systemd/deploy hooks)
   sync-to-sops        Sync vault secrets back to SOPS backup (requires BAO_TOKEN)
   setup-sync-token    Create a read-only sync token and store in SOPS (requires BAO_TOKEN)
+  bootstrap-approles  Generate AppRole credentials for all services and store in SOPS
   help                Show this help message
 
 Environment variables:
@@ -581,6 +582,126 @@ cmd_setup_sync_token() {
     echo ""
 }
 
+cmd_bootstrap_approles() {
+    require_running
+
+    echo "================================"
+    echo "Bootstrap AppRole Credentials"
+    echo "================================"
+    echo ""
+
+    require_file "$SECRETS_FILE" "Secrets file"
+    ensure_age_key prod
+
+    # Ensure vault is unsealed
+    local sealed_status
+    sealed_status=$(bao_exec status -format=json 2>/dev/null | grep '"sealed"' | tr -d ' ,"' || echo "")
+    if [[ "$sealed_status" != *"false"* ]]; then
+        echo "Vault is sealed — unsealing first..."
+        cmd_unseal
+    fi
+
+    # Read unseal key for root token generation
+    local unseal_key=""
+    if [ -f "$UNSEAL_KEY_PATH" ]; then
+        unseal_key=$(cat "$UNSEAL_KEY_PATH")
+    elif [ -f "$SECRETS_FILE" ]; then
+        unseal_key=$(sops -d --extract '["OPENBAO_UNSEAL_KEY"]' "$SECRETS_FILE" 2>/dev/null || echo "")
+    fi
+    if [ -z "$unseal_key" ]; then
+        die "No unseal key found. Required to generate root token."
+    fi
+
+    # Generate a temporary root token
+    echo "Generating temporary root token..."
+    local init_output otp nonce encoded root_token
+    init_output=$(bao_exec operator generate-root -init -format=json 2>/dev/null)
+    otp=$(echo "$init_output" | python3 -c "import sys,json; print(json.load(sys.stdin)['otp'])")
+    nonce=$(echo "$init_output" | python3 -c "import sys,json; print(json.load(sys.stdin)['nonce'])")
+
+    encoded=$(echo "$unseal_key" | bao_exec operator generate-root -nonce="$nonce" -format=json - 2>/dev/null | \
+        python3 -c "import sys,json; print(json.load(sys.stdin)['encoded_root_token'])")
+
+    root_token=$(bao_exec operator generate-root -decode="$encoded" -otp="$otp" 2>/dev/null)
+
+    if [ -z "$root_token" ]; then
+        die "Failed to generate root token"
+    fi
+    info "Root token generated"
+
+    # Export for bao_exec_env
+    export BAO_TOKEN="$root_token"
+
+    # Run setup (idempotent — creates AppRoles, policies, KV engine)
+    echo ""
+    echo "Running setup (idempotent)..."
+    cmd_setup
+
+    # Generate and store credentials for each service
+    echo ""
+    echo "Generating AppRole credentials for each service..."
+    local stored=0
+
+    for svc in $VAULT_SERVICES; do
+        local svc_upper
+        svc_upper=$(echo "$svc" | tr '[:lower:]' '[:upper:]')
+        local role_id_key="VAULT_${svc_upper}_ROLE_ID"
+        local secret_id_key="VAULT_${svc_upper}_SECRET_ID"
+
+        # Read role_id
+        local role_id
+        role_id=$(bao_exec_env read -format=json "auth/approle/role/${svc}/role-id" 2>/dev/null | \
+            python3 -c "import sys,json; print(json.load(sys.stdin)['data']['role_id'])")
+
+        if [ -z "$role_id" ]; then
+            warn "Failed to read role_id for ${svc} — skipping"
+            continue
+        fi
+
+        # Generate a new secret_id
+        local secret_id
+        secret_id=$(bao_exec_env write -f -format=json "auth/approle/role/${svc}/secret-id" 2>/dev/null | \
+            python3 -c "import sys,json; print(json.load(sys.stdin)['data']['secret_id'])")
+
+        if [ -z "$secret_id" ]; then
+            warn "Failed to generate secret_id for ${svc} — skipping"
+            continue
+        fi
+
+        # Store in SOPS
+        local escaped_role_id escaped_secret_id
+        escaped_role_id=$(printf '%s' "$role_id" | jq -Rs .)
+        escaped_secret_id=$(printf '%s' "$secret_id" | jq -Rs .)
+
+        sops --set "[\"${role_id_key}\"] ${escaped_role_id}" "$SECRETS_FILE" || {
+            warn "Failed to store ${role_id_key} in SOPS"
+            continue
+        }
+        sops --set "[\"${secret_id_key}\"] ${escaped_secret_id}" "$SECRETS_FILE" || {
+            warn "Failed to store ${secret_id_key} in SOPS"
+            continue
+        }
+
+        echo "  ${svc}: role_id + secret_id stored in SOPS"
+        stored=$((stored + 1))
+    done
+
+    # Revoke the temporary root token
+    echo ""
+    echo "Revoking temporary root token..."
+    bao_exec_env token revoke -self 2>/dev/null || warn "Failed to revoke root token (may have already expired)"
+    unset BAO_TOKEN
+
+    echo ""
+    success "Bootstrap complete! ${stored}/${#VAULT_SERVICES} services configured."
+    echo ""
+    echo "IMPORTANT: Commit and push the updated SOPS file:"
+    echo "  git add infra/secrets/prod.enc.env"
+    echo "  git commit -m 'chore: bootstrap AppRole credentials in SOPS'"
+    echo "  git push"
+    echo ""
+}
+
 cmd_auto_unseal() {
     local max_wait=${VAULT_AUTO_UNSEAL_TIMEOUT:-120}
     local waited=0
@@ -656,6 +777,7 @@ main() {
         auto-unseal)        cmd_auto_unseal "$@" ;;
         sync-to-sops)       cmd_sync_to_sops "$@" ;;
         setup-sync-token)   cmd_setup_sync_token "$@" ;;
+        bootstrap-approles) cmd_bootstrap_approles "$@" ;;
         help|--help|-h) usage ;;
         *)
             echo "Unknown command: $cmd"

--- a/tests/scripts/vault.bats
+++ b/tests/scripts/vault.bats
@@ -451,6 +451,46 @@ assert mappers[0]["config"]["claim.name"] == "realm_roles"
 }
 
 # ---------------------------------------------------------------------------
+# Bootstrap AppRole tests
+# ---------------------------------------------------------------------------
+
+@test "vault.sh has cmd_bootstrap_approles function" {
+  run grep "^cmd_bootstrap_approles()" scripts/vault.sh
+  [ "$status" -eq 0 ]
+}
+
+@test "vault.sh bootstrap-approles is in the dispatcher" {
+  run grep "bootstrap-approles)" scripts/vault.sh
+  [ "$status" -eq 0 ]
+}
+
+@test "vault.sh usage lists bootstrap-approles command" {
+  run bash scripts/vault.sh help
+  [[ "$output" == *"bootstrap-approles"* ]]
+}
+
+@test "cmd_bootstrap_approles generates root token and revokes it" {
+  run bash -c "sed -n '/^cmd_bootstrap_approles/,/^}/p' scripts/vault.sh | grep 'generate-root'"
+  [ "$status" -eq 0 ]
+  run bash -c "sed -n '/^cmd_bootstrap_approles/,/^}/p' scripts/vault.sh | grep 'token revoke -self'"
+  [ "$status" -eq 0 ]
+}
+
+@test "cmd_bootstrap_approles writes role_id and secret_id to SOPS" {
+  run bash -c "sed -n '/^cmd_bootstrap_approles/,/^}/p' scripts/vault.sh | grep 'sops --set'"
+  [ "$status" -eq 0 ]
+  run bash -c "sed -n '/^cmd_bootstrap_approles/,/^}/p' scripts/vault.sh | grep 'ROLE_ID'"
+  [ "$status" -eq 0 ]
+  run bash -c "sed -n '/^cmd_bootstrap_approles/,/^}/p' scripts/vault.sh | grep 'SECRET_ID'"
+  [ "$status" -eq 0 ]
+}
+
+@test "cmd_bootstrap_approles iterates all VAULT_SERVICES" {
+  run bash -c "sed -n '/^cmd_bootstrap_approles/,/^}/p' scripts/vault.sh | grep 'for svc in \$VAULT_SERVICES'"
+  [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
 # Secrets schema tests
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Adds `vault.sh bootstrap-approles` command that automates AppRole credential generation and SOPS storage for all services
- Generates temporary root token, runs idempotent setup, creates role_id + secret_id per service, stores in SOPS, revokes token
- Closes the gap where deploys fall back to SOPS instead of vault-first auth

## Plan
Single-command automation to replace manual per-service AppRole credential generation.

## Risks
- Root token is generated and revoked within the same command (short-lived)
- Existing secret_ids are not invalidated — new ones are additive
- SOPS file is modified in place (same pattern as sync-to-sops)

## Rollback
Remove the VAULT_*_ROLE_ID/SECRET_ID entries from SOPS; deploys continue working via SOPS fallback.

## Validation Evidence
- shellcheck passes: `shellcheck --severity=error scripts/vault.sh` (exit 0)
- BATS tests pass: 73/73 vault tests, 51/51 deploy tests
- Structural tests verify: function exists, dispatcher routes, usage lists command, generates+revokes root token, writes to SOPS, iterates all services

## Test plan
- [ ] CI passes (shellcheck, bats, pytest)
- [ ] Run `vault.sh bootstrap-approles` on VPS
- [ ] Redeploy auth and observability — confirm no fallback warning
- [ ] Verify vault-first auth path works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)