### PR TITLE
feat: harness UI dashboard overview & agent list polish

### DIFF
--- a/services/ui/src/__tests__/AgentsClient.test.tsx
+++ b/services/ui/src/__tests__/AgentsClient.test.tsx
@@ -1,0 +1,170 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, cleanup, waitFor } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+
+// Mock next/link
+vi.mock('next/link', () => ({
+  default: ({ children, href, ...props }: { children: React.ReactNode; href: string; [key: string]: any }) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}))
+
+// Mock global fetch
+const mockFetch = vi.fn()
+vi.stubGlobal('fetch', mockFetch)
+
+import AgentsClient from '@/app/agents/AgentsClient'
+
+const MOCK_SESSION = {
+  user: { name: 'Admin', email: 'admin@hill90.com', roles: ['admin'] },
+  expires: '2026-12-31',
+}
+
+const MOCK_AGENTS = [
+  {
+    id: 'agent-1',
+    agent_id: 'research-bot',
+    name: 'ResearchBot',
+    description: 'Researches topics',
+    status: 'running',
+    cpus: '0.5',
+    mem_limit: '512m',
+    pids_limit: 64,
+    model_policy_id: 'policy-1',
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    created_by: 'admin',
+  },
+  {
+    id: 'agent-2',
+    agent_id: 'writer-bot',
+    name: 'WriterBot',
+    description: 'Writes content',
+    status: 'stopped',
+    cpus: '1.0',
+    mem_limit: '1g',
+    pids_limit: 128,
+    model_policy_id: null,
+    created_at: '2026-02-01T00:00:00Z',
+    updated_at: '2026-02-01T00:00:00Z',
+    created_by: 'admin',
+  },
+]
+
+const MOCK_POLICIES = [
+  { id: 'policy-1', name: 'Default Policy' },
+  { id: 'policy-2', name: 'Restricted Policy' },
+]
+
+function mockFetchDefaults() {
+  mockFetch.mockImplementation((url: string) => {
+    if (url === '/api/agents') {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_AGENTS) })
+    }
+    if (url === '/api/model-policies') {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_POLICIES) })
+    }
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+  })
+}
+
+describe('AgentsClient', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockFetchDefaults()
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('renders agent cards with names and status', async () => {
+    render(<AgentsClient session={MOCK_SESSION as any} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('ResearchBot')).toBeInTheDocument()
+      expect(screen.getByText('WriterBot')).toBeInTheDocument()
+    })
+
+    expect(screen.getByText('Running')).toBeInTheDocument()
+    expect(screen.getByText('Stopped')).toBeInTheDocument()
+    expect(screen.getByText('2 agents')).toBeInTheDocument()
+  })
+
+  it('shows policy name badge on agents with assigned policy', async () => {
+    render(<AgentsClient session={MOCK_SESSION as any} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('ResearchBot')).toBeInTheDocument()
+    })
+
+    // ResearchBot has policy-1 assigned → should show "Default Policy" badge
+    expect(screen.getByText('Default Policy')).toBeInTheDocument()
+  })
+
+  it('does not show policy badge on agents without policy', async () => {
+    render(<AgentsClient session={MOCK_SESSION as any} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('WriterBot')).toBeInTheDocument()
+    })
+
+    // WriterBot has no policy → "Restricted Policy" should not appear (only Default Policy is shown)
+    const policyBadges = screen.queryAllByText('Restricted Policy')
+    expect(policyBadges.length).toBe(0)
+  })
+
+  it('shows resource info on agent cards', async () => {
+    render(<AgentsClient session={MOCK_SESSION as any} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('ResearchBot')).toBeInTheDocument()
+    })
+
+    expect(screen.getByText('0.5 CPU')).toBeInTheDocument()
+    expect(screen.getByText('512m RAM')).toBeInTheDocument()
+  })
+
+  it('shows empty state when no agents', async () => {
+    mockFetch.mockImplementation((url: string) => {
+      if (url === '/api/agents') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve([]) })
+      }
+      if (url === '/api/model-policies') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve([]) })
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+    })
+
+    render(<AgentsClient session={MOCK_SESSION as any} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('No agents yet')).toBeInTheDocument()
+    })
+  })
+
+  it('shows admin action buttons', async () => {
+    render(<AgentsClient session={MOCK_SESSION as any} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('ResearchBot')).toBeInTheDocument()
+    })
+
+    // Running agent should have Stop button
+    expect(screen.getByText('Stop')).toBeInTheDocument()
+    // Stopped agent should have Start button
+    expect(screen.getByText('Start')).toBeInTheDocument()
+  })
+
+  it('fetches both agents and policies on mount', async () => {
+    render(<AgentsClient session={MOCK_SESSION as any} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('ResearchBot')).toBeInTheDocument()
+    })
+
+    expect(mockFetch).toHaveBeenCalledWith('/api/agents')
+    expect(mockFetch).toHaveBeenCalledWith('/api/model-policies')
+  })
+})

