### PR TITLE
feat: harness UI usage & knowledge pages

### DIFF
--- a/services/ui/src/__tests__/KnowledgeClient.test.tsx
+++ b/services/ui/src/__tests__/KnowledgeClient.test.tsx
@@ -1,0 +1,261 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+
+// Mock global fetch
+const mockFetch = vi.fn()
+vi.stubGlobal('fetch', mockFetch)
+
+import KnowledgeClient from '@/app/harness/knowledge/KnowledgeClient'
+
+const MOCK_AGENTS = [
+  { id: 'agent-uuid-1', name: 'ResearchBot', agent_id: 'research-bot' },
+  { id: 'agent-uuid-2', name: 'WriterBot', agent_id: 'writer-bot' },
+]
+
+const MOCK_KNOWLEDGE_AGENTS = [
+  { agent_id: 'agent-uuid-1', entry_count: 5, last_updated: '2026-02-28T12:00:00Z' },
+  { agent_id: 'agent-uuid-2', entry_count: 3, last_updated: '2026-02-27T12:00:00Z' },
+]
+
+const MOCK_ENTRIES = [
+  {
+    id: 'entry-1',
+    agent_id: 'agent-uuid-1',
+    path: 'notes/setup.md',
+    title: 'Setup Notes',
+    entry_type: 'note',
+    tags: ['setup'],
+    status: 'active',
+    created_at: '2026-02-25T00:00:00Z',
+    updated_at: '2026-02-28T12:00:00Z',
+  },
+  {
+    id: 'entry-2',
+    agent_id: 'agent-uuid-1',
+    path: 'plans/migration.md',
+    title: 'Migration Plan',
+    entry_type: 'plan',
+    tags: ['migration', 'database'],
+    status: 'active',
+    created_at: '2026-02-26T00:00:00Z',
+    updated_at: '2026-02-28T12:00:00Z',
+  },
+]
+
+const MOCK_ENTRY_FULL = {
+  ...MOCK_ENTRIES[0],
+  content: '# Setup Notes\n\nThis is the content of the entry.',
+}
+
+const MOCK_SEARCH_RESULTS = {
+  results: [
+    {
+      id: 'entry-1',
+      agent_id: 'agent-uuid-1',
+      path: 'notes/setup.md',
+      title: 'Setup Notes',
+      entry_type: 'note',
+      tags: ['setup'],
+      score: 0.95,
+      headline: 'This is the <b>setup</b> guide',
+      created_at: '2026-02-25T00:00:00Z',
+      updated_at: '2026-02-28T12:00:00Z',
+    },
+  ],
+  count: 1,
+  search_type: 'text',
+  score_type: 'ts_rank',
+}
+
+function mockFetchDefaults() {
+  mockFetch.mockImplementation((url: string) => {
+    if (url === '/api/knowledge/agents') {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_KNOWLEDGE_AGENTS) })
+    }
+    if (url === '/api/agents') {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_AGENTS) })
+    }
+    if (typeof url === 'string' && url.startsWith('/api/knowledge/entries?')) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_ENTRIES) })
+    }
+    if (typeof url === 'string' && url.startsWith('/api/knowledge/entries/')) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_ENTRY_FULL) })
+    }
+    if (typeof url === 'string' && url.startsWith('/api/knowledge/search')) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_SEARCH_RESULTS) })
+    }
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+  })
+}
+
+describe('KnowledgeClient', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockFetchDefaults()
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('renders agent list with names and entry counts', async () => {
+    render(<KnowledgeClient />)
+
+    await waitFor(() => {
+      expect(screen.getByText('ResearchBot')).toBeInTheDocument()
+      expect(screen.getByText('WriterBot')).toBeInTheDocument()
+    })
+
+    // Entry counts rendered as "5 entries" split across text nodes
+    expect(screen.getByText(/5/)).toBeInTheDocument()
+    expect(screen.getByText(/3/)).toBeInTheDocument()
+  })
+
+  it('shows placeholder when no agent selected', async () => {
+    render(<KnowledgeClient />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Select an agent to browse knowledge')).toBeInTheDocument()
+    })
+  })
+
+  it('fetches entries when agent is selected', async () => {
+    render(<KnowledgeClient />)
+
+    await waitFor(() => {
+      expect(screen.getByText('ResearchBot')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByText('ResearchBot'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Setup Notes')).toBeInTheDocument()
+      expect(screen.getByText('Migration Plan')).toBeInTheDocument()
+    })
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('/api/knowledge/entries?agent_id=agent-uuid-1')
+    )
+  })
+
+  it('shows type filter badges', async () => {
+    render(<KnowledgeClient />)
+
+    await waitFor(() => {
+      expect(screen.getByText('ResearchBot')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByText('ResearchBot'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Setup Notes')).toBeInTheDocument()
+    })
+
+    // Type filter buttons
+    const buttons = screen.getAllByRole('button')
+    const buttonTexts = buttons.map(b => b.textContent)
+    expect(buttonTexts).toContain('All')
+    expect(buttonTexts).toContain('note')
+    expect(buttonTexts).toContain('plan')
+    expect(buttonTexts).toContain('decision')
+    expect(buttonTexts).toContain('journal')
+    expect(buttonTexts).toContain('research')
+  })
+
+  it('fetches and displays entry content on click', async () => {
+    render(<KnowledgeClient />)
+
+    await waitFor(() => {
+      expect(screen.getByText('ResearchBot')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByText('ResearchBot'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Setup Notes')).toBeInTheDocument()
+    })
+
+    // Click the entry row in the table
+    fireEvent.click(screen.getByText('Setup Notes'))
+
+    await waitFor(() => {
+      // Content is rendered in a <pre> tag
+      const preElement = document.querySelector('pre')
+      expect(preElement).not.toBeNull()
+      expect(preElement!.textContent).toContain('# Setup Notes')
+      expect(preElement!.textContent).toContain('This is the content of the entry.')
+    })
+
+    // Verify the fetch was called with the correct path
+    expect(mockFetch).toHaveBeenCalledWith('/api/knowledge/entries/agent-uuid-1/notes/setup.md')
+  })
+
+  it('performs search and shows results', async () => {
+    render(<KnowledgeClient />)
+
+    await waitFor(() => {
+      expect(screen.getByText('ResearchBot')).toBeInTheDocument()
+    })
+
+    const searchInput = screen.getByPlaceholderText('Search across all knowledge entries...')
+    fireEvent.change(searchInput, { target: { value: 'setup' } })
+
+    // Click the Search button
+    const searchButton = screen.getAllByRole('button').find(b => b.textContent === 'Search')!
+    fireEvent.click(searchButton)
+
+    await waitFor(() => {
+      expect(screen.getByText(/1 result/)).toBeInTheDocument()
+    })
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('/api/knowledge/search?q=setup')
+    )
+  })
+
+  it('clears search and returns to browse view', async () => {
+    render(<KnowledgeClient />)
+
+    await waitFor(() => {
+      expect(screen.getByText('ResearchBot')).toBeInTheDocument()
+    })
+
+    const searchInput = screen.getByPlaceholderText('Search across all knowledge entries...')
+    fireEvent.change(searchInput, { target: { value: 'setup' } })
+
+    const searchButton = screen.getAllByRole('button').find(b => b.textContent === 'Search')!
+    fireEvent.click(searchButton)
+
+    await waitFor(() => {
+      expect(screen.getByText(/1 result/)).toBeInTheDocument()
+    })
+
+    const clearButton = screen.getAllByRole('button').find(b => b.textContent === 'Clear')!
+    fireEvent.click(clearButton)
+
+    // Should return to agent browse view
+    await waitFor(() => {
+      expect(screen.getByText('Select an agent to browse knowledge')).toBeInTheDocument()
+    })
+  })
+
+  it('shows empty state when no knowledge agents', async () => {
+    mockFetch.mockImplementation((url: string) => {
+      if (url === '/api/knowledge/agents') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve([]) })
+      }
+      if (url === '/api/agents') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve([]) })
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+    })
+
+    render(<KnowledgeClient />)
+
+    await waitFor(() => {
+      expect(screen.getByText('No agents with knowledge entries yet')).toBeInTheDocument()
+    })
+  })
+})

