### PR TITLE
feat: connect LiteLLM to PostgreSQL for dashboard auth

### DIFF
--- a/deploy/compose/prod/docker-compose.ai.yml
+++ b/deploy/compose/prod/docker-compose.ai.yml
@@ -34,6 +34,7 @@ services:
       - LITELLM_MASTER_KEY=${LITELLM_MASTER_KEY}
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
       - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - DATABASE_URL=postgresql://${DB_USER}:${DB_PASSWORD}@postgres:5432/hill90_litellm
     command: ["--config", "/app/config.yaml", "--port", "4000"]
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request, sys; r=urllib.request.urlopen('http://localhost:4000/health/liveliness'); sys.exit(0 if r.status < 400 else 1)"]

--- a/platform/ai/litellm_config.yaml
+++ b/platform/ai/litellm_config.yaml
@@ -1,6 +1,7 @@
-# LiteLLM proxy configuration — stateless mode (no database)
+# LiteLLM proxy configuration
 # Provider API keys come from environment variables set via Docker Compose.
 # Master key is required and set via LITELLM_MASTER_KEY env var.
+# Database URL is required for dashboard/admin features.
 
 model_list:
   - model_name: claude-sonnet-4-20250514
@@ -41,6 +42,7 @@ model_list:
 
 general_settings:
   master_key: os.environ/LITELLM_MASTER_KEY
+  database_url: os.environ/DATABASE_URL
 
 litellm_settings:
   drop_params: true

--- a/platform/data/postgres/init.sh
+++ b/platform/data/postgres/init.sh
@@ -11,6 +11,9 @@ psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" -v d
     SELECT 'CREATE DATABASE hill90_akm'
     WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'hill90_akm')\gexec
 
+    SELECT 'CREATE DATABASE hill90_litellm'
+    WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'hill90_litellm')\gexec
+
     \c keycloak;
     CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 
@@ -20,8 +23,12 @@ psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" -v d
     \c hill90_akm;
     CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 
+    \c hill90_litellm;
+    CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
     \c postgres;
     GRANT ALL PRIVILEGES ON DATABASE keycloak TO :"db_user";
     GRANT ALL PRIVILEGES ON DATABASE hill90_api TO :"db_user";
     GRANT ALL PRIVILEGES ON DATABASE hill90_akm TO :"db_user";
+    GRANT ALL PRIVILEGES ON DATABASE hill90_litellm TO :"db_user";
 EOSQL

--- a/scripts/provision-litellm-db.sh
+++ b/scripts/provision-litellm-db.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Provision the hill90_litellm database on an existing PostgreSQL instance.
+# Run on VPS: bash scripts/provision-litellm-db.sh
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/_common.sh"
+
+# hill90 is the platform-invariant PostgreSQL superuser, set at VPS bootstrap
+# via POSTGRES_USER=hill90 in docker-compose.db.yml.
+DB_USER="${DB_USER:-hill90}"
+
+echo "Provisioning hill90_litellm database (user: $DB_USER)..."
+
+docker exec postgres psql -v ON_ERROR_STOP=1 --username "$DB_USER" --dbname postgres <<-EOSQL
+    SELECT 'CREATE DATABASE hill90_litellm'
+    WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'hill90_litellm')\\gexec
+
+    \\c hill90_litellm;
+    CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+    \\c postgres;
+    GRANT ALL PRIVILEGES ON DATABASE hill90_litellm TO $DB_USER;
+EOSQL
+
+echo "✓ hill90_litellm database provisioned"

--- a/scripts/provision-litellm-db.sh
+++ b/scripts/provision-litellm-db.sh
@@ -12,7 +12,7 @@ DB_USER="${DB_USER:-hill90}"
 
 echo "Provisioning hill90_litellm database (user: $DB_USER)..."
 
-docker exec postgres psql -v ON_ERROR_STOP=1 --username "$DB_USER" --dbname postgres <<-EOSQL
+docker exec -i postgres psql -v ON_ERROR_STOP=1 --username "$DB_USER" --dbname postgres <<-EOSQL
     SELECT 'CREATE DATABASE hill90_litellm'
     WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'hill90_litellm')\\gexec
 


### PR DESCRIPTION
## Summary
- Add `DATABASE_URL` env var to litellm service in `docker-compose.ai.yml`
- Add `database_url: os.environ/DATABASE_URL` to `litellm_config.yaml` general_settings
- Add `hill90_litellm` database to PostgreSQL init script (`platform/data/postgres/init.sh`)
- Add `scripts/provision-litellm-db.sh` for provisioning on running instance

