### PR TITLE
fix: add edge network to LiteLLM for internet egress

### DIFF
--- a/deploy/compose/prod/docker-compose.ai.yml
+++ b/deploy/compose/prod/docker-compose.ai.yml
@@ -4,6 +4,9 @@ version: '3.9'
 # Deploy with: make deploy-ai
 
 networks:
+  edge:
+    external: true
+    name: hill90_edge
   internal:
     external: true
     name: hill90_internal
@@ -17,12 +20,13 @@ volumes:
 
 services:
   # LiteLLM — stateless proxy for provider API routing
-  # On internal network only (needs internet egress for provider APIs)
+  # On edge (internet egress for provider APIs) + internal (reachable by AI service)
   litellm:
     image: docker.litellm.ai/berriai/litellm:main-v1.81.12-stable
     container_name: litellm
     restart: unless-stopped
     networks:
+      - edge
       - internal
     volumes:
       - ../../../platform/ai/litellm_config.yaml:/app/config.yaml:ro


### PR DESCRIPTION
## Summary
- LiteLLM container was only on `hill90_internal` (Docker `internal: true`), which blocks all internet access
- LiteLLM needs internet egress to reach provider APIs (OpenAI, Anthropic)
- Added `edge` network to LiteLLM service — same pattern as Keycloak (edge + internal)
- `traefik.enable=false` already set, preventing public exposure

## Plan
Runtime verification found the AI service returning 502 on `POST /v1/chat/completions`. AI logs showed `Server disconnected without sending a response`, LiteLLM logs showed `Failed to resolve 'raw.githubusercontent.com'` — confirming no internet egress from `hill90_internal`.

## Risks
- **Low**: Adding edge network to LiteLLM only exposes it to Traefik's Docker network, but `traefik.enable=false` prevents any route creation
- **No** provider API keys are exposed (they stay in LiteLLM container env only)

## Rollback
Revert to previous compose and redeploy AI stack.

## Validation Evidence
- `docker compose config --quiet` — exit 0
- `bats tests/scripts/deploy.bats` — all 51 tests pass
- `docker network inspect hill90_edge --format '{{.Internal}}'` — false (allows internet)
- `docker network inspect hill90_internal --format '{{.Internal}}'` — true (blocks internet)
