### PR TITLE
fix: add shared/model-router vault path for API service

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -153,7 +153,7 @@ vault_paths_for_service() {
     local service="$1"
     case "$service" in
         db)            echo "secret/shared/database" ;;
-        api)           echo "secret/shared/database secret/api/config secret/knowledge/config" ;;
+        api)           echo "secret/shared/database secret/api/config secret/knowledge/config secret/shared/model-router" ;;
         ai)            echo "secret/shared/database secret/ai/config secret/shared/model-router" ;;
         auth)          echo "secret/shared/database secret/auth/config" ;;
         ui)            echo "secret/ui/config" ;;

--- a/tests/scripts/deploy.bats
+++ b/tests/scripts/deploy.bats
@@ -314,7 +314,7 @@
 
 @test "_common.sh vault_paths_for_service returns correct paths" {
   source scripts/_common.sh
-  [ "$(vault_paths_for_service api)" = "secret/shared/database secret/api/config secret/knowledge/config" ]
+  [ "$(vault_paths_for_service api)" = "secret/shared/database secret/api/config secret/knowledge/config secret/shared/model-router" ]
   [ "$(vault_paths_for_service db)" = "secret/shared/database" ]
   [ "$(vault_paths_for_service auth)" = "secret/shared/database secret/auth/config" ]
   [ "$(vault_paths_for_service ai)" = "secret/shared/database secret/ai/config secret/shared/model-router" ]


### PR DESCRIPTION
## Summary
- API compose references `${MODEL_ROUTER_SIGNING_PRIVATE_KEY}` and `${MODEL_ROUTER_INTERNAL_SERVICE_TOKEN}` but `vault_paths_for_service("api")` did not include `secret/shared/model-router`
- Vault-first deploys left both model-router vars empty, blocking token generation and revocation
- Same bug pattern as PR #169 (AI service missing vault paths)

## Plan
1. Add `secret/shared/model-router` to `vault_paths_for_service api` in `_common.sh`
2. Update bats test expectation

## Risks
- Low risk: only adds a read-only vault path for existing secrets
- API vault policy already grants `secret/data/shared/*` so no policy change needed

## Rollback
- Revert commit; redeploy API (falls back to SOPS which loads all vars)

## Validation Evidence
- `check_secrets_schema.py` passes
- bats test updated to match new paths

## Test plan
- [ ] `check_secrets_schema.py` passes
- [ ] bats tests pass
- [ ] Redeploy API — `MODEL_ROUTER_SIGNING_PRIVATE_KEY` and `MODEL_ROUTER_INTERNAL_SERVICE_TOKEN` populated

Generated with [Claude Code](https://claude.com/claude-code)