--- a/services/ui/src/__tests__/UsageClient.test.tsx
+++ b/services/ui/src/__tests__/UsageClient.test.tsx
@@ -1,0 +1,178 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+
+// Mock global fetch
+const mockFetch = vi.fn()
+vi.stubGlobal('fetch', mockFetch)
+
+import UsageClient from '@/app/harness/usage/UsageClient'
+
+const MOCK_SUMMARY = {
+  total_requests: 142,
+  successful_requests: 140,
+  total_input_tokens: 50000,
+  total_output_tokens: 25000,
+  total_tokens: 75000,
+  total_cost_usd: 1.2345,
+}
+
+const MOCK_AGENTS = [
+  { id: 'agent-uuid-1', name: 'ResearchBot', agent_id: 'research-bot' },
+  { id: 'agent-uuid-2', name: 'WriterBot', agent_id: 'writer-bot' },
+]
+
+const MOCK_GROUPED_BY_AGENT = {
+  data: [
+    { agent_id: 'agent-uuid-1', total_requests: 100, total_tokens: 50000, total_cost_usd: 0.8 },
+    { agent_id: 'agent-uuid-2', total_requests: 42, total_tokens: 25000, total_cost_usd: 0.4345 },
+  ],
+  group_by: 'agent',
+}
+
+const MOCK_GROUPED_BY_MODEL = {
+  data: [
+    { model_name: 'gpt-4o-mini', total_requests: 120, total_tokens: 60000, total_cost_usd: 0.9 },
+    { model_name: 'claude-sonnet', total_requests: 22, total_tokens: 15000, total_cost_usd: 0.3345 },
+  ],
+  group_by: 'model',
+}
+
+function mockFetchResponses(grouped = MOCK_GROUPED_BY_AGENT) {
+  mockFetch.mockImplementation((url: string) => {
+    if (typeof url === 'string' && url.startsWith('/api/usage') && url.includes('group_by')) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(grouped) })
+    }
+    if (typeof url === 'string' && url.startsWith('/api/usage')) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_SUMMARY) })
+    }
+    if (url === '/api/agents') {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_AGENTS) })
+    }
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+  })
+}
+
+describe('UsageClient', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockFetchResponses()
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('renders summary cards with formatted values', async () => {
+    render(<UsageClient />)
+
+    await waitFor(() => {
+      expect(screen.getByText('142')).toBeInTheDocument()
+      expect(screen.getByText('75,000')).toBeInTheDocument()
+      expect(screen.getByText('$1.2345')).toBeInTheDocument()
+    })
+
+    expect(screen.getByText('Total Requests')).toBeInTheDocument()
+    expect(screen.getByText('Total Tokens')).toBeInTheDocument()
+    expect(screen.getByText('Estimated Cost')).toBeInTheDocument()
+  })
+
+  it('renders grouped data table with agent names', async () => {
+    render(<UsageClient />)
+
+    // Agent names appear in both table rows and the filter dropdown
+    await waitFor(() => {
+      expect(screen.getAllByText('ResearchBot').length).toBeGreaterThanOrEqual(1)
+      expect(screen.getAllByText('WriterBot').length).toBeGreaterThanOrEqual(1)
+    })
+  })
+
+  it('shows empty state when no data', async () => {
+    mockFetch.mockImplementation((url: string) => {
+      if (typeof url === 'string' && url.startsWith('/api/usage') && url.includes('group_by')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ data: [] }) })
+      }
+      if (typeof url === 'string' && url.startsWith('/api/usage')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_SUMMARY) })
+      }
+      if (url === '/api/agents') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve([]) })
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+    })
+
+    render(<UsageClient />)
+
+    await waitFor(() => {
+      expect(screen.getByText('No usage data yet')).toBeInTheDocument()
+    })
+  })
+
+  it('renders group-by toggle buttons', async () => {
+    render(<UsageClient />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Group by:')).toBeInTheDocument()
+    })
+
+    // Group-by buttons (Agent, Model, Day) exist as toggle buttons
+    const buttons = screen.getAllByRole('button')
+    const buttonTexts = buttons.map(b => b.textContent)
+    expect(buttonTexts).toContain('Agent')
+    expect(buttonTexts).toContain('Model')
+    expect(buttonTexts).toContain('Day')
+  })
+
+  it('changes group-by and re-fetches', async () => {
+    render(<UsageClient />)
+
+    await waitFor(() => {
+      expect(screen.getAllByText('ResearchBot').length).toBeGreaterThanOrEqual(1)
+    })
+
+    mockFetchResponses(MOCK_GROUPED_BY_MODEL)
+
+    // Click the "Model" group-by button (not the filter label)
+    const buttons = screen.getAllByRole('button')
+    const modelButton = buttons.find(b => b.textContent === 'Model')!
+    fireEvent.click(modelButton)
+
+    await waitFor(() => {
+      expect(screen.getByText('gpt-4o-mini')).toBeInTheDocument()
+    })
+  })
+
+  it('renders filter bar with date inputs and agent dropdown', async () => {
+    render(<UsageClient />)
+
+    await waitFor(() => {
+      expect(screen.getAllByText('ResearchBot').length).toBeGreaterThanOrEqual(1)
+    })
+
+    // Date inputs
+    const dateInputs = screen.getAllByDisplayValue(/^\d{4}-\d{2}-\d{2}$/)
+    expect(dateInputs.length).toBe(2)
+
+    // Agent dropdown
+    expect(screen.getByText('All agents')).toBeInTheDocument()
+
+    // Model filter input
+    expect(screen.getByPlaceholderText('Filter by model')).toBeInTheDocument()
+  })
+
+  it('shows table header matching group-by selection', async () => {
+    render(<UsageClient />)
+
+    await waitFor(() => {
+      expect(screen.getAllByText('ResearchBot').length).toBeGreaterThanOrEqual(1)
+    })
+
+    // Default group is 'agent', first column header should say "Agent"
+    const headers = screen.getAllByRole('columnheader')
+    expect(headers[0]).toHaveTextContent('Agent')
+    expect(headers[1]).toHaveTextContent('Requests')
+    expect(headers[2]).toHaveTextContent('Tokens')
+    expect(headers[3]).toHaveTextContent('Cost')
+  })
+})

