### PR TITLE
feat: harness UI models & policies pages

### DIFF
--- a/services/ui/src/__tests__/ModelsClient.test.tsx
+++ b/services/ui/src/__tests__/ModelsClient.test.tsx
@@ -1,0 +1,174 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+
+// Mock global fetch
+const mockFetch = vi.fn()
+vi.stubGlobal('fetch', mockFetch)
+
+import ModelsClient from '@/app/harness/models/ModelsClient'
+
+const MOCK_CONNECTIONS = [
+  { id: 'conn-1', name: 'My OpenAI Key', provider: 'openai' },
+  { id: 'conn-2', name: 'Anthropic Prod', provider: 'anthropic' },
+]
+
+const MOCK_MODELS = [
+  {
+    id: 'model-1',
+    name: 'GPT-4o Mini',
+    connection_id: 'conn-1',
+    litellm_model: 'gpt-4o-mini',
+    description: 'Fast and cheap',
+    is_active: true,
+    created_at: '2026-01-15T00:00:00Z',
+    updated_at: '2026-01-15T00:00:00Z',
+  },
+  {
+    id: 'model-2',
+    name: 'Claude Sonnet',
+    connection_id: 'conn-2',
+    litellm_model: 'claude-sonnet-4-5-20250929',
+    description: '',
+    is_active: true,
+    created_at: '2026-02-01T00:00:00Z',
+    updated_at: '2026-02-01T00:00:00Z',
+  },
+]
+
+function mockFetchResponses(models = MOCK_MODELS, connections = MOCK_CONNECTIONS) {
+  mockFetch.mockImplementation((url: string) => {
+    if (url === '/api/user-models') {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(models) })
+    }
+    if (url === '/api/provider-connections') {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(connections) })
+    }
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+  })
+}
+
+describe('ModelsClient', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockFetchResponses()
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('renders model table with connection names', async () => {
+    render(<ModelsClient />)
+
+    await waitFor(() => {
+      expect(screen.getByText('GPT-4o Mini')).toBeInTheDocument()
+      expect(screen.getByText('Claude Sonnet')).toBeInTheDocument()
+    })
+
+    expect(screen.getByText('2 models')).toBeInTheDocument()
+    expect(screen.getByText('My OpenAI Key')).toBeInTheDocument()
+    expect(screen.getByText('Anthropic Prod')).toBeInTheDocument()
+  })
+
+  it('shows provider model IDs', async () => {
+    render(<ModelsClient />)
+
+    await waitFor(() => {
+      expect(screen.getByText('gpt-4o-mini')).toBeInTheDocument()
+      expect(screen.getByText('claude-sonnet-4-5-20250929')).toBeInTheDocument()
+    })
+  })
+
+  it('shows empty state when no models', async () => {
+    mockFetchResponses([], MOCK_CONNECTIONS)
+
+    render(<ModelsClient />)
+
+    await waitFor(() => {
+      expect(screen.getByText('No models defined yet')).toBeInTheDocument()
+      expect(screen.getByText('Create a model to use with your provider connections.')).toBeInTheDocument()
+    })
+  })
+
+  it('shows connection-first hint when no connections exist', async () => {
+    mockFetchResponses([], [])
+
+    render(<ModelsClient />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Create a provider connection first, then add models.')).toBeInTheDocument()
+    })
+  })
+
+  it('disables Add Model when no connections', async () => {
+    mockFetchResponses([], [])
+
+    render(<ModelsClient />)
+
+    await waitFor(() => {
+      expect(screen.getByText('No models defined yet')).toBeInTheDocument()
+    })
+
+    const addButton = screen.getByText('Add Model')
+    expect(addButton).toBeDisabled()
+  })
+
+  it('opens create form with connection dropdown', async () => {
+    render(<ModelsClient />)
+
+    await waitFor(() => {
+      expect(screen.getByText('GPT-4o Mini')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByText('Add Model'))
+
+    expect(screen.getByText('New Model')).toBeInTheDocument()
+    expect(screen.getByText('Select a connection')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('GPT-4o Mini')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('gpt-4o-mini')).toBeInTheDocument()
+  })
+
+  it('submits create form with correct body', async () => {
+    render(<ModelsClient />)
+
+    await waitFor(() => {
+      expect(screen.getByText('GPT-4o Mini')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByText('Add Model'))
+
+    fireEvent.change(screen.getByPlaceholderText('GPT-4o Mini'), { target: { value: 'New Model' } })
+    fireEvent.change(screen.getByPlaceholderText('gpt-4o-mini'), { target: { value: 'gpt-4o' } })
+
+    // Select connection
+    const connectionSelect = screen.getByDisplayValue('Select a connection')
+    fireEvent.change(connectionSelect, { target: { value: 'conn-1' } })
+
+    fireEvent.click(screen.getByText('Create'))
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith('/api/user-models', expect.objectContaining({
+        method: 'POST',
+        body: expect.stringContaining('"name":"New Model"'),
+      }))
+    })
+  })
+
+  it('confirms before deleting', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false)
+
+    render(<ModelsClient />)
+
+    await waitFor(() => {
+      expect(screen.getByText('GPT-4o Mini')).toBeInTheDocument()
+    })
+
+    const deleteButtons = screen.getAllByText('Delete')
+    fireEvent.click(deleteButtons[0])
+
+    expect(confirmSpy).toHaveBeenCalled()
+    confirmSpy.mockRestore()
+  })
+})

