### PR TITLE
fix: address model-router review findings

### DIFF
--- a/deploy/compose/prod/docker-compose.ai.yml
+++ b/deploy/compose/prod/docker-compose.ai.yml
@@ -74,7 +74,7 @@ services:
       - OTEL_METRICS_EXPORTER=none
       - OTEL_LOGS_EXPORTER=none
     healthcheck:
-      test: ["CMD", "python", "-c", "import urllib.request, sys; r=urllib.request.urlopen('http://localhost:8000/health'); sys.exit(0 if r.status < 400 else 1)"]
+      test: ["CMD", "python", "-c", "import urllib.request, sys; r=urllib.request.urlopen('http://localhost:8000/health/ready'); sys.exit(0 if r.status < 400 else 1)"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/docs/site/openapi.yaml
+++ b/docs/site/openapi.yaml
@@ -55,7 +55,8 @@ components:
           type: string
           format: uuid
           nullable: true
-          description: ID of the model policy controlling LLM access for this agent
+          readOnly: true
+          description: ID of the model policy controlling LLM access for this agent (read-only, assigned server-side)
         error_message:
           type: string
           nullable: true
@@ -296,10 +297,6 @@ paths:
                   type: string
                 rules_md:
                   type: string
-                model_policy_id:
-                  type: string
-                  format: uuid
-                  description: ID of the model policy for LLM access
       responses:
         "201":
           description: Agent created
@@ -372,10 +369,6 @@ paths:
                   type: string
                 rules_md:
                   type: string
-                model_policy_id:
-                  type: string
-                  format: uuid
-                  description: ID of the model policy for LLM access
       responses:
         "200":
           description: Agent updated

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -76,7 +76,7 @@ cmd_verify() {
         db)            check_cmd='docker exec postgres pg_isready -U postgres'; diag_container="postgres" ;;
         auth)          check_cmd='[ "$(docker inspect --format="{{if .State.Health}}{{.State.Health.Status}}{{end}}" keycloak 2>/dev/null)" = "healthy" ]'; diag_container="keycloak" ;;
         api)           check_cmd='docker exec api node -e "require(\"http\").get(\"http://localhost:3000/health\",(r)=>{process.exit(r.statusCode===200?0:1)})"'; diag_container="api" ;;
-        ai)            check_cmd='docker exec ai python -c "import requests; r=requests.get(\"http://localhost:8000/health\"); exit(0 if r.ok else 1)"'; diag_container="ai" ;;
+        ai)            check_cmd='docker exec ai python -c "import urllib.request, sys; r=urllib.request.urlopen(\"http://localhost:8000/health/ready\"); sys.exit(0 if r.status < 400 else 1)"'; diag_container="ai" ;;
         mcp)           check_cmd='docker exec mcp python -c "import requests; r=requests.get(\"http://localhost:8001/health\"); exit(0 if r.ok else 1)"'; diag_container="mcp" ;;
         ui)            check_cmd='docker exec ui node -e "require(\"http\").get(\"http://localhost:3000/api/health\",(r)=>{process.exit(r.statusCode===200?0:1)})"'; diag_container="ui" ;;
         knowledge)     check_cmd='docker exec knowledge python -c "from urllib.request import urlopen; r=urlopen(\"http://localhost:8002/health\"); exit(0 if r.status == 200 else 1)"'; diag_container="knowledge" ;;

--- a/services/ai/app/main.py
+++ b/services/ai/app/main.py
@@ -122,8 +122,47 @@ async def require_agent_auth(authorization: str | None = Header(None)) -> AgentC
 
 @app.get("/health")
 async def health_check():
-    """Health check endpoint — no auth required."""
+    """Liveness check — process is running."""
     return {"status": "healthy", "service": "ai"}
+
+
+@app.get("/health/ready")
+async def readiness_check():
+    """Readiness check — all dependencies available for authenticated inference."""
+    errors = []
+
+    # Check DB pool
+    if _db_pool is None:
+        errors.append("db_pool_unavailable")
+    else:
+        try:
+            async with _db_pool.acquire() as conn:
+                await conn.fetchval("SELECT 1")
+        except Exception:
+            errors.append("db_query_failed")
+
+    # Check public key loaded
+    if _public_key is None:
+        errors.append("public_key_not_loaded")
+
+    # Check LiteLLM reachable
+    if _http_client is None:
+        errors.append("http_client_unavailable")
+    else:
+        settings = get_settings()
+        try:
+            resp = await _http_client.get(f"{settings.litellm_url}/health/liveliness", timeout=5.0)
+            if resp.status_code >= 400:
+                errors.append("litellm_unhealthy")
+        except Exception:
+            errors.append("litellm_unreachable")
+
+    if errors:
+        return JSONResponse(
+            status_code=503,
+            content={"status": "not_ready", "service": "ai", "errors": errors},
+        )
+    return {"status": "ready", "service": "ai"}
 
 
 @app.post("/v1/chat/completions")

