### PR TITLE
fix: use correct LiteLLM Docker registry and image tag

### DIFF
--- a/deploy/compose/prod/docker-compose.ai.yml
+++ b/deploy/compose/prod/docker-compose.ai.yml
@@ -19,7 +19,7 @@ services:
   # LiteLLM — stateless proxy for provider API routing
   # On internal network only (needs internet egress for provider APIs)
   litellm:
-    image: ghcr.io/berriai/litellm:main-v1.61.21-stable
+    image: docker.litellm.ai/berriai/litellm:main-v1.81.12-stable
     container_name: litellm
     restart: unless-stopped
     networks:


### PR DESCRIPTION
## Summary
- Fix deploy-ai failure from PR #165 merge
- Change LiteLLM image from `ghcr.io/berriai/litellm:main-v1.61.21-stable` (doesn't exist) to `docker.litellm.ai/berriai/litellm:main-v1.81.12-stable` (verified available)
- LiteLLM publishes images on their own registry (`docker.litellm.ai`), not GHCR

## Plan
Single-line fix: correct the Docker image registry and tag for the LiteLLM service in `docker-compose.ai.yml`.

## Risks
- None — this is a direct image reference fix. The old tag was non-existent (deploy failed). The new tag has been verified via `docker manifest inspect`.

## Rollback
- Revert this single commit if the new image has issues.

## Test plan
- [x] `docker manifest inspect docker.litellm.ai/berriai/litellm:main-v1.81.12-stable` confirms image exists
- [ ] CI compose validation passes
- [ ] Post-merge deploy-ai succeeds (LiteLLM container pulls and starts)

## Validation Evidence
Image verified locally:
```
docker manifest inspect docker.litellm.ai/berriai/litellm:main-v1.81.12-stable
# Returns valid OCI manifest
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)