### PR TITLE
feat: model-router phase 4 — delegated subagent narrowing & model aliases

### DIFF
--- a/deploy/compose/prod/docker-compose.ai.yml
+++ b/deploy/compose/prod/docker-compose.ai.yml
@@ -71,6 +71,7 @@ services:
       - DATABASE_URL=postgresql://${DB_USER}:${DB_PASSWORD}@postgres:5432/hill90_api
       - PUBLIC_KEY_PATH=/etc/akm/model-router-public.pem
       - MODEL_ROUTER_INTERNAL_SERVICE_TOKEN=${MODEL_ROUTER_INTERNAL_SERVICE_TOKEN}
+      - API_SERVICE_URL=http://api:3000
       - OTEL_SERVICE_NAME=ai
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://tempo:4318
       - OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf

--- a/services/ai/app/auth.py
+++ b/services/ai/app/auth.py
@@ -16,7 +16,11 @@ class AuthError(Exception):
 
 @dataclass
 class AgentClaims:
-    """Validated agent JWT claims — identity only, no model scopes."""
+    """Validated agent JWT claims — identity only, no model scopes.
+
+    For delegation (child) tokens, delegation_id and parent_jti are set.
+    For parent tokens, both are None.
+    """
 
     sub: str
     iss: str
@@ -24,6 +28,12 @@ class AgentClaims:
     exp: int
     iat: int
     jti: str
+    delegation_id: str | None = None
+    parent_jti: str | None = None
+
+    @property
+    def is_delegation(self) -> bool:
+        return self.delegation_id is not None
 
 
 EXPECTED_ISSUER = "hill90-api"