--- a/services/ui/src/__tests__/DashboardClient.test.tsx
+++ b/services/ui/src/__tests__/DashboardClient.test.tsx
@@ -1,0 +1,157 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, cleanup, waitFor } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+
+// Mock global fetch
+const mockFetch = vi.fn()
+vi.stubGlobal('fetch', mockFetch)
+
+import DashboardClient from '@/app/dashboard/DashboardClient'
+
+const MOCK_SESSION = {
+  user: { name: 'Admin Hill', email: 'admin@hill90.com', roles: ['admin'] },
+  expires: '2026-12-31',
+}
+
+const MOCK_HEALTH = {
+  services: [
+    { name: 'API', status: 'healthy', responseTime: 42 },
+    { name: 'AI', status: 'healthy', responseTime: 85 },
+    { name: 'Auth', status: 'healthy', responseTime: 30 },
+    { name: 'MCP', status: 'unhealthy' },
+  ],
+}
+
+const MOCK_AGENTS = [
+  { id: 'a1', status: 'running' },
+  { id: 'a2', status: 'stopped' },
+  { id: 'a3', status: 'stopped' },
+  { id: 'a4', status: 'error' },
+]
+
+const MOCK_POLICIES = [
+  { id: 'p1', name: 'Default Policy' },
+  { id: 'p2', name: 'Restricted Policy' },
+]
+
+const MOCK_USAGE = {
+  total_requests: '247',
+  total_tokens: '15000',
+  total_cost_usd: '0.5432',
+}
+
+function mockFetchDefaults() {
+  mockFetch.mockImplementation((url: string) => {
+    if (url === '/api/services/health') {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_HEALTH) })
+    }
+    if (url === '/api/agents') {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_AGENTS) })
+    }
+    if (url === '/api/model-policies') {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_POLICIES) })
+    }
+    if (typeof url === 'string' && url.startsWith('/api/usage')) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_USAGE) })
+    }
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+  })
+}
+
+describe('DashboardClient', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockFetchDefaults()
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('renders session info', async () => {
+    render(<DashboardClient session={MOCK_SESSION as any} />)
+
+    expect(screen.getByText('Admin Hill')).toBeInTheDocument()
+    expect(screen.getByText('admin@hill90.com')).toBeInTheDocument()
+    expect(screen.getByText('admin')).toBeInTheDocument()
+  })
+
+  it('renders harness overview with agent counts', async () => {
+    render(<DashboardClient session={MOCK_SESSION as any} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Harness Overview')).toBeInTheDocument()
+    })
+
+    // Total agents
+    expect(screen.getByText('4')).toBeInTheDocument()
+    // Status breakdown
+    expect(screen.getByText('1 running')).toBeInTheDocument()
+    expect(screen.getByText(/2 stopped/)).toBeInTheDocument()
+  })
+
+  it('renders harness overview with policy count', async () => {
+    render(<DashboardClient session={MOCK_SESSION as any} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Harness Overview')).toBeInTheDocument()
+    })
+
+    expect(screen.getByText('Policies')).toBeInTheDocument()
+    expect(screen.getByText('2')).toBeInTheDocument()
+  })
+
+  it('renders harness overview with usage totals', async () => {
+    render(<DashboardClient session={MOCK_SESSION as any} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Harness Overview')).toBeInTheDocument()
+    })
+
+    expect(screen.getByText('Requests (7d)')).toBeInTheDocument()
+    expect(screen.getByText('247')).toBeInTheDocument()
+    expect(screen.getByText('Cost (7d)')).toBeInTheDocument()
+    expect(screen.getByText('$0.5432')).toBeInTheDocument()
+  })
+
+  it('renders service health cards', async () => {
+    render(<DashboardClient session={MOCK_SESSION as any} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('API')).toBeInTheDocument()
+    })
+
+    expect(screen.getByText('AI')).toBeInTheDocument()
+    expect(screen.getByText('Auth')).toBeInTheDocument()
+    expect(screen.getByText('MCP')).toBeInTheDocument()
+  })
+
+  it('shows harness overview even when some fetches fail', async () => {
+    mockFetch.mockImplementation((url: string) => {
+      if (url === '/api/services/health') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_HEALTH) })
+      }
+      if (url === '/api/agents') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve([]) })
+      }
+      if (url === '/api/model-policies') {
+        return Promise.resolve({ ok: false, json: () => Promise.resolve({}) })
+      }
+      if (typeof url === 'string' && url.startsWith('/api/usage')) {
+        return Promise.resolve({ ok: false, json: () => Promise.resolve({}) })
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+    })
+
+    render(<DashboardClient session={MOCK_SESSION as any} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Harness Overview')).toBeInTheDocument()
+    })
+
+    // Should show 0 for everything gracefully (multiple 0s across cards)
+    expect(screen.getAllByText('0').length).toBeGreaterThanOrEqual(1)
+    expect(screen.getByText('$0.0000')).toBeInTheDocument()
+  })
+})

