### PR TITLE
feat: add knowledge API proxy routes and internal admin endpoints

### DIFF
--- a/docs/site/api-reference/knowledge.mdx
+++ b/docs/site/api-reference/knowledge.mdx
@@ -1,0 +1,33 @@
+---
+title: Knowledge API
+description: Read-only access to agent knowledge entries, search, and stats.
+---
+
+# Knowledge API
+
+The Knowledge API provides read-only access to agent knowledge. Agents write knowledge via the `akm` CLI; the Knowledge API lets humans browse what agents know.
+
+## Access Model
+
+- **Users** see knowledge from agents they own.
+- **Admins** see knowledge from all agents.
+- **Read-only** — only agents write knowledge through the AKM service.
+
+## Endpoints
+
+| Endpoint | Description |
+|----------|-------------|
+| `GET /knowledge/agents` | List agents with knowledge entry counts |
+| `GET /knowledge/entries` | List entries for a specific agent |
+| `GET /knowledge/entries/{agentId}/{path}` | Read a specific entry with full content |
+| `GET /knowledge/search` | Full-text search across knowledge entries |
+
+## Authentication
+
+All endpoints require a valid Keycloak JWT bearer token with the `user` role:
+
+```
+Authorization: Bearer YOUR_JWT_TOKEN
+```
+
+See the auto-generated endpoint pages below for request/response details.

--- a/docs/site/api-reference/overview.mdx
+++ b/docs/site/api-reference/overview.mdx
@@ -5,7 +5,7 @@ description: Hill90 REST API endpoint documentation.
 
 # API Reference
 
-The Hill90 API provides endpoints for agent management, user profiles, and platform health checks.
+The Hill90 API provides endpoints for agent management, agent knowledge, user profiles, and platform health checks.
 
 ## Base URL
 
@@ -56,6 +56,17 @@ See [Authentication](/getting-started/authentication) for details on obtaining t
 | `POST /agents/{id}/stop` | Bearer (admin) | Stop agent container |
 | `GET /agents/{id}/status` | Bearer | Get agent status |
 | `GET /agents/{id}/logs` | Bearer (admin) | Get agent logs (JSON or SSE stream) |
+
+### Knowledge
+
+| Endpoint | Auth | Description |
+|----------|------|-------------|
+| `GET /knowledge/agents` | Bearer | List agents with knowledge stats |
+| `GET /knowledge/entries` | Bearer | List entries for an agent |
+| `GET /knowledge/entries/{agentId}/{path}` | Bearer | Read a specific entry |
+| `GET /knowledge/search` | Bearer | Full-text search across entries |
+
+See [Knowledge API](/api-reference/knowledge) for details on access scoping.
 
 ## Auto-Generated Documentation
 

--- a/docs/site/docs.json
+++ b/docs/site/docs.json
@@ -48,7 +48,8 @@
         "group": "API Reference",
         "openapi": "/openapi.yaml",
         "pages": [
-          "api-reference/overview"
+          "api-reference/overview",
+          "api-reference/knowledge"
         ]
       }
     ]

--- a/docs/site/openapi.yaml
+++ b/docs/site/openapi.yaml
@@ -91,6 +91,99 @@ components:
         hasAvatar:
           type: boolean
 
+    KnowledgeEntry:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        agent_id:
+          type: string
+        path:
+          type: string
+        title:
+          type: string
+        entry_type:
+          type: string
+          enum: [note, plan, decision, journal, research]
+        content:
+          type: string
+          description: Full markdown content (only included in single-entry reads)
+        content_hash:
+          type: string
+        tags:
+          type: array
+          items:
+            type: string
+        status:
+          type: string
+          enum: [active, archived]
+        sync_status:
+          type: string
+          enum: [pending, synced, quarantined]
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+
+    KnowledgeAgent:
+      type: object
+      properties:
+        agent_id:
+          type: string
+        entry_count:
+          type: integer
+        last_updated:
+          type: string
+          format: date-time
+
+    KnowledgeSearchResult:
+      type: object
+      properties:
+        query:
+          type: string
+        results:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+                format: uuid
+              agent_id:
+                type: string
+              path:
+                type: string
+              title:
+                type: string
+              entry_type:
+                type: string
+              tags:
+                type: array
+                items:
+                  type: string
+              score:
+                type: number
+              headline:
+                type: string
+                description: Search result snippet with highlights
+              created_at:
+                type: string
+                format: date-time
+              updated_at:
+                type: string
+                format: date-time
+        count:
+          type: integer
+        search_type:
+          type: string
+          example: fts
+        score_type:
+          type: string
+          example: ts_rank
+
     Error:
       type: object
       properties:
@@ -612,3 +705,133 @@ paths:
           description: Not authenticated
         "403":
           description: Requires user role
+
+  /knowledge/agents:
+    get:
+      summary: List agents with knowledge
+      description: >
+        Returns agents that have knowledge entries, with entry counts and last updated
+        timestamps. Scoped to ownership — users see their own agents, admins see all.
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Agent knowledge stats
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/KnowledgeAgent"
+        "401":
+          description: Not authenticated
+        "403":
+          description: Requires user role
+
+  /knowledge/entries:
+    get:
+      summary: List knowledge entries
+      description: >
+        Returns knowledge entries for a specific agent. Requires agent_id query parameter.
+        Users can only list entries for agents they own. Admins can list any agent's entries.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: agent_id
+          in: query
+          required: true
+          schema:
+            type: string
+          description: Agent ID to list entries for
+        - name: type
+          in: query
+          schema:
+            type: string
+            enum: [note, plan, decision, journal, research]
+          description: Optional entry type filter
+      responses:
+        "200":
+          description: Entry list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/KnowledgeEntry"
+        "400":
+          description: Missing agent_id parameter
+        "401":
+          description: Not authenticated
+        "403":
+          description: Not authorized to view this agent's knowledge
+
+  /knowledge/entries/{agentId}/{path}:
+    parameters:
+      - name: agentId
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Agent ID
+      - name: path
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Entry path (e.g. notes/test.md)
+    get:
+      summary: Read knowledge entry
+      description: >
+        Returns a single knowledge entry with full content. Users can only read
+        entries from agents they own. Admins can read any entry.
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Entry detail with content
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/KnowledgeEntry"
+        "401":
+          description: Not authenticated
+        "403":
+          description: Not authorized to view this agent's knowledge
+        "404":
+          description: Entry not found
+
+  /knowledge/search:
+    get:
+      summary: Search knowledge entries
+      description: >
+        Full-text search across knowledge entries. Without agent_id, searches
+        across all owned agents (or all agents for admins). With agent_id,
+        searches only that agent's entries (ownership enforced for users).
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: q
+          in: query
+          required: true
+          schema:
+            type: string
+            minLength: 1
+          description: Search query
+        - name: agent_id
+          in: query
+          schema:
+            type: string
+          description: Optional agent ID to scope search
+      responses:
+        "200":
+          description: Search results
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/KnowledgeSearchResult"
+        "400":
+          description: Missing q parameter
+        "401":
+          description: Not authenticated
+        "403":
+          description: Not authorized to search this agent's knowledge

