### PR TITLE
fix: use printf %b for PEM files to convert escaped newlines

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -352,10 +352,10 @@ cmd_service() {
             if [ -z "$AKM_SIGNING_PUBLIC_KEY" ] || [ -z "$AKM_SIGNING_PRIVATE_KEY" ]; then
                 echo "WARNING: AKM signing keys not found in secrets — akm-keys volume will be empty"
             else
-                printf "%s\n" "$AKM_SIGNING_PUBLIC_KEY" | docker run --rm -i \
+                printf "%b\n" "$AKM_SIGNING_PUBLIC_KEY" | docker run --rm -i \
                     -v akm-keys:/etc/akm alpine sh -c \
                     "cat > /etc/akm/public.pem && chmod 644 /etc/akm/public.pem && chown 1000:1000 /etc/akm/public.pem"
-                printf "%s\n" "$AKM_SIGNING_PRIVATE_KEY" | docker run --rm -i \
+                printf "%b\n" "$AKM_SIGNING_PRIVATE_KEY" | docker run --rm -i \
                     -v akm-keys:/etc/akm alpine sh -c \
                     "cat > /etc/akm/private.pem && chmod 600 /etc/akm/private.pem && chown 1000:1000 /etc/akm/private.pem"
                 echo "akm-keys volume populated with public.pem and private.pem"


### PR DESCRIPTION
## Summary
- Change `printf "%s"` to `printf "%b"` when writing PEM files to the akm-keys volume

## Plan
SOPS stores multiline PEM keys with literal `\n` escape sequences. `printf "%s"` writes them verbatim, producing invalid PEM files that the knowledge service can't parse (`InvalidByte(0, 92)` — byte 92 is backslash). `printf "%b"` interprets the escapes into actual newline characters.

## Risks
| Risk | Likelihood | Impact | Mitigation |
|---|---|---|---|
| printf %b interprets other escapes | Low | Low | PEM content is base64 + dashes, no other escape sequences present |

## Rollback
Revert the commit. Manually fix PEM files on VPS as before.

## Validation Evidence
- `shellcheck -S warning` on deploy script — clean
- Smoke tested on VPS: fixed PEM files, restarted knowledge, API-generated JWT validated by knowledge service (200 response)

## Test plan
- [x] shellcheck clean
- [x] Smoke test: API generates Ed25519 JWT, knowledge validates it, returns 200
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
