### PR TITLE
fix: increase Tempo memory limit to resolve OOM crash loop

### DIFF
--- a/deploy/compose/prod/docker-compose.observability.yml
+++ b/deploy/compose/prod/docker-compose.observability.yml
@@ -69,7 +69,7 @@ services:
     image: grafana/tempo:2.7.2
     container_name: tempo
     restart: unless-stopped
-    mem_limit: 256m
+    mem_limit: 512m
     networks:
       - internal
     volumes:


### PR DESCRIPTION
## Summary
- Increase Tempo container `mem_limit` from 256m to 512m to break OOM crash loop
- Container has been OOM-killed 3370+ times with `ExitCode=137`
- 894 trace blocks accumulated over 11 days; in-memory blocklist management exceeds 256MB
- Cascading impact: `ai` and `mcp` services failing to export traces (DNS resolution / connection refused to Tempo)

## Linear
- Issue: Incident response — no Linear issue (operational fix)

## Validation Evidence
- Infra/Deploy: Post-merge deploy verification plan below

## Plan

### Diagnosis
Tempo's 256MB limit is insufficient for the current blocklist size. With 892 tracked entries (253 active + 639 compacted), the in-memory tenant index exceeds the container's OOM threshold. The compactor runs but retention cleanup cannot complete before the next OOM kill — creating a death spiral where old blocks can't be purged because the process can't stay alive long enough.

### Why 512m
- On-disk data is ~130MB. In-memory representation of 892 block metas plus WAL replay is the pressure source.
- 512m is a conservative first step, consistent with Loki's allocation for a similar workload.
- Host has 9GB free RAM; 256MB delta is negligible.
- Once retention purges blocks older than 7 days (~40% of current blocks), steady-state memory should drop well below 512m.

### Risks
| Risk | Likelihood | Impact | Mitigation |
|---|---|---|---|
| 512m still not enough | Low-Medium | Tempo continues crash-looping | Monitor V1/V2 after deploy; bump to 768m/1g if needed |
| Retention sweep memory spike | Low | Temporary OOM during bulk deletion | 512m provides 2x headroom |
| Other containers affected | Very Low | None expected | Host has 9GB free |

### Rollback
Revert the commit and redeploy. Realistic failure mode is 512m still insufficient — would increase further rather than revert.

### Post-deploy verification
- **V1**: Container running and healthy (`docker ps --filter name=tempo`)
- **V2**: `OOMKilled=false`, restart count not increasing
- **V3**: Tempo readiness endpoint returns `ready`
- **V4**: Prometheus target health shows `up`
- **V5**: OTLP export failures in `ai`/`mcp` resolving (follow-up)
- **V6**: Block meta count decreasing over time (follow-up)

## Test plan
- [x] Change is a single config value (mem_limit: 256m → 512m)
- [ ] CI checks pass
- [ ] Post-merge deploy verification (V1–V4)

## Notes
- This is not a guaranteed fix — it is the smallest reasonable increase that should allow the compactor/retention to break the death spiral.
- If 512m proves insufficient after deploy, a follow-up increase will be needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)