--- a/services/api/src/__tests__/docs.test.ts
+++ b/services/api/src/__tests__/docs.test.ts
@@ -147,6 +147,10 @@ const EXPECTED_PATHS = [
   '/agents/{id}/stop',
   '/agents/{id}/status',
   '/agents/{id}/logs',
+  '/knowledge/agents',
+  '/knowledge/entries',
+  '/knowledge/entries/{agentId}/{path}',
+  '/knowledge/search',
   '/profile',
   '/profile/avatar',
   '/profile/password',
@@ -188,8 +192,10 @@ function getRegisteredRoutes(expressApp: any): string[] {
     // Middleware-only layers (no .route, not a router): skip
   }
 
-  // Normalize :param to {param} and deduplicate
-  return [...new Set(routes.map(r => r.replace(/:(\w+)/g, '{$1}')))];
+  // Normalize :param to {param}, strip Express regex suffixes like (*), and deduplicate
+  return [...new Set(routes.map(r =>
+    r.replace(/:(\w+)/g, '{$1}').replace(/\(\*\)$/, '')
+  ))];
 }
 
 describe('Spec contract enforcement', () => {

--- a/services/api/src/__tests__/routes-knowledge.test.ts
+++ b/services/api/src/__tests__/routes-knowledge.test.ts
@@ -1,0 +1,295 @@
+import request from 'supertest';
+import * as crypto from 'crypto';
+import * as jwt from 'jsonwebtoken';
+import { createApp } from '../app';
+
+// Generate a throwaway RSA keypair for test signing
+const { privateKey, publicKey } = crypto.generateKeyPairSync('rsa', {
+  modulusLength: 2048,
+  publicKeyEncoding: { type: 'spki', format: 'pem' },
+  privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+});
+
+const TEST_ISSUER = 'https://auth.hill90.com/realms/hill90';
+
+// Mock pg pool
+const mockQuery = jest.fn();
+jest.mock('../db/pool', () => ({
+  getPool: () => ({ query: mockQuery }),
+}));
+
+// Mock akm-proxy
+const mockListAgents = jest.fn();
+const mockListEntries = jest.fn();
+const mockReadEntry = jest.fn();
+const mockSearchEntries = jest.fn();
+jest.mock('../services/akm-proxy', () => ({
+  listAgents: (...args: unknown[]) => mockListAgents(...args),
+  listEntries: (...args: unknown[]) => mockListEntries(...args),
+  readEntry: (...args: unknown[]) => mockReadEntry(...args),
+  searchEntries: (...args: unknown[]) => mockSearchEntries(...args),
+}));
+
+const app = createApp({
+  issuer: TEST_ISSUER,
+  getSigningKey: async () => publicKey,
+});
+
+function makeToken(sub: string, roles: string[]) {
+  return jwt.sign(
+    { sub, realm_roles: roles },
+    privateKey,
+    { algorithm: 'RS256', issuer: TEST_ISSUER, expiresIn: '5m' }
+  );
+}
+
+const adminToken = makeToken('admin-user', ['admin', 'user']);
+const userToken = makeToken('regular-user', ['user']);
+const noRoleToken = makeToken('no-role-user', []);
+
+describe('Knowledge proxy routes — auth', () => {
+  it('GET /knowledge/agents returns 401 without auth', async () => {
+    const res = await request(app).get('/knowledge/agents');
+    expect(res.status).toBe(401);
+  });
+
+  it('GET /knowledge/agents returns 403 without user role', async () => {
+    const res = await request(app)
+      .get('/knowledge/agents')
+      .set('Authorization', `Bearer ${noRoleToken}`);
+    expect(res.status).toBe(403);
+  });
+
+  it('GET /knowledge/entries returns 401 without auth', async () => {
+    const res = await request(app).get('/knowledge/entries?agent_id=test');
+    expect(res.status).toBe(401);
+  });
+
+  it('GET /knowledge/search returns 401 without auth', async () => {
+    const res = await request(app).get('/knowledge/search?q=test');
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('Knowledge proxy routes — list agents', () => {
+  beforeEach(() => {
+    mockQuery.mockReset();
+    mockListAgents.mockReset();
+    process.env.DATABASE_URL = 'postgresql://test:test@localhost:5432/test';
+  });
+
+  afterEach(() => {
+    delete process.env.DATABASE_URL;
+  });
+
+  it('admin sees all agents', async () => {
+    mockListAgents.mockResolvedValueOnce({
+      status: 200,
+      data: [
+        { agent_id: 'agent-a', entry_count: 5, last_updated: '2025-01-01T00:00:00Z' },
+        { agent_id: 'agent-b', entry_count: 3, last_updated: '2025-01-01T00:00:00Z' },
+      ],
+    });
+
+    const res = await request(app)
+      .get('/knowledge/agents')
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(2);
+  });
+
+  it('user sees only own agents', async () => {
+    mockListAgents.mockResolvedValueOnce({
+      status: 200,
+      data: [
+        { agent_id: 'agent-a', entry_count: 5, last_updated: '2025-01-01T00:00:00Z' },
+        { agent_id: 'agent-b', entry_count: 3, last_updated: '2025-01-01T00:00:00Z' },
+      ],
+    });
+    // Mock: user owns only agent-a
+    mockQuery.mockResolvedValueOnce({ rows: [{ agent_id: 'agent-a' }] });
+
+    const res = await request(app)
+      .get('/knowledge/agents')
+      .set('Authorization', `Bearer ${userToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+    expect(res.body[0].agent_id).toBe('agent-a');
+  });
+
+  it('returns 502 when knowledge service is down', async () => {
+    mockListAgents.mockResolvedValueOnce({
+      status: 502,
+      data: { error: 'Knowledge service unavailable' },
+    });
+
+    const res = await request(app)
+      .get('/knowledge/agents')
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(res.status).toBe(502);
+  });
+});
+
+describe('Knowledge proxy routes — list entries', () => {
+  beforeEach(() => {
+    mockQuery.mockReset();
+    mockListEntries.mockReset();
+    process.env.DATABASE_URL = 'postgresql://test:test@localhost:5432/test';
+  });
+
+  afterEach(() => {
+    delete process.env.DATABASE_URL;
+  });
+
+  it('returns 400 without agent_id', async () => {
+    const res = await request(app)
+      .get('/knowledge/entries')
+      .set('Authorization', `Bearer ${userToken}`);
+    expect(res.status).toBe(400);
+  });
+
+  it('user cannot list entries for unowned agent', async () => {
+    // Mock: user owns no agents
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    const res = await request(app)
+      .get('/knowledge/entries?agent_id=not-mine')
+      .set('Authorization', `Bearer ${userToken}`);
+    expect(res.status).toBe(403);
+  });
+
+  it('user can list entries for owned agent', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ agent_id: 'my-agent' }] });
+    mockListEntries.mockResolvedValueOnce({
+      status: 200,
+      data: [{ id: '1', agent_id: 'my-agent', path: 'notes/test.md', title: 'Test' }],
+    });
+
+    const res = await request(app)
+      .get('/knowledge/entries?agent_id=my-agent')
+      .set('Authorization', `Bearer ${userToken}`);
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+  });
+
+  it('admin can list entries for any agent', async () => {
+    mockListEntries.mockResolvedValueOnce({
+      status: 200,
+      data: [{ id: '1', agent_id: 'any-agent', path: 'notes/test.md', title: 'Test' }],
+    });
+
+    const res = await request(app)
+      .get('/knowledge/entries?agent_id=any-agent')
+      .set('Authorization', `Bearer ${adminToken}`);
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+  });
+});
+
+describe('Knowledge proxy routes — read entry', () => {
+  beforeEach(() => {
+    mockQuery.mockReset();
+    mockReadEntry.mockReset();
+    process.env.DATABASE_URL = 'postgresql://test:test@localhost:5432/test';
+  });
+
+  afterEach(() => {
+    delete process.env.DATABASE_URL;
+  });
+
+  it('user cannot read entry from unowned agent', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    const res = await request(app)
+      .get('/knowledge/entries/not-mine/notes/test.md')
+      .set('Authorization', `Bearer ${userToken}`);
+    expect(res.status).toBe(403);
+  });
+
+  it('user can read entry from owned agent', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ agent_id: 'my-agent' }] });
+    mockReadEntry.mockResolvedValueOnce({
+      status: 200,
+      data: { id: '1', agent_id: 'my-agent', path: 'notes/test.md', content: '# Test' },
+    });
+
+    const res = await request(app)
+      .get('/knowledge/entries/my-agent/notes/test.md')
+      .set('Authorization', `Bearer ${userToken}`);
+    expect(res.status).toBe(200);
+    expect(res.body.path).toBe('notes/test.md');
+  });
+
+  it('returns 404 for nonexistent entry', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ agent_id: 'my-agent' }] });
+    mockReadEntry.mockResolvedValueOnce({
+      status: 404,
+      data: { detail: 'entry not found' },
+    });
+
+    const res = await request(app)
+      .get('/knowledge/entries/my-agent/notes/nope.md')
+      .set('Authorization', `Bearer ${userToken}`);
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('Knowledge proxy routes — search', () => {
+  beforeEach(() => {
+    mockQuery.mockReset();
+    mockSearchEntries.mockReset();
+    process.env.DATABASE_URL = 'postgresql://test:test@localhost:5432/test';
+  });
+
+  afterEach(() => {
+    delete process.env.DATABASE_URL;
+  });
+
+  it('returns 400 without q param', async () => {
+    const res = await request(app)
+      .get('/knowledge/search')
+      .set('Authorization', `Bearer ${userToken}`);
+    expect(res.status).toBe(400);
+  });
+
+  it('admin searches all agents without filter', async () => {
+    mockSearchEntries.mockResolvedValueOnce({
+      status: 200,
+      data: { query: 'test', results: [{ id: '1', agent_id: 'a', score: 0.5 }], count: 1, search_type: 'fts', score_type: 'ts_rank' },
+    });
+
+    const res = await request(app)
+      .get('/knowledge/search?q=test')
+      .set('Authorization', `Bearer ${adminToken}`);
+    expect(res.status).toBe(200);
+    expect(res.body.count).toBe(1);
+  });
+
+  it('user search scoped to owned agents', async () => {
+    // Mock: user owns agent-a
+    mockQuery.mockResolvedValueOnce({ rows: [{ agent_id: 'agent-a' }] });
+    mockSearchEntries.mockResolvedValueOnce({
+      status: 200,
+      data: { query: 'test', results: [{ id: '1', agent_id: 'agent-a', score: 0.5 }], count: 1, search_type: 'fts', score_type: 'ts_rank' },
+    });
+
+    const res = await request(app)
+      .get('/knowledge/search?q=test')
+      .set('Authorization', `Bearer ${userToken}`);
+    expect(res.status).toBe(200);
+    // Should have searched only for agent-a
+    expect(mockSearchEntries).toHaveBeenCalledWith('test', 'agent-a');
+  });
+
+  it('user cannot search specific unowned agent', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    const res = await request(app)
+      .get('/knowledge/search?q=test&agent_id=not-mine')
+      .set('Authorization', `Bearer ${userToken}`);
+    expect(res.status).toBe(403);
+  });
+});

--- a/services/api/src/app.ts
+++ b/services/api/src/app.ts
@@ -2,6 +2,7 @@ import express, { Application } from 'express';
 import { createRequireAuth, createJwksKeyResolver } from './middleware/auth';
 import type { JwtHeader } from 'jsonwebtoken';
 import agentsRouter from './routes/agents';
+import knowledgeRouter from './routes/knowledge';
 import profileRouter from './routes/profile';
 import { requireRole } from './middleware/role';
 import { docsRouter, specRouter } from './routes/docs';
@@ -36,6 +37,9 @@ export function createApp(opts: AppOptions = {}): Application {
 
   // Agent management routes
   app.use('/agents', requireAuth, agentsRouter);
+
+  // Knowledge proxy routes (read-only, owner-scoped)
+  app.use('/knowledge', requireAuth, knowledgeRouter);
 
   // User profile routes
   app.use('/profile', requireAuth, profileRouter);

--- a/services/api/src/openapi/openapi.yaml
+++ b/services/api/src/openapi/openapi.yaml
@@ -91,6 +91,99 @@ components:
         hasAvatar:
           type: boolean
 
+    KnowledgeEntry:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        agent_id:
+          type: string
+        path:
+          type: string
+        title:
+          type: string
+        entry_type:
+          type: string
+          enum: [note, plan, decision, journal, research]
+        content:
+          type: string
+          description: Full markdown content (only included in single-entry reads)
+        content_hash:
+          type: string
+        tags:
+          type: array
+          items:
+            type: string
+        status:
+          type: string
+          enum: [active, archived]
+        sync_status:
+          type: string
+          enum: [pending, synced, quarantined]
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+
+    KnowledgeAgent:
+      type: object
+      properties:
+        agent_id:
+          type: string
+        entry_count:
+          type: integer
+        last_updated:
+          type: string
+          format: date-time
+
+    KnowledgeSearchResult:
+      type: object
+      properties:
+        query:
+          type: string
+        results:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+                format: uuid
+              agent_id:
+                type: string
+              path:
+                type: string
+              title:
+                type: string
+              entry_type:
+                type: string
+              tags:
+                type: array
+                items:
+                  type: string
+              score:
+                type: number
+              headline:
+                type: string
+                description: Search result snippet with highlights
+              created_at:
+                type: string
+                format: date-time
+              updated_at:
+                type: string
+                format: date-time
+        count:
+          type: integer
+        search_type:
+          type: string
+          example: fts
+        score_type:
+          type: string
+          example: ts_rank
+
     Error:
       type: object
       properties:
@@ -612,3 +705,133 @@ paths:
           description: Not authenticated
         "403":
           description: Requires user role
+
+  /knowledge/agents:
+    get:
+      summary: List agents with knowledge
+      description: >
+        Returns agents that have knowledge entries, with entry counts and last updated
+        timestamps. Scoped to ownership — users see their own agents, admins see all.
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Agent knowledge stats
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/KnowledgeAgent"
+        "401":
+          description: Not authenticated
+        "403":
+          description: Requires user role
+
+  /knowledge/entries:
+    get:
+      summary: List knowledge entries
+      description: >
+        Returns knowledge entries for a specific agent. Requires agent_id query parameter.
+        Users can only list entries for agents they own. Admins can list any agent's entries.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: agent_id
+          in: query
+          required: true
+          schema:
+            type: string
+          description: Agent ID to list entries for
+        - name: type
+          in: query
+          schema:
+            type: string
+            enum: [note, plan, decision, journal, research]
+          description: Optional entry type filter
+      responses:
+        "200":
+          description: Entry list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/KnowledgeEntry"
+        "400":
+          description: Missing agent_id parameter
+        "401":
+          description: Not authenticated
+        "403":
+          description: Not authorized to view this agent's knowledge
+
+  /knowledge/entries/{agentId}/{path}:
+    parameters:
+      - name: agentId
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Agent ID
+      - name: path
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Entry path (e.g. notes/test.md)
+    get:
+      summary: Read knowledge entry
+      description: >
+        Returns a single knowledge entry with full content. Users can only read
+        entries from agents they own. Admins can read any entry.
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Entry detail with content
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/KnowledgeEntry"
+        "401":
+          description: Not authenticated
+        "403":
+          description: Not authorized to view this agent's knowledge
+        "404":
+          description: Entry not found
+
+  /knowledge/search:
+    get:
+      summary: Search knowledge entries
+      description: >
+        Full-text search across knowledge entries. Without agent_id, searches
+        across all owned agents (or all agents for admins). With agent_id,
+        searches only that agent's entries (ownership enforced for users).
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: q
+          in: query
+          required: true
+          schema:
+            type: string
+            minLength: 1
+          description: Search query
+        - name: agent_id
+          in: query
+          schema:
+            type: string
+          description: Optional agent ID to scope search
+      responses:
+        "200":
+          description: Search results
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/KnowledgeSearchResult"
+        "400":
+          description: Missing q parameter
+        "401":
+          description: Not authenticated
+        "403":
+          description: Not authorized to search this agent's knowledge

--- a/services/api/src/routes/knowledge.ts
+++ b/services/api/src/routes/knowledge.ts
@@ -1,0 +1,169 @@
+/**
+ * Knowledge proxy routes — read-only access to agent knowledge.
+ *
+ * Auth pattern matches /agents router:
+ * - requireAuth at mount (Keycloak JWT validation in app.ts)
+ * - requireRole('user') per-route
+ * - scopeToOwner(req) for admin bypass vs user scoping
+ *
+ * Users see knowledge from their own agents. Admins see all agents' knowledge.
+ */
+
+import { Router, Request, Response } from 'express';
+import { requireRole } from '../middleware/role';
+import { scopeToOwner } from '../helpers/scope';
+import { getPool } from '../db/pool';
+import * as akmProxy from '../services/akm-proxy';
+
+const router = Router();
+
+/**
+ * Given a request, return the list of agent_ids the user is allowed to see.
+ * Admins: null (no filter — see all).
+ * Users: list of agent_ids they created.
+ */
+async function getAllowedAgentIds(req: Request): Promise<string[] | null> {
+  const scope = scopeToOwner(req);
+  if (scope.where === '1=1') {
+    return null; // admin — no filter
+  }
+  const { rows } = await getPool().query(
+    `SELECT agent_id FROM agents WHERE ${scope.where}`,
+    scope.params,
+  );
+  return rows.map((r: { agent_id: string }) => r.agent_id);
+}
+
+/**
+ * Check if a specific agent_id is owned by the requesting user.
+ */
+async function isAgentOwned(req: Request, agentId: string): Promise<boolean> {
+  const allowed = await getAllowedAgentIds(req);
+  if (allowed === null) return true; // admin
+  return allowed.includes(agentId);
+}
+
+// List agents with knowledge stats
+router.get('/agents', requireRole('user'), async (req: Request, res: Response) => {
+  try {
+    const result = await akmProxy.listAgents();
+    if (result.status !== 200) {
+      res.status(result.status).json(result.data);
+      return;
+    }
+
+    // Filter to owned agents for non-admin users
+    const allowed = await getAllowedAgentIds(req);
+    let agents = result.data as Array<{ agent_id: string }>;
+    if (allowed !== null) {
+      agents = agents.filter(a => allowed.includes(a.agent_id));
+    }
+
+    res.json(agents);
+  } catch (err) {
+    console.error('[knowledge] List agents error:', err);
+    res.status(500).json({ error: 'Failed to list knowledge agents' });
+  }
+});
+
+// List entries for an agent
+router.get('/entries', requireRole('user'), async (req: Request, res: Response) => {
+  try {
+    const agentId = req.query.agent_id as string;
+    if (!agentId) {
+      res.status(400).json({ error: 'agent_id query parameter is required' });
+      return;
+    }
+
+    if (!await isAgentOwned(req, agentId)) {
+      res.status(403).json({ error: 'Not authorized to view this agent\'s knowledge' });
+      return;
+    }
+
+    const type = req.query.type as string | undefined;
+    const result = await akmProxy.listEntries(agentId, type);
+    res.status(result.status).json(result.data);
+  } catch (err) {
+    console.error('[knowledge] List entries error:', err);
+    res.status(500).json({ error: 'Failed to list knowledge entries' });
+  }
+});
+
+// Read a specific entry
+router.get('/entries/:agentId/:path(*)', requireRole('user'), async (req: Request, res: Response) => {
+  try {
+    const { agentId } = req.params;
+    const path = req.params.path || req.params[0];
+
+    if (!await isAgentOwned(req, agentId)) {
+      res.status(403).json({ error: 'Not authorized to view this agent\'s knowledge' });
+      return;
+    }
+
+    const result = await akmProxy.readEntry(agentId, path);
+    res.status(result.status).json(result.data);
+  } catch (err) {
+    console.error('[knowledge] Read entry error:', err);
+    res.status(500).json({ error: 'Failed to read knowledge entry' });
+  }
+});
+
+// Search entries
+router.get('/search', requireRole('user'), async (req: Request, res: Response) => {
+  try {
+    const q = req.query.q as string;
+    if (!q) {
+      res.status(400).json({ error: 'q query parameter is required' });
+      return;
+    }
+
+    const agentId = req.query.agent_id as string | undefined;
+
+    // If agent_id specified, verify ownership
+    if (agentId) {
+      if (!await isAgentOwned(req, agentId)) {
+        res.status(403).json({ error: 'Not authorized to search this agent\'s knowledge' });
+        return;
+      }
+      const result = await akmProxy.searchEntries(q, agentId);
+      res.status(result.status).json(result.data);
+      return;
+    }
+
+    // No agent_id — admin searches all, user searches own agents only
+    const allowed = await getAllowedAgentIds(req);
+    if (allowed === null) {
+      // Admin: search all
+      const result = await akmProxy.searchEntries(q);
+      res.status(result.status).json(result.data);
+      return;
+    }
+
+    // User: search each owned agent and merge results
+    const allResults: Array<Record<string, unknown>> = [];
+    for (const aid of allowed) {
+      const result = await akmProxy.searchEntries(q, aid);
+      if (result.status === 200) {
+        const data = result.data as { results: Array<Record<string, unknown>> };
+        allResults.push(...data.results);
+      }
+    }
+
+    // Sort by score descending, limit to 20
+    allResults.sort((a, b) => ((b.score as number) || 0) - ((a.score as number) || 0));
+    const limited = allResults.slice(0, 20);
+
+    res.json({
+      query: q,
+      results: limited,
+      count: limited.length,
+      search_type: 'fts',
+      score_type: 'ts_rank',
+    });
+  } catch (err) {
+    console.error('[knowledge] Search error:', err);
+    res.status(500).json({ error: 'Failed to search knowledge' });
+  }
+});
+
+export default router;

--- a/services/api/src/services/akm-proxy.ts
+++ b/services/api/src/services/akm-proxy.ts
@@ -1,0 +1,61 @@
+/**
+ * Thin HTTP client for proxying requests to the knowledge service's
+ * internal admin endpoints. Authenticated with AKM_INTERNAL_SERVICE_TOKEN.
+ */
+
+const AKM_SERVICE_URL = process.env.AKM_SERVICE_URL || 'http://knowledge:8002';
+const AKM_INTERNAL_SERVICE_TOKEN = process.env.AKM_INTERNAL_SERVICE_TOKEN;
+
+export interface ProxyResponse {
+  status: number;
+  data: unknown;
+}
+
+async function proxyGet(path: string, params?: Record<string, string>): Promise<ProxyResponse> {
+  if (!AKM_INTERNAL_SERVICE_TOKEN) {
+    return { status: 503, data: { error: 'Knowledge service not configured' } };
+  }
+
+  const url = new URL(`${AKM_SERVICE_URL}${path}`);
+  if (params) {
+    for (const [key, value] of Object.entries(params)) {
+      if (value !== undefined && value !== null && value !== '') {
+        url.searchParams.set(key, value);
+      }
+    }
+  }
+
+  let resp: Response;
+  try {
+    resp = await fetch(url.toString(), {
+      headers: {
+        'Authorization': `Bearer ${AKM_INTERNAL_SERVICE_TOKEN}`,
+      },
+    });
+  } catch {
+    return { status: 502, data: { error: 'Knowledge service unavailable' } };
+  }
+
+  const data = await resp.json();
+  return { status: resp.status, data };
+}
+
+export async function listAgents(): Promise<ProxyResponse> {
+  return proxyGet('/internal/admin/agents');
+}
+
+export async function listEntries(agentId: string, type?: string): Promise<ProxyResponse> {
+  const params: Record<string, string> = { agent_id: agentId };
+  if (type) params.type = type;
+  return proxyGet('/internal/admin/entries', params);
+}
+
+export async function readEntry(agentId: string, path: string): Promise<ProxyResponse> {
+  return proxyGet(`/internal/admin/entries/${encodeURIComponent(agentId)}/${path}`);
+}
+
+export async function searchEntries(q: string, agentId?: string): Promise<ProxyResponse> {
+  const params: Record<string, string> = { q };
+  if (agentId) params.agent_id = agentId;
+  return proxyGet('/internal/admin/search', params);
+}

--- a/services/knowledge/app/main.py
+++ b/services/knowledge/app/main.py
@@ -15,7 +15,7 @@ from fastapi import FastAPI, Request, Response
 from app.config import Settings
 from app.db.migrate import run_migrations
 from app.middleware.agent_auth import AuthError, verify_agent_token
-from app.routes import context, entries, health, internal, journal, search
+from app.routes import context, entries, health, internal, internal_admin, journal, search
 from app.services.reconciler import reconcile
 
 logger = structlog.get_logger()
@@ -137,6 +137,7 @@ def create_app(
     app.include_router(journal.router)
     app.include_router(context.router)
     app.include_router(internal.router)
+    app.include_router(internal_admin.router)
 
     return app
 

--- a/services/knowledge/app/routes/internal_admin.py
+++ b/services/knowledge/app/routes/internal_admin.py
@@ -1,0 +1,165 @@
+"""Internal admin read-only endpoints for the API proxy layer.
+
+Authenticated with AKM_INTERNAL_SERVICE_TOKEN only. The API service
+enforces user-level authorization (ownership/admin scoping) before
+calling these endpoints. The knowledge service trusts the API service
+to pass the correct agent_id filters.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Query, Request
+
+router = APIRouter(prefix="/internal/admin", tags=["internal-admin"])
+
+
+def _verify_service_token(request: Request) -> None:
+    """Verify the internal service token from the Authorization header."""
+    internal_token = request.app.state.settings.internal_service_token
+    auth_header = request.headers.get("Authorization", "")
+    if auth_header != f"Bearer {internal_token}":
+        raise HTTPException(status_code=401, detail="invalid service token")
+
+
+def _serialize(row: dict[str, Any]) -> dict[str, Any]:
+    """Serialize DB row for JSON response."""
+    result = {}
+    for key, value in row.items():
+        if hasattr(value, "hex"):  # UUID
+            result[key] = str(value)
+        elif hasattr(value, "isoformat"):  # datetime
+            result[key] = value.isoformat()
+        else:
+            result[key] = value
+    return result
+
+
+@router.get("/agents")
+async def list_agents(request: Request) -> list[dict[str, Any]]:
+    """List distinct agent_ids with entry counts and last updated timestamps."""
+    _verify_service_token(request)
+    pool = request.app.state.pool
+
+    rows = await pool.fetch(
+        """SELECT agent_id,
+                  COUNT(*) AS entry_count,
+                  MAX(updated_at) AS last_updated
+           FROM knowledge_entries
+           WHERE status = 'active'
+           GROUP BY agent_id
+           ORDER BY last_updated DESC"""
+    )
+
+    return [_serialize(dict(r)) for r in rows]
+
+
+@router.get("/entries")
+async def list_entries(
+    request: Request,
+    agent_id: str = Query(..., description="Agent ID to filter by"),
+    type: str | None = Query(None, description="Optional entry type filter"),
+) -> list[dict[str, Any]]:
+    """List entries for a specific agent, optionally filtered by type."""
+    _verify_service_token(request)
+    pool = request.app.state.pool
+
+    if type:
+        rows = await pool.fetch(
+            """SELECT id, agent_id, path, title, entry_type, tags,
+                      status, sync_status, created_at, updated_at
+               FROM knowledge_entries
+               WHERE agent_id = $1 AND status = 'active' AND entry_type = $2
+               ORDER BY updated_at DESC""",
+            agent_id,
+            type,
+        )
+    else:
+        rows = await pool.fetch(
+            """SELECT id, agent_id, path, title, entry_type, tags,
+                      status, sync_status, created_at, updated_at
+               FROM knowledge_entries
+               WHERE agent_id = $1 AND status = 'active'
+               ORDER BY updated_at DESC""",
+            agent_id,
+        )
+
+    return [_serialize(dict(r)) for r in rows]
+
+
+@router.get("/entries/{agent_id}/{path:path}")
+async def read_entry(
+    agent_id: str,
+    path: str,
+    request: Request,
+) -> dict[str, Any]:
+    """Read a specific entry by agent_id and path."""
+    _verify_service_token(request)
+    pool = request.app.state.pool
+
+    row = await pool.fetchrow(
+        """SELECT id, agent_id, path, title, entry_type, body AS content,
+                  content_hash, tags, status, sync_status, created_at, updated_at
+           FROM knowledge_entries
+           WHERE agent_id = $1 AND path = $2 AND status = 'active'""",
+        agent_id,
+        path,
+    )
+
+    if row is None:
+        raise HTTPException(status_code=404, detail="entry not found")
+
+    return _serialize(dict(row))
+
+
+@router.get("/search")
+async def search_entries(
+    request: Request,
+    q: str = Query(..., min_length=1, description="Search query"),
+    agent_id: str | None = Query(None, description="Optional agent ID filter"),
+) -> dict[str, Any]:
+    """Search entries, optionally scoped to an agent_id."""
+    _verify_service_token(request)
+    pool = request.app.state.pool
+
+    if agent_id:
+        rows = await pool.fetch(
+            """SELECT id, agent_id, path, title, entry_type, tags,
+                      ts_rank(search_vector, websearch_to_tsquery('english', $2)) AS score,
+                      ts_headline('english', body, websearch_to_tsquery('english', $2),
+                                  'StartSel=**, StopSel=**, MaxFragments=3, MaxWords=50') AS headline,
+                      created_at, updated_at
+               FROM knowledge_entries
+               WHERE agent_id = $1
+                 AND status = 'active'
+                 AND search_vector @@ websearch_to_tsquery('english', $2)
+               ORDER BY score DESC
+               LIMIT 20""",
+            agent_id,
+            q,
+        )
+    else:
+        rows = await pool.fetch(
+            """SELECT id, agent_id, path, title, entry_type, tags,
+                      ts_rank(search_vector, websearch_to_tsquery('english', $1)) AS score,
+                      ts_headline('english', body, websearch_to_tsquery('english', $1),
+                                  'StartSel=**, StopSel=**, MaxFragments=3, MaxWords=50') AS headline,
+                      created_at, updated_at
+               FROM knowledge_entries
+               WHERE status = 'active'
+                 AND search_vector @@ websearch_to_tsquery('english', $1)
+               ORDER BY score DESC
+               LIMIT 20""",
+            q,
+        )
+
+    serialized = [_serialize(dict(r)) for r in rows]
+
+    return {
+        "query": q,
+        "results": serialized,
+        "count": len(serialized),
+        "search_type": "fts",
+        "score_type": "ts_rank",
+    }

--- a/services/knowledge/tests/integration/test_internal_admin.py
+++ b/services/knowledge/tests/integration/test_internal_admin.py
@@ -1,0 +1,240 @@
+"""Tests for internal admin read-only endpoints."""
+
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+
+
+VALID_FRONTMATTER = """---
+title: Test Entry
+type: note
+tags: [test]
+---
+This is test content.
+"""
+
+
+@pytest.mark.asyncio
+class TestInternalAdminAuth:
+    """Service token auth for /internal/admin/* endpoints."""
+
+    async def test_missing_service_token_returns_401(self, app_client: AsyncClient) -> None:
+        resp = await app_client.get("/internal/admin/agents")
+        assert resp.status_code == 401
+
+    async def test_invalid_service_token_returns_401(self, app_client: AsyncClient) -> None:
+        resp = await app_client.get(
+            "/internal/admin/agents",
+            headers={"Authorization": "Bearer wrong-token"},
+        )
+        assert resp.status_code == 401
+
+    async def test_valid_service_token_returns_200(self, app_client: AsyncClient) -> None:
+        resp = await app_client.get(
+            "/internal/admin/agents",
+            headers={"Authorization": "Bearer test-internal-token"},
+        )
+        assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+class TestInternalAdminAgents:
+    """GET /internal/admin/agents — list distinct agent_ids."""
+
+    async def test_empty_returns_empty_list(self, app_client: AsyncClient) -> None:
+        resp = await app_client.get(
+            "/internal/admin/agents",
+            headers={"Authorization": "Bearer test-internal-token"},
+        )
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    async def test_returns_agents_with_counts(
+        self, app_client: AsyncClient, agent_token: str
+    ) -> None:
+        # Create an entry so there's something to list
+        await app_client.post(
+            "/api/v1/entries",
+            json={"path": "notes/test.md", "content": VALID_FRONTMATTER},
+            headers={"Authorization": f"Bearer {agent_token}"},
+        )
+
+        resp = await app_client.get(
+            "/internal/admin/agents",
+            headers={"Authorization": "Bearer test-internal-token"},
+        )
+        assert resp.status_code == 200
+        agents = resp.json()
+        assert len(agents) >= 1
+        agent = next(a for a in agents if a["agent_id"] == "test-agent")
+        assert agent["entry_count"] >= 1
+        assert "last_updated" in agent
+
+
+@pytest.mark.asyncio
+class TestInternalAdminEntries:
+    """GET /internal/admin/entries — list/read entries by agent_id."""
+
+    async def test_list_requires_agent_id(self, app_client: AsyncClient) -> None:
+        resp = await app_client.get(
+            "/internal/admin/entries",
+            headers={"Authorization": "Bearer test-internal-token"},
+        )
+        # agent_id is required
+        assert resp.status_code == 422
+
+    async def test_list_entries_by_agent_id(
+        self, app_client: AsyncClient, agent_token: str
+    ) -> None:
+        # Create entry
+        await app_client.post(
+            "/api/v1/entries",
+            json={"path": "notes/admin-test.md", "content": VALID_FRONTMATTER},
+            headers={"Authorization": f"Bearer {agent_token}"},
+        )
+
+        resp = await app_client.get(
+            "/internal/admin/entries",
+            params={"agent_id": "test-agent"},
+            headers={"Authorization": "Bearer test-internal-token"},
+        )
+        assert resp.status_code == 200
+        entries = resp.json()
+        assert len(entries) >= 1
+        assert all(e["agent_id"] == "test-agent" for e in entries)
+
+    async def test_list_entries_filtered_by_type(
+        self, app_client: AsyncClient, agent_token: str
+    ) -> None:
+        await app_client.post(
+            "/api/v1/entries",
+            json={"path": "notes/typed.md", "content": VALID_FRONTMATTER},
+            headers={"Authorization": f"Bearer {agent_token}"},
+        )
+
+        resp = await app_client.get(
+            "/internal/admin/entries",
+            params={"agent_id": "test-agent", "type": "note"},
+            headers={"Authorization": "Bearer test-internal-token"},
+        )
+        assert resp.status_code == 200
+        entries = resp.json()
+        assert all(e["entry_type"] == "note" for e in entries)
+
+    async def test_list_entries_nonexistent_agent_returns_empty(
+        self, app_client: AsyncClient
+    ) -> None:
+        resp = await app_client.get(
+            "/internal/admin/entries",
+            params={"agent_id": "nonexistent-agent"},
+            headers={"Authorization": "Bearer test-internal-token"},
+        )
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    async def test_read_specific_entry(
+        self, app_client: AsyncClient, agent_token: str
+    ) -> None:
+        await app_client.post(
+            "/api/v1/entries",
+            json={"path": "notes/specific.md", "content": VALID_FRONTMATTER},
+            headers={"Authorization": f"Bearer {agent_token}"},
+        )
+
+        resp = await app_client.get(
+            "/internal/admin/entries/test-agent/notes/specific.md",
+            headers={"Authorization": "Bearer test-internal-token"},
+        )
+        assert resp.status_code == 200
+        entry = resp.json()
+        assert entry["path"] == "notes/specific.md"
+        assert entry["agent_id"] == "test-agent"
+        assert "content" in entry
+
+    async def test_read_nonexistent_entry_returns_404(
+        self, app_client: AsyncClient
+    ) -> None:
+        resp = await app_client.get(
+            "/internal/admin/entries/test-agent/notes/nope.md",
+            headers={"Authorization": "Bearer test-internal-token"},
+        )
+        assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+class TestInternalAdminSearch:
+    """GET /internal/admin/search — search entries."""
+
+    async def test_search_with_agent_id_filter(
+        self, app_client: AsyncClient, agent_token: str
+    ) -> None:
+        await app_client.post(
+            "/api/v1/entries",
+            json={
+                "path": "notes/searchable.md",
+                "content": "---\ntitle: Searchable\ntype: note\ntags: []\n---\nUnique searchable content here.",
+            },
+            headers={"Authorization": f"Bearer {agent_token}"},
+        )
+
+        resp = await app_client.get(
+            "/internal/admin/search",
+            params={"q": "searchable", "agent_id": "test-agent"},
+            headers={"Authorization": "Bearer test-internal-token"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["count"] >= 1
+        assert all(r["agent_id"] == "test-agent" for r in data["results"])
+
+    async def test_search_without_agent_id_searches_all(
+        self,
+        app_client: AsyncClient,
+        agent_token: str,
+        other_agent_token: str,
+    ) -> None:
+        # Create entries for two different agents
+        await app_client.post(
+            "/api/v1/entries",
+            json={
+                "path": "notes/cross1.md",
+                "content": "---\ntitle: Cross1\ntype: note\ntags: []\n---\nGlobalterm in agent one.",
+            },
+            headers={"Authorization": f"Bearer {agent_token}"},
+        )
+        await app_client.post(
+            "/api/v1/entries",
+            json={
+                "path": "notes/cross2.md",
+                "content": "---\ntitle: Cross2\ntype: note\ntags: []\n---\nGlobalterm in agent two.",
+            },
+            headers={"Authorization": f"Bearer {other_agent_token}"},
+        )
+
+        resp = await app_client.get(
+            "/internal/admin/search",
+            params={"q": "globalterm"},
+            headers={"Authorization": "Bearer test-internal-token"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        agent_ids = {r["agent_id"] for r in data["results"]}
+        assert "test-agent" in agent_ids
+        assert "other-agent" in agent_ids
+
+    async def test_search_empty_results(self, app_client: AsyncClient) -> None:
+        resp = await app_client.get(
+            "/internal/admin/search",
+            params={"q": "xyznonexistent123"},
+            headers={"Authorization": "Bearer test-internal-token"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["count"] == 0
+
+    async def test_search_requires_query(self, app_client: AsyncClient) -> None:
+        resp = await app_client.get(
+            "/internal/admin/search",
+            headers={"Authorization": "Bearer test-internal-token"},
+        )
+        assert resp.status_code == 422


### PR DESCRIPTION
## Summary
- Adds `/internal/admin/*` read-only endpoints to knowledge service (service token auth) for listing agents, entries, and cross-agent search
- Adds `/knowledge/*` proxy routes to API service with Keycloak JWT auth and owner-scoped access (users see own agents' knowledge, admins see all)
- Adds `akm-proxy.ts` thin HTTP client for forwarding requests from API to knowledge service
- Updates OpenAPI spec with `KnowledgeEntry`, `KnowledgeAgent`, `KnowledgeSearchResult` schemas and 4 new endpoints
- Updates Mintlify docs navigation and API reference overview with knowledge section
- Updates spec drift enforcement test to include knowledge routes

## Test plan
- [x] 18 API proxy route tests pass (auth, ownership scoping, proxy forwarding, error handling)
- [x] All 91 API tests pass (including spec contract enforcement)
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] Python lint clean (`ruff check`) and type check (`mypy`) on `internal_admin.py`
- [x] OpenAPI spec matches between `services/api/src/openapi/` and `docs/site/`
- [x] No forbidden patterns in `docs/site/` (SOPS check)
- [ ] Knowledge integration tests (require PostgreSQL — CI only)
- [ ] Smoke test on VPS: authenticated request through API proxy returns knowledge data

🤖 Generated with [Claude Code](https://claude.com/claude-code)