## Plan

Connect LiteLLM to PostgreSQL so the dashboard at `litellm.hill90.com` can authenticate
with the master key. LiteLLM's dashboard/admin features require a database backend.
Reuses existing `DB_USER`/`DB_PASSWORD` from `secret/shared/database` — no new secrets needed.

**Provision script privilege model:** Uses `$DB_USER` (defaults to `hill90`, the platform-invariant
PostgreSQL superuser) for both connection and GRANT. This matches `init.sh` and avoids the latent
bug in `provision-akm-db.sh` which hardcodes `--username postgres` (no such user exists on VPS).

**Bug found and fixed during verification:** `docker exec` without `-i` silently drops stdin, so
the heredoc content never reached psql. The provision script reported success while doing nothing.
Fixed by adding `-i` flag to `docker exec -i postgres psql ...`. This same bug exists in the
pre-existing `provision-akm-db.sh` (out of scope for this PR).

## Risks

| Risk | Mitigation |
|------|-----------|
| Bad DATABASE_URL causes litellm startup failure | URL uses same DB_USER/DB_PASSWORD vars as AI service; compose config validation catches syntax |
| LiteLLM Prisma migration failure on first connect | DB_USER has GRANT ALL; container restarts via `restart: unless-stopped` |
| Redeploy breaks LiteLLM | Rollback: revert config, redeploy to restore stateless mode |
| LiteLLM restart affects AI service | `depends_on: condition: service_healthy` — both restart together during deploy |

## Rollback

1. **Primary:** Revert code/config changes, redeploy AI service. Restores stateless LiteLLM.
2. **Optional cleanup:** Drop the `hill90_litellm` database via psql.

## Validation Evidence

### Config Verification (V1-V5, local)

| # | Check | Result |
|---|-------|--------|
| V1 | `docker compose config` exits 0 | PASS |
| V2 | DATABASE_URL in litellm env | PASS: `postgresql://:@postgres:5432/hill90_litellm` |
| V3 | litellm_config.yaml has database_url | PASS: `database_url: os.environ/DATABASE_URL` |
| V4 | init.sh has hill90_litellm | PASS: 4 occurrences (CREATE, \c, extension, GRANT) |
| V5 | Provision script uses $DB_USER, no hardcoded postgres | PASS |

### Database Verification (V6-V7, VPS post-provisioning)

| # | Check | Result |
|---|-------|--------|
| V6 | Database exists | PASS: `hill90_litellm \| hill90 \| UTF8` in `psql -lqt` |
| V7 | Database accessible | PASS: `SELECT 1` returns 1 row |

### Runtime Verification (V8-V11, VPS post-deploy)

| # | Check | Result |
|---|-------|--------|
| V8 | LiteLLM container healthy | PASS: `docker inspect` returns `healthy` |
| V9 | `/health/readiness` DB connected | PASS: `{"status":"connected","db":"connected","litellm_version":"1.81.12"}` |
| V10 | Master-key dashboard login | PASS: Playwright login with admin/MASTER_KEY, URL changed to `?login=success`, full admin dashboard rendered (Virtual Keys, Models, Usage, Teams, Settings sidebar), no "Authentication Error" or "Not connected to DB" |
| V11 | AI service still healthy | PASS: `docker inspect` returns `healthy` |

### Deviation from plan

The provision script initially failed silently because `docker exec` without `-i` drops stdin.
This was caught during V6 verification (database did not exist despite script reporting success).
Root cause identified, script fixed (added `-i` flag), committed as separate fix commit, DB dropped
and re-provisioned via the fixed script. No ad-hoc workarounds remain in the final state.

### Workaround assessment

**No workarounds required.** The `-i` flag fix is a durable code change included in this PR.
The database was provisioned entirely via the repo-tracked `provision-litellm-db.sh` script.
The deploy used the standard `deploy.sh ai prod` flow. Merge recommendation: **merge now**.

## Test plan
- [x] Compose config validates (V1)
- [x] DATABASE_URL present in rendered litellm env (V2)
- [x] litellm_config.yaml has database_url in general_settings (V3)
- [x] init.sh creates hill90_litellm database (V4)
- [x] Provision script uses correct privilege model (V5)
- [x] Database provisioned on VPS (V6-V7)
- [x] LiteLLM healthy with DB connected (V8-V9)
- [x] Master-key dashboard login works (V10)
- [x] AI service unaffected (V11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
