### PR TITLE
docs: update public docs with agent harness capabilities

### DIFF
--- a/docs/site/api-reference/knowledge.mdx
+++ b/docs/site/api-reference/knowledge.mdx
@@ -5,13 +5,25 @@ description: Read-only access to agent knowledge entries, search, and stats.
 
 # Knowledge API
 
-The Knowledge API provides read-only access to agent knowledge. Agents write knowledge via the `akm` CLI; the Knowledge API lets humans browse what agents know.
+The Knowledge API provides read-only access to agent knowledge. Agents maintain persistent memory across sessions — they write plans, decisions, journals, research notes, and other entries that survive container restarts. The Knowledge API lets you browse and search what your agents have learned.
+
+## Entry Types
+
+Agents organize knowledge into typed entries:
+
+| Type | Purpose |
+|------|---------|
+| `plan` | Action plans and implementation strategies |
+| `decision` | Recorded decisions with rationale |
+| `journal` | Append-only daily activity logs |
+| `research` | Research findings and references |
+| `note` | General-purpose notes |
 
 ## Access Model
 
 - **Users** see knowledge from agents they own.
 - **Admins** see knowledge from all agents.
-- **Read-only** — only agents write knowledge through the AKM service.
+- **Read-only** — only agents write knowledge through internal services.
 
 ## Endpoints
 

--- a/docs/site/api-reference/overview.mdx
+++ b/docs/site/api-reference/overview.mdx
@@ -5,7 +5,7 @@ description: Hill90 REST API endpoint documentation.
 
 # API Reference
 
-The Hill90 API provides endpoints for agent management, agent knowledge, user profiles, and platform health checks.
+The Hill90 API provides endpoints for agent management, model access configuration, agent knowledge, user profiles, and platform health checks.
 
 ## Base URL
 
@@ -59,6 +59,8 @@ See [Authentication](/getting-started/authentication) for details on obtaining t
 
 ### Knowledge
 
+Browse and search agent knowledge entries. Agents write knowledge; humans browse it here.
+
 | Endpoint | Auth | Description |
 |----------|------|-------------|
 | `GET /knowledge/agents` | Bearer | List agents with knowledge stats |
@@ -67,6 +69,49 @@ See [Authentication](/getting-started/authentication) for details on obtaining t
 | `GET /knowledge/search` | Bearer | Full-text search across entries |
 
 See [Knowledge API](/api-reference/knowledge) for details on access scoping.
+
+### Provider Connections
+
+Manage your own API key connections to LLM providers. Keys are encrypted at rest and never returned in responses.
+
+| Endpoint | Auth | Description |
+|----------|------|-------------|
+| `GET /provider-connections` | Bearer | List your provider connections |
+| `POST /provider-connections` | Bearer | Create a provider connection |
+| `PUT /provider-connections/{id}` | Bearer | Update a provider connection |
+| `DELETE /provider-connections/{id}` | Bearer | Delete a provider connection |
+| `POST /provider-connections/{id}/validate` | Bearer | Test if a provider key is valid |
+
+### User Models
+
+Define models that reference your provider connections. Model names must not conflict with platform models.
+
+| Endpoint | Auth | Description |
+|----------|------|-------------|
+| `GET /user-models` | Bearer | List your models |
+| `POST /user-models` | Bearer | Create a user model |
+| `PUT /user-models/{id}` | Bearer | Update a user model |
+| `DELETE /user-models/{id}` | Bearer | Delete a user model |
+
+### Model Policies
+
+Control which models an agent can access, with optional rate limits and token budgets. Users can create and manage their own policies; admins can also create platform-wide policies.
+
+| Endpoint | Auth | Description |
+|----------|------|-------------|
+| `GET /model-policies` | Bearer | List policies (own + platform) |
+| `POST /model-policies` | Bearer | Create a model policy |
+| `GET /model-policies/{id}` | Bearer | Get policy detail |
+| `PUT /model-policies/{id}` | Bearer | Update a policy |
+| `DELETE /model-policies/{id}` | Bearer | Delete a policy |
+
+### Usage
+
+Query model usage statistics with filtering and grouping options. Users see their own usage; admins see all.
+
+| Endpoint | Auth | Description |
+|----------|------|-------------|
+| `GET /usage` | Bearer | Query usage (filter by agent, model, date; group by agent, model, day) |
 
 ## Auto-Generated Documentation
 

