### PR TITLE
enhance: vault-first closeout — Ansible profile + docs + DR verified

### DIFF
--- a/docs/runbooks/disaster-recovery.md
+++ b/docs/runbooks/disaster-recovery.md
@@ -103,22 +103,13 @@ bash scripts/vault.sh seed
 
 ### 8. Generate and Store AppRole Credentials
 
-For each service, generate new AppRole credentials and store them in SOPS:
+Bootstrap all AppRole credentials automatically:
 
 ```bash
-# Example for api:
-bao read auth/approle/role/api/role-id
-bao write -f auth/approle/role/api/secret-id
+bash scripts/vault.sh bootstrap-approles
 ```
 
-Update SOPS with each service's role_id and secret_id:
-
-```bash
-make secrets-update KEY=VAULT_API_ROLE_ID VALUE="<role-id>"
-make secrets-update KEY=VAULT_API_SECRET_ID VALUE="<secret-id>"
-```
-
-Repeat for: `db`, `api`, `ai`, `auth`, `ui`, `mcp`, `minio`, `infra`, `observability`.
+This generates role_id + secret_id for all 9 services and stores them in SOPS. It temporarily generates a root token (via unseal key), runs setup, creates credentials, then revokes the root token.
 
 ### 9. Deploy Database
 
@@ -171,7 +162,8 @@ VPS recreate -> VPS config -> infra -> vault (deploy+init+unseal+setup+seed)
 
 ## Notes
 
-- Vault requires manual unseal after every container restart. This is by design (no auto-unseal).
+- Vault auto-unseals after deploy (`deploy.sh vault` calls `vault.sh auto-unseal`) and on VPS boot (systemd `hill90-vault-unseal` service). Manual unseal is available as fallback: `bash scripts/vault.sh unseal`.
 - SOPS is the bootstrap mechanism. All runtime secrets must be present in SOPS to seed vault on a fresh install.
+- `SOPS_AGE_KEY_FILE=/opt/hill90/secrets/keys/keys.txt` must be set in the deploy user's environment for SOPS fallback to work. The Ansible bootstrap (playbook 12) configures this automatically.
 - After recovery, run `vault.sh sync-to-sops` periodically to keep the SOPS backup current.
 - DNS records may need updating if the VPS IP changed: `bash scripts/hostinger.sh dns sync`.

--- a/docs/runbooks/secrets-workflow.md
+++ b/docs/runbooks/secrets-workflow.md
@@ -133,6 +133,16 @@ The token has `policy-sync` (read-only KV access) and is a periodic token with a
 - The encrypted SOPS file (already committed in the repo) is the only file transferred back.
 - The token is masked in CI logs via `::add-mask`.
 
+## VPS Environment Requirement
+
+The deploy user's shell must have `SOPS_AGE_KEY_FILE` set for SOPS operations (fallback decryption, seeding, sync):
+
+```
+export SOPS_AGE_KEY_FILE=/opt/hill90/secrets/keys/keys.txt
+```
+
+This is configured automatically by Ansible bootstrap (playbook `12-deploy-profile.yml`). If missing after a VPS rebuild, re-run the bootstrap or add it manually to `~/.bashrc`.
+
 ## Periodic Maintenance
 
 - **After any vault change**: Run `vault.sh sync-to-sops` manually or wait for the next scheduled sync.

