### PR TITLE
fix: increase LiteLLM memory limit from 512m to 1g

### DIFF
--- a/deploy/compose/prod/docker-compose.ai.yml
+++ b/deploy/compose/prod/docker-compose.ai.yml
@@ -41,7 +41,7 @@ services:
       timeout: 10s
       retries: 3
       start_period: 15s
-    mem_limit: 512m
+    mem_limit: 1g
     cpus: 1.0
     labels:
       - "traefik.enable=false"


### PR DESCRIPTION
## Summary
- LiteLLM uses ~245MB at idle and spikes to ~650MB when processing a chat completion request
- The 512m memory limit caused OOM kills on the first inference request
- No error was logged because the process was killed mid-response (container restarted cleanly)
- Increased limit to 1g based on observed peak usage of 650MB

## Plan
Discovered during runtime verification: inference requests caused LiteLLM container to restart silently. `docker stats` showed 245MB idle / 650MB peak usage.

## Risks
- **Low**: 1g is still conservative. VPS has sufficient memory headroom.

## Rollback
Revert compose change and redeploy AI stack.

## Validation Evidence
- `docker compose config --quiet` — exit 0
- `docker stats litellm` shows 650MB peak after processing a request (previously OOM at 512m)
- After `docker update --memory 1g litellm`, inference requests complete successfully