--- a/services/ui/src/app/api/knowledge/[...path]/route.ts
+++ b/services/ui/src/app/api/knowledge/[...path]/route.ts
@@ -1,0 +1,10 @@
+import { NextRequest } from 'next/server'
+import { proxyToApi } from '@/utils/api-proxy'
+
+async function proxyRequest(req: NextRequest, { params }: { params: Promise<{ path: string[] }> }) {
+  const { path } = await params
+  const pathStr = path.join('/')
+  return proxyToApi(req, `/knowledge/${pathStr}`, { label: 'knowledge-proxy' })
+}
+
+export const GET = proxyRequest

--- a/services/ui/src/app/api/usage/route.ts
+++ b/services/ui/src/app/api/usage/route.ts
@@ -1,0 +1,8 @@
+import { NextRequest } from 'next/server'
+import { proxyToApi } from '@/utils/api-proxy'
+
+async function proxyRequest(req: NextRequest) {
+  return proxyToApi(req, '/usage', { label: 'usage-proxy' })
+}
+
+export const GET = proxyRequest

--- a/services/ui/src/app/harness/knowledge/KnowledgeClient.tsx
+++ b/services/ui/src/app/harness/knowledge/KnowledgeClient.tsx
@@ -1,6 +1,168 @@
 'use client'
 