@@ -66,6 +76,14 @@ def verify_model_router_token(
     if revoked_jtis and jti in revoked_jtis:
         raise AuthError("token revoked")
 
+    delegation_id = payload.get("delegation_id")
+    parent_jti = payload.get("parent_jti")
+
+    # If this is a delegation token, check parent JTI is not revoked
+    if delegation_id and parent_jti:
+        if revoked_jtis and parent_jti in revoked_jtis:
+            raise AuthError("parent token revoked")
+
     return AgentClaims(
         sub=payload["sub"],
         iss=payload["iss"],
@@ -73,4 +91,6 @@ def verify_model_router_token(
         exp=payload["exp"],
         iat=payload["iat"],
         jti=jti,
+        delegation_id=delegation_id,
+        parent_jti=parent_jti,
     )

--- a/services/ai/app/config.py
+++ b/services/ai/app/config.py
@@ -22,6 +22,9 @@ class Settings(BaseSettings):
     # Internal service token for /internal/* endpoints
     model_router_internal_service_token: str = ""
 
+    # API service URL for delegation token signing (service-to-service)
+    api_service_url: str = "http://api:3000"
+
     # Service metadata
     environment: str = "production"
     port: int = 8000

--- a/services/ai/app/delegation.py
+++ b/services/ai/app/delegation.py
@@ -1,0 +1,285 @@
+"""Delegation management for subagent narrowing.
+
+Provides endpoints for creating, listing, and revoking delegations.
+A delegation binds a child JWT to a restricted subset of the parent's
+permissions (models, rate limits, budget).
+"""
+
+import json
+import uuid
+from dataclasses import dataclass
+from typing import Any
+
+import structlog
+
+from app.auth import AgentClaims
+from app.policy import AgentPolicy
+
+logger = structlog.get_logger()
+
+
+@dataclass
+class Delegation:
+    """A delegation record from the database."""
+    id: str
+    parent_agent_id: str
+    parent_jti: str
+    child_jti: str
+    child_label: str
+    allowed_models: list[str]
+    max_requests_per_minute: int | None
+    max_tokens_per_day: int | None
+    expires_at: int
+    revoked_at: str | None
+    created_at: str
+
+
+@dataclass
+class EffectivePolicy:
+    """Computed effective policy for a delegated request."""
+    allowed_models: list[str]
+    max_requests_per_minute: int | None
+    max_tokens_per_day: int | None
+    delegation_id: str
+
+
+def validate_narrowing(
+    parent_policy: AgentPolicy,
+    allowed_models: list[str],
+    max_rpm: int | None,
+    max_tpd: int | None,
+) -> list[str]:
+    """Validate that delegation constraints are a strict subset of parent policy.
+
+    Returns a list of violation messages. Empty list means valid.
+    """
+    violations = []
+
+    # Models must be a subset of parent's allowed models
+    for model in allowed_models:
+        if model not in parent_policy.allowed_models:
+            violations.append(f"model '{model}' not in parent's allowed_models")
+
+    # Rate limit must not exceed parent's
+    if max_rpm is not None and parent_policy.max_requests_per_minute is not None:
+        if max_rpm > parent_policy.max_requests_per_minute:
+            violations.append(
+                f"max_requests_per_minute {max_rpm} exceeds parent's limit of {parent_policy.max_requests_per_minute}"
+            )
+
+    # Budget must not exceed parent's
+    if max_tpd is not None and parent_policy.max_tokens_per_day is not None:
+        if max_tpd > parent_policy.max_tokens_per_day:
+            violations.append(
+                f"max_tokens_per_day {max_tpd} exceeds parent's limit of {parent_policy.max_tokens_per_day}"
+            )
+
+    return violations
+
+
+async def create_delegation(
+    conn: Any,
+    *,
+    parent_claims: AgentClaims,
+    parent_policy: AgentPolicy,
+    child_label: str,
+    allowed_models: list[str],
+    max_rpm: int | None,
+    max_tpd: int | None,
+    expires_at: int | None,
+) -> dict[str, Any]:
+    """Create a delegation record in the database.
+
+    Expects allowed_models to be pre-resolved (aliases already resolved by caller).
+    Caps expiry to parent JWT expiry.
+    Returns dict with id, allowed_models, max_rpm, max_tpd, expires_at.
+    """
+    # Cap expiry to parent JWT expiry
+    effective_expires = parent_claims.exp
+    if expires_at is not None:
+        effective_expires = min(expires_at, parent_claims.exp)
+
+    delegation_id = str(uuid.uuid4())
+
+    await conn.execute(
+        """
+        INSERT INTO model_delegations
+            (id, parent_agent_id, parent_jti, child_jti, child_label,
+             allowed_models, max_requests_per_minute, max_tokens_per_day,
+             expires_at, created_at)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, NOW())
+        """,
+        delegation_id,
+        parent_claims.sub,
+        parent_claims.jti,
+        f"pending-{delegation_id}",  # unique placeholder — updated after API service signs the child JWT
+        child_label,
+        json.dumps(allowed_models),
+        max_rpm,
+        max_tpd,
+        effective_expires,
+    )
+
+    return {
+        "id": delegation_id,
+        "allowed_models": allowed_models,
+        "max_requests_per_minute": max_rpm,
+        "max_tokens_per_day": max_tpd,
+        "expires_at": effective_expires,
+    }
+
+
+async def update_child_jti(conn: Any, *, delegation_id: str, child_jti: str) -> None:
+    """Update the child_jti on a delegation record after JWT signing."""
+    await conn.execute(
+        "UPDATE model_delegations SET child_jti = $1 WHERE id = $2",
+        child_jti,
+        delegation_id,
+    )
+
+
+async def lookup_delegation(conn: Any, *, delegation_id: str, agent_id: str) -> Delegation | None:
+    """Look up an active delegation record by ID and parent agent."""
+    row = await conn.fetchrow(
+        """
+        SELECT id, parent_agent_id, parent_jti, child_jti, child_label,
+               allowed_models, max_requests_per_minute, max_tokens_per_day,
+               expires_at, revoked_at, created_at
+        FROM model_delegations
+        WHERE id = $1 AND parent_agent_id = $2
+        """,
+        delegation_id,
+        agent_id,
+    )
+    if row is None:
+        return None
+    return _row_to_delegation(row)
+
+
+async def lookup_delegation_by_id(conn: Any, *, delegation_id: str) -> Delegation | None:
+    """Look up a delegation record by ID (for child request authorization)."""
+    row = await conn.fetchrow(
+        """
+        SELECT id, parent_agent_id, parent_jti, child_jti, child_label,
+               allowed_models, max_requests_per_minute, max_tokens_per_day,
+               expires_at, revoked_at, created_at
+        FROM model_delegations
+        WHERE id = $1
+        """,
+        delegation_id,
+    )
+    if row is None:
+        return None
+    return _row_to_delegation(row)
+
+
+async def list_delegations(conn: Any, *, agent_id: str) -> list[dict[str, Any]]:
+    """List all delegations for a parent agent."""
+    rows = await conn.fetch(
+        """
+        SELECT id, parent_agent_id, parent_jti, child_jti, child_label,
+               allowed_models, max_requests_per_minute, max_tokens_per_day,
+               expires_at, revoked_at, created_at
+        FROM model_delegations
+        WHERE parent_agent_id = $1
+        ORDER BY created_at ASC
+        """,
+        agent_id,
+    )
+    return [
+        {
+            "id": str(row["id"]),
+            "child_label": row["child_label"],
+            "allowed_models": _parse_models(row["allowed_models"]),
+            "max_requests_per_minute": row["max_requests_per_minute"],
+            "max_tokens_per_day": row["max_tokens_per_day"],
+            "expires_at": row["expires_at"],
+            "revoked_at": str(row["revoked_at"]) if row["revoked_at"] else None,
+            "created_at": str(row["created_at"]),
+        }
+        for row in rows
+    ]
+
+
+async def revoke_delegation(conn: Any, *, delegation_id: str, agent_id: str) -> Delegation | None:
+    """Revoke a delegation. Returns the delegation if found, None otherwise."""
+    row = await conn.fetchrow(
+        """
+        UPDATE model_delegations
+        SET revoked_at = NOW()
+        WHERE id = $1 AND parent_agent_id = $2 AND revoked_at IS NULL
+        RETURNING id, parent_agent_id, parent_jti, child_jti, child_label,
+                  allowed_models, max_requests_per_minute, max_tokens_per_day,
+                  expires_at, revoked_at, created_at
+        """,
+        delegation_id,
+        agent_id,
+    )
+    if row is None:
+        return None
+    return _row_to_delegation(row)
+
+
+def compute_effective_policy(
+    parent_policy: AgentPolicy,
+    delegation: Delegation,
+) -> EffectivePolicy:
+    """Compute the effective policy as intersection of parent policy and delegation."""
+    effective_models = [
+        m for m in delegation.allowed_models
+        if m in parent_policy.allowed_models
+    ]
+
+    effective_rpm = _min_non_null(
+        parent_policy.max_requests_per_minute,
+        delegation.max_requests_per_minute,
+    )
+
+    effective_tpd = _min_non_null(
+        parent_policy.max_tokens_per_day,
+        delegation.max_tokens_per_day,
+    )
+
+    return EffectivePolicy(
+        allowed_models=effective_models,
+        max_requests_per_minute=effective_rpm,
+        max_tokens_per_day=effective_tpd,
+        delegation_id=str(delegation.id),
+    )
+
+
+def _min_non_null(a: int | None, b: int | None) -> int | None:
+    """Return the minimum of two optional ints, treating None as unlimited."""
+    if a is None and b is None:
+        return None
+    if a is None:
+        return b
+    if b is None:
+        return a
+    return min(a, b)
+
+
+def _parse_models(value: Any) -> list[str]:
+    """Parse allowed_models from DB (handles list, JSON string)."""
+    if isinstance(value, list):
+        return value
+    if isinstance(value, str):
+        return json.loads(value)
+    return []
+
+
+def _row_to_delegation(row: Any) -> Delegation:
+    """Convert a DB row to a Delegation dataclass."""
+    return Delegation(
+        id=str(row["id"]),
+        parent_agent_id=row["parent_agent_id"],
+        parent_jti=row["parent_jti"],
+        child_jti=row["child_jti"],
+        child_label=row["child_label"],
+        allowed_models=_parse_models(row["allowed_models"]),
+        max_requests_per_minute=row["max_requests_per_minute"],
+        max_tokens_per_day=row["max_tokens_per_day"],
+        expires_at=row["expires_at"],
+        revoked_at=str(row["revoked_at"]) if row["revoked_at"] else None,
+        created_at=str(row["created_at"]),
+    )

--- a/services/ai/app/limits.py
+++ b/services/ai/app/limits.py
@@ -28,25 +28,44 @@ class BudgetResult:
 
 
 async def check_rate_limit(
-    conn: Any, *, agent_id: str, max_rpm: int
+    conn: Any, *, agent_id: str, max_rpm: int, delegation_id: str | None = None
 ) -> RateLimitResult:
     """Check if agent is within rate limit (requests per minute).
 
     Counts only provider-attempted requests (status IN ('success', 'error')).
     Denied requests are excluded to prevent cascading lockout.
+
+    If delegation_id is provided, counts only requests for that delegation.
+    Otherwise counts all requests for the agent (including all delegations).
     """
-    row = await conn.fetchrow(
-        """
-        SELECT
-            COUNT(*) AS cnt,
-            EXTRACT(EPOCH FROM (NOW() - MIN(created_at)))::int AS oldest_age_secs
-        FROM model_usage
-        WHERE agent_id = $1
-          AND status IN ('success', 'error')
-          AND created_at > NOW() - interval '1 minute'
-        """,
-        agent_id,
-    )
+    if delegation_id:
+        row = await conn.fetchrow(
+            """
+            SELECT
+                COUNT(*) AS cnt,
+                EXTRACT(EPOCH FROM (NOW() - MIN(created_at)))::int AS oldest_age_secs
+            FROM model_usage
+            WHERE agent_id = $1
+              AND delegation_id = $2
+              AND status IN ('success', 'error')
+              AND created_at > NOW() - interval '1 minute'
+            """,
+            agent_id,
+            delegation_id,
+        )
+    else:
+        row = await conn.fetchrow(
+            """
+            SELECT
+                COUNT(*) AS cnt,
+                EXTRACT(EPOCH FROM (NOW() - MIN(created_at)))::int AS oldest_age_secs
+            FROM model_usage
+            WHERE agent_id = $1
+              AND status IN ('success', 'error')
+              AND created_at > NOW() - interval '1 minute'
+            """,
+            agent_id,
+        )
 
     count = row["cnt"] if row else 0
     oldest_age = row["oldest_age_secs"] if row and row["oldest_age_secs"] is not None else 0
@@ -61,23 +80,40 @@ async def check_rate_limit(
 
 
 async def check_token_budget(
-    conn: Any, *, agent_id: str, max_tokens: int
+    conn: Any, *, agent_id: str, max_tokens: int, delegation_id: str | None = None
 ) -> BudgetResult:
     """Check if agent is within daily token budget.
 
     Sums tokens from provider-attempted requests only (status IN ('success', 'error')).
     Budget resets at UTC midnight.
+
+    If delegation_id is provided, sums only tokens for that delegation.
+    Otherwise sums all tokens for the agent (including all delegations).
     """
-    row = await conn.fetchrow(
-        """
-        SELECT COALESCE(SUM(input_tokens + output_tokens), 0) AS total_tokens
-        FROM model_usage
-        WHERE agent_id = $1
-          AND status IN ('success', 'error')
-          AND created_at >= date_trunc('day', NOW() AT TIME ZONE 'UTC') AT TIME ZONE 'UTC'
-        """,
-        agent_id,
-    )
+    if delegation_id:
+        row = await conn.fetchrow(
+            """
+            SELECT COALESCE(SUM(input_tokens + output_tokens), 0) AS total_tokens
+            FROM model_usage
+            WHERE agent_id = $1
+              AND delegation_id = $2
+              AND status IN ('success', 'error')
+              AND created_at >= date_trunc('day', NOW() AT TIME ZONE 'UTC') AT TIME ZONE 'UTC'
+            """,
+            agent_id,
+            delegation_id,
+        )
+    else:
+        row = await conn.fetchrow(
+            """
+            SELECT COALESCE(SUM(input_tokens + output_tokens), 0) AS total_tokens
+            FROM model_usage
+            WHERE agent_id = $1
+              AND status IN ('success', 'error')
+              AND created_at >= date_trunc('day', NOW() AT TIME ZONE 'UTC') AT TIME ZONE 'UTC'
+            """,
+            agent_id,
+        )
 
     tokens_used = row["total_tokens"] if row else 0
 

--- a/services/ai/app/main.py
+++ b/services/ai/app/main.py
@@ -8,6 +8,7 @@ from DB, and proxies completions through LiteLLM to provider APIs.
 import hmac
 import time
 from contextlib import asynccontextmanager
+from dataclasses import dataclass
 from typing import Any
 
 import anyio
@@ -20,8 +21,17 @@ from pydantic import BaseModel
 
 from app.auth import AuthError, AgentClaims, verify_model_router_token
 from app.config import Settings, get_settings, load_public_key
+from app.delegation import (
+    compute_effective_policy,
+    create_delegation,
+    list_delegations,
+    lookup_delegation_by_id,
+    revoke_delegation,
+    update_child_jti,
+    validate_narrowing,
+)
 from app.limits import check_rate_limit, check_token_budget
-from app.policy import resolve_agent_policy, resolve_model_policy
+from app.policy import resolve_agent_policy, resolve_alias, resolve_aliases_list, resolve_model_policy
 from app.proxy import StreamOpenResult, proxy_chat_completion, proxy_embeddings, stream_chat_completion
 from app.revocation import RevocationManager, revocation_manager
 from app.usage import log_usage
@@ -93,7 +103,7 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(
     title="Hill90 AI Service — Model Router",
-    version="0.3.0",
+    version="0.4.0",
     lifespan=lifespan,
 )
 
@@ -167,15 +177,180 @@ async def readiness_check():
     return {"status": "ready", "service": "ai"}
 
 
+@dataclass
+class PolicyResult:
+    """Result of policy enforcement — resolved model and delegation context."""
+    resolved_model: str
+    delegation_id: str | None = None
+
+
 async def _enforce_policy(
     claims: AgentClaims, requested_model: str, request_type: str
-) -> JSONResponse | None:
-    """Run policy, rate limit, and budget checks. Returns JSONResponse on denial, None on pass."""
+) -> JSONResponse | PolicyResult:
+    """Run policy, rate limit, and budget checks.
+
+    Returns JSONResponse on denial, PolicyResult on success.
+    PolicyResult carries the resolved model name (after alias resolution)
+    and delegation_id for usage logging.
+    """
     # Resolve full policy (models + limits) from DB
     async with get_db_conn() as conn:
         policy = await resolve_agent_policy(conn, agent_id=claims.sub)
 
-    if requested_model not in policy.allowed_models:
+    # Resolve alias before policy check
+    resolved_model = resolve_alias(requested_model, policy)
+
+    delegation_id: str | None = None
+
+    # Delegation path: look up delegation, compute effective policy
+    if claims.is_delegation:
+        async with get_db_conn() as conn:
+            deleg = await lookup_delegation_by_id(conn, delegation_id=claims.delegation_id)
+
+        if deleg is None:
+            raise HTTPException(
+                status_code=401,
+                detail=f"Delegation '{claims.delegation_id}' not found",
+            )
+
+        if deleg.revoked_at is not None:
+            raise HTTPException(status_code=401, detail="Delegation revoked")
+
+        if deleg.expires_at <= int(time.time()):
+            raise HTTPException(status_code=401, detail="Delegation expired")
+
+        effective = compute_effective_policy(policy, deleg)
+        delegation_id = effective.delegation_id
+
+        if resolved_model not in effective.allowed_models:
+            try:
+                async with get_db_conn() as conn:
+                    await log_usage(
+                        conn=conn,
+                        agent_id=claims.sub,
+                        model_name=resolved_model,
+                        request_type=request_type,
+                        status="error",
+                        latency_ms=0,
+                        delegation_id=delegation_id,
+                    )
+            except Exception as e:
+                logger.warning("usage_log_failed", error=str(e))
+            raise HTTPException(
+                status_code=403,
+                detail=f"Model '{requested_model}' not authorized for this delegation",
+            )
+
+        # Delegation-level rate limit
+        if effective.max_requests_per_minute is not None:
+            async with get_db_conn() as conn:
+                rl = await check_rate_limit(
+                    conn, agent_id=claims.sub,
+                    max_rpm=effective.max_requests_per_minute,
+                    delegation_id=delegation_id,
+                )
+            if not rl.allowed:
+                try:
+                    async with get_db_conn() as conn:
+                        await log_usage(
+                            conn=conn, agent_id=claims.sub, model_name=resolved_model,
+                            request_type=request_type, status="rate_limited",
+                            latency_ms=0, delegation_id=delegation_id,
+                        )
+                except Exception as e:
+                    logger.warning("usage_log_failed", error=str(e))
+                return JSONResponse(
+                    status_code=429,
+                    content={"error": {
+                        "type": "rate_limited",
+                        "message": f"Rate limit exceeded for delegation",
+                        "delegation_id": delegation_id,
+                        "limit": rl.limit, "window": "60s", "retry_after": rl.retry_after,
+                    }},
+                    headers={"Retry-After": str(rl.retry_after)},
+                )
+
+        # Delegation-level budget
+        if effective.max_tokens_per_day is not None:
+            async with get_db_conn() as conn:
+                budget = await check_token_budget(
+                    conn, agent_id=claims.sub,
+                    max_tokens=effective.max_tokens_per_day,
+                    delegation_id=delegation_id,
+                )
+            if not budget.allowed:
+                try:
+                    async with get_db_conn() as conn:
+                        await log_usage(
+                            conn=conn, agent_id=claims.sub, model_name=resolved_model,
+                            request_type=request_type, status="budget_exceeded",
+                            latency_ms=0, delegation_id=delegation_id,
+                        )
+                except Exception as e:
+                    logger.warning("usage_log_failed", error=str(e))
+                return JSONResponse(
+                    status_code=429,
+                    content={"error": {
+                        "type": "budget_exceeded",
+                        "message": "Daily token budget exhausted for delegation",
+                        "delegation_id": delegation_id,
+                        "limit": budget.limit, "used": budget.tokens_used,
+                        "resets_at": budget.resets_at,
+                    }},
+                )
+
+        # Parent-level rate limit (includes all delegations)
+        if policy.max_requests_per_minute is not None:
+            async with get_db_conn() as conn:
+                rl = await check_rate_limit(conn, agent_id=claims.sub, max_rpm=policy.max_requests_per_minute)
+            if not rl.allowed:
+                try:
+                    async with get_db_conn() as conn:
+                        await log_usage(
+                            conn=conn, agent_id=claims.sub, model_name=resolved_model,
+                            request_type=request_type, status="rate_limited",
+                            latency_ms=0, delegation_id=delegation_id,
+                        )
+                except Exception as e:
+                    logger.warning("usage_log_failed", error=str(e))
+                return JSONResponse(
+                    status_code=429,
+                    content={"error": {
+                        "type": "rate_limited",
+                        "message": f"Rate limit exceeded for agent '{claims.sub}'",
+                        "limit": rl.limit, "window": "60s", "retry_after": rl.retry_after,
+                    }},
+                    headers={"Retry-After": str(rl.retry_after)},
+                )
+
+        # Parent-level budget (includes all delegations)
+        if policy.max_tokens_per_day is not None:
+            async with get_db_conn() as conn:
+                budget = await check_token_budget(conn, agent_id=claims.sub, max_tokens=policy.max_tokens_per_day)
+            if not budget.allowed:
+                try:
+                    async with get_db_conn() as conn:
+                        await log_usage(
+                            conn=conn, agent_id=claims.sub, model_name=resolved_model,
+                            request_type=request_type, status="budget_exceeded",
+                            latency_ms=0, delegation_id=delegation_id,
+                        )
+                except Exception as e:
+                    logger.warning("usage_log_failed", error=str(e))
+                return JSONResponse(
+                    status_code=429,
+                    content={"error": {
+                        "type": "budget_exceeded",
+                        "message": f"Daily token budget exhausted for agent '{claims.sub}'",
+                        "limit": budget.limit, "used": budget.tokens_used,
+                        "resets_at": budget.resets_at,
+                    }},
+                )
+
+        return PolicyResult(resolved_model=resolved_model, delegation_id=delegation_id)
+
+    # Non-delegation (parent) path
+    if resolved_model not in policy.allowed_models:
         raise HTTPException(
             status_code=403,
             detail=f"Model '{requested_model}' not authorized for agent '{claims.sub}'",
@@ -191,7 +366,7 @@ async def _enforce_policy(
                     await log_usage(
                         conn=conn,
                         agent_id=claims.sub,
-                        model_name=requested_model,
+                        model_name=resolved_model,
                         request_type=request_type,
                         status="rate_limited",
                         latency_ms=0,
@@ -222,7 +397,7 @@ async def _enforce_policy(
                     await log_usage(
                         conn=conn,
                         agent_id=claims.sub,
-                        model_name=requested_model,
+                        model_name=resolved_model,
                         request_type=request_type,
                         status="budget_exceeded",
                         latency_ms=0,
@@ -242,7 +417,7 @@ async def _enforce_policy(
                 },
             )
 
-    return None
+    return PolicyResult(resolved_model=resolved_model)
 
 
 @app.post("/v1/chat/completions")
@@ -252,16 +427,22 @@ async def chat_completions(request: Request, claims: AgentClaims = Depends(requi
     body = await request.json()
     requested_model = body.get("model", "")
 
-    denial = await _enforce_policy(claims, requested_model, "chat.completion")
-    if denial is not None:
-        return denial
+    result_or_denial = await _enforce_policy(claims, requested_model, "chat.completion")
+    if isinstance(result_or_denial, JSONResponse):
+        return result_or_denial
+    policy_result: PolicyResult = result_or_denial
+
+    # Replace model in request body with resolved name (alias → real)
+    resolved_model = policy_result.resolved_model
+    delegation_id = policy_result.delegation_id
+    body["model"] = resolved_model
 
     if _http_client is None:
         raise HTTPException(status_code=503, detail="HTTP client not initialized")
 
     # Streaming path
     if body.get("stream") is True:
-        return await _handle_streaming(settings, body, claims, requested_model)
+        return await _handle_streaming(settings, body, claims, resolved_model, delegation_id)
 
     # Non-streaming path
     start = time.monotonic()
@@ -278,12 +459,13 @@ async def chat_completions(request: Request, claims: AgentClaims = Depends(requi
             await log_usage(
                 conn=conn,
                 agent_id=claims.sub,
-                model_name=requested_model,
+                model_name=resolved_model,
                 request_type="chat.completion",
                 status="error",
                 latency_ms=elapsed_ms,
+                delegation_id=delegation_id,
             )
-        logger.error("proxy_error", agent_id=claims.sub, model=requested_model, error=str(e))
+        logger.error("proxy_error", agent_id=claims.sub, model=resolved_model, error=str(e))
         raise HTTPException(status_code=502, detail="LiteLLM proxy error")
 
     elapsed_ms = int((time.monotonic() - start) * 1000)
@@ -294,13 +476,14 @@ async def chat_completions(request: Request, claims: AgentClaims = Depends(requi
             await log_usage(
                 conn=conn,
                 agent_id=claims.sub,
-                model_name=requested_model,
+                model_name=resolved_model,
                 request_type="chat.completion",
                 status=status,
                 latency_ms=elapsed_ms,
                 input_tokens=result["input_tokens"],
                 output_tokens=result["output_tokens"],
                 cost_usd=result["cost_usd"],
+                delegation_id=delegation_id,
             )
     except Exception as e:
         logger.warning("usage_log_failed", error=str(e))
@@ -308,7 +491,7 @@ async def chat_completions(request: Request, claims: AgentClaims = Depends(requi
     return JSONResponse(content=result["body"], status_code=result["status_code"])
 
 
-async def _handle_streaming(settings, body, claims, requested_model):
+async def _handle_streaming(settings, body, claims, requested_model, delegation_id=None):
     """Handle streaming chat completion with SSE passthrough and usage capture."""
 
     start = time.monotonic()
@@ -331,6 +514,7 @@ async def _handle_streaming(settings, body, claims, requested_model):
                     request_type="chat.completion",
                     status="error",
                     latency_ms=elapsed_ms,
+                    delegation_id=delegation_id,
                 )
         except Exception as log_err:
             logger.warning("usage_log_failed", error=str(log_err))
@@ -349,6 +533,7 @@ async def _handle_streaming(settings, body, claims, requested_model):
                     request_type="chat.completion",
                     status="error",
                     latency_ms=elapsed_ms,
+                    delegation_id=delegation_id,
                 )
         except Exception as log_err:
             logger.warning("usage_log_failed", error=str(log_err))
@@ -390,6 +575,7 @@ async def _handle_streaming(settings, body, claims, requested_model):
                             input_tokens=streaming_result.input_tokens,
                             output_tokens=streaming_result.output_tokens,
                             cost_usd=0.0 if cancelled else streaming_result.cost_usd,
+                            delegation_id=delegation_id,
                         )
             except Exception as e:
                 logger.warning("usage_log_failed", error=str(e))
@@ -408,9 +594,14 @@ async def embeddings(request: Request, claims: AgentClaims = Depends(require_age
     body = await request.json()
     requested_model = body.get("model", "")
 
-    denial = await _enforce_policy(claims, requested_model, "embedding")
-    if denial is not None:
-        return denial
+    result_or_denial = await _enforce_policy(claims, requested_model, "embedding")
+    if isinstance(result_or_denial, JSONResponse):
+        return result_or_denial
+    policy_result: PolicyResult = result_or_denial
+
+    resolved_model = policy_result.resolved_model
+    delegation_id = policy_result.delegation_id
+    body["model"] = resolved_model
 
     if _http_client is None:
         raise HTTPException(status_code=503, detail="HTTP client not initialized")
@@ -429,12 +620,13 @@ async def embeddings(request: Request, claims: AgentClaims = Depends(require_age
             await log_usage(
                 conn=conn,
                 agent_id=claims.sub,
-                model_name=requested_model,
+                model_name=resolved_model,
                 request_type="embedding",
                 status="error",
                 latency_ms=elapsed_ms,
+                delegation_id=delegation_id,
             )
-        logger.error("proxy_error", agent_id=claims.sub, model=requested_model, error=str(e))
+        logger.error("proxy_error", agent_id=claims.sub, model=resolved_model, error=str(e))
         raise HTTPException(status_code=502, detail="LiteLLM proxy error")
 
     elapsed_ms = int((time.monotonic() - start) * 1000)
@@ -445,13 +637,14 @@ async def embeddings(request: Request, claims: AgentClaims = Depends(require_age
             await log_usage(
                 conn=conn,
                 agent_id=claims.sub,
-                model_name=requested_model,
+                model_name=resolved_model,
                 request_type="embedding",
                 status=status,
                 latency_ms=elapsed_ms,
                 input_tokens=result["input_tokens"],
                 output_tokens=0,
                 cost_usd=result["cost_usd"],
+                delegation_id=delegation_id,
             )
     except Exception as e:
         logger.warning("usage_log_failed", error=str(e))
@@ -473,6 +666,165 @@ async def list_models(claims: AgentClaims = Depends(require_agent_auth)):
         ],
     }
 
+
+# ---- Delegation endpoints ----
+
+class DelegateRequest(BaseModel):
+    child_label: str
+    allowed_models: list[str]
+    max_requests_per_minute: int | None = None
+    max_tokens_per_day: int | None = None
+    expires_at: int | None = None
+
+
+@app.post("/v1/delegate")
+async def create_delegation_endpoint(
+    body: DelegateRequest,
+    claims: AgentClaims = Depends(require_agent_auth),
+):
+    """Create a delegation granting a child a strict subset of the parent's permissions."""
+    # Only parent tokens can create delegations
+    if claims.is_delegation:
+        raise HTTPException(status_code=403, detail="Delegation tokens cannot create sub-delegations")
+
+    settings = get_settings()
+
+    # Resolve parent policy
+    async with get_db_conn() as conn:
+        parent_policy = await resolve_agent_policy(conn, agent_id=claims.sub)
+
+    # Resolve aliases in requested models
+    resolved_models = resolve_aliases_list(body.allowed_models, parent_policy)
+
+    # Validate narrowing
+    violations = validate_narrowing(
+        parent_policy, resolved_models, body.max_requests_per_minute, body.max_tokens_per_day,
+    )
+    if violations:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "type": "delegation_invalid",
+                "message": "Cannot widen parent permissions",
+                "violations": violations,
+            },
+        )
+
+    # Create delegation record
+    async with get_db_conn() as conn:
+        deleg_info = await create_delegation(
+            conn,
+            parent_claims=claims,
+            parent_policy=parent_policy,
+            child_label=body.child_label,
+            allowed_models=body.allowed_models,
+            max_rpm=body.max_requests_per_minute,
+            max_tpd=body.max_tokens_per_day,
+            expires_at=body.expires_at,
+        )
+
+    # Request child JWT from API service
+    if _http_client is None:
+        raise HTTPException(status_code=503, detail="HTTP client not initialized")
+
+    try:
+        resp = await _http_client.post(
+            f"{settings.api_service_url}/internal/delegation-token",
+            headers={
+                "Authorization": f"Bearer {settings.model_router_internal_service_token}",
+                "Content-Type": "application/json",
+            },
+            json={
+                "sub": claims.sub,
+                "delegation_id": deleg_info["id"],
+                "parent_jti": claims.jti,
+                "expires_at": deleg_info["expires_at"],
+            },
+            timeout=10.0,
+        )
+    except Exception as e:
+        # Clean up the pending delegation record
+        try:
+            async with get_db_conn() as conn:
+                await conn.execute(
+                    "DELETE FROM model_delegations WHERE id = $1", deleg_info["id"],
+                )
+        except Exception:
+            pass
+        logger.error("delegation_token_request_failed", error=str(e))
+        raise HTTPException(status_code=502, detail="Failed to sign delegation token")
+
+    if resp.status_code != 200:
+        # Clean up the pending delegation record
+        try:
+            async with get_db_conn() as conn:
+                await conn.execute(
+                    "DELETE FROM model_delegations WHERE id = $1", deleg_info["id"],
+                )
+        except Exception:
+            pass
+        logger.error("delegation_token_sign_failed", status=resp.status_code, body=resp.text)
+        raise HTTPException(status_code=502, detail="Failed to sign delegation token")
+
+    token_result = resp.json()
+
+    # Update child_jti on the delegation record
+    async with get_db_conn() as conn:
+        await update_child_jti(
+            conn, delegation_id=deleg_info["id"], child_jti=token_result["jti"],
+        )
+
+    logger.info(
+        "delegation_created",
+        delegation_id=deleg_info["id"],
+        parent_agent=claims.sub,
+        child_label=body.child_label,
+    )
+
+    return {
+        "token": token_result["token"],
+        "delegation_id": deleg_info["id"],
+        "expires_at": deleg_info["expires_at"],
+    }
+
+
+@app.get("/v1/delegations")
+async def list_delegations_endpoint(claims: AgentClaims = Depends(require_agent_auth)):
+    """List all delegations for the authenticated agent."""
+    async with get_db_conn() as conn:
+        delegations = await list_delegations(conn, agent_id=claims.sub)
+    return {"delegations": delegations}
+
+
+@app.post("/v1/delegate/{delegation_id}/revoke")
+async def revoke_delegation_endpoint(
+    delegation_id: str,
+    claims: AgentClaims = Depends(require_agent_auth),
+):
+    """Revoke a specific delegation. Only the parent agent can revoke."""
+    if claims.is_delegation:
+        raise HTTPException(status_code=403, detail="Delegation tokens cannot revoke delegations")
+
+    async with get_db_conn() as conn:
+        deleg = await revoke_delegation(conn, delegation_id=delegation_id, agent_id=claims.sub)
+
+    if deleg is None:
+        raise HTTPException(status_code=404, detail="Delegation not found or already revoked")
+
+    # Add child JTI to revocation set
+    async with get_db_conn() as conn:
+        await revocation_manager.revoke(
+            conn,
+            jti=deleg.child_jti,
+            agent_id=claims.sub,
+            expires_at=deleg.expires_at,
+        )
+
+    logger.info("delegation_revoked", delegation_id=delegation_id, child_jti=deleg.child_jti)
+    return {"status": "revoked", "delegation_id": delegation_id}
+
+
+# ---- Internal endpoints ----
 
 class RevokeRequest(BaseModel):
     jti: str

--- a/services/ai/app/policy.py
+++ b/services/ai/app/policy.py
@@ -13,15 +13,16 @@ from typing import Any
 
 @dataclass
 class AgentPolicy:
-    """Resolved policy for an agent — models, rate limits, and budget."""
+    """Resolved policy for an agent — models, rate limits, budget, and aliases."""
     allowed_models: list[str]
     max_requests_per_minute: int | None
     max_tokens_per_day: int | None
+    model_aliases: dict[str, str] | None = None
 
 
-_POLICY_COLUMNS = "mp.id, mp.name, mp.allowed_models, mp.max_requests_per_minute, mp.max_tokens_per_day"
+_POLICY_COLUMNS = "mp.id, mp.name, mp.allowed_models, mp.max_requests_per_minute, mp.max_tokens_per_day, mp.model_aliases"
 
-_EMPTY_POLICY = AgentPolicy(allowed_models=[], max_requests_per_minute=None, max_tokens_per_day=None)
+_EMPTY_POLICY = AgentPolicy(allowed_models=[], max_requests_per_minute=None, max_tokens_per_day=None, model_aliases=None)
 
 
 async def resolve_agent_policy(conn: Any, *, agent_id: str) -> AgentPolicy:
@@ -54,6 +55,7 @@ async def resolve_agent_policy(conn: Any, *, agent_id: str) -> AgentPolicy:
         allowed_models=_extract_allowed_models(row),
         max_requests_per_minute=row["max_requests_per_minute"],
         max_tokens_per_day=row["max_tokens_per_day"],
+        model_aliases=_extract_model_aliases(row),
     )
 
 
@@ -74,3 +76,33 @@ def _extract_allowed_models(row: Any) -> list[str]:
     if isinstance(models, str):
         return json.loads(models)
     return []
+
+
+def _extract_model_aliases(row: Any) -> dict[str, str] | None:
+    """Extract model_aliases from a DB row (handles dict, JSON text, or None)."""
+    aliases = row.get("model_aliases")
+    if aliases is None:
+        return None
+    if isinstance(aliases, dict):
+        return aliases
+    if isinstance(aliases, str):
+        parsed = json.loads(aliases)
+        return parsed if isinstance(parsed, dict) else None
+    return None
+
+
+def resolve_alias(requested_model: str, policy: AgentPolicy) -> str:
+    """Resolve a model alias to its real model name.
+
+    Single-pass lookup — no recursion. If the requested name is found in
+    the policy's model_aliases, returns the target. Otherwise returns the
+    requested name unchanged (treated as a literal model name).
+    """
+    if policy.model_aliases and requested_model in policy.model_aliases:
+        return policy.model_aliases[requested_model]
+    return requested_model
+
+
+def resolve_aliases_list(models: list[str], policy: AgentPolicy) -> list[str]:
+    """Resolve a list of model names/aliases to real model names."""
+    return [resolve_alias(m, policy) for m in models]

--- a/services/ai/app/usage.py
+++ b/services/ai/app/usage.py
@@ -17,14 +17,15 @@ async def log_usage(
     input_tokens: int = 0,
     output_tokens: int = 0,
     cost_usd: float = 0.0,
+    delegation_id: str | None = None,
 ) -> None:
     """Write a usage record to model_usage including token counts and cost."""
     await conn.execute(
         """
         INSERT INTO model_usage
             (agent_id, model_name, request_type, status, latency_ms,
-             input_tokens, output_tokens, cost_usd)
-        VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+             input_tokens, output_tokens, cost_usd, delegation_id)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
         """,
         agent_id,
         model_name,
@@ -34,6 +35,7 @@ async def log_usage(
         input_tokens,
         output_tokens,
         cost_usd,
+        delegation_id,
     )
 
 

--- a/services/ai/tests/test_delegation.py
+++ b/services/ai/tests/test_delegation.py
@@ -1,0 +1,401 @@
+"""Tests for delegation management and subagent narrowing."""
+
+import json
+import time
+import uuid
+
+import pytest
+
+from app.auth import AuthError, verify_model_router_token
+from app.delegation import (
+    Delegation,
+    compute_effective_policy,
+    validate_narrowing,
+)
+from app.policy import AgentPolicy, resolve_alias, resolve_aliases_list
+
+
+# ---- validate_narrowing tests ----
+
+class TestValidateNarrowing:
+    """Validate that delegation constraints are a strict subset of parent policy."""
+
+    def _parent_policy(self, **kwargs):
+        defaults = dict(
+            allowed_models=["gpt-4o-mini", "gpt-4o", "text-embedding-3-small"],
+            max_requests_per_minute=30,
+            max_tokens_per_day=100000,
+            model_aliases=None,
+        )
+        defaults.update(kwargs)
+        return AgentPolicy(**defaults)
+
+    def test_valid_narrowing(self):
+        """Subset models and lower limits pass validation."""
+        violations = validate_narrowing(
+            self._parent_policy(),
+            allowed_models=["gpt-4o-mini"],
+            max_rpm=5,
+            max_tpd=10000,
+        )
+        assert violations == []
+
+    def test_rejects_model_not_in_parent(self):
+        """Model not in parent's allowlist is rejected."""
+        violations = validate_narrowing(
+            self._parent_policy(),
+            allowed_models=["gpt-4o-mini", "claude-sonnet-4-20250514"],
+            max_rpm=5,
+            max_tpd=10000,
+        )
+        assert len(violations) == 1
+        assert "claude-sonnet-4-20250514" in violations[0]
+
+    def test_rejects_higher_rpm(self):
+        """RPM exceeding parent's limit is rejected."""
+        violations = validate_narrowing(
+            self._parent_policy(),
+            allowed_models=["gpt-4o-mini"],
+            max_rpm=50,
+            max_tpd=10000,
+        )
+        assert len(violations) == 1
+        assert "max_requests_per_minute" in violations[0]
+
+    def test_rejects_higher_tpd(self):
+        """TPD exceeding parent's limit is rejected."""
+        violations = validate_narrowing(
+            self._parent_policy(),
+            allowed_models=["gpt-4o-mini"],
+            max_rpm=5,
+            max_tpd=500000,
+        )
+        assert len(violations) == 1
+        assert "max_tokens_per_day" in violations[0]
+
+    def test_multiple_violations(self):
+        """Multiple violations are reported."""
+        violations = validate_narrowing(
+            self._parent_policy(),
+            allowed_models=["claude-sonnet-4-20250514"],
+            max_rpm=50,
+            max_tpd=500000,
+        )
+        assert len(violations) == 3
+
+    def test_none_limits_accepted_when_parent_has_none(self):
+        """Delegation with None limits is accepted when parent has None."""
+        policy = self._parent_policy(max_requests_per_minute=None, max_tokens_per_day=None)
+        violations = validate_narrowing(
+            policy,
+            allowed_models=["gpt-4o-mini"],
+            max_rpm=None,
+            max_tpd=None,
+        )
+        assert violations == []
+
+    def test_child_limits_accepted_when_parent_unlimited(self):
+        """Child can set limits even when parent has no limits."""
+        policy = self._parent_policy(max_requests_per_minute=None, max_tokens_per_day=None)
+        violations = validate_narrowing(
+            policy,
+            allowed_models=["gpt-4o-mini"],
+            max_rpm=10,
+            max_tpd=50000,
+        )
+        assert violations == []
+
+
+# ---- compute_effective_policy tests ----
+
+class TestComputeEffectivePolicy:
+    """Compute intersection of parent policy and delegation."""
+
+    def _parent_policy(self, **kwargs):
+        defaults = dict(
+            allowed_models=["gpt-4o-mini", "gpt-4o", "text-embedding-3-small"],
+            max_requests_per_minute=30,
+            max_tokens_per_day=100000,
+            model_aliases=None,
+        )
+        defaults.update(kwargs)
+        return AgentPolicy(**defaults)
+
+    def _delegation(self, **kwargs):
+        defaults = dict(
+            id=str(uuid.uuid4()),
+            parent_agent_id="orchestrator",
+            parent_jti="parent-jti-abc",
+            child_jti="child-jti-xyz",
+            child_label="researcher",
+            allowed_models=["gpt-4o-mini"],
+            max_requests_per_minute=5,
+            max_tokens_per_day=10000,
+            expires_at=int(time.time()) + 3600,
+            revoked_at=None,
+            created_at="2025-01-01T00:00:00",
+        )
+        defaults.update(kwargs)
+        return Delegation(**defaults)
+
+    def test_model_intersection(self):
+        """Effective models are intersection of parent and delegation."""
+        effective = compute_effective_policy(
+            self._parent_policy(),
+            self._delegation(allowed_models=["gpt-4o-mini"]),
+        )
+        assert effective.allowed_models == ["gpt-4o-mini"]
+
+    def test_model_removed_from_parent(self):
+        """If parent policy no longer includes a model, effective is empty."""
+        effective = compute_effective_policy(
+            self._parent_policy(allowed_models=["gpt-4o"]),
+            self._delegation(allowed_models=["gpt-4o-mini"]),
+        )
+        assert effective.allowed_models == []
+
+    def test_rpm_minimum(self):
+        """Effective RPM is minimum of parent and delegation."""
+        effective = compute_effective_policy(
+            self._parent_policy(max_requests_per_minute=30),
+            self._delegation(max_requests_per_minute=5),
+        )
+        assert effective.max_requests_per_minute == 5
+
+    def test_tpd_minimum(self):
+        """Effective TPD is minimum of parent and delegation."""
+        effective = compute_effective_policy(
+            self._parent_policy(max_tokens_per_day=100000),
+            self._delegation(max_tokens_per_day=10000),
+        )
+        assert effective.max_tokens_per_day == 10000
+
+    def test_parent_none_defers_to_delegation(self):
+        """When parent has no limit, delegation limit applies."""
+        effective = compute_effective_policy(
+            self._parent_policy(max_requests_per_minute=None),
+            self._delegation(max_requests_per_minute=5),
+        )
+        assert effective.max_requests_per_minute == 5
+
+    def test_delegation_none_defers_to_parent(self):
+        """When delegation has no limit, parent limit applies."""
+        effective = compute_effective_policy(
+            self._parent_policy(max_requests_per_minute=30),
+            self._delegation(max_requests_per_minute=None),
+        )
+        assert effective.max_requests_per_minute == 30
+
+    def test_both_none_stays_none(self):
+        """When both have no limit, effective is None (unlimited)."""
+        effective = compute_effective_policy(
+            self._parent_policy(max_requests_per_minute=None),
+            self._delegation(max_requests_per_minute=None),
+        )
+        assert effective.max_requests_per_minute is None
+
+    def test_delegation_id_set(self):
+        """Effective policy carries delegation ID."""
+        deleg = self._delegation()
+        effective = compute_effective_policy(self._parent_policy(), deleg)
+        assert effective.delegation_id == deleg.id
+
+
+# ---- Auth with delegation claims ----
+
+class TestDelegationAuth:
+    """Auth verification for delegation (child) tokens."""
+
+    def test_child_token_with_delegation_claims(self, ed25519_keypair, make_jwt):
+        """Child token with delegation_id and parent_jti is accepted."""
+        import jwt as pyjwt
+        private_pem, public_pem = ed25519_keypair
+        now = int(time.time())
+        payload = {
+            "sub": "orchestrator",
+            "aud": "hill90-model-router",
+            "iss": "hill90-api",
+            "exp": now + 3600,
+            "iat": now,
+            "jti": "child-jti-xyz",
+            "delegation_id": "deleg-uuid-123",
+            "parent_jti": "parent-jti-abc",
+        }
+        token = pyjwt.encode(payload, private_pem, algorithm="EdDSA")
+
+        claims = verify_model_router_token(token, public_pem)
+        assert claims.delegation_id == "deleg-uuid-123"
+        assert claims.parent_jti == "parent-jti-abc"
+        assert claims.is_delegation is True
+
+    def test_parent_token_has_no_delegation(self, ed25519_keypair, make_jwt):
+        """Parent token has delegation_id=None and is_delegation=False."""
+        _, public_pem = ed25519_keypair
+        token = make_jwt()
+        claims = verify_model_router_token(token, public_pem)
+        assert claims.delegation_id is None
+        assert claims.parent_jti is None
+        assert claims.is_delegation is False
+
+    def test_child_token_rejected_when_parent_jti_revoked(self, ed25519_keypair):
+        """Child token is rejected when parent JTI is in revoked set."""
+        import jwt as pyjwt
+        private_pem, public_pem = ed25519_keypair
+        now = int(time.time())
+        payload = {
+            "sub": "orchestrator",
+            "aud": "hill90-model-router",
+            "iss": "hill90-api",
+            "exp": now + 3600,
+            "iat": now,
+            "jti": "child-jti-xyz",
+            "delegation_id": "deleg-uuid-123",
+            "parent_jti": "parent-jti-abc",
+        }
+        token = pyjwt.encode(payload, private_pem, algorithm="EdDSA")
+
+        revoked = {"parent-jti-abc"}
+        with pytest.raises(AuthError, match="parent token revoked"):
+            verify_model_router_token(token, public_pem, revoked_jtis=revoked)
+
+    def test_child_token_ok_when_parent_jti_not_revoked(self, ed25519_keypair):
+        """Child token passes when parent JTI is not in revoked set."""
+        import jwt as pyjwt
+        private_pem, public_pem = ed25519_keypair
+        now = int(time.time())
+        payload = {
+            "sub": "orchestrator",
+            "aud": "hill90-model-router",
+            "iss": "hill90-api",
+            "exp": now + 3600,
+            "iat": now,
+            "jti": "child-jti-xyz",
+            "delegation_id": "deleg-uuid-123",
+            "parent_jti": "parent-jti-abc",
+        }
+        token = pyjwt.encode(payload, private_pem, algorithm="EdDSA")
+
+        revoked = {"some-other-jti"}
+        claims = verify_model_router_token(token, public_pem, revoked_jtis=revoked)
+        assert claims.jti == "child-jti-xyz"
+
+    def test_child_token_rejected_when_own_jti_revoked(self, ed25519_keypair):
+        """Child token is rejected when its own JTI is revoked."""
+        import jwt as pyjwt
+        private_pem, public_pem = ed25519_keypair
+        now = int(time.time())
+        payload = {
+            "sub": "orchestrator",
+            "aud": "hill90-model-router",
+            "iss": "hill90-api",
+            "exp": now + 3600,
+            "iat": now,
+            "jti": "child-jti-xyz",
+            "delegation_id": "deleg-uuid-123",
+            "parent_jti": "parent-jti-abc",
+        }
+        token = pyjwt.encode(payload, private_pem, algorithm="EdDSA")
+
+        revoked = {"child-jti-xyz"}
+        with pytest.raises(AuthError, match="token revoked"):
+            verify_model_router_token(token, public_pem, revoked_jtis=revoked)
+
+
+# ---- Model alias resolution ----
+
+class TestAliasResolution:
+    """Model alias resolution from policy."""
+
+    def _policy(self, aliases=None, **kwargs):
+        defaults = dict(
+            allowed_models=["gpt-4o-mini", "gpt-4o", "text-embedding-3-small"],
+            max_requests_per_minute=30,
+            max_tokens_per_day=100000,
+            model_aliases=aliases,
+        )
+        defaults.update(kwargs)
+        return AgentPolicy(**defaults)
+
+    def test_alias_resolves_to_real_model(self):
+        """Known alias resolves to target model."""
+        policy = self._policy(aliases={"fast": "gpt-4o-mini", "smart": "gpt-4o"})
+        assert resolve_alias("fast", policy) == "gpt-4o-mini"
+        assert resolve_alias("smart", policy) == "gpt-4o"
+
+    def test_unknown_name_passthrough(self):
+        """Unknown name is returned unchanged."""
+        policy = self._policy(aliases={"fast": "gpt-4o-mini"})
+        assert resolve_alias("gpt-4o-mini", policy) == "gpt-4o-mini"
+        assert resolve_alias("turbo", policy) == "turbo"
+
+    def test_no_recursive_resolution(self):
+        """Alias value is NOT resolved again (no recursion)."""
+        policy = self._policy(aliases={"fast": "smart", "smart": "gpt-4o"})
+        # "fast" → "smart" (literal, NOT resolved to "gpt-4o")
+        assert resolve_alias("fast", policy) == "smart"
+
+    def test_none_aliases_passthrough(self):
+        """When model_aliases is None, all names pass through."""
+        policy = self._policy(aliases=None)
+        assert resolve_alias("fast", policy) == "fast"
+
+    def test_empty_aliases_passthrough(self):
+        """When model_aliases is empty dict, all names pass through."""
+        policy = self._policy(aliases={})
+        assert resolve_alias("fast", policy) == "fast"
+
+    def test_resolve_aliases_list(self):
+        """Batch resolution of a list of names."""
+        policy = self._policy(aliases={"fast": "gpt-4o-mini", "embed": "text-embedding-3-small"})
+        result = resolve_aliases_list(["fast", "gpt-4o", "embed"], policy)
+        assert result == ["gpt-4o-mini", "gpt-4o", "text-embedding-3-small"]
+
+
+# ---- Usage logging with delegation_id ----
+
+class TestUsageWithDelegation:
+    """Usage logging includes delegation_id."""
+
+    @pytest.mark.asyncio
+    async def test_usage_logged_with_delegation_id(self, mock_db_pool):
+        """Delegation request includes delegation_id in usage record."""
+        pool, conn = mock_db_pool
+        conn.execute.return_value = None
+
+        from app.usage import log_usage
+        await log_usage(
+            conn=conn,
+            agent_id="orchestrator",
+            model_name="gpt-4o-mini",
+            request_type="chat.completion",
+            status="success",
+            latency_ms=150,
+            delegation_id="deleg-uuid-123",
+        )
+
+        conn.execute.assert_called_once()
+        call_args = conn.execute.call_args
+        sql = call_args[0][0]
+        assert "delegation_id" in sql
+        params = call_args[0][1:]
+        assert params[8] == "deleg-uuid-123"  # 9th param (index 8)
+
+    @pytest.mark.asyncio
+    async def test_usage_logged_without_delegation_id(self, mock_db_pool):
+        """Parent request has delegation_id=None in usage record."""
+        pool, conn = mock_db_pool
+        conn.execute.return_value = None
+
+        from app.usage import log_usage
+        await log_usage(
+            conn=conn,
+            agent_id="orchestrator",
+            model_name="gpt-4o-mini",
+            request_type="chat.completion",
+            status="success",
+            latency_ms=150,
+        )
+
+        call_args = conn.execute.call_args
+        params = call_args[0][1:]
+        assert params[8] is None  # delegation_id defaults to None

--- a/services/ai/tests/test_proxy.py
+++ b/services/ai/tests/test_proxy.py
@@ -261,9 +261,9 @@ class TestUsageLogging:
         assert "output_tokens" in sql
         assert "cost_usd" in sql
         # Params: agent_id, model_name, request_type, status, latency_ms,
-        #         input_tokens, output_tokens, cost_usd
+        #         input_tokens, output_tokens, cost_usd, delegation_id
         params = call_args[0][1:]
-        assert len(params) == 8
+        assert len(params) == 9
 
     @pytest.mark.asyncio
     async def test_logs_usage_defaults_to_zero(self, mock_db_pool):

--- a/services/api/src/__tests__/docs.test.ts
+++ b/services/api/src/__tests__/docs.test.ts
@@ -159,7 +159,7 @@ const EXPECTED_PATHS = [
   '/profile/password',
 ];
 
-const INFRA_PATHS = ['/docs', '/openapi.json'];
+const INFRA_PATHS = ['/docs', '/openapi.json', '/internal/delegation-token'];
 
 /**
  * Introspect Express app._router.stack to extract all registered route paths.

--- a/services/api/src/__tests__/model-router-delegation.test.ts
+++ b/services/api/src/__tests__/model-router-delegation.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Tests for model-router delegation token signing and endpoint.
+ */
+
+import * as crypto from 'crypto';
+
+// Generate test Ed25519 keypair
+const { publicKey: testPublicKey, privateKey: testPrivateKey } = crypto.generateKeyPairSync('ed25519');
+const testPrivatePem = testPrivateKey.export({ type: 'pkcs8', format: 'pem' }) as string;
+
+// Set env before importing module
+process.env.MODEL_ROUTER_SIGNING_PRIVATE_KEY = testPrivatePem;
+process.env.MODEL_ROUTER_INTERNAL_SERVICE_TOKEN = 'test-service-token-abc123';
+
+import { signDelegationToken } from '../services/model-router-delegation';
+
+function decodeJwt(token: string): { header: any; payload: any } {
+  const [headerB64, payloadB64] = token.split('.');
+  return {
+    header: JSON.parse(Buffer.from(headerB64, 'base64url').toString()),
+    payload: JSON.parse(Buffer.from(payloadB64, 'base64url').toString()),
+  };
+}
+
+function verifyEd25519Jwt(token: string, publicKey: crypto.KeyObject): boolean {
+  const [headerB64, payloadB64, signatureB64] = token.split('.');
+  const signingInput = `${headerB64}.${payloadB64}`;
+  const signature = Buffer.from(signatureB64, 'base64url');
+  return crypto.verify(null, Buffer.from(signingInput), publicKey, signature);
+}
+
+describe('signDelegationToken', () => {
+  const baseRequest = {
+    sub: 'orchestrator-agent',
+    delegation_id: '550e8400-e29b-41d4-a716-446655440000',
+    parent_jti: 'parent-jti-abc',
+    expires_at: Math.floor(Date.now() / 1000) + 3600,
+  };
+
+  it('signs JWT with delegation claims', () => {
+    const result = signDelegationToken(baseRequest);
+    const { payload } = decodeJwt(result.token);
+
+    expect(payload.sub).toBe('orchestrator-agent');
+    expect(payload.delegation_id).toBe('550e8400-e29b-41d4-a716-446655440000');
+    expect(payload.parent_jti).toBe('parent-jti-abc');
+    expect(payload.iss).toBe('hill90-api');
+    expect(payload.aud).toBe('hill90-model-router');
+  });
+
+  it('sets exp from request', () => {
+    const expiresAt = Math.floor(Date.now() / 1000) + 7200;
+    const result = signDelegationToken({ ...baseRequest, expires_at: expiresAt });
+    const { payload } = decodeJwt(result.token);
+
+    expect(payload.exp).toBe(expiresAt);
+  });
+
+  it('generates unique JTI per call', () => {
+    const result1 = signDelegationToken(baseRequest);
+    const result2 = signDelegationToken(baseRequest);
+
+    expect(result1.jti).not.toBe(result2.jti);
+    expect(result1.jti).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+  });
+
+  it('signature verifies with the public key', () => {
+    const result = signDelegationToken(baseRequest);
+    const valid = verifyEd25519Jwt(result.token, testPublicKey);
+    expect(valid).toBe(true);
+  });
+
+  it('returns jti matching JWT payload', () => {
+    const result = signDelegationToken(baseRequest);
+    const { payload } = decodeJwt(result.token);
+    expect(result.jti).toBe(payload.jti);
+  });
+});
+
+describe('POST /internal/delegation-token', () => {
+  // Use supertest for HTTP-level endpoint tests
+  let request: any;
+
+  beforeAll(async () => {
+    const supertest = await import('supertest');
+    // Re-import app (env vars already set above)
+    const { createApp } = await import('../app');
+    const app = createApp({ issuer: 'https://test-issuer' });
+    request = supertest.default(app);
+  });
+
+  const validBody = {
+    sub: 'orchestrator-agent',
+    delegation_id: '550e8400-e29b-41d4-a716-446655440000',
+    parent_jti: 'parent-jti-abc',
+    expires_at: Math.floor(Date.now() / 1000) + 3600,
+  };
+
+  it('signs and returns token with valid service token', async () => {
+    const res = await request
+      .post('/internal/delegation-token')
+      .set('Authorization', 'Bearer test-service-token-abc123')
+      .send(validBody)
+      .expect(200);
+
+    expect(res.body.token).toBeTruthy();
+    expect(res.body.jti).toBeTruthy();
+
+    const { payload } = decodeJwt(res.body.token);
+    expect(payload.delegation_id).toBe(validBody.delegation_id);
+    expect(payload.parent_jti).toBe(validBody.parent_jti);
+    expect(payload.sub).toBe(validBody.sub);
+  });
+
+  it('rejects missing Authorization header', async () => {
+    await request
+      .post('/internal/delegation-token')
+      .send(validBody)
+      .expect(403);
+  });
+
+  it('rejects invalid service token', async () => {
+    await request
+      .post('/internal/delegation-token')
+      .set('Authorization', 'Bearer wrong-token')
+      .send(validBody)
+      .expect(403);
+  });
+
+  it('rejects missing required fields', async () => {
+    await request
+      .post('/internal/delegation-token')
+      .set('Authorization', 'Bearer test-service-token-abc123')
+      .send({ sub: 'agent' })
+      .expect(400);
+  });
+});

--- a/services/api/src/__tests__/routes-model-policies.test.ts
+++ b/services/api/src/__tests__/routes-model-policies.test.ts
@@ -155,7 +155,7 @@ describe('Model Policy CRUD routes', () => {
   // Update
   it('PUT /model-policies/:id updates policy', async () => {
     mockQuery
-      .mockResolvedValueOnce({ rows: [{ id: 'p1' }] }) // existence check
+      .mockResolvedValueOnce({ rows: [{ id: 'p1', allowed_models: ['gpt-4o-mini'] }] }) // existence check
       .mockResolvedValueOnce({
         rows: [{ id: 'p1', name: 'default', allowed_models: ['gpt-4o', 'gpt-4o-mini'], max_requests_per_minute: 20, max_tokens_per_day: null }],
       });
@@ -187,7 +187,7 @@ describe('Model Policy CRUD routes', () => {
 
   it('PUT /model-policies/:id can clear limits to null', async () => {
     mockQuery
-      .mockResolvedValueOnce({ rows: [{ id: 'p1' }] })
+      .mockResolvedValueOnce({ rows: [{ id: 'p1', allowed_models: ['gpt-4o-mini'] }] })
       .mockResolvedValueOnce({
         rows: [{ id: 'p1', name: 'default', max_requests_per_minute: null, max_tokens_per_day: null }],
       });
@@ -202,6 +202,73 @@ describe('Model Policy CRUD routes', () => {
     expect(updateCall[1][4]).toBeNull();  // rpm value = null
     expect(updateCall[1][5]).toBe(true);  // tpdProvided
     expect(updateCall[1][6]).toBeNull();  // tpd value = null
+  });
+
+  // Aliases
+  it('POST /model-policies creates policy with aliases', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: 'p3', name: 'aliased', allowed_models: ['gpt-4o-mini', 'gpt-4o'], model_aliases: { fast: 'gpt-4o-mini', smart: 'gpt-4o' } }],
+    });
+    const res = await request(app)
+      .post('/model-policies')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({
+        name: 'aliased',
+        allowed_models: ['gpt-4o-mini', 'gpt-4o'],
+        model_aliases: { fast: 'gpt-4o-mini', smart: 'gpt-4o' },
+      });
+    expect(res.status).toBe(201);
+    expect(res.body.model_aliases).toEqual({ fast: 'gpt-4o-mini', smart: 'gpt-4o' });
+  });
+
+  it('POST /model-policies rejects alias target not in allowed_models', async () => {
+    const res = await request(app)
+      .post('/model-policies')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({
+        name: 'bad-alias',
+        allowed_models: ['gpt-4o-mini'],
+        model_aliases: { smart: 'gpt-4o' },
+      });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("'smart'");
+    expect(res.body.error).toContain("'gpt-4o'");
+  });
+
+  it('PUT /model-policies/:id updates aliases', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ id: 'p1', allowed_models: ['gpt-4o-mini', 'gpt-4o'] }] })
+      .mockResolvedValueOnce({
+        rows: [{ id: 'p1', name: 'default', model_aliases: { fast: 'gpt-4o-mini' } }],
+      });
+    const res = await request(app)
+      .put('/model-policies/p1')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ model_aliases: { fast: 'gpt-4o-mini' } });
+    expect(res.status).toBe(200);
+  });
+
+  it('PUT /model-policies/:id rejects alias target not in allowed_models', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: 'p1', allowed_models: ['gpt-4o-mini'] }] });
+    const res = await request(app)
+      .put('/model-policies/p1')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ model_aliases: { smart: 'gpt-4o' } });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("'smart'");
+  });
+
+  it('GET /model-policies returns model_aliases', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        { id: 'p1', name: 'default', allowed_models: ['gpt-4o-mini'], model_aliases: { fast: 'gpt-4o-mini' } },
+      ],
+    });
+    const res = await request(app)
+      .get('/model-policies')
+      .set('Authorization', `Bearer ${adminToken}`);
+    expect(res.status).toBe(200);
+    expect(res.body[0].model_aliases).toEqual({ fast: 'gpt-4o-mini' });
   });
 
   // Delete