--- a/services/ai/tests/test_internal.py
+++ b/services/ai/tests/test_internal.py
@@ -25,6 +25,85 @@ class TestHealthEndpoint:
         assert data["status"] == "healthy"
 
 
+class TestReadinessEndpoint:
+    """Readiness check endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_readiness_returns_503_when_db_unavailable(self):
+        """GET /health/ready returns 503 when DB pool is None."""
+        from app.main import app
+        import app.main as main_module
+
+        original_pool = main_module._db_pool
+        main_module._db_pool = None
+
+        try:
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                resp = await client.get("/health/ready")
+            assert resp.status_code == 503
+            data = resp.json()
+            assert "db_pool_unavailable" in data["errors"]
+        finally:
+            main_module._db_pool = original_pool
+
+    @pytest.mark.asyncio
+    async def test_readiness_returns_503_when_public_key_missing(self):
+        """GET /health/ready returns 503 when public key is not loaded."""
+        from app.main import app
+        import app.main as main_module
+
+        original_key = main_module._public_key
+        main_module._public_key = None
+
+        try:
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                resp = await client.get("/health/ready")
+            assert resp.status_code == 503
+            data = resp.json()
+            assert "public_key_not_loaded" in data["errors"]
+        finally:
+            main_module._public_key = original_key
+
+    @pytest.mark.asyncio
+    async def test_readiness_returns_200_when_all_deps_available(self):
+        """GET /health/ready returns 200 when DB, key, and LiteLLM are available."""
+        from app.main import app
+        import app.main as main_module
+
+        mock_pool = MagicMock()
+        mock_conn = AsyncMock()
+        mock_conn.fetchval.return_value = 1
+        mock_pool.acquire.return_value.__aenter__ = AsyncMock(return_value=mock_conn)
+        mock_pool.acquire.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        mock_client = AsyncMock()
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_client.get.return_value = mock_resp
+
+        original_pool = main_module._db_pool
+        original_client = main_module._http_client
+        original_key = main_module._public_key
+        main_module._db_pool = mock_pool
+        main_module._http_client = mock_client
+        main_module._public_key = b"fake-key"
+
+        try:
+            with patch("app.main.get_settings") as mock_settings:
+                mock_settings.return_value.litellm_url = "http://litellm:4000"
+                transport = ASGITransport(app=app)
+                async with AsyncClient(transport=transport, base_url="http://test") as client:
+                    resp = await client.get("/health/ready")
+            assert resp.status_code == 200
+            assert resp.json()["status"] == "ready"
+        finally:
+            main_module._db_pool = original_pool
+            main_module._http_client = original_client
+            main_module._public_key = original_key
+
+
 class TestRevokeEndpoint:
     """Internal token revocation endpoint."""
 

--- a/services/api/src/openapi/openapi.yaml
+++ b/services/api/src/openapi/openapi.yaml
@@ -55,7 +55,8 @@ components:
           type: string
           format: uuid
           nullable: true
-          description: ID of the model policy controlling LLM access for this agent
+          readOnly: true
+          description: ID of the model policy controlling LLM access for this agent (read-only, assigned server-side)
         error_message:
           type: string
           nullable: true
@@ -296,10 +297,6 @@ paths:
                   type: string
                 rules_md:
                   type: string
-                model_policy_id:
-                  type: string
-                  format: uuid
-                  description: ID of the model policy for LLM access
       responses:
         "201":
           description: Agent created
@@ -372,10 +369,6 @@ paths:
                   type: string
                 rules_md:
                   type: string
-                model_policy_id:
-                  type: string
-                  format: uuid
-                  description: ID of the model policy for LLM access
       responses:
         "200":
           description: Agent updated


### PR DESCRIPTION
## Summary
- Remove model_policy_id from create/update request schemas (not wired in Phase 1)
- Add /health/ready readiness endpoint checking DB, public key, and LiteLLM
- Update Docker healthcheck and deploy verifier to use /health/ready
- Sync docs/site OpenAPI mirror

Relates to AI-1

## Plan
Address three code review findings from model-router feature (PR #165).

## Risks
- Readiness endpoint adds a LiteLLM health check call per Docker healthcheck interval (30s). Lightweight GET, no impact.

## Rollback
- Revert commit to restore previous behavior.

## Validation Evidence
- AI service: 24/24 tests pass (3 new readiness tests)
- API service: 103/103 tests pass
- Secrets schema: all checks passed
- shellcheck: no new warnings
- OpenAPI docs mirror synced

## Test plan
- [x] AI service tests pass (24/24)
- [x] API service tests pass (103/103)
- [x] secrets schema check passes
- [ ] CI green