+import { useState, useEffect, useCallback } from 'react'
+
+interface KnowledgeAgent {
+  agent_id: string
+  entry_count: number
+  last_updated: string
+}
+
+interface KnowledgeEntry {
+  id: string
+  agent_id: string
+  path: string
+  title: string
+  entry_type: string
+  tags: string[]
+  status: string
+  created_at: string
+  updated_at: string
+}
+
+interface KnowledgeEntryFull extends KnowledgeEntry {
+  content: string
+}
+
+interface SearchResult {
+  id: string
+  agent_id: string
+  path: string
+  title: string
+  entry_type: string
+  tags: string[]
+  score: number
+  headline: string
+  created_at: string
+  updated_at: string
+}
+
+interface Agent {
+  id: string
+  name: string
+  agent_id: string
+}
+
+const ENTRY_TYPES = ['note', 'plan', 'decision', 'journal', 'research'] as const
+
+function typeBadgeColor(type: string): string {
+  switch (type) {
+    case 'plan': return 'bg-blue-900/40 text-blue-400 border-blue-700'
+    case 'decision': return 'bg-purple-900/40 text-purple-400 border-purple-700'
+    case 'journal': return 'bg-amber-900/40 text-amber-400 border-amber-700'
+    case 'research': return 'bg-cyan-900/40 text-cyan-400 border-cyan-700'
+    case 'note':
+    default: return 'bg-navy-700/50 text-mountain-300 border-navy-600'
+  }
+}
+
 export default function KnowledgeClient() {
+  const [knowledgeAgents, setKnowledgeAgents] = useState<KnowledgeAgent[]>([])
+  const [agents, setAgents] = useState<Agent[]>([])
+  const [entries, setEntries] = useState<KnowledgeEntry[]>([])
+  const [selectedAgent, setSelectedAgent] = useState<string | null>(null)
+  const [selectedEntry, setSelectedEntry] = useState<KnowledgeEntryFull | null>(null)
+  const [typeFilter, setTypeFilter] = useState<string>('')
+  const [searchQuery, setSearchQuery] = useState('')
+  const [searchResults, setSearchResults] = useState<SearchResult[]>([])
+  const [isSearching, setIsSearching] = useState(false)
+  const [loading, setLoading] = useState(true)
+  const [entriesLoading, setEntriesLoading] = useState(false)
+  const [contentLoading, setContentLoading] = useState(false)
+
+  const agentName = useCallback((agentId: string) =>
+    agents.find((a) => a.id === agentId || a.agent_id === agentId)?.name ?? agentId.substring(0, 8),
+  [agents])
+
+  const fetchInitialData = useCallback(async () => {
+    try {
+      const [kaRes, agentsRes] = await Promise.all([
+        fetch('/api/knowledge/agents'),
+        fetch('/api/agents'),
+      ])
+      if (kaRes.ok) setKnowledgeAgents(await kaRes.json())
+      if (agentsRes.ok) setAgents(await agentsRes.json())
+    } catch (err) {
+      console.error('Failed to fetch knowledge data:', err)
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    fetchInitialData()
+  }, [fetchInitialData])
+
+  const fetchEntries = useCallback(async (agentId: string) => {
+    setEntriesLoading(true)
+    setSelectedEntry(null)
+    try {
+      const params = new URLSearchParams({ agent_id: agentId })
+      if (typeFilter) params.set('type', typeFilter)
+      const res = await fetch(`/api/knowledge/entries?${params}`)
+      if (res.ok) setEntries(await res.json())
+    } catch (err) {
+      console.error('Failed to fetch entries:', err)
+    } finally {
+      setEntriesLoading(false)
+    }
+  }, [typeFilter])
+
+  useEffect(() => {
+    if (selectedAgent) {
+      fetchEntries(selectedAgent)
+    }
+  }, [selectedAgent, fetchEntries])
+
+  const fetchContent = async (entry: KnowledgeEntry) => {
+    setContentLoading(true)
+    try {
+      const res = await fetch(`/api/knowledge/entries/${entry.agent_id}/${entry.path}`)
+      if (res.ok) {
+        const full: KnowledgeEntryFull = await res.json()
+        setSelectedEntry(full)
+      }
+    } catch (err) {
+      console.error('Failed to fetch entry content:', err)
+    } finally {
+      setContentLoading(false)
+    }
+  }
+
+  const handleSearch = async () => {
+    if (!searchQuery.trim()) {
+      setIsSearching(false)
+      setSearchResults([])
+      return
+    }
+    setIsSearching(true)
+    try {
+      const params = new URLSearchParams({ q: searchQuery.trim() })
+      if (selectedAgent) params.set('agent_id', selectedAgent)
+      const res = await fetch(`/api/knowledge/search?${params}`)
+      if (res.ok) {
+        const data = await res.json()
+        setSearchResults(data.results || [])
+      }
+    } catch (err) {
+      console.error('Failed to search knowledge:', err)
+    }
+  }
+
+  const clearSearch = () => {
+    setSearchQuery('')
+    setIsSearching(false)
+    setSearchResults([])
+  }
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-24">
+        <div className="h-8 w-8 rounded-full border-2 border-brand-500 border-t-transparent animate-spin" />
+      </div>
+    )
+  }
+
   return (
     <>
       <div className="mb-8">
@@ -9,12 +171,237 @@ export default function KnowledgeClient() {
           Browse and search what your agents have learned.
         </p>
       </div>
-      <div className="rounded-lg border border-navy-700 bg-navy-800 p-12 text-center">
-        <p className="text-mountain-400 mb-2">Coming soon</p>
-        <p className="text-sm text-mountain-500">
-          Agents build persistent memory across sessions — plans, decisions, journals, research, and notes. Browse entries by agent or search across all knowledge.
-        </p>
+
+      {/* Search bar */}
+      <div className="rounded-lg border border-navy-700 bg-navy-800 p-4 mb-6">
+        <div className="flex items-center gap-3">
+          <input
+            type="text"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            onKeyDown={(e) => e.key === 'Enter' && handleSearch()}
+            placeholder="Search across all knowledge entries..."
+            className="flex-1 rounded-md border border-navy-600 bg-navy-900 px-3 py-1.5 text-sm text-white placeholder-mountain-500 focus:border-brand-500 focus:outline-none"
+          />
+          <button
+            onClick={handleSearch}
+            className="px-4 py-1.5 text-sm font-medium rounded-md bg-brand-600 hover:bg-brand-500 text-white transition-colors cursor-pointer"
+          >
+            Search
+          </button>
+          {isSearching && (
+            <button
+              onClick={clearSearch}
+              className="px-3 py-1.5 text-sm font-medium rounded-md border border-navy-600 text-mountain-400 hover:text-white hover:border-navy-500 transition-colors cursor-pointer"
+            >
+              Clear
+            </button>
+          )}
+        </div>
       </div>
+
+      {/* Search results */}
+      {isSearching ? (
+        <div>
+          <p className="text-sm text-mountain-400 mb-4">
+            {searchResults.length} result{searchResults.length !== 1 ? 's' : ''} for &ldquo;{searchQuery}&rdquo;
+          </p>
+          {searchResults.length === 0 ? (
+            <div className="rounded-lg border border-navy-700 bg-navy-800 p-12 text-center">
+              <p className="text-mountain-400">No results found</p>
+            </div>
+          ) : (
+            <div className="space-y-3">
+              {searchResults.map((result) => (
+                <div key={result.id} className="rounded-lg border border-navy-700 bg-navy-800 p-4">
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <div className="flex items-center gap-2 mb-1">
+                        <span className="text-white font-medium">{result.title}</span>
+                        <span className={`px-1.5 py-0.5 text-xs rounded border ${typeBadgeColor(result.entry_type)}`}>
+                          {result.entry_type}
+                        </span>
+                      </div>
+                      <p className="text-xs text-mountain-500 mb-2">
+                        {agentName(result.agent_id)} &middot; {result.path}
+                      </p>
+                      {result.headline && (
+                        <p className="text-sm text-mountain-300"
+                          dangerouslySetInnerHTML={{ __html: result.headline }}
+                        />
+                      )}
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      ) : (
+        /* Two-panel layout */
+        <div className="grid grid-cols-1 lg:grid-cols-4 gap-6">
+          {/* Left panel: Agent list */}
+          <div className="lg:col-span-1">
+            <h2 className="text-sm font-medium text-mountain-400 mb-3">Agents</h2>
+            {knowledgeAgents.length === 0 ? (
+              <div className="rounded-lg border border-navy-700 bg-navy-800 p-6 text-center">
+                <p className="text-sm text-mountain-500">No agents with knowledge entries yet</p>
+              </div>
+            ) : (
+              <div className="space-y-2">
+                {knowledgeAgents.map((ka) => (
+                  <button
+                    key={ka.agent_id}
+                    onClick={() => { setSelectedAgent(ka.agent_id); clearSearch() }}
+                    className={`w-full text-left rounded-lg border p-3 transition-colors cursor-pointer ${
+                      selectedAgent === ka.agent_id
+                        ? 'bg-brand-900/30 border-brand-700 text-white'
+                        : 'bg-navy-800 border-navy-700 text-mountain-300 hover:border-navy-500'
+                    }`}
+                  >
+                    <div className="font-medium text-sm">{agentName(ka.agent_id)}</div>
+                    <div className="text-xs text-mountain-500 mt-1">
+                      {ka.entry_count} entr{ka.entry_count !== 1 ? 'ies' : 'y'}
+                      {ka.last_updated && (
+                        <> &middot; {new Date(ka.last_updated).toLocaleDateString()}</>
+                      )}
+                    </div>
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* Right panel: Entry list + content */}
+          <div className="lg:col-span-3">
+            {!selectedAgent ? (
+              <div className="rounded-lg border border-navy-700 bg-navy-800 p-12 text-center">
+                <p className="text-mountain-400 mb-2">Select an agent to browse knowledge</p>
+                <p className="text-sm text-mountain-500">
+                  Agents build persistent memory across sessions — plans, decisions, journals, research, and notes.
+                </p>
+              </div>
+            ) : (
+              <>
+                {/* Type filter */}
+                <div className="flex items-center gap-2 mb-4">
+                  <span className="text-sm text-mountain-400">Type:</span>
+                  <button
+                    onClick={() => setTypeFilter('')}
+                    className={`px-2.5 py-1 text-xs font-medium rounded-md border transition-colors cursor-pointer ${
+                      typeFilter === ''
+                        ? 'bg-brand-900/50 text-brand-400 border-brand-700'
+                        : 'bg-navy-900 text-mountain-400 border-navy-700 hover:border-navy-500'
+                    }`}
+                  >
+                    All
+                  </button>
+                  {ENTRY_TYPES.map((type) => (
+                    <button
+                      key={type}
+                      onClick={() => setTypeFilter(type)}
+                      className={`px-2.5 py-1 text-xs font-medium rounded-md border transition-colors cursor-pointer ${
+                        typeFilter === type
+                          ? 'bg-brand-900/50 text-brand-400 border-brand-700'
+                          : 'bg-navy-900 text-mountain-400 border-navy-700 hover:border-navy-500'
+                      }`}
+                    >
+                      {type}
+                    </button>
+                  ))}
+                </div>
+
+                {entriesLoading ? (
+                  <div className="flex items-center justify-center py-12">
+                    <div className="h-6 w-6 rounded-full border-2 border-brand-500 border-t-transparent animate-spin" />
+                  </div>
+                ) : entries.length === 0 ? (
+                  <div className="rounded-lg border border-navy-700 bg-navy-800 p-12 text-center">
+                    <p className="text-mountain-400">No entries found</p>
+                    {typeFilter && (
+                      <p className="text-sm text-mountain-500 mt-1">
+                        Try clearing the type filter.
+                      </p>
+                    )}
+                  </div>
+                ) : (
+                  <div className="grid grid-cols-1 gap-4">
+                    {/* Entry list */}
+                    <div className="rounded-lg border border-navy-700 overflow-hidden">
+                      <table className="w-full text-sm">
+                        <thead>
+                          <tr className="bg-navy-800 text-mountain-400 text-left">
+                            <th className="px-4 py-3 font-medium">Title</th>
+                            <th className="px-4 py-3 font-medium">Type</th>
+                            <th className="px-4 py-3 font-medium">Updated</th>
+                          </tr>
+                        </thead>
+                        <tbody className="divide-y divide-navy-700">
+                          {entries.map((entry) => (
+                            <tr
+                              key={entry.id}
+                              onClick={() => fetchContent(entry)}
+                              className={`cursor-pointer transition-colors ${
+                                selectedEntry?.id === entry.id
+                                  ? 'bg-brand-900/20'
+                                  : 'bg-navy-900 hover:bg-navy-800'
+                              }`}
+                            >
+                              <td className="px-4 py-3 text-white">{entry.title}</td>
+                              <td className="px-4 py-3">
+                                <span className={`px-1.5 py-0.5 text-xs rounded border ${typeBadgeColor(entry.entry_type)}`}>
+                                  {entry.entry_type}
+                                </span>
+                              </td>
+                              <td className="px-4 py-3 text-mountain-400">
+                                {new Date(entry.updated_at).toLocaleDateString()}
+                              </td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+
+                    {/* Content view */}
+                    {contentLoading ? (
+                      <div className="flex items-center justify-center py-12">
+                        <div className="h-6 w-6 rounded-full border-2 border-brand-500 border-t-transparent animate-spin" />
+                      </div>
+                    ) : selectedEntry ? (
+                      <div className="rounded-lg border border-navy-700 bg-navy-800 p-5">
+                        <div className="flex items-center gap-2 mb-4">
+                          <h3 className="text-lg font-semibold text-white">{selectedEntry.title}</h3>
+                          <span className={`px-1.5 py-0.5 text-xs rounded border ${typeBadgeColor(selectedEntry.entry_type)}`}>
+                            {selectedEntry.entry_type}
+                          </span>
+                        </div>
+                        <div className="flex items-center gap-3 text-xs text-mountain-500 mb-4">
+                          <span>{selectedEntry.path}</span>
+                          <span>&middot;</span>
+                          <span>{new Date(selectedEntry.updated_at).toLocaleDateString()}</span>
+                          {selectedEntry.tags.length > 0 && (
+                            <>
+                              <span>&middot;</span>
+                              <span>{selectedEntry.tags.join(', ')}</span>
+                            </>
+                          )}
+                        </div>
+                        <pre className="whitespace-pre-wrap text-sm text-mountain-200 bg-navy-900 rounded-lg p-4 overflow-auto max-h-[600px] border border-navy-700">
+                          {selectedEntry.content}
+                        </pre>
+                      </div>
+                    ) : (
+                      <div className="rounded-lg border border-navy-700 bg-navy-800 p-8 text-center">
+                        <p className="text-sm text-mountain-500">Click an entry to view its content.</p>
+                      </div>
+                    )}
+                  </div>
+                )}
+              </>
+            )}
+          </div>
+        </div>
+      )}
     </>
   )
 }

--- a/services/ui/src/app/harness/usage/UsageClient.tsx
+++ b/services/ui/src/app/harness/usage/UsageClient.tsx
@@ -1,6 +1,106 @@
 'use client'
 
+import { useState, useEffect, useCallback } from 'react'
+
+interface UsageSummary {
+  total_requests: number
+  successful_requests: number
+  total_input_tokens: number
+  total_output_tokens: number
+  total_tokens: number
+  total_cost_usd: number
+}
+
+interface GroupedRow extends UsageSummary {
+  agent_id?: string
+  model_name?: string
+  day?: string
+}
+
+interface Agent {
+  id: string
+  name: string
+  agent_id: string
+}
+
+type GroupBy = 'agent' | 'model' | 'day'
+
+function sevenDaysAgo(): string {
+  const d = new Date()
+  d.setDate(d.getDate() - 7)
+  return d.toISOString().split('T')[0]
+}
+
+function today(): string {
+  return new Date().toISOString().split('T')[0]
+}
+
 export default function UsageClient() {
+  const [summary, setSummary] = useState<UsageSummary | null>(null)
+  const [groupedData, setGroupedData] = useState<GroupedRow[]>([])
+  const [agents, setAgents] = useState<Agent[]>([])
+  const [loading, setLoading] = useState(true)
+  const [groupBy, setGroupBy] = useState<GroupBy>('agent')
+  const [fromDate, setFromDate] = useState(sevenDaysAgo)
+  const [toDate, setToDate] = useState(today)
+  const [agentFilter, setAgentFilter] = useState('')
+  const [modelFilter, setModelFilter] = useState('')
+
+  const agentName = useCallback((id: string) =>
+    agents.find((a) => a.id === id)?.name ?? id.substring(0, 8),
+  [agents])
+
+  const buildQuery = useCallback((extra?: Record<string, string>) => {
+    const params = new URLSearchParams()
+    if (fromDate) params.set('from', fromDate)
+    if (toDate) params.set('to', toDate)
+    if (agentFilter) params.set('agent_id', agentFilter)
+    if (modelFilter) params.set('model_name', modelFilter)
+    if (extra) {
+      for (const [k, v] of Object.entries(extra)) params.set(k, v)
+    }
+    return params.toString()
+  }, [fromDate, toDate, agentFilter, modelFilter])
+
+  const fetchData = useCallback(async () => {
+    setLoading(true)
+    try {
+      const [summaryRes, groupedRes, agentsRes] = await Promise.all([
+        fetch(`/api/usage?${buildQuery()}`),
+        fetch(`/api/usage?${buildQuery({ group_by: groupBy })}`),
+        fetch('/api/agents'),
+      ])
+      if (summaryRes.ok) setSummary(await summaryRes.json())
+      if (groupedRes.ok) {
+        const data = await groupedRes.json()
+        setGroupedData(data.data || [])
+      }
+      if (agentsRes.ok) setAgents(await agentsRes.json())
+    } catch (err) {
+      console.error('Failed to fetch usage:', err)
+    } finally {
+      setLoading(false)
+    }
+  }, [buildQuery, groupBy])
+
+  useEffect(() => {
+    fetchData()
+  }, [fetchData])
+
+  const groupByOptions: { value: GroupBy; label: string }[] = [
+    { value: 'agent', label: 'Agent' },
+    { value: 'model', label: 'Model' },
+    { value: 'day', label: 'Day' },
+  ]
+
+  if (loading && !summary) {
+    return (
+      <div className="flex items-center justify-center py-24">
+        <div className="h-8 w-8 rounded-full border-2 border-brand-500 border-t-transparent animate-spin" />
+      </div>
+    )
+  }
+
   return (
     <>
       <div className="mb-8">
@@ -9,12 +109,132 @@ export default function UsageClient() {
           Track model usage across your agents.
         </p>
       </div>
-      <div className="rounded-lg border border-navy-700 bg-navy-800 p-12 text-center">
-        <p className="text-mountain-400 mb-2">Coming soon</p>
-        <p className="text-sm text-mountain-500">
-          View usage statistics grouped by agent, model, or day. Filter by date range and see estimated costs.
-        </p>
+
+      {/* Summary cards */}
+      {summary && (
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-6">
+          <SummaryCard label="Total Requests" value={summary.total_requests.toLocaleString()} />
+          <SummaryCard label="Total Tokens" value={summary.total_tokens.toLocaleString()} />
+          <SummaryCard label="Estimated Cost" value={`$${summary.total_cost_usd.toFixed(4)}`} />
+        </div>
+      )}
+
+      {/* Filter bar */}
+      <div className="rounded-lg border border-navy-700 bg-navy-800 p-4 mb-6">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
+          <div>
+            <label className="block text-xs text-mountain-400 mb-1">From</label>
+            <input
+              type="date"
+              value={fromDate}
+              onChange={(e) => setFromDate(e.target.value)}
+              className="w-full rounded-md border border-navy-600 bg-navy-900 px-3 py-1.5 text-sm text-white focus:border-brand-500 focus:outline-none"
+            />
+          </div>
+          <div>
+            <label className="block text-xs text-mountain-400 mb-1">To</label>
+            <input
+              type="date"
+              value={toDate}
+              onChange={(e) => setToDate(e.target.value)}
+              className="w-full rounded-md border border-navy-600 bg-navy-900 px-3 py-1.5 text-sm text-white focus:border-brand-500 focus:outline-none"
+            />
+          </div>
+          <div>
+            <label className="block text-xs text-mountain-400 mb-1">Agent</label>
+            <select
+              value={agentFilter}
+              onChange={(e) => setAgentFilter(e.target.value)}
+              className="w-full rounded-md border border-navy-600 bg-navy-900 px-3 py-1.5 text-sm text-white focus:border-brand-500 focus:outline-none"
+            >
+              <option value="">All agents</option>
+              {agents.map((a) => (
+                <option key={a.id} value={a.id}>{a.name}</option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label className="block text-xs text-mountain-400 mb-1">Model</label>
+            <input
+              type="text"
+              value={modelFilter}
+              onChange={(e) => setModelFilter(e.target.value)}
+              placeholder="Filter by model"
+              className="w-full rounded-md border border-navy-600 bg-navy-900 px-3 py-1.5 text-sm text-white placeholder-mountain-500 focus:border-brand-500 focus:outline-none"
+            />
+          </div>
+        </div>
       </div>
+
+      {/* Group-by toggle */}
+      <div className="flex items-center gap-2 mb-4">
+        <span className="text-sm text-mountain-400">Group by:</span>
+        {groupByOptions.map((opt) => (
+          <button
+            key={opt.value}
+            onClick={() => setGroupBy(opt.value)}
+            className={`px-3 py-1.5 text-xs font-medium rounded-md border transition-colors cursor-pointer ${
+              groupBy === opt.value
+                ? 'bg-brand-900/50 text-brand-400 border-brand-700'
+                : 'bg-navy-900 text-mountain-400 border-navy-700 hover:border-navy-500'
+            }`}
+          >
+            {opt.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Data table */}
+      {groupedData.length === 0 ? (
+        <div className="rounded-lg border border-navy-700 bg-navy-800 p-12 text-center">
+          <p className="text-mountain-400 mb-4">No usage data yet</p>
+          <p className="text-sm text-mountain-500">
+            Start an agent with a model policy to begin tracking usage.
+          </p>
+        </div>
+      ) : (
+        <div className="rounded-lg border border-navy-700 overflow-hidden">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="bg-navy-800 text-mountain-400 text-left">
+                <th className="px-4 py-3 font-medium">
+                  {groupBy === 'agent' ? 'Agent' : groupBy === 'model' ? 'Model' : 'Date'}
+                </th>
+                <th className="px-4 py-3 font-medium text-right">Requests</th>
+                <th className="px-4 py-3 font-medium text-right">Tokens</th>
+                <th className="px-4 py-3 font-medium text-right">Cost</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-navy-700">
+              {groupedData.map((row, i) => {
+                const groupLabel = groupBy === 'agent'
+                  ? agentName(row.agent_id || '')
+                  : groupBy === 'model'
+                  ? row.model_name || 'Unknown'
+                  : row.day || 'Unknown'
+
+                return (
+                  <tr key={i} className="bg-navy-900 hover:bg-navy-800 transition-colors">
+                    <td className="px-4 py-3 text-white">{groupLabel}</td>
+                    <td className="px-4 py-3 text-mountain-300 text-right">{row.total_requests.toLocaleString()}</td>
+                    <td className="px-4 py-3 text-mountain-300 text-right">{row.total_tokens.toLocaleString()}</td>
+                    <td className="px-4 py-3 text-mountain-300 text-right">${Number(row.total_cost_usd).toFixed(4)}</td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
     </>
+  )
+}
+
+function SummaryCard({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-lg border border-navy-700 bg-navy-800 p-4">
+      <dt className="text-sm text-mountain-400">{label}</dt>
+      <dd className="text-2xl font-bold text-white mt-1">{value}</dd>
+    </div>
   )
 }


### PR DESCRIPTION
## Summary
- Replace Usage placeholder with full data-driven page: summary cards (requests/tokens/cost), filter bar (date range, agent dropdown, model text filter), group-by toggle (agent/model/day), data table with client-side agent name join
- Replace Knowledge placeholder with full two-panel browser: agent list (left), entry table + content view (right), type filter badges (note/plan/decision/journal/research), `<pre>` content rendering, cross-agent full-text search with headline snippets
- Add BFF proxy routes: `GET /api/usage` (query param forwarding), `GET /api/knowledge/[...path]` (catch-all for agents, entries, search)
- 15 new tests (7 UsageClient, 8 KnowledgeClient)

## Plan Reference
PR 3 of the approved Harness Control Plane UI plan (steps 10-12).

## Test plan
- [x] `npx vitest run` — 155/155 tests pass (20 suites)
- [x] `npx next build` — builds successfully, all routes resolve
- [x] All harness nav links resolve (no 404s)
- [ ] CI: Run Tests workflow passes
- [ ] CI: security/snyk passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)