### PR TITLE
fix: shield streaming disconnect usage log from cancellation

### DIFF
--- a/services/ai/app/main.py
+++ b/services/ai/app/main.py
@@ -376,18 +376,21 @@ async def _handle_streaming(settings, body, claims, requested_model):
             else:
                 status = "success"
             try:
-                async with get_db_conn() as conn:
-                    await log_usage(
-                        conn=conn,
-                        agent_id=claims.sub,
-                        model_name=requested_model,
-                        request_type="chat.completion",
-                        status=status,
-                        latency_ms=elapsed_ms,
-                        input_tokens=streaming_result.input_tokens,
-                        output_tokens=streaming_result.output_tokens,
-                        cost_usd=0.0 if cancelled else streaming_result.cost_usd,
-                    )
+                # Shield from cancellation so the DB write completes even on client disconnect.
+                # Without this, anyio cancels the DB call and usage is never logged.
+                with anyio.CancelScope(shield=True):
+                    async with get_db_conn() as conn:
+                        await log_usage(
+                            conn=conn,
+                            agent_id=claims.sub,
+                            model_name=requested_model,
+                            request_type="chat.completion",
+                            status=status,
+                            latency_ms=elapsed_ms,
+                            input_tokens=streaming_result.input_tokens,
+                            output_tokens=streaming_result.output_tokens,
+                            cost_usd=0.0 if cancelled else streaming_result.cost_usd,
+                        )
             except Exception as e:
                 logger.warning("usage_log_failed", error=str(e))
 


### PR DESCRIPTION
## Summary

- Wraps the `log_usage()` call in `_stream_and_log()`'s `finally` block with `anyio.CancelScope(shield=True)`
- Without shielding, anyio cancels the async DB write when the client disconnects, so `client_disconnect` usage rows are never written

## Risks

- `CancelScope(shield=True)` means the DB write will complete even if the task is cancelled. If the DB is slow/hanging, this could delay cleanup. Mitigated by the connection pool timeout (asyncpg default).

## Rollback

Revert this single-line change.

## Validation Evidence

- **Tests**: 80 Python tests pass (no change to test files)
- **Discovery**: Runtime verification on VPS showed streaming success path logs correctly, but `--max-time 2` disconnect produced zero `model_usage` rows — the `finally` block's DB write was being cancelled

## Test plan

- [ ] CI passes
- [ ] Redeploy AI service, repeat disconnect test, confirm `client_disconnect` row appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)