--- a/services/api/src/__tests__/routes-usage.test.ts
+++ b/services/api/src/__tests__/routes-usage.test.ts
@@ -201,4 +201,47 @@ describe('Usage query routes', () => {
     expect(call[1]).toContain('my-agent');
     expect(call[1]).toContain('embedding');
   });
+
+  it('GET /usage filters by status', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ total_requests: '3', successful_requests: '0', total_input_tokens: '0', total_output_tokens: '0', total_tokens: '0', total_cost_usd: '0.000000' }],
+    });
+    const res = await request(app)
+      .get('/usage?status=client_disconnect')
+      .set('Authorization', `Bearer ${adminToken}`);
+    expect(res.status).toBe(200);
+    const call = mockQuery.mock.calls[0];
+    expect(call[0]).toContain('status = $');
+    expect(call[1]).toContain('client_disconnect');
+  });
+
+  it('GET /usage filters by delegation_id', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ total_requests: '5', successful_requests: '5', total_input_tokens: '1000', total_output_tokens: '500', total_tokens: '1500', total_cost_usd: '0.010000' }],
+    });
+    const res = await request(app)
+      .get('/usage?delegation_id=550e8400-e29b-41d4-a716-446655440000')
+      .set('Authorization', `Bearer ${adminToken}`);
+    expect(res.status).toBe(200);
+    const call = mockQuery.mock.calls[0];
+    expect(call[0]).toContain('delegation_id = $');
+    expect(call[1]).toContain('550e8400-e29b-41d4-a716-446655440000');
+  });
+
+  it('GET /usage supports group_by=delegation', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        { delegation_id: 'deleg-1', total_requests: '5', successful_requests: '5', total_input_tokens: '2500', total_output_tokens: '1000', total_tokens: '3500', total_cost_usd: '0.020000' },
+        { delegation_id: null, total_requests: '10', successful_requests: '9', total_input_tokens: '5000', total_output_tokens: '2000', total_tokens: '7000', total_cost_usd: '0.035000' },
+      ],
+    });
+    const res = await request(app)
+      .get('/usage?group_by=delegation')
+      .set('Authorization', `Bearer ${adminToken}`);
+    expect(res.status).toBe(200);
+    expect(res.body.group_by).toBe('delegation');
+    expect(res.body.data).toHaveLength(2);
+    const call = mockQuery.mock.calls[0];
+    expect(call[0]).toContain('GROUP BY delegation_id');
+  });
 });