--- a/services/ui/src/app/agents/AgentsClient.tsx
+++ b/services/ui/src/app/agents/AgentsClient.tsx
@@ -13,25 +13,38 @@ interface Agent {
   cpus: string
   mem_limit: string
   pids_limit: number
+  model_policy_id: string | null
   created_at: string
   updated_at: string
   created_by: string
 }
 
+interface ModelPolicy {
+  id: string
+  name: string
+}
+
 export default function AgentsClient({ session }: { session: Session }) {
   const [agents, setAgents] = useState<Agent[]>([])
+  const [policies, setPolicies] = useState<ModelPolicy[]>([])
   const [loading, setLoading] = useState(true)
   const [actionLoading, setActionLoading] = useState<string | null>(null)
 
   const isAdmin = session.user?.roles?.includes('admin')
 
-  const fetchAgents = useCallback(async () => {
+  const policyName = useCallback((id: string | null) => {
+    if (!id) return null
+    return policies.find((p) => p.id === id)?.name ?? null
+  }, [policies])
+
+  const fetchData = useCallback(async () => {
     try {
-      const res = await fetch('/api/agents')
-      if (res.ok) {
-        const data = await res.json()
-        setAgents(data)
-      }
+      const [agentsRes, policiesRes] = await Promise.all([
+        fetch('/api/agents'),
+        fetch('/api/model-policies'),
+      ])
+      if (agentsRes.ok) setAgents(await agentsRes.json())
+      if (policiesRes.ok) setPolicies(await policiesRes.json())
     } catch (err) {
       console.error('Failed to fetch agents:', err)
     } finally {
@@ -40,8 +53,8 @@ export default function AgentsClient({ session }: { session: Session }) {
   }, [])
 
   useEffect(() => {
-    fetchAgents()
-  }, [fetchAgents])
+    fetchData()
+  }, [fetchData])
 
   const handleAction = async (agentId: string, action: 'start' | 'stop') => {
     setActionLoading(agentId)
@@ -51,7 +64,7 @@ export default function AgentsClient({ session }: { session: Session }) {
         const data = await res.json()
         alert(data.error || `Failed to ${action} agent`)
       }
-      await fetchAgents()
+      await fetchData()
     } catch (err) {
       console.error(`Failed to ${action} agent:`, err)
     } finally {
@@ -96,62 +109,73 @@ export default function AgentsClient({ session }: { session: Session }) {
         </div>
       ) : (
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-          {agents.map((agent) => (
-            <div
-              key={agent.id}
-              className="rounded-lg border border-navy-700 bg-navy-800 p-5 flex flex-col"
-            >
-              <div className="flex items-center justify-between mb-2">
-                <Link
-                  href={`/agents/${agent.id}`}
-                  className="font-semibold text-white hover:text-brand-400 transition-colors truncate"
-                >
-                  {agent.name}
-                </Link>
-                <StatusBadge status={agent.status} />
-              </div>
+          {agents.map((agent) => {
+            const policy = policyName(agent.model_policy_id)
+            return (
+              <div
+                key={agent.id}
+                className="rounded-lg border border-navy-700 bg-navy-800 p-5 flex flex-col"
+              >
+                <div className="flex items-center justify-between mb-2">
+                  <Link
+                    href={`/agents/${agent.id}`}
+                    className="font-semibold text-white hover:text-brand-400 transition-colors truncate"
+                  >
+                    {agent.name}
+                  </Link>
+                  <StatusBadge status={agent.status} />
+                </div>
 
-              <p className="text-sm text-mountain-400 mb-3 line-clamp-2 flex-1">
-                {agent.description || 'No description'}
-              </p>
+                <p className="text-sm text-mountain-400 mb-3 line-clamp-2 flex-1">
+                  {agent.description || 'No description'}
+                </p>
 
-              <div className="flex items-center gap-3 text-xs text-mountain-500 mb-4">
-                <span>{agent.cpus} CPU</span>
-                <span>{agent.mem_limit} RAM</span>
-                <span>{agent.pids_limit} PIDs</span>
-              </div>
+                <div className="flex items-center gap-3 text-xs text-mountain-500 mb-3">
+                  <span>{agent.cpus} CPU</span>
+                  <span>{agent.mem_limit} RAM</span>
+                  <span>{agent.pids_limit} PIDs</span>
+                </div>
 
-              <div className="flex items-center gap-2">
-                {isAdmin && (
-                  <>
-                    {agent.status === 'stopped' || agent.status === 'error' ? (
-                      <button
-                        onClick={() => handleAction(agent.id, 'start')}
-                        disabled={actionLoading === agent.id}
-                        className="px-3 py-1.5 text-xs font-medium rounded-md bg-brand-600 hover:bg-brand-500 text-white transition-colors disabled:opacity-50 cursor-pointer disabled:cursor-not-allowed"
-                      >
-                        {actionLoading === agent.id ? 'Starting...' : 'Start'}
-                      </button>
-                    ) : agent.status === 'running' ? (
-                      <button
-                        onClick={() => handleAction(agent.id, 'stop')}
-                        disabled={actionLoading === agent.id}
-                        className="px-3 py-1.5 text-xs font-medium rounded-md bg-red-600 hover:bg-red-500 text-white transition-colors disabled:opacity-50 cursor-pointer disabled:cursor-not-allowed"
-                      >
-                        {actionLoading === agent.id ? 'Stopping...' : 'Stop'}
-                      </button>
-                    ) : null}
-                  </>
+                {policy && (
+                  <div className="mb-3">
+                    <span className="inline-flex items-center px-2 py-0.5 text-xs font-medium rounded-md bg-brand-900/30 text-brand-400 border border-brand-800">
+                      {policy}
+                    </span>
+                  </div>
                 )}
-                <Link
-                  href={`/agents/${agent.id}`}
-                  className="px-3 py-1.5 text-xs font-medium rounded-md border border-navy-600 text-mountain-400 hover:text-white hover:border-navy-500 transition-colors"
-                >
-                  Details
-                </Link>
+
+                <div className="flex items-center gap-2">
+                  {isAdmin && (
+                    <>
+                      {agent.status === 'stopped' || agent.status === 'error' ? (
+                        <button
+                          onClick={() => handleAction(agent.id, 'start')}
+                          disabled={actionLoading === agent.id}
+                          className="px-3 py-1.5 text-xs font-medium rounded-md bg-brand-600 hover:bg-brand-500 text-white transition-colors disabled:opacity-50 cursor-pointer disabled:cursor-not-allowed"
+                        >
+                          {actionLoading === agent.id ? 'Starting...' : 'Start'}
+                        </button>
+                      ) : agent.status === 'running' ? (
+                        <button
+                          onClick={() => handleAction(agent.id, 'stop')}
+                          disabled={actionLoading === agent.id}
+                          className="px-3 py-1.5 text-xs font-medium rounded-md bg-red-600 hover:bg-red-500 text-white transition-colors disabled:opacity-50 cursor-pointer disabled:cursor-not-allowed"
+                        >
+                          {actionLoading === agent.id ? 'Stopping...' : 'Stop'}
+                        </button>
+                      ) : null}
+                    </>
+                  )}
+                  <Link
+                    href={`/agents/${agent.id}`}
+                    className="px-3 py-1.5 text-xs font-medium rounded-md border border-navy-600 text-mountain-400 hover:text-white hover:border-navy-500 transition-colors"
+                  >
+                    Details
+                  </Link>
+                </div>
               </div>
-            </div>
-          ))}
+            )
+          })}
         </div>
       )}
     </>

--- a/services/ui/src/app/dashboard/DashboardClient.tsx
+++ b/services/ui/src/app/dashboard/DashboardClient.tsx
@@ -1,12 +1,24 @@
-'use client';
+'use client'
 
-import { useState, useEffect, useCallback } from 'react';
-import type { Session } from 'next-auth';
+import { useState, useEffect, useCallback } from 'react'
+import type { Session } from 'next-auth'
 
 interface ServiceHealth {
-  name: string;
-  status: 'healthy' | 'unhealthy' | 'loading';
-  responseTime?: number;
+  name: string
+  status: 'healthy' | 'unhealthy' | 'loading'
+  responseTime?: number
+}
+
+interface HarnessOverview {
+  agents: { total: number; running: number; stopped: number; error: number }
+  policies: number
+  usage: { requests: number; tokens: number; cost: number }
+}
+
+function sevenDaysAgo(): string {
+  const d = new Date()
+  d.setDate(d.getDate() - 7)
+  return d.toISOString().split('T')[0]
 }
 
 export default function DashboardClient({ session }: { session: Session }) {
@@ -15,29 +27,65 @@ export default function DashboardClient({ session }: { session: Session }) {
     { name: 'AI', status: 'loading' },
     { name: 'Auth', status: 'loading' },
     { name: 'MCP', status: 'loading' },
-  ]);
-  const [lastChecked, setLastChecked] = useState<string>('');
+  ])
+  const [lastChecked, setLastChecked] = useState<string>('')
+  const [harness, setHarness] = useState<HarnessOverview | null>(null)
 
   const checkHealth = useCallback(async () => {
     setServices((prev) =>
       prev.map((s) => ({ ...s, status: 'loading' as const }))
-    );
+    )
     try {
-      const res = await fetch('/api/services/health');
-      const data = await res.json();
-      setServices(data.services);
-      setLastChecked(new Date().toLocaleTimeString());
+      const res = await fetch('/api/services/health')
+      const data = await res.json()
+      setServices(data.services)
+      setLastChecked(new Date().toLocaleTimeString())
     } catch {
       setServices((prev) =>
         prev.map((s) => ({ ...s, status: 'unhealthy' as const }))
-      );
-      setLastChecked(new Date().toLocaleTimeString());
+      )
+      setLastChecked(new Date().toLocaleTimeString())
     }
-  }, []);
+  }, [])
+
+  const fetchHarness = useCallback(async () => {
+    try {
+      const [agentsRes, policiesRes, usageRes] = await Promise.all([
+        fetch('/api/agents'),
+        fetch('/api/model-policies'),
+        fetch(`/api/usage?from=${sevenDaysAgo()}`),
+      ])
+
+      const agents = agentsRes.ok ? await agentsRes.json() : []
+      const policies = policiesRes.ok ? await policiesRes.json() : []
+      const usage = usageRes.ok ? await usageRes.json() : null
+
+      const agentCounts = { total: 0, running: 0, stopped: 0, error: 0 }
+      for (const a of agents) {
+        agentCounts.total++
+        if (a.status === 'running') agentCounts.running++
+        else if (a.status === 'error') agentCounts.error++
+        else agentCounts.stopped++
+      }
+
+      setHarness({
+        agents: agentCounts,
+        policies: policies.length,
+        usage: {
+          requests: Number(usage?.total_requests ?? 0),
+          tokens: Number(usage?.total_tokens ?? 0),
+          cost: Number(usage?.total_cost_usd ?? 0),
+        },
+      })
+    } catch (err) {
+      console.error('Failed to fetch harness overview:', err)
+    }
+  }, [])
 
   useEffect(() => {
-    checkHealth();
-  }, [checkHealth]);
+    checkHealth()
+    fetchHarness()
+  }, [checkHealth, fetchHarness])
 
   return (
     <>
@@ -63,6 +111,47 @@ export default function DashboardClient({ session }: { session: Session }) {
           </div>
         </dl>
       </div>
+
+      {/* Harness overview */}
+      {harness && (
+        <div className="rounded-lg border border-navy-700 bg-navy-800 p-5 mb-8">
+          <h2 className="text-lg font-semibold text-white mb-3">Harness Overview</h2>
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 text-sm">
+            <div>
+              <dt className="text-mountain-400">Agents</dt>
+              <dd className="text-white mt-1">
+                <span className="text-2xl font-bold">{harness.agents.total}</span>
+                {harness.agents.total > 0 && (
+                  <span className="text-xs text-mountain-500 ml-2">
+                    {harness.agents.running > 0 && (
+                      <span className="text-brand-400">{harness.agents.running} running</span>
+                    )}
+                    {harness.agents.running > 0 && harness.agents.stopped > 0 && ' · '}
+                    {harness.agents.stopped > 0 && (
+                      <span>{harness.agents.stopped} stopped</span>
+                    )}
+                    {harness.agents.error > 0 && (
+                      <span className="text-red-400"> · {harness.agents.error} error</span>
+                    )}
+                  </span>
+                )}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-mountain-400">Policies</dt>
+              <dd className="text-2xl font-bold text-white mt-1">{harness.policies}</dd>
+            </div>
+            <div>
+              <dt className="text-mountain-400">Requests (7d)</dt>
+              <dd className="text-2xl font-bold text-white mt-1">{harness.usage.requests.toLocaleString()}</dd>
+            </div>
+            <div>
+              <dt className="text-mountain-400">Cost (7d)</dt>
+              <dd className="text-2xl font-bold text-white mt-1">${harness.usage.cost.toFixed(4)}</dd>
+            </div>
+          </div>
+        </div>
+      )}
 
       {/* Service health */}
       <div className="flex items-center justify-between mb-8">
@@ -102,7 +191,7 @@ export default function DashboardClient({ session }: { session: Session }) {
         ))}
       </div>
     </>