--- a/docs/site/architecture/overview.mdx
+++ b/docs/site/architecture/overview.mdx
@@ -21,11 +21,13 @@ The platform is organized into four layers:
 
 ### Application Layer
 
-Five application services handle business logic:
+Application services handle business logic:
 
-- **API** — REST API gateway (Express/TypeScript) for agent management and user profiles
-- **AI** — LangChain/LangGraph agents (FastAPI/Python)
+- **API** — REST API gateway (Express/TypeScript) for agent management, model policies, and user profiles
+- **AI (Model-Router)** — Internal policy-gated LLM inference gateway (FastAPI/Python)
+- **Knowledge (AKM)** — Persistent agent memory with full-text search (FastAPI/Python)
 - **MCP** — Model Context Protocol gateway (FastAPI/Python), JWT-authenticated
+- **Agentbox** — Sandboxed agent runtime containers (FastMCP/Python)
 - **Keycloak** — Identity provider (OIDC/OAuth2) at `auth.hill90.com`
 - **UI** — Next.js frontend application
 
@@ -54,10 +56,13 @@ Internet
 Traefik (edge network)
    |
    +-- Public Services (HTTP-01 certs)
-   |     API, AI, MCP, Keycloak, UI
+   |     API, MCP Gateway, Keycloak, UI
    |
    +-- Internal Services
-   |     PostgreSQL, MinIO
+   |     AI (Model-Router), Knowledge (AKM), PostgreSQL, MinIO
+   |
+   +-- Agent Network
+   |     Agentbox → AI Service, Knowledge Service
    |
    +-- Observability
          Prometheus, Loki, Tempo, Grafana
@@ -68,15 +73,16 @@ Traefik (edge network)
 | Network | Purpose | Access |
 |---------|---------|--------|
 | `edge` | Public-facing services | Internet via Traefik |
-| `internal` | Databases, storage, observability | Service-to-service only |
+| `internal` | Service-to-service communication | API, AI, Knowledge, databases |
+| `agent_internal` | Agent container isolation | Agentbox → AI + Knowledge only |
 
-VPN-only services (Traefik dashboard, Grafana, MinIO console) are protected by IP whitelist middleware, accessible only through the VPN network.
+VPN-only services (Traefik dashboard, Grafana, MinIO console) are protected by IP whitelist middleware, accessible only through the VPN network. The AI service and Knowledge service are internal-only — they are not publicly routed through Traefik.
 
 ## Certificate Management
 
 | Challenge Type | Used For | How It Works |
 |----------------|----------|--------------|
-| HTTP-01 | Public services (API, AI, UI, etc.) | Let's Encrypt validates via port 80 |
+| HTTP-01 | Public services (API, MCP Gateway, UI, etc.) | Let's Encrypt validates via port 80 |
 | DNS-01 | VPN-only services (Traefik dashboard, Grafana) | DNS TXT record validation via DNS Manager webhook |
 
 The **DNS Manager** is an internal webhook that translates Traefik ACME requests into DNS API calls for TXT record management.

--- a/docs/site/architecture/services.mdx
+++ b/docs/site/architecture/services.mdx
@@ -11,27 +11,47 @@ Hill90 is composed of application services, infrastructure services, and an obse
 
 | Service | Language | URL | Description |
 |---------|----------|-----|-------------|
-| **API** | TypeScript (Express) | `api.hill90.com` | REST API gateway — agent CRUD, user profiles, avatar management |
-| **AI** | Python (FastAPI) | `ai.hill90.com` | LangChain/LangGraph AI agents and operations |
+| **API** | TypeScript (Express) | `api.hill90.com` | REST API gateway — agent CRUD, model management, user profiles |
+| **AI (Model-Router)** | Python (FastAPI) | Internal only | Policy-gated LLM inference gateway for agents |
+| **Knowledge (AKM)** | Python (FastAPI) | Internal only | Persistent agent memory with full-text search |
 | **MCP** | Python (FastAPI) | `ai.hill90.com/mcp` | Model Context Protocol gateway (JWT-authenticated) |
+| **Agentbox** | Python (FastMCP) | Internal only | Sandboxed agent runtime containers |
 | **Keycloak** | Java | `auth.hill90.com` | OIDC/OAuth2 identity provider |
 | **UI** | TypeScript (Next.js) | `hill90.com` | Frontend application with Auth.js v5 session management |
 
 ### API Service
 