--- a/docs/runbooks/vault-unseal.md
+++ b/docs/runbooks/vault-unseal.md
@@ -142,6 +142,18 @@ docker inspect --format='{{.State.Health.Status}}' openbao
 # Should show: healthy
 ```
 
+## SOPS Fallback Requirement
+
+When vault is unavailable, deploy scripts fall back to SOPS for secrets. This requires the `SOPS_AGE_KEY_FILE` environment variable:
+
+```
+SOPS_AGE_KEY_FILE=/opt/hill90/secrets/keys/keys.txt
+```
+
+The Ansible bootstrap (playbook `12-deploy-profile.yml`) adds this to the deploy user's `.bashrc` automatically. The vault-unseal systemd service also sets this via its `Environment=` directive.
+
+If the variable is missing, SOPS fallback will fail with "Age key not found".
+
 ## Ansible Installation
 
 The systemd service is installed by Ansible playbook `infra/ansible/playbooks/11-vault-unseal.yml`, which runs during VPS bootstrap. To re-install manually:

--- a/infra/ansible/playbooks/12-deploy-profile.yml
+++ b/infra/ansible/playbooks/12-deploy-profile.yml
@@ -1,0 +1,15 @@
+---
+# Deploy User Profile Setup
+# Ensures environment variables needed for SOPS fallback are set in .bashrc.
+
+- name: Ensure SOPS_AGE_KEY_FILE is exported in deploy user .bashrc
+  blockinfile:
+    path: "{{ deploy_home }}/.bashrc"
+    marker: "# {mark} MANAGED BY ANSIBLE - Hill90 environment"
+    block: |
+      # SOPS age key for secrets decryption (fallback path when vault is unavailable)
+      export SOPS_AGE_KEY_FILE={{ age_key_path }}/keys.txt
+    create: no
+    owner: "{{ deploy_user }}"
+    group: "{{ deploy_user }}"
+    mode: '0644'

--- a/infra/ansible/playbooks/bootstrap.yml
+++ b/infra/ansible/playbooks/bootstrap.yml
@@ -43,6 +43,9 @@
     - name: "11 - Vault Auto-Unseal"
       import_tasks: 11-vault-unseal.yml
 
+    - name: "12 - Deploy Profile"
+      import_tasks: 12-deploy-profile.yml
+
     # NOTE: Playbooks 09-traefik.yml and 10-portainer.yml are NOT run during bootstrap
     # Infrastructure containers (Traefik, dns-manager, Portainer) are deployed separately
     # via: make deploy-infra


### PR DESCRIPTION
## Summary

- Add Ansible playbook `12-deploy-profile.yml` that exports `SOPS_AGE_KEY_FILE` in the deploy user's `.bashrc`, ensuring SOPS fallback survives VPS rebuilds
- Import playbook 12 in `bootstrap.yml` after vault auto-unseal (playbook 11)
- Update `disaster-recovery.md`: replace manual AppRole generation with `bootstrap-approles` command, update auto-unseal notes, add `SOPS_AGE_KEY_FILE` requirement
- Update `secrets-workflow.md`: add VPS environment requirement section
- Update `vault-unseal.md`: add SOPS fallback requirement section

## Plan

Scope is surgical: one new Ansible playbook + three doc updates. No code logic changes.

## Risks

- Ansible `blockinfile` is idempotent — re-runs won't duplicate the export
- No runtime behavior changes to deploy scripts

## Rollback

Revert commit; remove playbook 12 import from bootstrap.yml.

## Validation Evidence

### All 9 services vault-first authenticated (no SOPS fallback)

```
OpenBao authenticated for auth
OpenBao authenticated for api
OpenBao authenticated for ai
OpenBao authenticated for mcp
OpenBao authenticated for ui
OpenBao authenticated for infra
OpenBao authenticated for observability
```
(db and minio authenticated in earlier deploys)

### DR test: SOPS fallback + vault recovery

```
# Step 1: Stop vault
docker stop openbao → exited

# Step 2: Deploy with vault down
WARNING: OpenBao not available, using SOPS fallback
UI Service Deployment Complete! ✓

# Step 3: Restore vault
docker start openbao → auto-unseal → healthy

# Step 4: Deploy with vault back
OpenBao authenticated for ui ✓
```

### auth.hill90.com healthy
```
curl -s -o /dev/null -w '%{http_code}' https://auth.hill90.com/realms/hill90/.well-known/openid-configuration
200
```

### All containers healthy
```
18 containers up — keycloak, api, ai, mcp, ui, openbao, postgres, minio, traefik, dns-manager, portainer, grafana, prometheus, loki, tempo, promtail, node-exporter, cadvisor
```

## Test plan

- [ ] CI passes (markdown links, shellcheck)
- [ ] Ansible playbook YAML is valid
- [ ] Doc links resolve correctly
- [x] VPS: all 9 services deploy with vault-first auth
- [x] VPS: SOPS fallback works when vault is down
- [x] VPS: vault-first resumes after vault is restored
- [x] auth.hill90.com returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)