### PR TITLE
fix: add shared/database and shared/model-router vault paths for AI service

### DIFF
--- a/platform/vault/policies/policy-ai.hcl
+++ b/platform/vault/policies/policy-ai.hcl
@@ -7,6 +7,15 @@ path "secret/metadata/ai/*" {
   capabilities = ["read", "list"]
 }
 
+# Shared database credentials (DB_USER, DB_PASSWORD for policy/usage tables)
+path "secret/data/shared/database" {
+  capabilities = ["read"]
+}
+
+path "secret/metadata/shared/database" {
+  capabilities = ["read"]
+}
+
 # Shared model-router internal service token (for verifying revocation requests from API)
 path "secret/data/shared/model-router" {
   capabilities = ["read"]

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -154,7 +154,7 @@ vault_paths_for_service() {
     case "$service" in
         db)            echo "secret/shared/database" ;;
         api)           echo "secret/shared/database secret/api/config secret/knowledge/config" ;;
-        ai)            echo "secret/ai/config" ;;
+        ai)            echo "secret/shared/database secret/ai/config secret/shared/model-router" ;;
         auth)          echo "secret/shared/database secret/auth/config" ;;
         ui)            echo "secret/ui/config" ;;
         minio)         echo "secret/minio/config" ;;

--- a/tests/scripts/deploy.bats
+++ b/tests/scripts/deploy.bats
@@ -317,7 +317,7 @@
   [ "$(vault_paths_for_service api)" = "secret/shared/database secret/api/config secret/knowledge/config" ]
   [ "$(vault_paths_for_service db)" = "secret/shared/database" ]
   [ "$(vault_paths_for_service auth)" = "secret/shared/database secret/auth/config" ]
-  [ "$(vault_paths_for_service ai)" = "secret/ai/config" ]
+  [ "$(vault_paths_for_service ai)" = "secret/shared/database secret/ai/config secret/shared/model-router" ]
   [ "$(vault_paths_for_service ui)" = "secret/ui/config" ]
   [ "$(vault_paths_for_service minio)" = "secret/minio/config" ]
   [ "$(vault_paths_for_service infra)" = "secret/infra/traefik secret/infra/dns-manager" ]


### PR DESCRIPTION
## Summary
- AI service compose references `${DB_USER}`, `${DB_PASSWORD}`, and `${MODEL_ROUTER_INTERNAL_SERVICE_TOKEN}` but `vault_paths_for_service("ai")` only loaded `secret/ai/config`
- This caused empty DB credentials when deploying via vault-first path, leaving the AI service unable to connect to postgres (`db_pool_unavailable` on `/health/ready`)
- Added `secret/shared/database` and `secret/shared/model-router` to AI vault paths
- Added read access to `secret/data/shared/database` in AI vault policy

## Plan
1. Add `secret/shared/database` and `secret/shared/model-router` to `vault_paths_for_service ai` in `_common.sh`
2. Add `secret/data/shared/database` read policy to `policy-ai.hcl`
3. Update bats test expectation for AI vault paths

## Risks
- Low risk: only adds read-only vault paths for existing secrets
- No changes to compose, deploy flow, or runtime behavior beyond enabling correct secret loading

## Rollback
- Revert commit; redeploy AI service (will fall back to SOPS which loads all vars)

## Validation Evidence
- `check_secrets_schema.py` passes
- bats test updated to match new paths

## Test plan
- [ ] `check_secrets_schema.py` passes
- [ ] bats tests pass (updated vault_paths_for_service assertion)
- [ ] Redeploy AI service — container becomes healthy
- [ ] AI service `/health/ready` returns 200

Generated with [Claude Code](https://claude.com/claude-code)