-The API service is the primary REST gateway. It handles:
-- Agent lifecycle management (create, read, update, delete)
-- Agent container operations (start, stop, status, logs)
+The API service is the primary REST gateway and control plane. It handles:
+- Agent lifecycle management (create, configure, start, stop, delete)
+- Agent container operations (status, logs, config generation)
+- Provider connections and user model management (BYOK)
+- Model policy management and assignment
+- Usage tracking queries
+- Knowledge entry browsing and search (proxied from AKM)
 - User profile and avatar management
 - JWT validation via Keycloak
 
-### AI Service
+### AI Service (Model-Router)
 
-The AI service hosts LangChain/LangGraph agents for AI operations. It provides endpoints for interacting with AI models and running agent workflows.
+The AI service is an internal model-router gateway — it is not publicly accessible. Agent containers reach it on the internal network to perform LLM inference. It enforces model access policies (allowed models, rate limits, token budgets), resolves user-owned model configurations, and proxies requests to LLM providers. Supports chat completions (streaming and non-streaming) and embeddings.
+
+### Knowledge Service (AKM)
+
+The Agent Knowledge Manager provides persistent memory for agent containers. Agents write knowledge entries (plans, decisions, journals, research notes) that survive across sessions. The service provides full-text search, append-only journaling, and intelligent context assembly with configurable token budgets. Knowledge is scoped per agent — agents cannot read each other's entries. Users can browse and search their agents' knowledge via the API service proxy.
+
+### Agentbox
+
+Each agent runs in a sandboxed container with configurable tools:
+- **Shell** — Policy-gated command execution with allowlists and deny patterns
+- **Filesystem** — Policy-gated file operations with path restrictions
+- **Identity** — Agent personality (SOUL.md) and rules (RULES.md)
+- **Health** — Container health monitoring
+
+Agentbox containers are network-isolated and can only communicate with the AI service (for inference) and Knowledge service (for memory). They cannot reach the public internet or other services.
 
 ### MCP Service
 
-The MCP (Model Context Protocol) gateway exposes tool-augmented AI capabilities. All requests require Keycloak JWT authentication.
+The MCP (Model Context Protocol) gateway exposes tool-augmented AI capabilities at `ai.hill90.com/mcp`. All requests require Keycloak JWT authentication. This is the only publicly routed service on the `ai.hill90.com` hostname.
 
 ### Keycloak
 

--- a/docs/site/getting-started/overview.mdx
+++ b/docs/site/getting-started/overview.mdx
@@ -7,8 +7,10 @@ description: What Hill90 is, how it works, and the technology stack.
 
 Hill90 is a production-ready microservices platform hosted on a single VPS. It provides:
 
-- A **REST API** for managing AI agents and user profiles
-- An **AI service** powered by LangChain/LangGraph
+- A **REST API** for managing AI agents, model access, and user profiles
+- **Sandboxed agent containers** with configurable tools and resource limits
+- **Policy-gated LLM inference** with bring-your-own-key (BYOK) model management
+- **Persistent agent knowledge** — memory that survives across sessions, with full-text search
 - A **Model Context Protocol (MCP) gateway** for tool-augmented AI
 - A **Next.js frontend** with Keycloak-backed authentication
 - Full **observability** via the LGTM stack (Loki, Grafana, Tempo, Prometheus)
@@ -38,18 +40,22 @@ Internet
 Traefik (reverse proxy, automatic HTTPS)
    |
    +-- API Service (Express, TypeScript)
-   +-- AI Service (FastAPI, Python)
    +-- MCP Gateway (FastAPI, Python)
    +-- Keycloak (Identity Provider)
    +-- UI (Next.js)
    |
 Internal Network
+   +-- AI Service / Model-Router (FastAPI, Python)
+   +-- Knowledge Service / AKM (FastAPI, Python)
    +-- PostgreSQL
    +-- MinIO (S3 storage)
    +-- Observability Stack (Prometheus, Grafana, Loki, Tempo)