-  );
+  )
 }
 
 function StatusBadge({ status }: { status: string }) {
@@ -112,7 +201,7 @@ function StatusBadge({ status }: { status: string }) {
         <span className="h-2 w-2 rounded-full bg-mountain-400 animate-pulse" />
         Checking
       </span>
-    );
+    )
   }
   if (status === 'healthy') {
     return (
@@ -120,12 +209,12 @@ function StatusBadge({ status }: { status: string }) {
         <span className="h-2 w-2 rounded-full bg-brand-500" />
         Healthy
       </span>
-    );
+    )
   }
   return (
     <span className="inline-flex items-center gap-1.5 text-xs font-medium text-red-400">
       <span className="h-2 w-2 rounded-full bg-red-500" />
       Unhealthy
     </span>
-  );
+  )
 }

--- a/services/ui/src/app/harness/usage/UsageClient.tsx
+++ b/services/ui/src/app/harness/usage/UsageClient.tsx
@@ -47,7 +47,7 @@ export default function UsageClient() {
   const [modelFilter, setModelFilter] = useState('')
 
   const agentName = useCallback((id: string) =>
-    agents.find((a) => a.id === id)?.name ?? id.substring(0, 8),
+    agents.find((a) => a.id === id || a.agent_id === id)?.name ?? id.substring(0, 8),
   [agents])
 
   const buildQuery = useCallback((extra?: Record<string, string>) => {


### PR DESCRIPTION
## Summary
- Add Harness Overview card to Dashboard: agent counts by status, policy count, 7-day request/cost totals
- Add policy name badge to agent cards in agent list (client-side join via `/api/model-policies`)
- Fix Usage page agent name resolution to match on both `a.id` (UUID) and `a.agent_id` (slug)
- Tests for all Dashboard and AgentsClient changes (13 new tests)

This is PR 4 (final) of the Harness Control Plane UI plan.

## Plan
Final planned PR delivering dashboard enhancement, agent list polish, and usage display cleanup carried from PR 3 verification.

## Risks
- Dashboard fetches 3 endpoints on load (agents, policies, usage) — all are fast, user-scoped queries
- Agent list now fetches policies alongside agents — small additional request, policies list is typically short

## Rollback
Revert this single commit. No backend changes, no migrations. Previous UI behavior fully preserved.

## Validation Evidence
- `npx vitest run`: 168/168 tests pass (22 test files)
- `npx next build`: succeeds with no type errors
- New tests: `DashboardClient.test.tsx` (6 tests), `AgentsClient.test.tsx` (7 tests)
- Existing tests unaffected

## Test plan
- [ ] Dashboard loads Harness Overview card with agent counts, policy count, usage totals
- [ ] Dashboard gracefully shows zeroes when API calls fail
- [ ] Agent list shows policy name badge for agents with assigned policy
- [ ] Agent list omits badge for agents without policy
- [ ] Usage table resolves agent names by slug (not truncated UUID)
- [ ] All 168 vitest tests pass
- [ ] `next build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)