--- a/services/ui/src/__tests__/PoliciesClient.test.tsx
+++ b/services/ui/src/__tests__/PoliciesClient.test.tsx
@@ -1,0 +1,227 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+
+// Mock global fetch
+const mockFetch = vi.fn()
+vi.stubGlobal('fetch', mockFetch)
+
+import PoliciesClient from '@/app/harness/policies/PoliciesClient'
+
+const MOCK_USER_MODELS = [
+  { id: 'model-1', name: 'GPT-4o Mini', litellm_model: 'gpt-4o-mini' },
+  { id: 'model-2', name: 'Claude Sonnet', litellm_model: 'claude-sonnet-4-5-20250929' },
+]
+
+const MOCK_POLICIES = [
+  {
+    id: 'policy-1',
+    name: 'Default Policy',
+    description: 'Standard access',
+    allowed_models: ['GPT-4o Mini', 'Claude Sonnet'],
+    max_requests_per_minute: 60,
+    max_tokens_per_day: 1000000,
+    model_aliases: { fast: 'GPT-4o Mini' },
+    created_at: '2026-01-15T00:00:00Z',
+    updated_at: '2026-01-15T00:00:00Z',
+    created_by: 'admin',
+  },
+  {
+    id: 'policy-2',
+    name: 'Budget Policy',
+    description: '',
+    allowed_models: ['GPT-4o Mini'],
+    max_requests_per_minute: null,
+    max_tokens_per_day: 100000,
+    model_aliases: null,
+    created_at: '2026-02-01T00:00:00Z',
+    updated_at: '2026-02-01T00:00:00Z',
+    created_by: 'user',
+  },
+]
+
+function mockFetchResponses(policies = MOCK_POLICIES, models = MOCK_USER_MODELS) {
+  mockFetch.mockImplementation((url: string) => {
+    if (url === '/api/model-policies') {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(policies) })
+    }
+    if (url === '/api/user-models') {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(models) })
+    }
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+  })
+}
+
+describe('PoliciesClient', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockFetchResponses()
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('renders policy rows with model chips', async () => {
+    render(<PoliciesClient />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Default Policy')).toBeInTheDocument()
+      expect(screen.getByText('Budget Policy')).toBeInTheDocument()
+    })
+
+    expect(screen.getByText('2 policies')).toBeInTheDocument()
+
+    // Model chips shown in summary row (first 3 models shown)
+    const gptChips = screen.getAllByText('GPT-4o Mini')
+    expect(gptChips.length).toBeGreaterThanOrEqual(2) // in both policy rows
+  })
+
+  it('shows rate limit and token budget in summary', async () => {
+    render(<PoliciesClient />)
+
+    await waitFor(() => {
+      expect(screen.getByText('60 req/min')).toBeInTheDocument()
+      expect(screen.getByText('1,000,000 tok/day')).toBeInTheDocument()
+      expect(screen.getByText('No rate limit')).toBeInTheDocument()
+      expect(screen.getByText('100,000 tok/day')).toBeInTheDocument()
+    })
+  })
+
+  it('shows empty state when no policies', async () => {
+    mockFetchResponses([], MOCK_USER_MODELS)
+
+    render(<PoliciesClient />)
+
+    await waitFor(() => {
+      expect(screen.getByText('No model policies yet')).toBeInTheDocument()
+      expect(screen.getByText('Create a policy to control which models your agents can access.')).toBeInTheDocument()
+    })
+  })
+
+  it('expands policy to show detail', async () => {
+    render(<PoliciesClient />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Default Policy')).toBeInTheDocument()
+    })
+
+    // Click the Default Policy row to expand it
+    fireEvent.click(screen.getByText('Default Policy'))
+
+    // Should show description, full allowed models, and aliases
+    await waitFor(() => {
+      expect(screen.getByText('Standard access')).toBeInTheDocument()
+      expect(screen.getByText('Model Aliases')).toBeInTheDocument()
+      expect(screen.getByText('fast')).toBeInTheDocument()
+    })
+  })
+
+  it('shows model alias mapping in expanded detail', async () => {
+    render(<PoliciesClient />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Default Policy')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByText('Default Policy'))
+
+    await waitFor(() => {
+      // Alias: fast → GPT-4o Mini
+      expect(screen.getByText('fast')).toBeInTheDocument()
+    })
+  })
+
+  it('opens create form with model multi-select', async () => {
+    render(<PoliciesClient />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Default Policy')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByText('Add Policy'))
+
+    expect(screen.getByText('New Policy')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('Agent Default Policy')).toBeInTheDocument()
+
+    // Model toggle buttons from user models
+    const modelButtons = screen.getAllByText('GPT-4o Mini')
+    expect(modelButtons.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('toggles model selection in create form', async () => {
+    render(<PoliciesClient />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Default Policy')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByText('Add Policy'))
+
+    // Find the toggle buttons in the form (Allowed Models section)
+    const formSection = screen.getByText('Allowed Models').parentElement!
+    const gptButton = formSection.querySelector('button')!
+    expect(gptButton).toBeInTheDocument()
+
+    // Click to select — should get brand styling
+    fireEvent.click(gptButton)
+    expect(gptButton.className).toContain('brand')
+
+    // Click again to deselect
+    fireEvent.click(gptButton)
+    expect(gptButton.className).not.toContain('bg-brand')
+  })
+
+  it('submits create form with correct body', async () => {
+    render(<PoliciesClient />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Default Policy')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByText('Add Policy'))
+
+    // Fill name
+    fireEvent.change(screen.getByPlaceholderText('Agent Default Policy'), { target: { value: 'Test Policy' } })
+
+    // Select a model
+    const formSection = screen.getByText('Allowed Models').parentElement!
+    const gptButton = formSection.querySelector('button')!
+    fireEvent.click(gptButton)
+
+    // Set rate limit
+    fireEvent.change(screen.getByPlaceholderText('60'), { target: { value: '30' } })
+
+    fireEvent.click(screen.getByText('Create'))
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith('/api/model-policies', expect.objectContaining({
+        method: 'POST',
+        body: expect.stringContaining('"name":"Test Policy"'),
+      }))
+    })
+  })
+
+  it('confirms before deleting', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false)
+
+    render(<PoliciesClient />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Default Policy')).toBeInTheDocument()
+    })
+
+    // Expand to see delete button
+    fireEvent.click(screen.getByText('Default Policy'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Delete')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByText('Delete'))
+
+    expect(confirmSpy).toHaveBeenCalled()
+    confirmSpy.mockRestore()
+  })
+})

--- a/services/ui/src/app/api/user-models/[...path]/route.ts
+++ b/services/ui/src/app/api/user-models/[...path]/route.ts
@@ -1,0 +1,13 @@
+import { NextRequest } from 'next/server'
+import { proxyToApi } from '@/utils/api-proxy'
+
+async function proxyRequest(req: NextRequest, { params }: { params: Promise<{ path: string[] }> }) {
+  const { path } = await params
+  const pathStr = path.join('/')
+  return proxyToApi(req, `/user-models/${pathStr}`, { label: 'user-models-proxy' })
+}
+
+export const GET = proxyRequest
+export const POST = proxyRequest
+export const PUT = proxyRequest
+export const DELETE = proxyRequest

--- a/services/ui/src/app/api/user-models/route.ts
+++ b/services/ui/src/app/api/user-models/route.ts
@@ -1,0 +1,9 @@
+import { NextRequest } from 'next/server'
+import { proxyToApi } from '@/utils/api-proxy'
+
+async function proxyRequest(req: NextRequest) {
+  return proxyToApi(req, '/user-models', { label: 'user-models-proxy' })
+}
+
+export const GET = proxyRequest
+export const POST = proxyRequest

--- a/services/ui/src/app/harness/models/ModelsClient.tsx
+++ b/services/ui/src/app/harness/models/ModelsClient.tsx
@@ -1,20 +1,306 @@
 'use client'
 
+import { useState, useEffect, useCallback } from 'react'
+
+interface UserModel {
+  id: string
+  name: string
+  connection_id: string
+  litellm_model: string
+  description: string
+  is_active: boolean
+  created_at: string
+  updated_at: string
+}
+
+interface ProviderConnection {
+  id: string
+  name: string
+  provider: string
+}
+
 export default function ModelsClient() {
+  const [models, setModels] = useState<UserModel[]>([])
+  const [connections, setConnections] = useState<ProviderConnection[]>([])
+  const [loading, setLoading] = useState(true)
+  const [showCreate, setShowCreate] = useState(false)
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [actionLoading, setActionLoading] = useState<string | null>(null)
+  const [formData, setFormData] = useState({ name: '', connection_id: '', litellm_model: '', description: '' })
+  const [formError, setFormError] = useState('')
+
+  const fetchData = useCallback(async () => {
+    try {
+      const [modelsRes, connsRes] = await Promise.all([
+        fetch('/api/user-models'),
+        fetch('/api/provider-connections'),
+      ])
+      if (modelsRes.ok) setModels(await modelsRes.json())
+      if (connsRes.ok) setConnections(await connsRes.json())
+    } catch (err) {
+      console.error('Failed to fetch data:', err)
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    fetchData()
+  }, [fetchData])
+
+  const connectionName = (id: string) =>
+    connections.find((c) => c.id === id)?.name ?? id.substring(0, 8)
+
+  const connectionProvider = (id: string) =>
+    connections.find((c) => c.id === id)?.provider ?? ''
+
+  const resetForm = () => {
+    setFormData({ name: '', connection_id: '', litellm_model: '', description: '' })
+    setFormError('')
+    setShowCreate(false)
+    setEditingId(null)
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setFormError('')
+
+    if (!formData.name.trim()) {
+      setFormError('Name is required')
+      return
+    }
+    if (!formData.connection_id) {
+      setFormError('Connection is required')
+      return
+    }
+    if (!formData.litellm_model.trim()) {
+      setFormError('Provider model ID is required')
+      return
+    }
+
+    const body: Record<string, string> = {
+      name: formData.name.trim(),
+      connection_id: formData.connection_id,
+      litellm_model: formData.litellm_model.trim(),
+    }
+    if (formData.description.trim()) {
+      body.description = formData.description.trim()
+    }
+
+    try {
+      const url = editingId
+        ? `/api/user-models/${editingId}`
+        : '/api/user-models'
+      const res = await fetch(url, {
+        method: editingId ? 'PUT' : 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      })
+
+      if (res.ok) {
+        resetForm()
+        await fetchData()
+      } else {
+        const data = await res.json()
+        setFormError(data.error || 'Failed to save model')
+      }
+    } catch {
+      setFormError('Request failed')
+    }
+  }
+
+  const handleEdit = (model: UserModel) => {
+    setFormData({
+      name: model.name,
+      connection_id: model.connection_id,
+      litellm_model: model.litellm_model,
+      description: model.description || '',
+    })
+    setEditingId(model.id)
+    setShowCreate(true)
+  }
+
+  const handleDelete = async (model: UserModel) => {
+    if (!confirm(`Delete model "${model.name}"? Policies referencing this model will need to be updated.`)) return
+    setActionLoading(model.id)
+    try {
+      const res = await fetch(`/api/user-models/${model.id}`, { method: 'DELETE' })
+      if (res.ok) {
+        await fetchData()
+      } else {
+        const data = await res.json()
+        alert(data.error || 'Failed to delete model')
+      }
+    } catch {
+      alert('Failed to delete model')
+    } finally {
+      setActionLoading(null)
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-24">
+        <div className="h-8 w-8 rounded-full border-2 border-brand-500 border-t-transparent animate-spin" />
+      </div>
+    )
+  }
+
   return (
     <>
-      <div className="mb-8">
-        <h1 className="text-2xl font-bold">User Models</h1>
-        <p className="text-sm text-mountain-400 mt-1">
-          Define models that reference your provider connections.
-        </p>
+      <div className="flex items-center justify-between mb-8">
+        <div>
+          <h1 className="text-2xl font-bold">User Models</h1>
+          <p className="text-sm text-mountain-400 mt-1">
+            {models.length} model{models.length !== 1 ? 's' : ''}
+          </p>
+        </div>
+        <button
+          onClick={() => { resetForm(); setShowCreate(true) }}
+          disabled={connections.length === 0}
+          title={connections.length === 0 ? 'Create a provider connection first' : undefined}
+          className="px-4 py-2 text-sm font-medium rounded-lg bg-brand-600 hover:bg-brand-500 text-white transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          Add Model
+        </button>
       </div>
-      <div className="rounded-lg border border-navy-700 bg-navy-800 p-12 text-center">
-        <p className="text-mountain-400 mb-2">Coming soon</p>
-        <p className="text-sm text-mountain-500">
-          Create models that map to your provider connections. Assign them to policies to control agent access.
-        </p>
-      </div>
+
+      {/* Create/Edit form */}
+      {showCreate && (
+        <div className="rounded-lg border border-navy-700 bg-navy-800 p-5 mb-6">
+          <h2 className="text-lg font-semibold text-white mb-4">
+            {editingId ? 'Edit Model' : 'New Model'}
+          </h2>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <div>
+                <label className="block text-sm text-mountain-400 mb-1">Name</label>
+                <input
+                  type="text"
+                  value={formData.name}
+                  onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+                  className="w-full rounded-md border border-navy-600 bg-navy-900 px-3 py-2 text-sm text-white placeholder-mountain-500 focus:border-brand-500 focus:outline-none"
+                  placeholder="GPT-4o Mini"
+                />
+              </div>
+              <div>
+                <label className="block text-sm text-mountain-400 mb-1">Connection</label>
+                <select
+                  value={formData.connection_id}
+                  onChange={(e) => setFormData({ ...formData, connection_id: e.target.value })}
+                  className="w-full rounded-md border border-navy-600 bg-navy-900 px-3 py-2 text-sm text-white focus:border-brand-500 focus:outline-none"
+                >
+                  <option value="">Select a connection</option>
+                  {connections.map((c) => (
+                    <option key={c.id} value={c.id}>{c.name} ({c.provider})</option>
+                  ))}
+                </select>
+              </div>
+            </div>
+            <div>
+              <label className="block text-sm text-mountain-400 mb-1">Provider Model ID</label>
+              <input
+                type="text"
+                value={formData.litellm_model}
+                onChange={(e) => setFormData({ ...formData, litellm_model: e.target.value })}
+                className="w-full rounded-md border border-navy-600 bg-navy-900 px-3 py-2 text-sm text-white placeholder-mountain-500 focus:border-brand-500 focus:outline-none"
+                placeholder="gpt-4o-mini"
+              />
+            </div>
+            <div>
+              <label className="block text-sm text-mountain-400 mb-1">
+                Description <span className="text-mountain-500">(optional)</span>
+              </label>
+              <input
+                type="text"
+                value={formData.description}
+                onChange={(e) => setFormData({ ...formData, description: e.target.value })}
+                className="w-full rounded-md border border-navy-600 bg-navy-900 px-3 py-2 text-sm text-white placeholder-mountain-500 focus:border-brand-500 focus:outline-none"
+                placeholder="Fast and affordable for most tasks"
+              />
+            </div>
+            {formError && (
+              <p className="text-sm text-red-400">{formError}</p>
+            )}
+            <div className="flex items-center gap-2">
+              <button
+                type="submit"
+                className="px-4 py-2 text-sm font-medium rounded-lg bg-brand-600 hover:bg-brand-500 text-white transition-colors cursor-pointer"
+              >
+                {editingId ? 'Update' : 'Create'}
+              </button>
+              <button
+                type="button"
+                onClick={resetForm}
+                className="px-4 py-2 text-sm font-medium rounded-lg border border-navy-600 text-mountain-400 hover:text-white hover:border-navy-500 transition-colors cursor-pointer"
+              >
+                Cancel
+              </button>
+            </div>
+          </form>
+        </div>
+      )}
+
+      {/* Models table */}
+      {models.length === 0 ? (
+        <div className="rounded-lg border border-navy-700 bg-navy-800 p-12 text-center">
+          <p className="text-mountain-400 mb-4">No models defined yet</p>
+          <p className="text-sm text-mountain-500">
+            {connections.length === 0
+              ? 'Create a provider connection first, then add models.'
+              : 'Create a model to use with your provider connections.'}
+          </p>
+        </div>
+      ) : (
+        <div className="rounded-lg border border-navy-700 overflow-hidden">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="bg-navy-800 text-mountain-400 text-left">
+                <th className="px-4 py-3 font-medium">Name</th>
+                <th className="px-4 py-3 font-medium">Provider Model</th>
+                <th className="px-4 py-3 font-medium">Connection</th>
+                <th className="px-4 py-3 font-medium">Created</th>
+                <th className="px-4 py-3 font-medium w-28"></th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-navy-700">
+              {models.map((model) => (
+                <tr key={model.id} className="bg-navy-900 hover:bg-navy-800 transition-colors">
+                  <td className="px-4 py-3">
+                    <div className="text-white font-medium">{model.name}</div>
+                    {model.description && (
+                      <div className="text-xs text-mountain-500 mt-0.5">{model.description}</div>
+                    )}
+                  </td>
+                  <td className="px-4 py-3 font-mono text-xs text-mountain-300">{model.litellm_model}</td>
+                  <td className="px-4 py-3">
+                    <span className="text-mountain-300">{connectionName(model.connection_id)}</span>
+                    <span className="text-mountain-500 text-xs ml-1">({connectionProvider(model.connection_id)})</span>
+                  </td>
+                  <td className="px-4 py-3 text-mountain-400">{new Date(model.created_at).toLocaleDateString()}</td>
+                  <td className="px-4 py-3">
+                    <div className="flex items-center gap-2 justify-end">
+                      <button
+                        onClick={() => handleEdit(model)}
+                        className="px-2.5 py-1 text-xs font-medium rounded-md border border-navy-600 text-mountain-400 hover:text-white hover:border-navy-500 transition-colors cursor-pointer"
+                      >
+                        Edit
+                      </button>
+                      <button
+                        onClick={() => handleDelete(model)}
+                        disabled={actionLoading === model.id}
+                        className="px-2.5 py-1 text-xs font-medium rounded-md border border-red-700 text-red-400 hover:bg-red-900/30 transition-colors disabled:opacity-50 cursor-pointer disabled:cursor-not-allowed"
+                      >
+                        Delete
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
     </>
   )
 }

--- a/services/ui/src/app/harness/policies/PoliciesClient.tsx
+++ b/services/ui/src/app/harness/policies/PoliciesClient.tsx
@@ -1,20 +1,436 @@
 'use client'
 
+import { useState, useEffect, useCallback } from 'react'
+
+interface ModelPolicy {
+  id: string
+  name: string
+  description: string
+  allowed_models: string[]
+  max_requests_per_minute: number | null
+  max_tokens_per_day: number | null
+  model_aliases?: Record<string, string>
+  created_at: string
+  updated_at: string
+  created_by: string | null
+}
+
+interface UserModel {
+  id: string
+  name: string
+  litellm_model: string
+}
+
 export default function PoliciesClient() {
+  const [policies, setPolicies] = useState<ModelPolicy[]>([])
+  const [userModels, setUserModels] = useState<UserModel[]>([])
+  const [loading, setLoading] = useState(true)
+  const [showCreate, setShowCreate] = useState(false)
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [expandedId, setExpandedId] = useState<string | null>(null)
+  const [actionLoading, setActionLoading] = useState<string | null>(null)
+  const [formData, setFormData] = useState({
+    name: '',
+    description: '',
+    allowed_models: [] as string[],
+    max_requests_per_minute: '',
+    max_tokens_per_day: '',
+  })
+  const [formError, setFormError] = useState('')
+
+  const fetchData = useCallback(async () => {
+    try {
+      const [policiesRes, modelsRes] = await Promise.all([
+        fetch('/api/model-policies'),
+        fetch('/api/user-models'),
+      ])
+      if (policiesRes.ok) setPolicies(await policiesRes.json())
+      if (modelsRes.ok) setUserModels(await modelsRes.json())
+    } catch (err) {
+      console.error('Failed to fetch data:', err)
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    fetchData()
+  }, [fetchData])
+
+  // Collect available model names from user models for the multi-select
+  const availableModels = userModels.map((m) => m.name)
+
+  const resetForm = () => {
+    setFormData({ name: '', description: '', allowed_models: [], max_requests_per_minute: '', max_tokens_per_day: '' })
+    setFormError('')
+    setShowCreate(false)
+    setEditingId(null)
+  }
+
+  const toggleModel = (modelName: string) => {
+    setFormData((prev) => ({
+      ...prev,
+      allowed_models: prev.allowed_models.includes(modelName)
+        ? prev.allowed_models.filter((m) => m !== modelName)
+        : [...prev.allowed_models, modelName],
+    }))
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setFormError('')
+
+    if (!formData.name.trim()) {
+      setFormError('Name is required')
+      return
+    }
+    if (formData.allowed_models.length === 0) {
+      setFormError('At least one allowed model is required')
+      return
+    }
+
+    const body: Record<string, unknown> = {
+      name: formData.name.trim(),
+      allowed_models: formData.allowed_models,
+    }
+    if (formData.description.trim()) {
+      body.description = formData.description.trim()
+    }
+    if (formData.max_requests_per_minute) {
+      body.max_requests_per_minute = parseInt(formData.max_requests_per_minute, 10)
+    } else {
+      body.max_requests_per_minute = null
+    }
+    if (formData.max_tokens_per_day) {
+      body.max_tokens_per_day = parseInt(formData.max_tokens_per_day, 10)
+    } else {
+      body.max_tokens_per_day = null
+    }
+
+    try {
+      const url = editingId
+        ? `/api/model-policies/${editingId}`
+        : '/api/model-policies'
+      const res = await fetch(url, {
+        method: editingId ? 'PUT' : 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      })
+
+      if (res.ok) {
+        resetForm()
+        await fetchData()
+      } else {
+        const data = await res.json()
+        setFormError(data.error || 'Failed to save policy')
+      }
+    } catch {
+      setFormError('Request failed')
+    }
+  }
+
+  const handleEdit = (policy: ModelPolicy) => {
+    setFormData({
+      name: policy.name,
+      description: policy.description || '',
+      allowed_models: [...policy.allowed_models],
+      max_requests_per_minute: policy.max_requests_per_minute?.toString() ?? '',
+      max_tokens_per_day: policy.max_tokens_per_day?.toString() ?? '',
+    })
+    setEditingId(policy.id)
+    setShowCreate(true)
+  }
+
+  const handleDelete = async (policy: ModelPolicy) => {
+    if (!confirm(`Delete policy "${policy.name}"? Agents using this policy will lose their model access configuration.`)) return
+    setActionLoading(policy.id)
+    try {
+      const res = await fetch(`/api/model-policies/${policy.id}`, { method: 'DELETE' })
+      if (res.ok) {
+        await fetchData()
+      } else {
+        const data = await res.json()
+        alert(data.error || 'Failed to delete policy')
+      }
+    } catch {
+      alert('Failed to delete policy')
+    } finally {
+      setActionLoading(null)
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-24">
+        <div className="h-8 w-8 rounded-full border-2 border-brand-500 border-t-transparent animate-spin" />
+      </div>
+    )
+  }
+
   return (
     <>
-      <div className="mb-8">
-        <h1 className="text-2xl font-bold">Model Policies</h1>
-        <p className="text-sm text-mountain-400 mt-1">
-          Control which models your agents can access, with rate limits and token budgets.
-        </p>
+      <div className="flex items-center justify-between mb-8">
+        <div>
+          <h1 className="text-2xl font-bold">Model Policies</h1>
+          <p className="text-sm text-mountain-400 mt-1">
+            {policies.length} polic{policies.length !== 1 ? 'ies' : 'y'}
+          </p>
+        </div>
+        <button
+          onClick={() => { resetForm(); setShowCreate(true) }}
+          className="px-4 py-2 text-sm font-medium rounded-lg bg-brand-600 hover:bg-brand-500 text-white transition-colors cursor-pointer"
+        >
+          Add Policy
+        </button>
       </div>
-      <div className="rounded-lg border border-navy-700 bg-navy-800 p-12 text-center">
-        <p className="text-mountain-400 mb-2">Coming soon</p>
-        <p className="text-sm text-mountain-500">
-          Create policies that define allowed models, rate limits, and token budgets. Assign policies to agents to control their model access.
-        </p>
-      </div>
+
+      {/* Create/Edit form */}
+      {showCreate && (
+        <div className="rounded-lg border border-navy-700 bg-navy-800 p-5 mb-6">
+          <h2 className="text-lg font-semibold text-white mb-4">
+            {editingId ? 'Edit Policy' : 'New Policy'}
+          </h2>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <div>
+                <label className="block text-sm text-mountain-400 mb-1">Name</label>
+                <input
+                  type="text"
+                  value={formData.name}
+                  onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+                  className="w-full rounded-md border border-navy-600 bg-navy-900 px-3 py-2 text-sm text-white placeholder-mountain-500 focus:border-brand-500 focus:outline-none"
+                  placeholder="Agent Default Policy"
+                />
+              </div>
+              <div>
+                <label className="block text-sm text-mountain-400 mb-1">
+                  Description <span className="text-mountain-500">(optional)</span>
+                </label>
+                <input
+                  type="text"
+                  value={formData.description}
+                  onChange={(e) => setFormData({ ...formData, description: e.target.value })}
+                  className="w-full rounded-md border border-navy-600 bg-navy-900 px-3 py-2 text-sm text-white placeholder-mountain-500 focus:border-brand-500 focus:outline-none"
+                  placeholder="Standard access for production agents"
+                />
+              </div>
+            </div>
+
+            <div>
+              <label className="block text-sm text-mountain-400 mb-2">Allowed Models</label>
+              {availableModels.length === 0 ? (
+                <p className="text-sm text-mountain-500">No user models available. Create models first.</p>
+              ) : (
+                <div className="flex flex-wrap gap-2">
+                  {availableModels.map((name) => (
+                    <button
+                      key={name}
+                      type="button"
+                      onClick={() => toggleModel(name)}
+                      className={`px-3 py-1.5 text-xs font-medium rounded-md border transition-colors cursor-pointer ${
+                        formData.allowed_models.includes(name)
+                          ? 'bg-brand-900/50 text-brand-400 border-brand-700'
+                          : 'bg-navy-900 text-mountain-400 border-navy-600 hover:border-navy-500'
+                      }`}
+                    >
+                      {name}
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <div>
+                <label className="block text-sm text-mountain-400 mb-1">
+                  Rate Limit <span className="text-mountain-500">(requests/min, blank = unlimited)</span>
+                </label>
+                <input
+                  type="number"
+                  min="1"
+                  value={formData.max_requests_per_minute}
+                  onChange={(e) => setFormData({ ...formData, max_requests_per_minute: e.target.value })}
+                  className="w-full rounded-md border border-navy-600 bg-navy-900 px-3 py-2 text-sm text-white placeholder-mountain-500 focus:border-brand-500 focus:outline-none"
+                  placeholder="60"
+                />
+              </div>
+              <div>
+                <label className="block text-sm text-mountain-400 mb-1">
+                  Token Budget <span className="text-mountain-500">(tokens/day, blank = unlimited)</span>
+                </label>
+                <input
+                  type="number"
+                  min="1"
+                  value={formData.max_tokens_per_day}
+                  onChange={(e) => setFormData({ ...formData, max_tokens_per_day: e.target.value })}
+                  className="w-full rounded-md border border-navy-600 bg-navy-900 px-3 py-2 text-sm text-white placeholder-mountain-500 focus:border-brand-500 focus:outline-none"
+                  placeholder="1000000"
+                />
+              </div>
+            </div>
+
+            {formError && (
+              <p className="text-sm text-red-400">{formError}</p>
+            )}
+            <div className="flex items-center gap-2">
+              <button
+                type="submit"
+                className="px-4 py-2 text-sm font-medium rounded-lg bg-brand-600 hover:bg-brand-500 text-white transition-colors cursor-pointer"
+              >
+                {editingId ? 'Update' : 'Create'}
+              </button>
+              <button
+                type="button"
+                onClick={resetForm}
+                className="px-4 py-2 text-sm font-medium rounded-lg border border-navy-600 text-mountain-400 hover:text-white hover:border-navy-500 transition-colors cursor-pointer"
+              >
+                Cancel
+              </button>
+            </div>
+          </form>
+        </div>
+      )}
+
+      {/* Policies table */}
+      {policies.length === 0 ? (
+        <div className="rounded-lg border border-navy-700 bg-navy-800 p-12 text-center">
+          <p className="text-mountain-400 mb-4">No model policies yet</p>
+          <p className="text-sm text-mountain-500">
+            Create a policy to control which models your agents can access.
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {policies.map((policy) => {
+            const isExpanded = expandedId === policy.id
+            const aliases = policy.model_aliases && Object.keys(policy.model_aliases).length > 0
+              ? policy.model_aliases
+              : null
+
+            return (
+              <div
+                key={policy.id}
+                className="rounded-lg border border-navy-700 bg-navy-900 overflow-hidden"
+              >
+                {/* Summary row */}
+                <div
+                  className="flex items-center gap-4 px-4 py-3 cursor-pointer hover:bg-navy-800 transition-colors"
+                  onClick={() => setExpandedId(isExpanded ? null : policy.id)}
+                  role="button"
+                  tabIndex={0}
+                  aria-expanded={isExpanded}
+                  onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') setExpandedId(isExpanded ? null : policy.id) }}
+                >
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-3">
+                      <span className="font-medium text-white">{policy.name}</span>
+                      <div className="flex flex-wrap gap-1">
+                        {policy.allowed_models.slice(0, 3).map((m) => (
+                          <span
+                            key={m}
+                            className="px-2 py-0.5 text-xs rounded-md bg-brand-900/50 text-brand-400 border border-brand-700"
+                          >
+                            {m}
+                          </span>
+                        ))}
+                        {policy.allowed_models.length > 3 && (
+                          <span className="px-2 py-0.5 text-xs rounded-md bg-navy-800 text-mountain-400 border border-navy-700">
+                            +{policy.allowed_models.length - 3}
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-4 text-xs text-mountain-400 shrink-0">
+                    <span>{policy.max_requests_per_minute ? `${policy.max_requests_per_minute} req/min` : 'No rate limit'}</span>
+                    <span>{policy.max_tokens_per_day ? `${policy.max_tokens_per_day.toLocaleString()} tok/day` : 'No token budget'}</span>
+                    <svg
+                      className={`w-4 h-4 transition-transform ${isExpanded ? 'rotate-180' : ''}`}
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                    >
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                    </svg>
+                  </div>
+                </div>
+
+                {/* Expanded detail */}
+                {isExpanded && (
+                  <div className="border-t border-navy-700 px-4 py-4 bg-navy-800/50">
+                    <dl className="grid grid-cols-1 sm:grid-cols-2 gap-4 text-sm mb-4">
+                      {policy.description && (
+                        <div className="sm:col-span-2">
+                          <dt className="text-mountain-400">Description</dt>
+                          <dd className="text-white mt-1">{policy.description}</dd>
+                        </div>
+                      )}
+                      <div>
+                        <dt className="text-mountain-400">Allowed Models</dt>
+                        <dd className="flex flex-wrap gap-1 mt-1">
+                          {policy.allowed_models.map((m) => (
+                            <span
+                              key={m}
+                              className="px-2 py-0.5 text-xs rounded-md bg-brand-900/50 text-brand-400 border border-brand-700"
+                            >
+                              {m}
+                            </span>
+                          ))}
+                        </dd>
+                      </div>
+                      <div>
+                        <dt className="text-mountain-400">Limits</dt>
+                        <dd className="text-white mt-1">
+                          {policy.max_requests_per_minute
+                            ? `${policy.max_requests_per_minute} requests/min`
+                            : 'Unlimited requests'}
+                          {' / '}
+                          {policy.max_tokens_per_day
+                            ? `${policy.max_tokens_per_day.toLocaleString()} tokens/day`
+                            : 'Unlimited tokens'}
+                        </dd>
+                      </div>
+                      {aliases && (
+                        <div className="sm:col-span-2">
+                          <dt className="text-mountain-400">Model Aliases</dt>
+                          <dd className="mt-1 space-y-1">
+                            {Object.entries(aliases).map(([alias, target]) => (
+                              <div key={alias} className="text-xs font-mono">
+                                <span className="text-mountain-300">{alias}</span>
+                                <span className="text-mountain-500 mx-2">&rarr;</span>
+                                <span className="text-brand-400">{target}</span>
+                              </div>
+                            ))}
+                          </dd>
+                        </div>
+                      )}
+                      <div>
+                        <dt className="text-mountain-400">Created</dt>
+                        <dd className="text-white mt-1">{new Date(policy.created_at).toLocaleString()}</dd>
+                      </div>
+                    </dl>
+                    <div className="flex items-center gap-2">
+                      <button
+                        onClick={() => handleEdit(policy)}
+                        className="px-3 py-1.5 text-xs font-medium rounded-md border border-navy-600 text-mountain-400 hover:text-white hover:border-navy-500 transition-colors cursor-pointer"
+                      >
+                        Edit
+                      </button>
+                      <button
+                        onClick={() => handleDelete(policy)}
+                        disabled={actionLoading === policy.id}
+                        className="px-3 py-1.5 text-xs font-medium rounded-md border border-red-700 text-red-400 hover:bg-red-900/30 transition-colors disabled:opacity-50 cursor-pointer disabled:cursor-not-allowed"
+                      >
+                        Delete
+                      </button>
+                    </div>
+                  </div>
+                )}
+              </div>
+            )
+          })}
+        </div>
+      )}
     </>
   )
 }


### PR DESCRIPTION
## Summary
- Replace Models placeholder with full CRUD page: table with name, provider model ID, connection name (client-side join from `/api/provider-connections`), created date; create/edit form with connection dropdown, provider model ID field, description
- Replace Policies placeholder with full CRUD page: expandable rows showing allowed model chips, rate limit, token budget; create/edit form with model multi-select toggle buttons, rate/token limit inputs; model aliases read-only display in expanded detail
- Add BFF proxy routes for `/api/user-models` (GET, POST) and `/api/user-models/[...path]` (PUT, DELETE)

## Plan Reference
PR 2 of 4 in Harness Control Plane UI plan (steps 7-9).

## Files Changed (6 files, +1147 -22)

| File | Change |
|------|--------|
| `src/app/api/user-models/route.ts` | NEW — BFF proxy GET/POST |
| `src/app/api/user-models/[...path]/route.ts` | NEW — BFF proxy catch-all |
| `src/app/harness/models/ModelsClient.tsx` | Replaced placeholder with full CRUD (~308 lines) |
| `src/app/harness/policies/PoliciesClient.tsx` | Replaced placeholder with full CRUD (~438 lines) |
| `src/__tests__/ModelsClient.test.tsx` | NEW — 8 tests |
| `src/__tests__/PoliciesClient.test.tsx` | NEW — 9 tests |

## Tests Added
- **ModelsClient.test.tsx** (8 tests): render table with connection name join, provider model IDs, empty state, connection-first hint, disabled Add when no connections, create form with connection dropdown, submit with correct body, confirm before delete
- **PoliciesClient.test.tsx** (9 tests): render rows with model chips, rate/token limits in summary, empty state, expand to show detail, model alias display, create form with model multi-select, toggle model selection, submit with correct body, confirm before delete

## Verification

```
$ npx vitest run src/__tests__/ModelsClient.test.tsx src/__tests__/PoliciesClient.test.tsx \
    src/__tests__/api-proxy.test.ts src/__tests__/ConnectionsClient.test.tsx src/__tests__/agents-proxy.test.ts
 ✓ src/__tests__/agents-proxy.test.ts (5 tests)
 ✓ src/__tests__/api-proxy.test.ts (7 tests)
 ✓ src/__tests__/ConnectionsClient.test.tsx (8 tests)
 ✓ src/__tests__/ModelsClient.test.tsx (8 tests)
 ✓ src/__tests__/PoliciesClient.test.tsx (9 tests)
 Test Files  5 passed (5)
      Tests  37 passed (37)

$ npx next build
 ✓ Build succeeds — all routes present, no type errors
 Routes: /api/user-models, /api/user-models/[...path],
         /harness/models, /harness/policies (+ all prior routes)
```

## Deviations from Plan
None.

## Test plan
- [x] `npx vitest run` — new + existing tests pass (37/37)
- [x] `npx next build` — build succeeds, all routes present
- [x] Models page replaces placeholder completely
- [x] Policies page replaces placeholder completely
- [ ] CI: Run Tests workflow
- [ ] CI: security/snyk scan
- [ ] CI: Agent Loop gate (advisory)

🤖 Generated with [Claude Code](https://claude.com/claude-code)