+   |
+Agent Network
+   +-- Agentbox containers → AI Service, Knowledge Service
 ```
 
-Traffic enters through Traefik, which handles TLS termination, routing, and load balancing. Public services use HTTP-01 certificates, while admin-only services use DNS-01 certificates and are restricted to the VPN network.
+Traffic enters through Traefik, which handles TLS termination, routing, and load balancing. Public services use HTTP-01 certificates, while admin-only services use DNS-01 certificates and are restricted to the VPN network. The AI service and Knowledge service are internal-only — agent containers communicate with them on an isolated network.
 
 ## Next Steps
 

--- a/docs/site/getting-started/quickstart.mdx
+++ b/docs/site/getting-started/quickstart.mdx
@@ -5,9 +5,7 @@ description: Get started with the Hill90 platform.
 
 # Quickstart
 
-<Info>
-  This guide is a work in progress. Full quickstart content will be added in a future update.
-</Info>
+This guide walks through the core Hill90 workflow: creating an agent, configuring model access, and querying agent knowledge and usage.
 
 ## Prerequisites
 
@@ -19,12 +17,11 @@ description: Get started with the Hill90 platform.
 
 The Hill90 UI is available at [hill90.com](https://hill90.com). Sign in with your Keycloak credentials to access the dashboard.
 
-## Making Your First API Call
+## 1. Health Check
 
-Once authenticated, you can interact with the Hill90 API:
+Verify the API is running (no authentication required):
 
 ```bash
-# Health check (no authentication required)
 curl https://api.hill90.com/health
 ```
 
@@ -35,16 +32,176 @@ curl https://api.hill90.com/health
 }
 ```
 
-For authenticated endpoints, include your JWT bearer token:
+## 2. Authenticate
+
+For all remaining calls, include your Keycloak JWT bearer token:
 
 ```bash
-curl -H "Authorization: Bearer YOUR_TOKEN" \
-  https://api.hill90.com/agents
+export TOKEN="YOUR_JWT_TOKEN"
 ```
 