--- a/services/api/src/app.ts
+++ b/services/api/src/app.ts
@@ -8,6 +8,7 @@ import profileRouter from './routes/profile';
 import usageRouter from './routes/usage';
 import { requireRole } from './middleware/role';
 import { docsRouter, specRouter } from './routes/docs';
+import { delegationTokenHandler } from './services/model-router-delegation';
 
 interface AppOptions {
   issuer?: string;
@@ -23,6 +24,9 @@ export function createApp(opts: AppOptions = {}): Application {
   app.get('/health', (_req, res) => {
     res.json({ status: 'healthy', service: 'api' });
   });
+
+  // Internal service-to-service endpoint (service-token auth, not Keycloak)
+  app.post('/internal/delegation-token', delegationTokenHandler);
 
   // Protected routes
   const issuer = opts.issuer || process.env.KEYCLOAK_ISSUER || 'https://auth.hill90.com/realms/hill90';

--- a/services/api/src/db/migrations/009_create_delegations.sql
+++ b/services/api/src/db/migrations/009_create_delegations.sql
@@ -1,0 +1,22 @@
+-- Migration 009: Create model_delegations table for delegated subagent narrowing.
+--
+-- A delegation binds a child JWT to a restricted subset of the parent's permissions.
+-- The child JWT is signed by the API service and carries delegation_id + parent_jti claims.
+-- Parent revocation cascades: if parent_jti is revoked, all children fail auth.
+
+CREATE TABLE model_delegations (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  parent_agent_id VARCHAR(128) NOT NULL,
+  parent_jti VARCHAR(128) NOT NULL,
+  child_jti VARCHAR(128) NOT NULL UNIQUE,
+  child_label VARCHAR(128) NOT NULL,
+  allowed_models JSONB NOT NULL,
+  max_requests_per_minute INT DEFAULT NULL,
+  max_tokens_per_day INT DEFAULT NULL,
+  expires_at BIGINT NOT NULL,
+  revoked_at TIMESTAMPTZ DEFAULT NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX idx_delegations_parent ON model_delegations(parent_agent_id);
+CREATE INDEX idx_delegations_child_jti ON model_delegations(child_jti);

--- a/services/api/src/db/migrations/010_add_delegation_id_to_usage.sql
+++ b/services/api/src/db/migrations/010_add_delegation_id_to_usage.sql
@@ -1,0 +1,9 @@
+-- Migration 010: Add delegation_id to model_usage for per-child usage attribution.
+--
+-- Nullable: parent (non-delegated) requests have NULL delegation_id.
+-- Partial index covers only delegation rows for efficient per-child queries.
+
+ALTER TABLE model_usage ADD COLUMN delegation_id UUID DEFAULT NULL;
+
+CREATE INDEX idx_model_usage_delegation ON model_usage(delegation_id)
+  WHERE delegation_id IS NOT NULL;

--- a/services/api/src/db/migrations/011_add_model_aliases.sql
+++ b/services/api/src/db/migrations/011_add_model_aliases.sql
@@ -1,0 +1,12 @@
+-- Migration 011: Add model_aliases JSONB column to model_policies.
+--
+-- Aliases let admins define semantic model names ("fast" -> "gpt-4o-mini")
+-- so delegation and policy can be expressed in terms of capabilities.
+-- Alias resolution is single-pass, policy-scoped, no recursion.
+
+ALTER TABLE model_policies ADD COLUMN model_aliases JSONB DEFAULT '{}'::jsonb;
+
+-- Seed default aliases on the 'default' policy
+UPDATE model_policies
+SET model_aliases = '{"fast": "gpt-4o-mini", "smart": "gpt-4o", "embed": "text-embedding-3-small"}'::jsonb
+WHERE name = 'default';

--- a/services/api/src/routes/model-policies.ts
+++ b/services/api/src/routes/model-policies.ts
@@ -21,7 +21,7 @@ router.use(requireRole('admin'));
 router.get('/', async (_req: Request, res: Response) => {
   try {
     const { rows } = await getPool().query(
-      `SELECT id, name, description, allowed_models, max_requests_per_minute, max_tokens_per_day,
+      `SELECT id, name, description, allowed_models, model_aliases, max_requests_per_minute, max_tokens_per_day,
               created_at, updated_at, updated_by
        FROM model_policies ORDER BY created_at ASC`
     );
@@ -36,7 +36,7 @@ router.get('/', async (_req: Request, res: Response) => {
 router.get('/:id', async (req: Request, res: Response) => {
   try {
     const { rows } = await getPool().query(
-      `SELECT id, name, description, allowed_models, max_requests_per_minute, max_tokens_per_day,
+      `SELECT id, name, description, allowed_models, model_aliases, max_requests_per_minute, max_tokens_per_day,
               created_at, updated_at, updated_by
        FROM model_policies WHERE id = $1`,
       [req.params.id]
@@ -56,7 +56,7 @@ router.get('/:id', async (req: Request, res: Response) => {
 router.post('/', async (req: Request, res: Response) => {
   try {
     const user = (req as any).user;
-    const { name, description, allowed_models, max_requests_per_minute, max_tokens_per_day } = req.body;
+    const { name, description, allowed_models, max_requests_per_minute, max_tokens_per_day, model_aliases } = req.body;
 
     if (!name) {
       res.status(400).json({ error: 'name is required' });
@@ -67,14 +67,28 @@ router.post('/', async (req: Request, res: Response) => {
       return;
     }
 
+    // Validate model_aliases: each alias target must be in allowed_models
+    const aliases = model_aliases || {};
+    if (typeof aliases !== 'object' || Array.isArray(aliases)) {
+      res.status(400).json({ error: 'model_aliases must be an object' });
+      return;
+    }
+    for (const [alias, target] of Object.entries(aliases)) {
+      if (!allowed_models.includes(target)) {
+        res.status(400).json({ error: `Alias '${alias}' target '${target}' is not in allowed_models` });
+        return;
+      }
+    }
+
     const { rows } = await getPool().query(
-      `INSERT INTO model_policies (name, description, allowed_models, max_requests_per_minute, max_tokens_per_day, updated_by)
-       VALUES ($1, $2, $3, $4, $5, $6)
+      `INSERT INTO model_policies (name, description, allowed_models, model_aliases, max_requests_per_minute, max_tokens_per_day, updated_by)
+       VALUES ($1, $2, $3, $4, $5, $6, $7)
        RETURNING *`,
       [
         name,
         description || '',
         JSON.stringify(allowed_models),
+        JSON.stringify(aliases),
         max_requests_per_minute ?? null,
         max_tokens_per_day ?? null,
         user.sub,
@@ -96,7 +110,7 @@ router.post('/', async (req: Request, res: Response) => {
 router.put('/:id', async (req: Request, res: Response) => {
   try {
     const user = (req as any).user;
-    const { name, description, allowed_models, max_requests_per_minute, max_tokens_per_day } = req.body;
+    const { name, description, allowed_models, max_requests_per_minute, max_tokens_per_day, model_aliases } = req.body;
 
     if (allowed_models !== undefined && !Array.isArray(allowed_models)) {
       res.status(400).json({ error: 'allowed_models must be an array' });
@@ -104,7 +118,7 @@ router.put('/:id', async (req: Request, res: Response) => {
     }
 
     const { rows: existing } = await getPool().query(
-      'SELECT id FROM model_policies WHERE id = $1',
+      'SELECT id, allowed_models FROM model_policies WHERE id = $1',
       [req.params.id]
     );
     if (existing.length === 0) {
@@ -112,9 +126,26 @@ router.put('/:id', async (req: Request, res: Response) => {
       return;
     }
 
+    // Validate model_aliases if provided
+    if (model_aliases !== undefined) {
+      if (typeof model_aliases !== 'object' || Array.isArray(model_aliases)) {
+        res.status(400).json({ error: 'model_aliases must be an object' });
+        return;
+      }
+      // Validate against the effective allowed_models (new list if provided, otherwise existing)
+      const effectiveModels = allowed_models || existing[0].allowed_models;
+      for (const [alias, target] of Object.entries(model_aliases)) {
+        if (!effectiveModels.includes(target)) {
+          res.status(400).json({ error: `Alias '${alias}' target '${target}' is not in allowed_models` });
+          return;
+        }
+      }
+    }
+
     // Use CASE for nullable limit fields to allow clearing to NULL (unlimited)
     const rpmProvided = 'max_requests_per_minute' in req.body;
     const tpdProvided = 'max_tokens_per_day' in req.body;
+    const aliasesProvided = 'model_aliases' in req.body;
 
     const { rows } = await getPool().query(
       `UPDATE model_policies SET
@@ -123,9 +154,10 @@ router.put('/:id', async (req: Request, res: Response) => {
         allowed_models = COALESCE($3, allowed_models),
         max_requests_per_minute = CASE WHEN $4::boolean THEN $5::integer ELSE max_requests_per_minute END,
         max_tokens_per_day = CASE WHEN $6::boolean THEN $7::integer ELSE max_tokens_per_day END,
-        updated_by = $8,
+        model_aliases = CASE WHEN $8::boolean THEN $9::jsonb ELSE model_aliases END,
+        updated_by = $10,
         updated_at = NOW()
-       WHERE id = $9
+       WHERE id = $11
        RETURNING *`,
       [
         name || null,
@@ -135,6 +167,8 @@ router.put('/:id', async (req: Request, res: Response) => {
         rpmProvided ? (max_requests_per_minute ?? null) : null,
         tpdProvided,
         tpdProvided ? (max_tokens_per_day ?? null) : null,
+        aliasesProvided,
+        aliasesProvided ? JSON.stringify(model_aliases) : null,
         user.sub,
         req.params.id,
       ]

--- a/services/api/src/routes/usage.ts
+++ b/services/api/src/routes/usage.ts
@@ -18,7 +18,7 @@ router.use(requireRole('admin'));
 // Query usage with optional filtering and aggregation
 router.get('/', async (req: Request, res: Response) => {
   try {
-    const { agent_id, model_name, request_type, from, to, group_by } = req.query;
+    const { agent_id, model_name, request_type, status, delegation_id, from, to, group_by } = req.query;
 
     const conditions: string[] = [];
     const params: any[] = [];
@@ -36,6 +36,14 @@ router.get('/', async (req: Request, res: Response) => {
       conditions.push(`request_type = $${paramIdx++}`);
       params.push(request_type);
     }
+    if (status) {
+      conditions.push(`status = $${paramIdx++}`);
+      params.push(status);
+    }
+    if (delegation_id) {
+      conditions.push(`delegation_id = $${paramIdx++}::uuid`);
+      params.push(delegation_id);
+    }
 
     // Date range defaults to today — explicit UTC offset so the cast is
     // unambiguous regardless of the DB session timezone setting.
@@ -50,10 +58,11 @@ router.get('/', async (req: Request, res: Response) => {
 
     const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
 
-    if (group_by === 'agent' || group_by === 'model' || group_by === 'day' || group_by === 'request_type') {
+    if (group_by === 'agent' || group_by === 'model' || group_by === 'day' || group_by === 'request_type' || group_by === 'delegation') {
       const groupCol = group_by === 'agent' ? 'agent_id'
         : group_by === 'model' ? 'model_name'
         : group_by === 'request_type' ? 'request_type'
+        : group_by === 'delegation' ? 'delegation_id'
         : "date_trunc('day', created_at)::date";
       const selectAlias = group_by === 'day' ? `${groupCol} AS day` : groupCol;
 

--- a/services/api/src/services/model-router-delegation.ts
+++ b/services/api/src/services/model-router-delegation.ts
@@ -1,0 +1,114 @@
+/**
+ * Model-router delegation token signing.
+ *
+ * Signs child JWTs for delegated subagent narrowing. Called by the AI service
+ * via internal service-to-service endpoint. The child JWT carries delegation_id
+ * and parent_jti claims that distinguish it from parent tokens.
+ */
+
+import * as crypto from 'crypto';
+import { Router, Request, Response } from 'express';
+
+const MODEL_ROUTER_SIGNING_PRIVATE_KEY = process.env.MODEL_ROUTER_SIGNING_PRIVATE_KEY;
+const MODEL_ROUTER_INTERNAL_SERVICE_TOKEN = process.env.MODEL_ROUTER_INTERNAL_SERVICE_TOKEN;
+
+let cachedPrivateKey: crypto.KeyObject | null = null;
+
+function getPrivateKey(): crypto.KeyObject {
+  if (cachedPrivateKey) return cachedPrivateKey;
+  if (!MODEL_ROUTER_SIGNING_PRIVATE_KEY) {
+    throw new Error('MODEL_ROUTER_SIGNING_PRIVATE_KEY not configured');
+  }
+  cachedPrivateKey = crypto.createPrivateKey(MODEL_ROUTER_SIGNING_PRIVATE_KEY);
+  return cachedPrivateKey;
+}
+
+function base64url(input: string | Buffer): string {
+  const buf = typeof input === 'string' ? Buffer.from(input) : input;
+  return buf.toString('base64url');
+}
+
+export interface DelegationTokenRequest {
+  sub: string;
+  delegation_id: string;
+  parent_jti: string;
+  expires_at: number;
+}
+
+export interface DelegationTokenResult {
+  token: string;
+  jti: string;
+}
+
+/**
+ * Sign a child JWT for a delegated subagent.
+ *
+ * Same iss/aud as parent tokens — the AI service verifies both with the
+ * same public key. The delegation_id and parent_jti claims distinguish
+ * child tokens from parent tokens.
+ */
+export function signDelegationToken(req: DelegationTokenRequest): DelegationTokenResult {
+  const privateKey = getPrivateKey();
+  const jti = crypto.randomUUID();
+  const now = Math.floor(Date.now() / 1000);
+
+  const header = base64url(JSON.stringify({ alg: 'EdDSA', typ: 'JWT' }));
+  const payload = base64url(JSON.stringify({
+    sub: req.sub,
+    iss: 'hill90-api',
+    aud: 'hill90-model-router',
+    delegation_id: req.delegation_id,
+    parent_jti: req.parent_jti,
+    exp: req.expires_at,
+    iat: now,
+    jti,
+  }));
+
+  const signingInput = `${header}.${payload}`;
+  const signature = crypto.sign(null, Buffer.from(signingInput), privateKey);
+  const token = `${signingInput}.${signature.toString('base64url')}`;
+
+  return { token, jti };
+}
+
+/**
+ * Express handler for POST /internal/delegation-token.
+ *
+ * Authenticated via MODEL_ROUTER_INTERNAL_SERVICE_TOKEN (HMAC comparison).
+ * Not reachable externally — only on hill90_internal Docker network.
+ */
+export function delegationTokenHandler(req: Request, res: Response): void {
+  // Validate service token
+  const authHeader = req.headers.authorization;
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    res.status(403).json({ error: 'Missing service token' });
+    return;
+  }
+
+  const token = authHeader.slice(7);
+  if (!MODEL_ROUTER_INTERNAL_SERVICE_TOKEN) {
+    res.status(503).json({ error: 'Service token not configured' });
+    return;
+  }
+
+  const expected = Buffer.from(MODEL_ROUTER_INTERNAL_SERVICE_TOKEN);
+  const received = Buffer.from(token);
+  if (expected.length !== received.length || !crypto.timingSafeEqual(expected, received)) {
+    res.status(403).json({ error: 'Invalid service token' });
+    return;
+  }
+
+  // Validate request body
+  const { sub, delegation_id, parent_jti, expires_at } = req.body;
+  if (!sub || !delegation_id || !parent_jti || !expires_at) {
+    res.status(400).json({ error: 'Missing required fields: sub, delegation_id, parent_jti, expires_at' });
+    return;
+  }
+
+  try {
+    const result = signDelegationToken({ sub, delegation_id, parent_jti, expires_at });
+    res.json(result);
+  } catch (err: any) {
+    res.status(500).json({ error: `Token signing failed: ${err.message}` });
+  }
+}


### PR DESCRIPTION
## Summary

- **Delegated subagent narrowing**: Parent agents create delegation tokens granting children a strict subset of permissions (models, rate limits, budget). Server-side delegation records, separate child JWTs (signed by API service), auditable, revocable with cascading parent revocation.
- **Model aliases**: Admin-defined semantic model names (`"fast"` → `"gpt-4o-mini"`) per policy, resolved by AI service before forwarding to LiteLLM. Single-pass, no recursion, validated at CRUD time.
- **Usage attribution**: `delegation_id` column on `model_usage` enables per-child usage queries with new filters (`status`, `delegation_id`, `group_by=delegation`).

## Plan

Closed-loop plan: `.claude/plans/mutable-seeking-feigenbaum.md` — 12 implementation steps, 9 runtime verification items, fallback deferred to Phase 5.

### Architecture

```
Parent Agent → POST /v1/delegate → AI Service validates narrowing → 
  AI calls POST /internal/delegation-token → API Service signs child JWT →
  AI stores delegation record → returns child token to parent

Child Agent → POST /v1/chat/completions (child JWT) → AI Service:
  1. Verify child JWT (Ed25519)
  2. Check parent_jti not revoked (cascading)
  3. Lookup delegation record
  4. Compute effective policy (parent ∩ delegation)
  5. Dual-level rate limit + budget enforcement
  6. Proxy to LiteLLM with resolved model name
  7. Log usage with delegation_id
```

### Key Design Decisions

- **Signing key isolation preserved**: API service holds Ed25519 private key, AI service has public key only. Child JWTs signed via internal service-to-service call.
- **Reuse existing service token**: `MODEL_ROUTER_INTERNAL_SERVICE_TOKEN` authenticates AI→API calls (same token used for API→AI revocation calls).
- **Dual-level enforcement**: Both delegation-level AND parent-level rate/budget checks — a child can be individually capped even when parent has budget remaining.
- **Alias resolution at delegation creation**: Aliases resolved to real model names when delegation is created, making delegations stable against alias remapping.

## Risks

- AI→API internal call adds latency to delegation creation (not hot path — setup operation only)
- Delegation DB lookup on every child request (indexed by child_jti, single row fetch)
- Dual rate/budget queries double DB load for delegated requests (uses existing composite indexes)
- Provider fallback bypasses policy — deferred to Phase 5 (see plan section 7)

## Rollback

- Revert this PR; no LiteLLM config changes. Existing parent JWT flow is unaffected.
- Migrations are additive (new table, new nullable columns) — safe to leave in place.

## Validation Evidence

- 262 tests passing (108 AI service + 154 API service)
- New test suites: `test_delegation.py` (28 tests), `model-router-delegation.test.ts` (9 tests)
- Extended test suites: `routes-model-policies.test.ts` (+5 alias tests), `routes-usage.test.ts` (+3 filter tests)
- Code review findings addressed: unique child_jti placeholder, double alias resolution removed

## Test plan

- [ ] CI passes (unit tests, lint, security scan)
- [ ] Migrations apply cleanly on VPS
- [ ] Delegation creation: parent with 3 models delegates 1 → DB record correct
- [ ] Child authorized: child requests allowed model → 200, usage has delegation_id
- [ ] Child denied (model): child requests model outside delegation → 403
- [ ] Child denied (budget): exhaust delegation budget → 429 while parent has budget
- [ ] Cascading revocation: stop parent → child request returns 401
- [ ] Individual revocation: revoke one delegation → that child gets 401, others unaffected
- [ ] Alias resolution: request "fast" → resolves to gpt-4o-mini, usage logged with real name
- [ ] Alias with delegation: delegate ["fast"] → stored as ["gpt-4o-mini"], child requests "fast" → works

🤖 Generated with [Claude Code](https://claude.com/claude-code)