### PR TITLE
fix: widen model_usage.status to VARCHAR(32)

### DIFF
--- a/services/api/src/db/migrations/008_widen_model_usage_status.sql
+++ b/services/api/src/db/migrations/008_widen_model_usage_status.sql
@@ -1,0 +1,3 @@
+-- Widen model_usage.status from VARCHAR(16) to VARCHAR(32) to accommodate
+-- 'client_disconnect' (17 chars) and future status values.
+ALTER TABLE model_usage ALTER COLUMN status TYPE VARCHAR(32);


### PR DESCRIPTION
## Summary

- Migration 008: `ALTER TABLE model_usage ALTER COLUMN status TYPE VARCHAR(32)`
- The `client_disconnect` status value (17 chars) exceeds the existing `VARCHAR(16)` limit
- Discovered during Phase 3 runtime verification — disconnect usage log fails with `value too long for type character varying(16)`

## Risks

- `ALTER COLUMN TYPE` on a small table is fast and non-blocking. No data loss — widening a varchar is safe.

## Rollback

`ALTER TABLE model_usage ALTER COLUMN status TYPE VARCHAR(16)` (only safe if no rows exceed 16 chars)

## Validation Evidence

- Runtime evidence: AI service log shows `usage_log_failed error=value too long for type character varying(16)` when client disconnects mid-stream
- Migration is additive and idempotent-safe

## Test plan

- [ ] CI passes
- [ ] Deploy DB migration, then retry disconnect test
- [ ] Confirm `client_disconnect` row appears in `model_usage`

🤖 Generated with [Claude Code](https://claude.com/claude-code)