-See the [API Reference](/api-reference/overview) for full endpoint documentation.
+See [Authentication](/getting-started/authentication) for details on obtaining tokens.
+
+## 3. Create an Agent
+
+Define an agent with a unique slug, name, and optional identity documents:
+
+```bash
+curl -X POST https://api.hill90.com/agents \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "agent_id": "my-first-agent",
+    "name": "My First Agent",
+    "description": "A test agent",
+    "soul_md": "You are a helpful research assistant.",
+    "rules_md": "Always cite your sources."
+  }'
+```
+
+```json
+{
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "agent_id": "my-first-agent",
+  "name": "My First Agent",
+  "status": "stopped",
+  ...
+}
+```
+
+## 4. Create a Provider Connection
+
+Register your LLM provider API key. The key is encrypted at rest and never returned in responses:
+
+```bash
+curl -X POST https://api.hill90.com/provider-connections \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "My OpenAI Key",
+    "provider": "openai",
+    "api_key": "sk-..."
+  }'
+```
+
+```json
+{
+  "id": "660e8400-e29b-41d4-a716-446655440001",
+  "name": "My OpenAI Key",
+  "provider": "openai",
+  "is_valid": null,
+  ...
+}
+```
+
+## 5. Create a User Model
+
+Define a model that references your provider connection:
+
+```bash
+curl -X POST https://api.hill90.com/user-models \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "my-gpt4o",
+    "connection_id": "660e8400-e29b-41d4-a716-446655440001",
+    "litellm_model": "openai/gpt-4o"
+  }'
+```
+
+## 6. Create a Model Policy
+
+Define which models the agent can access, with optional rate limits:
+
+```bash
+curl -X POST https://api.hill90.com/model-policies \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "standard-access",
+    "allowed_models": ["my-gpt4o"],
+    "max_requests_per_minute": 10,
+    "max_tokens_per_day": 100000
+  }'
+```
+
+## 7. Assign the Policy to Your Agent
+
+Update the agent to use the model policy:
+
+```bash
+curl -X PUT https://api.hill90.com/agents/550e8400-e29b-41d4-a716-446655440000 \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model_policy_id": "POLICY_UUID_FROM_STEP_6"
+  }'
+```
+
+## 8. Start the Agent
+
+Start the agent container (requires admin role):
+
+```bash
+curl -X POST https://api.hill90.com/agents/550e8400-e29b-41d4-a716-446655440000/start \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+```json
+{
+  "status": "running",
+  "container_id": "abc123..."
+}
+```
+
+The agent is now running in a sandboxed container with access to LLM inference (via the model policy) and persistent knowledge storage.
+
+## 9. Browse Agent Knowledge
+
+After the agent runs, browse what it has learned:
+
+```bash
+# List agents with knowledge entries
+curl -H "Authorization: Bearer $TOKEN" \
+  https://api.hill90.com/knowledge/agents
+
+# List entries for a specific agent
+curl -H "Authorization: Bearer $TOKEN" \
+  "https://api.hill90.com/knowledge/entries?agent_id=my-first-agent"
+
+# Search across knowledge
+curl -H "Authorization: Bearer $TOKEN" \
+  "https://api.hill90.com/knowledge/search?q=research+findings"
+```
+
+## 10. Query Usage
+
+Check how much the agent has consumed:
+
+```bash
+# Summary of today's usage
+curl -H "Authorization: Bearer $TOKEN" \
+  https://api.hill90.com/usage
+
+# Usage grouped by model
+curl -H "Authorization: Bearer $TOKEN" \
+  "https://api.hill90.com/usage?group_by=model"
+```
+
+```json
+{
+  "total_requests": 42,
+  "successful_requests": 40,
+  "total_input_tokens": 15000,
+  "total_output_tokens": 8000,
+  "total_tokens": 23000,
+  "total_cost_usd": 0.035
+}
+```
 
 ## Next Steps
 
 - [Authentication](/getting-started/authentication) — Learn how to obtain and use JWT tokens
 - [API Reference](/api-reference/overview) — Explore all available endpoints
+- [Knowledge API](/api-reference/knowledge) — Browse agent knowledge entries
+- [Architecture](/architecture/overview) — Understand the platform architecture

--- a/docs/site/index.mdx
+++ b/docs/site/index.mdx
@@ -25,6 +25,9 @@ Hill90 is a Docker-based microservices platform hosted on a single VPS, providin
 ## Key Features
 
 - **AI Agent Management** — Create, configure, start, and stop sandboxed AI agents via REST API.
+- **Bring Your Own Key** — Register your own LLM provider keys. Keys are encrypted at rest and never exposed.
+- **Model Policies & Usage Tracking** — Control which models agents can access with rate limits and token budgets. Track usage and costs.
+- **Agent Knowledge & Memory** — Agents maintain persistent knowledge across sessions. Browse and search what your agents have learned.
 - **Identity & Access Control** — Keycloak OIDC/OAuth2 with JWT-based API authentication.
 - **Automatic HTTPS** — Traefik reverse proxy with Let's Encrypt (HTTP-01 and DNS-01 challenges).
 - **Full Observability** — Prometheus, Grafana, Loki, and Tempo for metrics, logs, and traces.


### PR DESCRIPTION
## Summary

PR 2 of the documentation consolidation plan (stacked on #182). Updates all public-facing docs in `docs/site/` to reflect the current agent harness architecture.

- **services.mdx**: Replace stale AI/LangChain description with model-router, add Knowledge (AKM) and Agentbox services
- **architecture/overview.mdx**: Update network diagram with `agent_internal`, add AI/Knowledge as internal services
- **api-reference/overview.mdx**: Add endpoint tables for Provider Connections (5), User Models (4), Model Policies (5), Usage (1)
- **quickstart.mdx**: Remove WIP banner; full workflow — health → agent → connection → model → policy → start → knowledge → usage
- **getting-started/overview.mdx**: Replace LangChain with BYOK, agent knowledge, sandboxed containers in feature list
- **index.mdx**: Add BYOK, model policies, agent knowledge to Key Features
- **knowledge.mdx**: Add entry types table and description of persistent agent memory

## Verification Evidence

- `grep -ri "langchain\|langgraph" docs/site/` → zero matches
- `grep -ri "litellm" docs/site/ --include="*.mdx"` → only `litellm_model` API field name in quickstart (required API field)
- `grep -ri "AES-256-GCM\|Ed25519\|EdDSA\|vault path\|secret/" docs/site/` → zero matches (only `nonce` in package-lock.json)
- `bash scripts/checks/check_docs_secrets.sh` → PASS
- `python3 scripts/checks/check_md_links.py` → PASS
- All `docs.json` nav entries verified to reference existing files

## Test Plan

- [ ] CI checks pass (Agent Loop, Run Tests, Snyk)
- [ ] No forbidden terms in `docs/site/` (LangChain, LangGraph, SOPS, vault paths, encryption details)
- [ ] All markdown links resolve
- [ ] `docs.json` nav entries all reference existing `.mdx` files
- [ ] Quickstart curl examples use correct request shapes per OpenAPI spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)