### PR TITLE
feat: shared knowledge phase 2 — UI surface + web page ingestion

### DIFF
--- a/docs/site/openapi.yaml
+++ b/docs/site/openapi.yaml
@@ -1253,6 +1253,18 @@ paths:
         schema:
           type: string
           format: uuid
+    get:
+      summary: Get source by ID
+      description: Returns a single source with its metadata, status, and chunk count.
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Source details
+        "401":
+          description: Not authenticated
+        "404":
+          description: Source not found
     delete:
       summary: Delete source
       description: Deletes a source and its documents/chunks (cascade).

--- a/services/api/src/openapi/openapi.yaml
+++ b/services/api/src/openapi/openapi.yaml
@@ -1253,6 +1253,18 @@ paths:
         schema:
           type: string
           format: uuid
+    get:
+      summary: Get source by ID
+      description: Returns a single source with its metadata, status, and chunk count.
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Source details
+        "401":
+          description: Not authenticated
+        "404":
+          description: Source not found
     delete:
       summary: Delete source
       description: Deletes a source and its documents/chunks (cascade).

--- a/services/api/src/routes/shared-knowledge.ts
+++ b/services/api/src/routes/shared-knowledge.ts
@@ -165,10 +165,17 @@ router.get('/sources/:id', requireRole('user'), async (req: Request, res: Respon
       return;
     }
 
-    // Verify ownership/visibility via the source's created_by
+    // Verify access via parent collection visibility/ownership
+    const src = result.data as { collection_id: string };
+    const collection = await skProxy.getCollection(src.collection_id);
+    if (collection.status !== 200) {
+      res.status(404).json({ error: 'Source not found' });
+      return;
+    }
+
     const scope = scopeToOwner(req);
-    const src = result.data as { created_by: string };
-    if (scope.where !== '1=1' && src.created_by !== (req as any).user.sub) {
+    const col = collection.data as { created_by: string; visibility: string };
+    if (scope.where !== '1=1' && col.created_by !== (req as any).user.sub && col.visibility !== 'shared') {
       res.status(404).json({ error: 'Source not found' });
       return;
     }

--- a/services/api/src/routes/shared-knowledge.ts
+++ b/services/api/src/routes/shared-knowledge.ts
@@ -157,6 +157,29 @@ router.get('/sources', requireRole('user'), async (req: Request, res: Response) 
   }
 });
 
+router.get('/sources/:id', requireRole('user'), async (req: Request, res: Response) => {
+  try {
+    const result = await skProxy.getSource(req.params.id);
+    if (result.status !== 200) {
+      res.status(result.status).json(result.data);
+      return;
+    }
+
+    // Verify ownership/visibility via the source's created_by
+    const scope = scopeToOwner(req);
+    const src = result.data as { created_by: string };
+    if (scope.where !== '1=1' && src.created_by !== (req as any).user.sub) {
+      res.status(404).json({ error: 'Source not found' });
+      return;
+    }
+
+    res.json(result.data);
+  } catch (err) {
+    console.error('[shared-knowledge] Get source error:', err);
+    res.status(500).json({ error: 'Failed to get source' });
+  }
+});
+
 router.post('/sources', requireRole('user'), async (req: Request, res: Response) => {
   try {
     const user = (req as any).user;

--- a/services/knowledge/app/services/ingest.py
+++ b/services/knowledge/app/services/ingest.py
@@ -37,33 +37,31 @@ async def ingest_source(
 
     Creates source, ingest job, runs chunker, stores document + chunks.
     Returns the source with ingest job summary.
+
+    For web_page sources, the fetch happens after source/job creation so
+    that failures leave a source record in error state (visible in UI)
+    rather than returning a bare 422 with no DB record.
     """
     if source_type not in ("text", "markdown", "web_page"):
         raise IngestError(f"unsupported source_type: {source_type}")
 
-    # Web page: fetch URL, extract text, then treat like text
+    # Pre-validation (before any DB writes)
     if source_type == "web_page":
         if not source_url or not source_url.strip():
             raise IngestError("source_url is required for web_page sources")
-
-        try:
-            result = await fetch_and_extract(source_url)
-        except FetchError as exc:
-            raise IngestError(str(exc))
-
-        raw_content = result["content"]
-        if not title or title.strip() == source_url:
-            title = result.get("title", title)
+        # Placeholder — real content fetched after source/job records exist
+        raw_content = ""
+        content_hash = ""
     else:
         if not raw_content or not raw_content.strip():
             raise IngestError("content is required for text/markdown sources")
 
-    if len(raw_content.encode()) > MAX_SOURCE_SIZE:
-        raise IngestError(
-            f"content exceeds maximum size of {MAX_SOURCE_SIZE // 1024}KB"
-        )
+        if len(raw_content.encode()) > MAX_SOURCE_SIZE:
+            raise IngestError(
+                f"content exceeds maximum size of {MAX_SOURCE_SIZE // 1024}KB"
+            )
 
-    content_hash = hashlib.sha256(raw_content.encode()).hexdigest()
+        content_hash = hashlib.sha256(raw_content.encode()).hexdigest()
 
     # Create source record
     source = await shared_store.create_source(
@@ -83,6 +81,19 @@ async def ingest_source(
     try:
         # Mark job as running
         await shared_store.update_ingest_job(pool, job["id"], status="running")
+
+        # Web page: fetch and extract content now (after source/job exist)
+        if source_type == "web_page":
+            result = await fetch_and_extract(source_url)
+            raw_content = result["content"]
+            if not title or title.strip() == source_url:
+                title = result.get("title", title)
+            content_hash = hashlib.sha256(raw_content.encode()).hexdigest()
+
+            if len(raw_content.encode()) > MAX_SOURCE_SIZE:
+                raise IngestError(
+                    f"extracted content exceeds maximum size of {MAX_SOURCE_SIZE // 1024}KB"
+                )
 
         # Run chunker
         chunks: list[Chunk]

--- a/services/knowledge/app/services/ingest.py
+++ b/services/knowledge/app/services/ingest.py
@@ -14,6 +14,7 @@ import structlog
 
 from app.services import shared_store
 from app.services.text_chunker import MAX_SOURCE_SIZE, Chunk, chunk_markdown, chunk_text
+from app.services.web_page_fetcher import FetchError, fetch_and_extract
 
 logger = structlog.get_logger()
 
@@ -37,15 +38,25 @@ async def ingest_source(
     Creates source, ingest job, runs chunker, stores document + chunks.
     Returns the source with ingest job summary.
     """
-    # V1: reject web_page
-    if source_type == "web_page":
-        raise IngestError("web_page ingestion not yet supported (Phase 2)")
-
-    if source_type not in ("text", "markdown"):
+    if source_type not in ("text", "markdown", "web_page"):
         raise IngestError(f"unsupported source_type: {source_type}")
 
-    if not raw_content or not raw_content.strip():
-        raise IngestError("content is required for text/markdown sources")
+    # Web page: fetch URL, extract text, then treat like text
+    if source_type == "web_page":
+        if not source_url or not source_url.strip():
+            raise IngestError("source_url is required for web_page sources")
+
+        try:
+            result = await fetch_and_extract(source_url)
+        except FetchError as exc:
+            raise IngestError(str(exc))
+
+        raw_content = result["content"]
+        if not title or title.strip() == source_url:
+            title = result.get("title", title)
+    else:
+        if not raw_content or not raw_content.strip():
+            raise IngestError("content is required for text/markdown sources")
 
     if len(raw_content.encode()) > MAX_SOURCE_SIZE:
         raise IngestError(
@@ -77,7 +88,7 @@ async def ingest_source(
         chunks: list[Chunk]
         if source_type == "markdown":
             chunks = chunk_markdown(raw_content)
-        else:
+        else:  # text and web_page
             chunks = chunk_text(raw_content)
 
         if not chunks:

--- a/services/knowledge/app/services/web_page_fetcher.py
+++ b/services/knowledge/app/services/web_page_fetcher.py
@@ -1,0 +1,249 @@
+"""Web page fetcher with SSRF protection.
+
+Implements the Fetch Safety Contract:
+- URL validation (scheme, credentials, port, internal hostnames)
+- Pre-connect DNS resolution check against blocked CIDR ranges
+- Manual redirect following with re-validation on every hop
+- Error messages omit resolved IP addresses
+- Response size limits
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import socket
+from typing import Any
+from urllib.parse import urlparse
+
+import httpx
+import structlog
+import trafilatura
+
+logger = structlog.get_logger()
+
+MAX_RESPONSE_BYTES = 2 * 1024 * 1024  # 2 MB
+MAX_REDIRECTS = 3
+CONNECT_TIMEOUT = 10.0  # seconds
+READ_TIMEOUT = 30.0  # seconds
+USER_AGENT = "Hill90-KnowledgeService/1.0"
+ALLOWED_PORTS = {80, 443}
+
+# Docker service hostnames that must never be fetched
+BLOCKED_HOSTNAMES = frozenset({
+    "postgres",
+    "api",
+    "ai",
+    "keycloak",
+    "litellm",
+    "openbao",
+    "minio",
+    "tempo",
+    "knowledge",
+    "docker-proxy",
+    "promtail",
+    "loki",
+    "prometheus",
+    "grafana",
+})
+
+# Tailscale/CGNAT range not covered by is_private in all Python versions
+_TAILSCALE_CGNAT = ipaddress.ip_network("100.64.0.0/10")
+
+
+class FetchError(Exception):
+    """Raised when URL fetch fails validation or network checks."""
+
+
+def _is_blocked_ip(ip_str: str) -> bool:
+    """Check if an IP address falls in any blocked range.
+
+    Expects a valid IP address string. Returns False for unparseable
+    strings (hostnames are checked separately).
+    """
+    try:
+        addr = ipaddress.ip_address(ip_str)
+    except ValueError:
+        return False  # Not an IP address (e.g. hostname) — checked elsewhere
+
+    if addr.is_loopback:
+        return True
+    if addr.is_private:
+        return True
+    if addr.is_link_local:
+        return True
+    if addr.is_reserved:
+        return True
+    if addr.is_multicast:
+        return True
+    if addr.is_unspecified:
+        return True
+
+    # Explicit Tailscale/CGNAT check (100.64.0.0/10)
+    if isinstance(addr, ipaddress.IPv4Address) and addr in _TAILSCALE_CGNAT:
+        return True
+
+    return False
+
+
+def _validate_url(url: str) -> tuple[str, str, int | None]:
+    """Validate URL before any network I/O.
+
+    Returns (scheme, hostname, port) if valid.
+    Raises FetchError with category-only message if invalid.
+    """
+    parsed = urlparse(url)
+
+    # Step 1-2: scheme
+    if parsed.scheme not in ("http", "https"):
+        raise FetchError(f"URL scheme '{parsed.scheme}' is not allowed; only http/https are accepted")
+
+    # Step 3: hostname
+    hostname = parsed.hostname
+    if not hostname:
+        raise FetchError("URL has no hostname")
+
+    # Step 5: credentials
+    if parsed.username or parsed.password:
+        raise FetchError("URL must not contain credentials (user:pass@host)")
+
+    # Step 6: internal hostnames (check before port to give clearer errors)
+    hostname_lower = hostname.lower()
+    if hostname_lower in BLOCKED_HOSTNAMES:
+        raise FetchError(f"Hostname '{hostname_lower}' matches an internal service name")
+
+    # Step 4: port
+    port = parsed.port
+    if port is not None and port not in ALLOWED_PORTS:
+        raise FetchError(f"Non-standard port {port} is not allowed; only 80 and 443 are accepted")
+
+    # Check if hostname is an IP literal in a blocked range
+    try:
+        ipaddress.ip_address(hostname)
+        # It's an IP literal — check against blocked ranges
+        if _is_blocked_ip(hostname):
+            raise FetchError("URL points to a blocked IP address range")
+    except ValueError:
+        pass  # Not an IP literal — will resolve via DNS later
+
+    return parsed.scheme, hostname, port
+
+
+def _resolve_and_check(hostname: str, port: int | None) -> None:
+    """Resolve hostname via DNS and check all IPs against blocked ranges.
+
+    Raises FetchError if any resolved IP is blocked.
+    Does NOT include the resolved IP in the error message.
+    """
+    resolve_port = port or 443
+    try:
+        results = socket.getaddrinfo(hostname, resolve_port, proto=socket.IPPROTO_TCP)
+    except socket.gaierror:
+        raise FetchError(f"DNS resolution failed for hostname '{hostname}'")
+
+    if not results:
+        raise FetchError(f"DNS resolution returned no results for hostname '{hostname}'")
+
+    for family, _type, _proto, _canonname, sockaddr in results:
+        ip_str = sockaddr[0]
+        if _is_blocked_ip(ip_str):
+            raise FetchError(
+                f"Hostname '{hostname}' resolves to a blocked private/internal IP address range"
+            )
+
+
+async def fetch_and_extract(url: str) -> dict[str, Any]:
+    """Fetch a web page and extract its text content.
+
+    Returns dict with keys: url, title, content, content_type.
+    Raises FetchError on validation failure, network error, or extraction failure.
+    """
+    # URL validation (before any network I/O)
+    scheme, hostname, port = _validate_url(url)
+
+    # DNS resolution check (before HTTP connect)
+    _resolve_and_check(hostname, port)
+
+    current_url = url
+    redirects = 0
+
+    async with httpx.AsyncClient(
+        timeout=httpx.Timeout(connect=CONNECT_TIMEOUT, read=READ_TIMEOUT, write=READ_TIMEOUT, pool=READ_TIMEOUT),
+        follow_redirects=False,
+        headers={"User-Agent": USER_AGENT},
+    ) as client:
+        while True:
+            try:
+                response = await client.get(current_url)
+            except httpx.ConnectTimeout:
+                raise FetchError(f"Connection timed out fetching '{hostname}'")
+            except httpx.ReadTimeout:
+                raise FetchError(f"Read timed out fetching '{hostname}'")
+            except httpx.ConnectError as exc:
+                raise FetchError(f"Connection failed for '{hostname}': {exc}")
+            except httpx.HTTPError as exc:
+                raise FetchError(f"HTTP error fetching '{hostname}': {exc}")
+
+            # Handle redirects manually with re-validation
+            if response.is_redirect:
+                redirects += 1
+                if redirects > MAX_REDIRECTS:
+                    raise FetchError(
+                        f"Too many redirects (max {MAX_REDIRECTS}) fetching '{hostname}'"
+                    )
+
+                location = response.headers.get("location", "")
+                if not location:
+                    raise FetchError("Redirect response missing Location header")
+
+                # Resolve relative redirects
+                if location.startswith("/"):
+                    parsed_current = urlparse(current_url)
+                    location = f"{parsed_current.scheme}://{parsed_current.netloc}{location}"
+
+                # Re-validate the redirect target
+                redir_scheme, redir_hostname, redir_port = _validate_url(location)
+                _resolve_and_check(redir_hostname, redir_port)
+
+                current_url = location
+                continue
+
+            # Non-redirect response
+            break
+
+    # Check response size
+    content_length = response.headers.get("content-length")
+    if content_length and int(content_length) > MAX_RESPONSE_BYTES:
+        raise FetchError(
+            f"Response size {int(content_length)} bytes exceeds limit of {MAX_RESPONSE_BYTES} bytes"
+        )
+
+    if len(response.text.encode()) > MAX_RESPONSE_BYTES:
+        raise FetchError(
+            f"Response body exceeds size limit of {MAX_RESPONSE_BYTES} bytes"
+        )
+
+    # Extract content with trafilatura
+    html = response.text
+    content_type = response.headers.get("content-type", "text/html")
+    extracted = trafilatura.extract(html)
+
+    if not extracted or not extracted.strip():
+        raise FetchError(f"Could not extract readable content from URL '{hostname}'")
+
+    # Try to get title from trafilatura metadata
+    metadata = trafilatura.extract(html, output_format="xmltei", include_comments=False)
+    title = hostname  # fallback
+
+    logger.info(
+        "web_page_fetched",
+        url=url,
+        hostname=hostname,
+        content_length=len(extracted),
+    )
+
+    return {
+        "url": url,
+        "title": title,
+        "content": extracted,
+        "content_type": content_type,
+    }

--- a/services/knowledge/app/services/web_page_fetcher.py
+++ b/services/knowledge/app/services/web_page_fetcher.py
@@ -173,7 +173,10 @@ async def fetch_and_extract(url: str) -> dict[str, Any]:
     ) as client:
         while True:
             try:
-                response = await client.get(current_url)
+                response = await client.send(
+                    client.build_request("GET", current_url),
+                    stream=True,
+                )
             except httpx.ConnectTimeout:
                 raise FetchError(f"Connection timed out fetching '{hostname}'")
             except httpx.ReadTimeout:
@@ -185,6 +188,7 @@ async def fetch_and_extract(url: str) -> dict[str, Any]:
 
             # Handle redirects manually with re-validation
             if response.is_redirect:
+                await response.aclose()
                 redirects += 1
                 if redirects > MAX_REDIRECTS:
                     raise FetchError(
@@ -207,24 +211,35 @@ async def fetch_and_extract(url: str) -> dict[str, Any]:
                 current_url = location
                 continue
 
-            # Non-redirect response
+            # Non-redirect response — check Content-Length header first
+            content_length = response.headers.get("content-length")
+            if content_length and int(content_length) > MAX_RESPONSE_BYTES:
+                await response.aclose()
+                raise FetchError(
+                    f"Response size {int(content_length)} bytes exceeds limit of {MAX_RESPONSE_BYTES} bytes"
+                )
+
+            # Stream body with incremental size enforcement
+            chunks: list[bytes] = []
+            bytes_read = 0
+            try:
+                async for chunk in response.aiter_bytes(chunk_size=65536):
+                    bytes_read += len(chunk)
+                    if bytes_read > MAX_RESPONSE_BYTES:
+                        raise FetchError(
+                            f"Response body exceeds size limit of {MAX_RESPONSE_BYTES} bytes"
+                        )
+                    chunks.append(chunk)
+            finally:
+                await response.aclose()
+
+            body = b"".join(chunks)
             break
 
-    # Check response size
-    content_length = response.headers.get("content-length")
-    if content_length and int(content_length) > MAX_RESPONSE_BYTES:
-        raise FetchError(
-            f"Response size {int(content_length)} bytes exceeds limit of {MAX_RESPONSE_BYTES} bytes"
-        )
-
-    if len(response.text.encode()) > MAX_RESPONSE_BYTES:
-        raise FetchError(
-            f"Response body exceeds size limit of {MAX_RESPONSE_BYTES} bytes"
-        )
-
     # Extract content with trafilatura
-    html = response.text
     content_type = response.headers.get("content-type", "text/html")
+    encoding = response.charset_encoding or "utf-8"
+    html = body.decode(encoding, errors="replace")
     extracted = trafilatura.extract(html)
 
     if not extracted or not extracted.strip():

--- a/services/knowledge/poetry.lock
+++ b/services/knowledge/poetry.lock
@@ -111,6 +111,21 @@ gssauth = ["gssapi ; platform_system != \"Windows\"", "sspilib ; platform_system
 test = ["distro (>=1.9.0,<1.10.0)", "flake8 (>=6.1,<7.0)", "flake8-pyi (>=24.1.0,<24.2.0)", "gssapi ; platform_system == \"Linux\"", "k5test ; platform_system == \"Linux\"", "mypy (>=1.8.0,<1.9.0)", "sspilib ; platform_system == \"Windows\"", "uvloop (>=0.15.3) ; platform_system != \"Windows\" and python_version < \"3.14.0\""]
 
 [[package]]
+name = "babel"
+version = "2.18.0"
+description = "Internationalization utilities"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "babel-2.18.0-py3-none-any.whl", hash = "sha256:e2b422b277c2b9a9630c1d7903c2a00d0830c409c59ac8cae9081c92f1aeba35"},
+    {file = "babel-2.18.0.tar.gz", hash = "sha256:b80b99a14bd085fcacfa15c9165f651fbb3406e66cc603abf11c5750937c992d"},
+]
+
+[package.extras]
+dev = ["backports.zoneinfo ; python_version < \"3.9\"", "freezegun (>=1.0,<2.0)", "jinja2 (>=3.0)", "pytest (>=6.0)", "pytest-cov", "pytz", "setuptools", "tzdata ; sys_platform == \"win32\""]
+
+[[package]]
 name = "certifi"
 version = "2026.2.25"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -372,6 +387,26 @@ files = [
 markers = {main = "platform_system == \"Windows\" or sys_platform == \"win32\"", dev = "sys_platform == \"win32\""}
 
 [[package]]
+name = "courlan"
+version = "1.3.2"
+description = "Clean, filter and sample URLs to optimize data collection – includes spam, content type and language filters."
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "courlan-1.3.2-py3-none-any.whl", hash = "sha256:d0dab52cf5b5b1000ee2839fbc2837e93b2514d3cb5bb61ae158a55b7a04c6be"},
+    {file = "courlan-1.3.2.tar.gz", hash = "sha256:0b66f4db3a9c39a6e22dd247c72cfaa57d68ea660e94bb2c84ec7db8712af190"},
+]
+
+[package.dependencies]
+babel = ">=2.16.0"
+tld = ">=0.13"
+urllib3 = ">=1.26,<3"
+
+[package.extras]
+dev = ["black", "flake8", "mypy", "pytest", "pytest-cov", "types-urllib3"]
+
+[[package]]
 name = "coverage"
 version = "7.13.4"
 description = "Code coverage measurement for Python"
@@ -551,6 +586,29 @@ test = ["certifi (>=2024)", "cryptography-vectors (==44.0.3)", "pretend (>=0.7)"
 test-randomorder = ["pytest-randomly"]
 
 [[package]]
+name = "dateparser"
+version = "1.3.0"
+description = "Date parsing library designed to parse dates from HTML pages"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "dateparser-1.3.0-py3-none-any.whl", hash = "sha256:8dc678b0a526e103379f02ae44337d424bd366aac727d3c6cf52ce1b01efbb5a"},
+    {file = "dateparser-1.3.0.tar.gz", hash = "sha256:5bccf5d1ec6785e5be71cc7ec80f014575a09b4923e762f850e57443bddbf1a5"},
+]
+
+[package.dependencies]
+python-dateutil = ">=2.7.0"
+pytz = ">=2024.2"
+regex = ">=2024.9.11"
+tzlocal = ">=0.2"
+
+[package.extras]
+calendars = ["convertdate (>=2.2.1)", "hijridate"]
+fasttext = ["fasttext (>=0.9.1)", "numpy (>=1.22.0,<2)"]
+langdetect = ["langdetect (>=1.0.0)"]
+
+[[package]]
 name = "fastapi"
 version = "0.109.2"
 description = "FastAPI framework, high performance, easy to learn, fast to code, ready for production"
@@ -599,6 +657,30 @@ files = [
     {file = "h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86"},
     {file = "h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1"},
 ]
+
+[[package]]
+name = "htmldate"
+version = "1.9.4"
+description = "Fast and robust extraction of original and updated publication dates from URLs and web pages."
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "htmldate-1.9.4-py3-none-any.whl", hash = "sha256:1b94bcc4e08232a5b692159903acf95548b6a7492dddca5bb123d89d6325921c"},
+    {file = "htmldate-1.9.4.tar.gz", hash = "sha256:1129063e02dd0354b74264de71e950c0c3fcee191178321418ccad2074cc8ed0"},
+]
+
+[package.dependencies]
+charset_normalizer = ">=3.4.0"
+dateparser = ">=1.1.2"
+lxml = {version = ">=5.3.0", markers = "platform_system != \"Darwin\" or python_version > \"3.8\""}
+python-dateutil = ">=2.9.0.post0"
+urllib3 = ">=1.26,<3"
+
+[package.extras]
+all = ["htmldate[dev]", "htmldate[speed]"]
+dev = ["black", "flake8", "mypy", "pytest", "pytest-cov", "types-dateparser", "types-lxml", "types-python-dateutil", "types-urllib3"]
+speed = ["backports-datetime-fromisoformat ; python_version < \"3.11\"", "faust-cchardet (>=2.1.19)", "urllib3[brotli]"]
 
 [[package]]
 name = "httpcore"
@@ -752,6 +834,21 @@ files = [
 ]
 
 [[package]]
+name = "justext"
+version = "3.0.2"
+description = "Heuristic based boilerplate removal tool"
+optional = false
+python-versions = "*"
+groups = ["main"]
+files = [
+    {file = "justext-3.0.2-py2.py3-none-any.whl", hash = "sha256:62b1c562b15c3c6265e121cc070874243a443bfd53060e869393f09d6b6cc9a7"},
+    {file = "justext-3.0.2.tar.gz", hash = "sha256:13496a450c44c4cd5b5a75a5efcd9996066d2a189794ea99a49949685a0beb05"},
+]
+
+[package.dependencies]
+lxml = {version = ">=4.4.2", extras = ["html-clean"]}
+
+[[package]]
 name = "librt"
 version = "0.8.1"
 description = "Mypyc runtime library"
@@ -851,6 +948,180 @@ files = [
     {file = "librt-0.8.1-cp39-cp39-win_amd64.whl", hash = "sha256:64548cde61b692dc0dc379f4b5f59a2f582c2ebe7890d09c1ae3b9e66fa015b7"},
     {file = "librt-0.8.1.tar.gz", hash = "sha256:be46a14693955b3bd96014ccbdb8339ee8c9346fbe11c1b78901b55125f14c73"},
 ]
+
+[[package]]
+name = "lxml"
+version = "6.0.2"
+description = "Powerful and Pythonic XML processing library combining libxml2/libxslt with the ElementTree API."
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "lxml-6.0.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:e77dd455b9a16bbd2a5036a63ddbd479c19572af81b624e79ef422f929eef388"},
+    {file = "lxml-6.0.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:5d444858b9f07cefff6455b983aea9a67f7462ba1f6cbe4a21e8bf6791bf2153"},
+    {file = "lxml-6.0.2-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f952dacaa552f3bb8834908dddd500ba7d508e6ea6eb8c52eb2d28f48ca06a31"},
+    {file = "lxml-6.0.2-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:71695772df6acea9f3c0e59e44ba8ac50c4f125217e84aab21074a1a55e7e5c9"},
+    {file = "lxml-6.0.2-cp310-cp310-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:17f68764f35fd78d7c4cc4ef209a184c38b65440378013d24b8aecd327c3e0c8"},
+    {file = "lxml-6.0.2-cp310-cp310-manylinux_2_26_i686.manylinux_2_28_i686.whl", hash = "sha256:058027e261afed589eddcfe530fcc6f3402d7fd7e89bfd0532df82ebc1563dba"},
+    {file = "lxml-6.0.2-cp310-cp310-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a8ffaeec5dfea5881d4c9d8913a32d10cfe3923495386106e4a24d45300ef79c"},
+    {file = "lxml-6.0.2-cp310-cp310-manylinux_2_31_armv7l.whl", hash = "sha256:f2e3b1a6bb38de0bc713edd4d612969dd250ca8b724be8d460001a387507021c"},
+    {file = "lxml-6.0.2-cp310-cp310-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d6690ec5ec1cce0385cb20896b16be35247ac8c2046e493d03232f1c2414d321"},
+    {file = "lxml-6.0.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:f2a50c3c1d11cad0ebebbac357a97b26aa79d2bcaf46f256551152aa85d3a4d1"},
+    {file = "lxml-6.0.2-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:3efe1b21c7801ffa29a1112fab3b0f643628c30472d507f39544fd48e9549e34"},
+    {file = "lxml-6.0.2-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:59c45e125140b2c4b33920d21d83681940ca29f0b83f8629ea1a2196dc8cfe6a"},
+    {file = "lxml-6.0.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:452b899faa64f1805943ec1c0c9ebeaece01a1af83e130b69cdefeda180bb42c"},
+    {file = "lxml-6.0.2-cp310-cp310-win32.whl", hash = "sha256:1e786a464c191ca43b133906c6903a7e4d56bef376b75d97ccbb8ec5cf1f0a4b"},
+    {file = "lxml-6.0.2-cp310-cp310-win_amd64.whl", hash = "sha256:dacf3c64ef3f7440e3167aa4b49aa9e0fb99e0aa4f9ff03795640bf94531bcb0"},
+    {file = "lxml-6.0.2-cp310-cp310-win_arm64.whl", hash = "sha256:45f93e6f75123f88d7f0cfd90f2d05f441b808562bf0bc01070a00f53f5028b5"},
+    {file = "lxml-6.0.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:13e35cbc684aadf05d8711a5d1b5857c92e5e580efa9a0d2be197199c8def607"},
+    {file = "lxml-6.0.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3b1675e096e17c6fe9c0e8c81434f5736c0739ff9ac6123c87c2d452f48fc938"},
+    {file = "lxml-6.0.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8ac6e5811ae2870953390452e3476694196f98d447573234592d30488147404d"},
+    {file = "lxml-6.0.2-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5aa0fc67ae19d7a64c3fe725dc9a1bb11f80e01f78289d05c6f62545affec438"},
+    {file = "lxml-6.0.2-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:de496365750cc472b4e7902a485d3f152ecf57bd3ba03ddd5578ed8ceb4c5964"},
+    {file = "lxml-6.0.2-cp311-cp311-manylinux_2_26_i686.manylinux_2_28_i686.whl", hash = "sha256:200069a593c5e40b8f6fc0d84d86d970ba43138c3e68619ffa234bc9bb806a4d"},
+    {file = "lxml-6.0.2-cp311-cp311-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7d2de809c2ee3b888b59f995625385f74629707c9355e0ff856445cdcae682b7"},
+    {file = "lxml-6.0.2-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:b2c3da8d93cf5db60e8858c17684c47d01fee6405e554fb55018dd85fc23b178"},
+    {file = "lxml-6.0.2-cp311-cp311-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:442de7530296ef5e188373a1ea5789a46ce90c4847e597856570439621d9c553"},
+    {file = "lxml-6.0.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:2593c77efde7bfea7f6389f1ab249b15ed4aa5bc5cb5131faa3b843c429fbedb"},
+    {file = "lxml-6.0.2-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:3e3cb08855967a20f553ff32d147e14329b3ae70ced6edc2f282b94afbc74b2a"},
+    {file = "lxml-6.0.2-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:2ed6c667fcbb8c19c6791bbf40b7268ef8ddf5a96940ba9404b9f9a304832f6c"},
+    {file = "lxml-6.0.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b8f18914faec94132e5b91e69d76a5c1d7b0c73e2489ea8929c4aaa10b76bbf7"},
+    {file = "lxml-6.0.2-cp311-cp311-win32.whl", hash = "sha256:6605c604e6daa9e0d7f0a2137bdc47a2e93b59c60a65466353e37f8272f47c46"},
+    {file = "lxml-6.0.2-cp311-cp311-win_amd64.whl", hash = "sha256:e5867f2651016a3afd8dd2c8238baa66f1e2802f44bc17e236f547ace6647078"},
+    {file = "lxml-6.0.2-cp311-cp311-win_arm64.whl", hash = "sha256:4197fb2534ee05fd3e7afaab5d8bfd6c2e186f65ea7f9cd6a82809c887bd1285"},
+    {file = "lxml-6.0.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a59f5448ba2ceccd06995c95ea59a7674a10de0810f2ce90c9006f3cbc044456"},
+    {file = "lxml-6.0.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:e8113639f3296706fbac34a30813929e29247718e88173ad849f57ca59754924"},
+    {file = "lxml-6.0.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a8bef9b9825fa8bc816a6e641bb67219489229ebc648be422af695f6e7a4fa7f"},
+    {file = "lxml-6.0.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:65ea18d710fd14e0186c2f973dc60bb52039a275f82d3c44a0e42b43440ea534"},
+    {file = "lxml-6.0.2-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c371aa98126a0d4c739ca93ceffa0fd7a5d732e3ac66a46e74339acd4d334564"},
+    {file = "lxml-6.0.2-cp312-cp312-manylinux_2_26_i686.manylinux_2_28_i686.whl", hash = "sha256:700efd30c0fa1a3581d80a748157397559396090a51d306ea59a70020223d16f"},
+    {file = "lxml-6.0.2-cp312-cp312-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c33e66d44fe60e72397b487ee92e01da0d09ba2d66df8eae42d77b6d06e5eba0"},
+    {file = "lxml-6.0.2-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:90a345bbeaf9d0587a3aaffb7006aa39ccb6ff0e96a57286c0cb2fd1520ea192"},
+    {file = "lxml-6.0.2-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:064fdadaf7a21af3ed1dcaa106b854077fbeada827c18f72aec9346847cd65d0"},
+    {file = "lxml-6.0.2-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fbc74f42c3525ac4ffa4b89cbdd00057b6196bcefe8bce794abd42d33a018092"},
+    {file = "lxml-6.0.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:6ddff43f702905a4e32bc24f3f2e2edfe0f8fde3277d481bffb709a4cced7a1f"},
+    {file = "lxml-6.0.2-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:6da5185951d72e6f5352166e3da7b0dc27aa70bd1090b0eb3f7f7212b53f1bb8"},
+    {file = "lxml-6.0.2-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:57a86e1ebb4020a38d295c04fc79603c7899e0df71588043eb218722dabc087f"},
+    {file = "lxml-6.0.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:2047d8234fe735ab77802ce5f2297e410ff40f5238aec569ad7c8e163d7b19a6"},
+    {file = "lxml-6.0.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6f91fd2b2ea15a6800c8e24418c0775a1694eefc011392da73bc6cef2623b322"},
+    {file = "lxml-6.0.2-cp312-cp312-win32.whl", hash = "sha256:3ae2ce7d6fedfb3414a2b6c5e20b249c4c607f72cb8d2bb7cc9c6ec7c6f4e849"},
+    {file = "lxml-6.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:72c87e5ee4e58a8354fb9c7c84cbf95a1c8236c127a5d1b7683f04bed8361e1f"},
+    {file = "lxml-6.0.2-cp312-cp312-win_arm64.whl", hash = "sha256:61cb10eeb95570153e0c0e554f58df92ecf5109f75eacad4a95baa709e26c3d6"},
+    {file = "lxml-6.0.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:9b33d21594afab46f37ae58dfadd06636f154923c4e8a4d754b0127554eb2e77"},
+    {file = "lxml-6.0.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:6c8963287d7a4c5c9a432ff487c52e9c5618667179c18a204bdedb27310f022f"},
+    {file = "lxml-6.0.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1941354d92699fb5ffe6ed7b32f9649e43c2feb4b97205f75866f7d21aa91452"},
+    {file = "lxml-6.0.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:bb2f6ca0ae2d983ded09357b84af659c954722bbf04dea98030064996d156048"},
+    {file = "lxml-6.0.2-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:eb2a12d704f180a902d7fa778c6d71f36ceb7b0d317f34cdc76a5d05aa1dd1df"},
+    {file = "lxml-6.0.2-cp313-cp313-manylinux_2_26_i686.manylinux_2_28_i686.whl", hash = "sha256:6ec0e3f745021bfed19c456647f0298d60a24c9ff86d9d051f52b509663feeb1"},
+    {file = "lxml-6.0.2-cp313-cp313-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:846ae9a12d54e368933b9759052d6206a9e8b250291109c48e350c1f1f49d916"},
+    {file = "lxml-6.0.2-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ef9266d2aa545d7374938fb5c484531ef5a2ec7f2d573e62f8ce722c735685fd"},
+    {file = "lxml-6.0.2-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:4077b7c79f31755df33b795dc12119cb557a0106bfdab0d2c2d97bd3cf3dffa6"},
+    {file = "lxml-6.0.2-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a7c5d5e5f1081955358533be077166ee97ed2571d6a66bdba6ec2f609a715d1a"},
+    {file = "lxml-6.0.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:8f8d0cbd0674ee89863a523e6994ac25fd5be9c8486acfc3e5ccea679bad2679"},
+    {file = "lxml-6.0.2-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:2cbcbf6d6e924c28f04a43f3b6f6e272312a090f269eff68a2982e13e5d57659"},
+    {file = "lxml-6.0.2-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:dfb874cfa53340009af6bdd7e54ebc0d21012a60a4e65d927c2e477112e63484"},
+    {file = "lxml-6.0.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:fb8dae0b6b8b7f9e96c26fdd8121522ce5de9bb5538010870bd538683d30e9a2"},
+    {file = "lxml-6.0.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:358d9adae670b63e95bc59747c72f4dc97c9ec58881d4627fe0120da0f90d314"},
+    {file = "lxml-6.0.2-cp313-cp313-win32.whl", hash = "sha256:e8cd2415f372e7e5a789d743d133ae474290a90b9023197fd78f32e2dc6873e2"},
+    {file = "lxml-6.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:b30d46379644fbfc3ab81f8f82ae4de55179414651f110a1514f0b1f8f6cb2d7"},
+    {file = "lxml-6.0.2-cp313-cp313-win_arm64.whl", hash = "sha256:13dcecc9946dca97b11b7c40d29fba63b55ab4170d3c0cf8c0c164343b9bfdcf"},
+    {file = "lxml-6.0.2-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:b0c732aa23de8f8aec23f4b580d1e52905ef468afb4abeafd3fec77042abb6fe"},
+    {file = "lxml-6.0.2-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:4468e3b83e10e0317a89a33d28f7aeba1caa4d1a6fd457d115dd4ffe90c5931d"},
+    {file = "lxml-6.0.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:abd44571493973bad4598a3be7e1d807ed45aa2adaf7ab92ab7c62609569b17d"},
+    {file = "lxml-6.0.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:370cd78d5855cfbffd57c422851f7d3864e6ae72d0da615fca4dad8c45d375a5"},
+    {file = "lxml-6.0.2-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:901e3b4219fa04ef766885fb40fa516a71662a4c61b80c94d25336b4934b71c0"},
+    {file = "lxml-6.0.2-cp314-cp314-manylinux_2_26_i686.manylinux_2_28_i686.whl", hash = "sha256:a4bf42d2e4cf52c28cc1812d62426b9503cdb0c87a6de81442626aa7d69707ba"},
+    {file = "lxml-6.0.2-cp314-cp314-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b2c7fdaa4d7c3d886a42534adec7cfac73860b89b4e5298752f60aa5984641a0"},
+    {file = "lxml-6.0.2-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:98a5e1660dc7de2200b00d53fa00bcd3c35a3608c305d45a7bbcaf29fa16e83d"},
+    {file = "lxml-6.0.2-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:dc051506c30b609238d79eda75ee9cab3e520570ec8219844a72a46020901e37"},
+    {file = "lxml-6.0.2-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:8799481bbdd212470d17513a54d568f44416db01250f49449647b5ab5b5dccb9"},
+    {file = "lxml-6.0.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9261bb77c2dab42f3ecd9103951aeca2c40277701eb7e912c545c1b16e0e4917"},
+    {file = "lxml-6.0.2-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:65ac4a01aba353cfa6d5725b95d7aed6356ddc0a3cd734de00124d285b04b64f"},
+    {file = "lxml-6.0.2-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:b22a07cbb82fea98f8a2fd814f3d1811ff9ed76d0fc6abc84eb21527596e7cc8"},
+    {file = "lxml-6.0.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:d759cdd7f3e055d6bc8d9bec3ad905227b2e4c785dc16c372eb5b5e83123f48a"},
+    {file = "lxml-6.0.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:945da35a48d193d27c188037a05fec5492937f66fb1958c24fc761fb9d40d43c"},
+    {file = "lxml-6.0.2-cp314-cp314-win32.whl", hash = "sha256:be3aaa60da67e6153eb15715cc2e19091af5dc75faef8b8a585aea372507384b"},
+    {file = "lxml-6.0.2-cp314-cp314-win_amd64.whl", hash = "sha256:fa25afbadead523f7001caf0c2382afd272c315a033a7b06336da2637d92d6ed"},
+    {file = "lxml-6.0.2-cp314-cp314-win_arm64.whl", hash = "sha256:063eccf89df5b24e361b123e257e437f9e9878f425ee9aae3144c77faf6da6d8"},
+    {file = "lxml-6.0.2-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:6162a86d86893d63084faaf4ff937b3daea233e3682fb4474db07395794fa80d"},
+    {file = "lxml-6.0.2-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:414aaa94e974e23a3e92e7ca5b97d10c0cf37b6481f50911032c69eeb3991bba"},
+    {file = "lxml-6.0.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:48461bd21625458dd01e14e2c38dd0aea69addc3c4f960c30d9f59d7f93be601"},
+    {file = "lxml-6.0.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:25fcc59afc57d527cfc78a58f40ab4c9b8fd096a9a3f964d2781ffb6eb33f4ed"},
+    {file = "lxml-6.0.2-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5179c60288204e6ddde3f774a93350177e08876eaf3ab78aa3a3649d43eb7d37"},
+    {file = "lxml-6.0.2-cp314-cp314t-manylinux_2_26_i686.manylinux_2_28_i686.whl", hash = "sha256:967aab75434de148ec80597b75062d8123cadf2943fb4281f385141e18b21338"},
+    {file = "lxml-6.0.2-cp314-cp314t-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d100fcc8930d697c6561156c6810ab4a508fb264c8b6779e6e61e2ed5e7558f9"},
+    {file = "lxml-6.0.2-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2ca59e7e13e5981175b8b3e4ab84d7da57993eeff53c07764dcebda0d0e64ecd"},
+    {file = "lxml-6.0.2-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:957448ac63a42e2e49531b9d6c0fa449a1970dbc32467aaad46f11545be9af1d"},
+    {file = "lxml-6.0.2-cp314-cp314t-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b7fc49c37f1786284b12af63152fe1d0990722497e2d5817acfe7a877522f9a9"},
+    {file = "lxml-6.0.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e19e0643cc936a22e837f79d01a550678da8377d7d801a14487c10c34ee49c7e"},
+    {file = "lxml-6.0.2-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:1db01e5cf14345628e0cbe71067204db658e2fb8e51e7f33631f5f4735fefd8d"},
+    {file = "lxml-6.0.2-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:875c6b5ab39ad5291588aed6925fac99d0097af0dd62f33c7b43736043d4a2ec"},
+    {file = "lxml-6.0.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:cdcbed9ad19da81c480dfd6dd161886db6096083c9938ead313d94b30aadf272"},
+    {file = "lxml-6.0.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:80dadc234ebc532e09be1975ff538d154a7fa61ea5031c03d25178855544728f"},
+    {file = "lxml-6.0.2-cp314-cp314t-win32.whl", hash = "sha256:da08e7bb297b04e893d91087df19638dc7a6bb858a954b0cc2b9f5053c922312"},
+    {file = "lxml-6.0.2-cp314-cp314t-win_amd64.whl", hash = "sha256:252a22982dca42f6155125ac76d3432e548a7625d56f5a273ee78a5057216eca"},
+    {file = "lxml-6.0.2-cp314-cp314t-win_arm64.whl", hash = "sha256:bb4c1847b303835d89d785a18801a883436cdfd5dc3d62947f9c49e24f0f5a2c"},
+    {file = "lxml-6.0.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:a656ca105115f6b766bba324f23a67914d9c728dafec57638e2b92a9dcd76c62"},
+    {file = "lxml-6.0.2-cp38-cp38-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c54d83a2188a10ebdba573f16bd97135d06c9ef60c3dc495315c7a28c80a263f"},
+    {file = "lxml-6.0.2-cp38-cp38-manylinux_2_26_i686.manylinux_2_28_i686.whl", hash = "sha256:1ea99340b3c729beea786f78c38f60f4795622f36e305d9c9be402201efdc3b7"},
+    {file = "lxml-6.0.2-cp38-cp38-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:af85529ae8d2a453feee4c780d9406a5e3b17cee0dd75c18bd31adcd584debc3"},
+    {file = "lxml-6.0.2-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:fe659f6b5d10fb5a17f00a50eb903eb277a71ee35df4615db573c069bcf967ac"},
+    {file = "lxml-6.0.2-cp38-cp38-win32.whl", hash = "sha256:5921d924aa5468c939d95c9814fa9f9b5935a6ff4e679e26aaf2951f74043512"},
+    {file = "lxml-6.0.2-cp38-cp38-win_amd64.whl", hash = "sha256:0aa7070978f893954008ab73bb9e3c24a7c56c054e00566a21b553dc18105fca"},
+    {file = "lxml-6.0.2-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:2c8458c2cdd29589a8367c09c8f030f1d202be673f0ca224ec18590b3b9fb694"},
+    {file = "lxml-6.0.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:3fee0851639d06276e6b387f1c190eb9d7f06f7f53514e966b26bae46481ec90"},
+    {file = "lxml-6.0.2-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b2142a376b40b6736dfc214fd2902409e9e3857eff554fed2d3c60f097e62a62"},
+    {file = "lxml-6.0.2-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a6b5b39cc7e2998f968f05309e666103b53e2edd01df8dc51b90d734c0825444"},
+    {file = "lxml-6.0.2-cp39-cp39-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d4aec24d6b72ee457ec665344a29acb2d35937d5192faebe429ea02633151aad"},
+    {file = "lxml-6.0.2-cp39-cp39-manylinux_2_26_i686.manylinux_2_28_i686.whl", hash = "sha256:b42f4d86b451c2f9d06ffb4f8bbc776e04df3ba070b9fe2657804b1b40277c48"},
+    {file = "lxml-6.0.2-cp39-cp39-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6cdaefac66e8b8f30e37a9b4768a391e1f8a16a7526d5bc77a7928408ef68e93"},
+    {file = "lxml-6.0.2-cp39-cp39-manylinux_2_31_armv7l.whl", hash = "sha256:b738f7e648735714bbb82bdfd030203360cfeab7f6e8a34772b3c8c8b820568c"},
+    {file = "lxml-6.0.2-cp39-cp39-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:daf42de090d59db025af61ce6bdb2521f0f102ea0e6ea310f13c17610a97da4c"},
+    {file = "lxml-6.0.2-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:66328dabea70b5ba7e53d94aa774b733cf66686535f3bc9250a7aab53a91caaf"},
+    {file = "lxml-6.0.2-cp39-cp39-musllinux_1_2_armv7l.whl", hash = "sha256:e237b807d68a61fc3b1e845407e27e5eb8ef69bc93fe8505337c1acb4ee300b6"},
+    {file = "lxml-6.0.2-cp39-cp39-musllinux_1_2_riscv64.whl", hash = "sha256:ac02dc29fd397608f8eb15ac1610ae2f2f0154b03f631e6d724d9e2ad4ee2c84"},
+    {file = "lxml-6.0.2-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:817ef43a0c0b4a77bd166dc9a09a555394105ff3374777ad41f453526e37f9cb"},
+    {file = "lxml-6.0.2-cp39-cp39-win32.whl", hash = "sha256:bc532422ff26b304cfb62b328826bd995c96154ffd2bac4544f37dbb95ecaa8f"},
+    {file = "lxml-6.0.2-cp39-cp39-win_amd64.whl", hash = "sha256:995e783eb0374c120f528f807443ad5a83a656a8624c467ea73781fc5f8a8304"},
+    {file = "lxml-6.0.2-cp39-cp39-win_arm64.whl", hash = "sha256:08b9d5e803c2e4725ae9e8559ee880e5328ed61aa0935244e0515d7d9dbec0aa"},
+    {file = "lxml-6.0.2-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:e748d4cf8fef2526bb2a589a417eba0c8674e29ffcb570ce2ceca44f1e567bf6"},
+    {file = "lxml-6.0.2-pp310-pypy310_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:4ddb1049fa0579d0cbd00503ad8c58b9ab34d1254c77bc6a5576d96ec7853dba"},
+    {file = "lxml-6.0.2-pp310-pypy310_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cb233f9c95f83707dae461b12b720c1af9c28c2d19208e1be03387222151daf5"},
+    {file = "lxml-6.0.2-pp310-pypy310_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bc456d04db0515ce3320d714a1eac7a97774ff0849e7718b492d957da4631dd4"},
+    {file = "lxml-6.0.2-pp310-pypy310_pp73-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2613e67de13d619fd283d58bda40bff0ee07739f624ffee8b13b631abf33083d"},
+    {file = "lxml-6.0.2-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:24a8e756c982c001ca8d59e87c80c4d9dcd4d9b44a4cbeb8d9be4482c514d41d"},
+    {file = "lxml-6.0.2-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:1c06035eafa8404b5cf475bb37a9f6088b0aca288d4ccc9d69389750d5543700"},
+    {file = "lxml-6.0.2-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c7d13103045de1bdd6fe5d61802565f1a3537d70cd3abf596aa0af62761921ee"},
+    {file = "lxml-6.0.2-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0a3c150a95fbe5ac91de323aa756219ef9cf7fde5a3f00e2281e30f33fa5fa4f"},
+    {file = "lxml-6.0.2-pp311-pypy311_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:60fa43be34f78bebb27812ed90f1925ec99560b0fa1decdb7d12b84d857d31e9"},
+    {file = "lxml-6.0.2-pp311-pypy311_pp73-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:21c73b476d3cfe836be731225ec3421fa2f048d84f6df6a8e70433dff1376d5a"},
+    {file = "lxml-6.0.2-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:27220da5be049e936c3aca06f174e8827ca6445a4353a1995584311487fc4e3e"},
+    {file = "lxml-6.0.2.tar.gz", hash = "sha256:cd79f3367bd74b317dda655dc8fcfa304d9eb6e4fb06b7168c5cf27f96e0cd62"},
+]
+
+[package.dependencies]
+lxml_html_clean = {version = "*", optional = true, markers = "extra == \"html-clean\""}
+
+[package.extras]
+cssselect = ["cssselect (>=0.7)"]
+html-clean = ["lxml_html_clean"]
+html5 = ["html5lib"]
+htmlsoup = ["BeautifulSoup4"]
+
+[[package]]
+name = "lxml-html-clean"
+version = "0.4.4"
+description = "HTML cleaner from lxml project"
+optional = false
+python-versions = "*"
+groups = ["main"]
+files = [
+    {file = "lxml_html_clean-0.4.4-py3-none-any.whl", hash = "sha256:ce2ef506614ecb85ee1c5fe0a2aa45b06a19514ec7949e9c8f34f06925cfabcb"},
+    {file = "lxml_html_clean-0.4.4.tar.gz", hash = "sha256:58f39a9d632711202ed1d6d0b9b47a904e306c85de5761543b90e3e3f736acfb"},
+]
+
+[package.dependencies]
+lxml = "*"
 
 [[package]]
 name = "mypy"
@@ -1498,6 +1769,21 @@ pytest = ">=4.6"
 testing = ["fields", "hunter", "process-tests", "pytest-xdist", "six", "virtualenv"]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+description = "Extensions to the standard Python datetime module"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+groups = ["main"]
+files = [
+    {file = "python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3"},
+    {file = "python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"},
+]
+
+[package.dependencies]
+six = ">=1.5"
+
+[[package]]
 name = "python-dotenv"
 version = "1.2.1"
 description = "Read key-value pairs from a .env file and set them as environment variables"
@@ -1511,6 +1797,18 @@ files = [
 
 [package.extras]
 cli = ["click (>=5.0)"]
+
+[[package]]
+name = "pytz"
+version = "2025.2"
+description = "World timezone definitions, modern and historical"
+optional = false
+python-versions = "*"
+groups = ["main"]
+files = [
+    {file = "pytz-2025.2-py2.py3-none-any.whl", hash = "sha256:5ddf76296dd8c44c26eb8f4b6f35488f3ccbf6fbbd7adee0b7262d43f0ec2f00"},
+    {file = "pytz-2025.2.tar.gz", hash = "sha256:360b9e3dbb49a209c21ad61809c7fb453643e048b38924c765813546746e81c3"},
+]
 
 [[package]]
 name = "pyyaml"
@@ -1596,6 +1894,130 @@ files = [
 ]
 
 [[package]]
+name = "regex"
+version = "2026.2.28"
+description = "Alternative regular expression module, to replace re."
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "regex-2026.2.28-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:fc48c500838be6882b32748f60a15229d2dea96e59ef341eaa96ec83538f498d"},
+    {file = "regex-2026.2.28-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2afa673660928d0b63d84353c6c08a8a476ddfc4a47e11742949d182e6863ce8"},
+    {file = "regex-2026.2.28-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:7ab218076eb0944549e7fe74cf0e2b83a82edb27e81cc87411f76240865e04d5"},
+    {file = "regex-2026.2.28-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:94d63db12e45a9b9f064bfe4800cefefc7e5f182052e4c1b774d46a40ab1d9bb"},
+    {file = "regex-2026.2.28-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:195237dc327858a7721bf8b0bbbef797554bc13563c3591e91cd0767bacbe359"},
+    {file = "regex-2026.2.28-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b387a0d092dac157fb026d737dde35ff3e49ef27f285343e7c6401851239df27"},
+    {file = "regex-2026.2.28-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3935174fa4d9f70525a4367aaff3cb8bc0548129d114260c29d9dfa4a5b41692"},
+    {file = "regex-2026.2.28-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2b2b23587b26496ff5fd40df4278becdf386813ec00dc3533fa43a4cf0e2ad3c"},
+    {file = "regex-2026.2.28-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3b24bd7e9d85dc7c6a8bd2aa14ecd234274a0248335a02adeb25448aecdd420d"},
+    {file = "regex-2026.2.28-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:bd477d5f79920338107f04aa645f094032d9e3030cc55be581df3d1ef61aa318"},
+    {file = "regex-2026.2.28-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:b49eb78048c6354f49e91e4b77da21257fecb92256b6d599ae44403cab30b05b"},
+    {file = "regex-2026.2.28-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:a25c7701e4f7a70021db9aaf4a4a0a67033c6318752146e03d1b94d32006217e"},
+    {file = "regex-2026.2.28-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:9dd450db6458387167e033cfa80887a34c99c81d26da1bf8b0b41bf8c9cac88e"},
+    {file = "regex-2026.2.28-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:2954379dd20752e82d22accf3ff465311cbb2bac6c1f92c4afd400e1757f7451"},
+    {file = "regex-2026.2.28-cp310-cp310-win32.whl", hash = "sha256:1f8b17be5c27a684ea6759983c13506bd77bfc7c0347dff41b18ce5ddd2ee09a"},
+    {file = "regex-2026.2.28-cp310-cp310-win_amd64.whl", hash = "sha256:dd8847c4978bc3c7e6c826fb745f5570e518b8459ac2892151ce6627c7bc00d5"},
+    {file = "regex-2026.2.28-cp310-cp310-win_arm64.whl", hash = "sha256:73cdcdbba8028167ea81490c7f45280113e41db2c7afb65a276f4711fa3bcbff"},
+    {file = "regex-2026.2.28-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:e621fb7c8dc147419b28e1702f58a0177ff8308a76fa295c71f3e7827849f5d9"},
+    {file = "regex-2026.2.28-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:0d5bef2031cbf38757a0b0bc4298bb4824b6332d28edc16b39247228fbdbad97"},
+    {file = "regex-2026.2.28-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:bcb399ed84eabf4282587ba151f2732ad8168e66f1d3f85b1d038868fe547703"},
+    {file = "regex-2026.2.28-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7c1b34dfa72f826f535b20712afa9bb3ba580020e834f3c69866c5bddbf10098"},
+    {file = "regex-2026.2.28-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:851fa70df44325e1e4cdb79c5e676e91a78147b1b543db2aec8734d2add30ec2"},
+    {file = "regex-2026.2.28-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:516604edd17b1c2c3e579cf4e9b25a53bf8fa6e7cedddf1127804d3e0140ca64"},
+    {file = "regex-2026.2.28-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e7ce83654d1ab701cb619285a18a8e5a889c1216d746ddc710c914ca5fd71022"},
+    {file = "regex-2026.2.28-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f2791948f7c70bb9335a9102df45e93d428f4b8128020d85920223925d73b9e1"},
+    {file = "regex-2026.2.28-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:03a83cc26aa2acda6b8b9dfe748cf9e84cbd390c424a1de34fdcef58961a297a"},
+    {file = "regex-2026.2.28-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:ec6f5674c5dc836994f50f1186dd1fafde4be0666aae201ae2fcc3d29d8adf27"},
+    {file = "regex-2026.2.28-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:50c2fc924749543e0eacc93ada6aeeb3ea5f6715825624baa0dccaec771668ae"},
+    {file = "regex-2026.2.28-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:ba55c50f408fb5c346a3a02d2ce0ebc839784e24f7c9684fde328ff063c3cdea"},
+    {file = "regex-2026.2.28-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:edb1b1b3a5576c56f08ac46f108c40333f222ebfd5cf63afdfa3aab0791ebe5b"},
+    {file = "regex-2026.2.28-cp311-cp311-win32.whl", hash = "sha256:948c12ef30ecedb128903c2c2678b339746eb7c689c5c21957c4a23950c96d15"},
+    {file = "regex-2026.2.28-cp311-cp311-win_amd64.whl", hash = "sha256:fd63453f10d29097cc3dc62d070746523973fb5aa1c66d25f8558bebd47fed61"},
+    {file = "regex-2026.2.28-cp311-cp311-win_arm64.whl", hash = "sha256:00f2b8d9615aa165fdff0a13f1a92049bfad555ee91e20d246a51aa0b556c60a"},
+    {file = "regex-2026.2.28-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:fcf26c3c6d0da98fada8ae4ef0aa1c3405a431c0a77eb17306d38a89b02adcd7"},
+    {file = "regex-2026.2.28-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:02473c954af35dd2defeb07e44182f5705b30ea3f351a7cbffa9177beb14da5d"},
+    {file = "regex-2026.2.28-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:9b65d33a17101569f86d9c5966a8b1d7fbf8afdda5a8aa219301b0a80f58cf7d"},
+    {file = "regex-2026.2.28-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e71dcecaa113eebcc96622c17692672c2d104b1d71ddf7adeda90da7ddeb26fc"},
+    {file = "regex-2026.2.28-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:481df4623fa4969c8b11f3433ed7d5e3dc9cec0f008356c3212b3933fb77e3d8"},
+    {file = "regex-2026.2.28-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:64e7c6ad614573e0640f271e811a408d79a9e1fe62a46adb602f598df42a818d"},
+    {file = "regex-2026.2.28-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6b08a06976ff4fb0d83077022fde3eca06c55432bb997d8c0495b9a4e9872f4"},
+    {file = "regex-2026.2.28-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:864cdd1a2ef5716b0ab468af40139e62ede1b3a53386b375ec0786bb6783fc05"},
+    {file = "regex-2026.2.28-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:511f7419f7afab475fd4d639d4aedfc54205bcb0800066753ef68a59f0f330b5"},
+    {file = "regex-2026.2.28-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:b42f7466e32bf15a961cf09f35fa6323cc72e64d3d2c990b10de1274a5da0a59"},
+    {file = "regex-2026.2.28-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:8710d61737b0c0ce6836b1da7109f20d495e49b3809f30e27e9560be67a257bf"},
+    {file = "regex-2026.2.28-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:4390c365fd2d45278f45afd4673cb90f7285f5701607e3ad4274df08e36140ae"},
+    {file = "regex-2026.2.28-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:cb3b1db8ff6c7b8bf838ab05583ea15230cb2f678e569ab0e3a24d1e8320940b"},
+    {file = "regex-2026.2.28-cp312-cp312-win32.whl", hash = "sha256:f8ed9a5d4612df9d4de15878f0bc6aa7a268afbe5af21a3fdd97fa19516e978c"},
+    {file = "regex-2026.2.28-cp312-cp312-win_amd64.whl", hash = "sha256:01d65fd24206c8e1e97e2e31b286c59009636c022eb5d003f52760b0f42155d4"},
+    {file = "regex-2026.2.28-cp312-cp312-win_arm64.whl", hash = "sha256:c0b5ccbb8ffb433939d248707d4a8b31993cb76ab1a0187ca886bf50e96df952"},
+    {file = "regex-2026.2.28-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:6d63a07e5ec8ce7184452cb00c41c37b49e67dc4f73b2955b5b8e782ea970784"},
+    {file = "regex-2026.2.28-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e59bc8f30414d283ae8ee1617b13d8112e7135cb92830f0ec3688cb29152585a"},
+    {file = "regex-2026.2.28-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:de0cf053139f96219ccfabb4a8dd2d217c8c82cb206c91d9f109f3f552d6b43d"},
+    {file = "regex-2026.2.28-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fb4db2f17e6484904f986c5a657cec85574c76b5c5e61c7aae9ffa1bc6224f95"},
+    {file = "regex-2026.2.28-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:52b017b35ac2214d0db5f4f90e303634dc44e4aba4bd6235a27f97ecbe5b0472"},
+    {file = "regex-2026.2.28-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:69fc560ccbf08a09dc9b52ab69cacfae51e0ed80dc5693078bdc97db2f91ae96"},
+    {file = "regex-2026.2.28-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e61eea47230eba62a31f3e8a0e3164d0f37ef9f40529fb2c79361bc6b53d2a92"},
+    {file = "regex-2026.2.28-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4f5c0b182ad4269e7381b7c27fdb0408399881f7a92a4624fd5487f2971dfc11"},
+    {file = "regex-2026.2.28-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:96f6269a2882fbb0ee76967116b83679dc628e68eaea44e90884b8d53d833881"},
+    {file = "regex-2026.2.28-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:b5acd4b6a95f37c3c3828e5d053a7d4edaedb85de551db0153754924cb7c83e3"},
+    {file = "regex-2026.2.28-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:2234059cfe33d9813a3677ef7667999caea9eeaa83fef98eb6ce15c6cf9e0215"},
+    {file = "regex-2026.2.28-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:c15af43c72a7fb0c97cbc66fa36a43546eddc5c06a662b64a0cbf30d6ac40944"},
+    {file = "regex-2026.2.28-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9185cc63359862a6e80fe97f696e04b0ad9a11c4ac0a4a927f979f611bfe3768"},
+    {file = "regex-2026.2.28-cp313-cp313-win32.whl", hash = "sha256:fb66e5245db9652abd7196ace599b04d9c0e4aa7c8f0e2803938377835780081"},
+    {file = "regex-2026.2.28-cp313-cp313-win_amd64.whl", hash = "sha256:71a911098be38c859ceb3f9a9ce43f4ed9f4c6720ad8684a066ea246b76ad9ff"},
+    {file = "regex-2026.2.28-cp313-cp313-win_arm64.whl", hash = "sha256:39bb5727650b9a0275c6a6690f9bb3fe693a7e6cc5c3155b1240aedf8926423e"},
+    {file = "regex-2026.2.28-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:97054c55db06ab020342cc0d35d6f62a465fa7662871190175f1ad6c655c028f"},
+    {file = "regex-2026.2.28-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0d25a10811de831c2baa6aef3c0be91622f44dd8d31dd12e69f6398efb15e48b"},
+    {file = "regex-2026.2.28-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:d6cfe798d8da41bb1862ed6e0cba14003d387c3c0c4a5d45591076ae9f0ce2f8"},
+    {file = "regex-2026.2.28-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fd0ce43e71d825b7c0661f9c54d4d74bd97c56c3fd102a8985bcfea48236bacb"},
+    {file = "regex-2026.2.28-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:00945d007fd74a9084d2ab79b695b595c6b7ba3698972fadd43e23230c6979c1"},
+    {file = "regex-2026.2.28-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bec23c11cbbf09a4df32fe50d57cbdd777bc442269b6e39a1775654f1c95dee2"},
+    {file = "regex-2026.2.28-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5cdcc17d935c8f9d3f4db5c2ebe2640c332e3822ad5d23c2f8e0228e6947943a"},
+    {file = "regex-2026.2.28-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a448af01e3d8031c89c5d902040b124a5e921a25c4e5e07a861ca591ce429341"},
+    {file = "regex-2026.2.28-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:10d28e19bd4888e4abf43bd3925f3c134c52fdf7259219003588a42e24c2aa25"},
+    {file = "regex-2026.2.28-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:99985a2c277dcb9ccb63f937451af5d65177af1efdeb8173ac55b61095a0a05c"},
+    {file = "regex-2026.2.28-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:e1e7b24cb3ae9953a560c563045d1ba56ee4749fbd05cf21ba571069bd7be81b"},
+    {file = "regex-2026.2.28-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:d8511a01d0e4ee1992eb3ba19e09bc1866fe03f05129c3aec3fdc4cbc77aad3f"},
+    {file = "regex-2026.2.28-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:aaffaecffcd2479ce87aa1e74076c221700b7c804e48e98e62500ee748f0f550"},
+    {file = "regex-2026.2.28-cp313-cp313t-win32.whl", hash = "sha256:ef77bdde9c9eba3f7fa5b58084b29bbcc74bcf55fdbeaa67c102a35b5bd7e7cc"},
+    {file = "regex-2026.2.28-cp313-cp313t-win_amd64.whl", hash = "sha256:98adf340100cbe6fbaf8e6dc75e28f2c191b1be50ffefe292fb0e6f6eefdb0d8"},
+    {file = "regex-2026.2.28-cp313-cp313t-win_arm64.whl", hash = "sha256:2fb950ac1d88e6b6a9414381f403797b236f9fa17e1eee07683af72b1634207b"},
+    {file = "regex-2026.2.28-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:78454178c7df31372ea737996fb7f36b3c2c92cccc641d251e072478afb4babc"},
+    {file = "regex-2026.2.28-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:5d10303dd18cedfd4d095543998404df656088240bcfd3cd20a8f95b861f74bd"},
+    {file = "regex-2026.2.28-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:19a9c9e0a8f24f39d575a6a854d516b48ffe4cbdcb9de55cb0570a032556ecff"},
+    {file = "regex-2026.2.28-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:09500be324f49b470d907b3ef8af9afe857f5cca486f853853f7945ddbf75911"},
+    {file = "regex-2026.2.28-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:fb1c4ff62277d87a7335f2c1ea4e0387b8f2b3ad88a64efd9943906aafad4f33"},
+    {file = "regex-2026.2.28-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b8b3f1be1738feadc69f62daa250c933e85c6f34fa378f54a7ff43807c1b9117"},
+    {file = "regex-2026.2.28-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dc8ed8c3f41c27acb83f7b6a9eb727a73fc6663441890c5cb3426a5f6a91ce7d"},
+    {file = "regex-2026.2.28-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fa539be029844c0ce1114762d2952ab6cfdd7c7c9bd72e0db26b94c3c36dcc5a"},
+    {file = "regex-2026.2.28-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7900157786428a79615a8264dac1f12c9b02957c473c8110c6b1f972dcecaddf"},
+    {file = "regex-2026.2.28-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:0b1d2b07614d95fa2bf8a63fd1e98bd8fa2b4848dc91b1efbc8ba219fdd73952"},
+    {file = "regex-2026.2.28-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:b389c61aa28a79c2e0527ac36da579869c2e235a5b208a12c5b5318cda2501d8"},
+    {file = "regex-2026.2.28-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:f467cb602f03fbd1ab1908f68b53c649ce393fde056628dc8c7e634dab6bfc07"},
+    {file = "regex-2026.2.28-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e8c8cb2deba42f5ec1ede46374e990f8adc5e6456a57ac1a261b19be6f28e4e6"},
+    {file = "regex-2026.2.28-cp314-cp314-win32.whl", hash = "sha256:9036b400b20e4858d56d117108d7813ed07bb7803e3eed766675862131135ca6"},
+    {file = "regex-2026.2.28-cp314-cp314-win_amd64.whl", hash = "sha256:1d367257cd86c1cbb97ea94e77b373a0bbc2224976e247f173d19e8f18b4afa7"},
+    {file = "regex-2026.2.28-cp314-cp314-win_arm64.whl", hash = "sha256:5e68192bb3a1d6fb2836da24aa494e413ea65853a21505e142e5b1064a595f3d"},
+    {file = "regex-2026.2.28-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:a5dac14d0872eeb35260a8e30bac07ddf22adc1e3a0635b52b02e180d17c9c7e"},
+    {file = "regex-2026.2.28-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:ec0c608b7a7465ffadb344ed7c987ff2f11ee03f6a130b569aa74d8a70e8333c"},
+    {file = "regex-2026.2.28-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c7815afb0ca45456613fdaf60ea9c993715511c8d53a83bc468305cbc0ee23c7"},
+    {file = "regex-2026.2.28-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b059e71ec363968671693a78c5053bd9cb2fe410f9b8e4657e88377ebd603a2e"},
+    {file = "regex-2026.2.28-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b8cf76f1a29f0e99dcfd7aef1551a9827588aae5a737fe31442021165f1920dc"},
+    {file = "regex-2026.2.28-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:180e08a435a0319e6a4821c3468da18dc7001987e1c17ae1335488dfe7518dd8"},
+    {file = "regex-2026.2.28-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1e496956106fd59ba6322a8ea17141a27c5040e5ee8f9433ae92d4e5204462a0"},
+    {file = "regex-2026.2.28-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:bba2b18d70eeb7b79950f12f633beeecd923f7c9ad6f6bae28e59b4cb3ab046b"},
+    {file = "regex-2026.2.28-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:6db7bfae0f8a2793ff1f7021468ea55e2699d0790eb58ee6ab36ae43aa00bc5b"},
+    {file = "regex-2026.2.28-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:d0b02e8b7e5874b48ae0f077ecca61c1a6a9f9895e9c6dfb191b55b242862033"},
+    {file = "regex-2026.2.28-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:25b6eb660c5cf4b8c3407a1ed462abba26a926cc9965e164268a3267bcc06a43"},
+    {file = "regex-2026.2.28-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:5a932ea8ad5d0430351ff9c76c8db34db0d9f53c1d78f06022a21f4e290c5c18"},
+    {file = "regex-2026.2.28-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:1c2c95e1a2b0f89d01e821ff4de1be4b5d73d1f4b0bf679fa27c1ad8d2327f1a"},
+    {file = "regex-2026.2.28-cp314-cp314t-win32.whl", hash = "sha256:bbb882061f742eb5d46f2f1bd5304055be0a66b783576de3d7eef1bed4778a6e"},
+    {file = "regex-2026.2.28-cp314-cp314t-win_amd64.whl", hash = "sha256:6591f281cb44dc13de9585b552cec6fc6cf47fb2fe7a48892295ee9bc4a612f9"},
+    {file = "regex-2026.2.28-cp314-cp314t-win_arm64.whl", hash = "sha256:dee50f1be42222f89767b64b283283ef963189da0dda4a515aa54a5563c62dec"},
+    {file = "regex-2026.2.28.tar.gz", hash = "sha256:a729e47d418ea11d03469f321aaf67cdee8954cde3ff2cf8403ab87951ad10f2"},
+]
+
+[[package]]
 name = "requests"
 version = "2.32.5"
 description = "Python HTTP for Humans."
@@ -1645,6 +2067,18 @@ files = [
 ]
 
 [[package]]
+name = "six"
+version = "1.17.0"
+description = "Python 2 and 3 compatibility utilities"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+groups = ["main"]
+files = [
+    {file = "six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274"},
+    {file = "six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"},
+]
+
+[[package]]
 name = "starlette"
 version = "0.36.3"
 description = "The little ASGI library that shines."
@@ -1679,6 +2113,43 @@ dev = ["freezegun (>=0.2.8)", "mypy (>=1.4)", "pretend", "pytest (>=6.0)", "pyte
 docs = ["cogapp", "furo", "myst-parser", "sphinx", "sphinx-notfound-page", "sphinxcontrib-mermaid", "sphinxext-opengraph", "twisted"]
 tests = ["freezegun (>=0.2.8)", "pretend", "pytest (>=6.0)", "pytest-asyncio (>=0.17)", "simplejson"]
 typing = ["mypy (>=1.4)", "rich", "twisted"]
+
+[[package]]
+name = "tld"
+version = "0.13.1"
+description = "Extract the top-level domain (TLD) from the URL given."
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "tld-0.13.1-py2.py3-none-any.whl", hash = "sha256:a2d35109433ac83486ddf87e3c4539ab2c5c2478230e5d9c060a18af4b03aa7c"},
+    {file = "tld-0.13.1.tar.gz", hash = "sha256:75ec00936cbcf564f67361c41713363440b6c4ef0f0c1592b5b0fbe72c17a350"},
+]
+
+[[package]]
+name = "trafilatura"
+version = "2.0.0"
+description = "Python & Command-line tool to gather text and metadata on the Web: Crawling, scraping, extraction, output as CSV, JSON, HTML, MD, TXT, XML."
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "trafilatura-2.0.0-py3-none-any.whl", hash = "sha256:77eb5d1e993747f6f20938e1de2d840020719735690c840b9a1024803a4cd51d"},
+    {file = "trafilatura-2.0.0.tar.gz", hash = "sha256:ceb7094a6ecc97e72fea73c7dba36714c5c5b577b6470e4520dca893706d6247"},
+]
+
+[package.dependencies]
+certifi = "*"
+charset_normalizer = ">=3.4.0"
+courlan = ">=1.3.2"
+htmldate = ">=1.9.2"
+justext = ">=3.0.1"
+lxml = {version = ">=5.3.0", markers = "platform_system != \"Darwin\" or python_version > \"3.8\""}
+urllib3 = ">=1.26,<3"
+
+[package.extras]
+all = ["brotli", "cchardet (>=2.1.7) ; python_version < \"3.11\"", "faust-cchardet (>=2.1.19) ; python_version >= \"3.11\"", "htmldate[speed] (>=1.9.2)", "py3langid (>=0.3.0)", "pycurl (>=7.45.3)", "urllib3[socks]", "zstandard (>=0.23.0)"]
+dev = ["flake8", "mypy", "pytest", "pytest-cov", "types-lxml", "types-urllib3"]
 
 [[package]]
 name = "types-pyyaml"
@@ -1718,6 +2189,37 @@ files = [
 
 [package.dependencies]
 typing-extensions = ">=4.12.0"
+
+[[package]]
+name = "tzdata"
+version = "2025.3"
+description = "Provider of IANA time zone data"
+optional = false
+python-versions = ">=2"
+groups = ["main"]
+markers = "platform_system == \"Windows\""
+files = [
+    {file = "tzdata-2025.3-py2.py3-none-any.whl", hash = "sha256:06a47e5700f3081aab02b2e513160914ff0694bce9947d6b76ebd6bf57cfc5d1"},
+    {file = "tzdata-2025.3.tar.gz", hash = "sha256:de39c2ca5dc7b0344f2eba86f49d614019d29f060fc4ebc8a417896a620b56a7"},
+]
+
+[[package]]
+name = "tzlocal"
+version = "5.3.1"
+description = "tzinfo object for the local timezone"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "tzlocal-5.3.1-py3-none-any.whl", hash = "sha256:eb1a66c3ef5847adf7a834f1be0800581b683b5608e74f86ecbcef8ab91bb85d"},
+    {file = "tzlocal-5.3.1.tar.gz", hash = "sha256:cceffc7edecefea1f595541dbd6e990cb1ea3d19bf01b2809f362a03dd7921fd"},
+]
+
+[package.dependencies]
+tzdata = {version = "*", markers = "platform_system == \"Windows\""}
+
+[package.extras]
+devenv = ["check-manifest", "pytest (>=4.3)", "pytest-cov", "pytest-mock (>=3.3)", "zest.releaser"]
 
 [[package]]
 name = "urllib3"
@@ -2135,4 +2637,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "c03be2dbfadd52b7c8aa545d468d75432594e54a1cd5633e2ddfcfa3745fa898"
+content-hash = "5cf37e53abb9e34f0389c9b3a06b603068d4547ab985e628e793a422a7d22d5a"

--- a/services/knowledge/pyproject.toml
+++ b/services/knowledge/pyproject.toml
@@ -21,6 +21,7 @@ opentelemetry-exporter-otlp-proto-http = "^1.39.1"
 opentelemetry-instrumentation-fastapi = ">=0.60b1"
 opentelemetry-instrumentation-asyncpg = ">=0.60b1"
 httpx = "^0.28.1"
+trafilatura = "^2.0.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.0.0"

--- a/services/knowledge/tests/integration/test_shared_ingest.py
+++ b/services/knowledge/tests/integration/test_shared_ingest.py
@@ -1,5 +1,7 @@
 """Integration tests for shared knowledge ingestion."""
 
+from unittest.mock import AsyncMock, patch
+
 import pytest
 
 pytestmark = pytest.mark.integration
@@ -79,8 +81,15 @@ class TestIngestJobLifecycle:
         assert data["ingest_job"]["chunk_count"] >= 1
 
 
-class TestIngestRejectsWebPage:
-    async def test_ingest_rejects_web_page(self, app_client):
+class TestIngestWebPage:
+    @patch("app.services.ingest.fetch_and_extract", new_callable=AsyncMock)
+    async def test_ingest_web_page_success(self, mock_fetch, app_client):
+        mock_fetch.return_value = {
+            "url": "https://example.com/article",
+            "title": "Example Article",
+            "content": "This is the extracted article content with enough text to chunk.",
+            "content_type": "text/html",
+        }
         cid = await _create_collection(app_client, "Web Page Col")
         resp = await app_client.post(
             "/internal/admin/shared/sources",
@@ -89,13 +98,52 @@ class TestIngestRejectsWebPage:
                 "collection_id": cid,
                 "title": "Web Page Test",
                 "source_type": "web_page",
-                "source_url": "https://example.com",
-                "raw_content": "",
+                "source_url": "https://example.com/article",
+                "created_by": "user-ingest",
+            },
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["source"]["status"] == "active"
+        assert data["source"]["source_url"] == "https://example.com/article"
+        assert data["ingest_job"]["status"] == "completed"
+        assert data["ingest_job"]["chunk_count"] >= 1
+        mock_fetch.assert_called_once_with("https://example.com/article")
+
+    @patch("app.services.ingest.fetch_and_extract", new_callable=AsyncMock)
+    async def test_ingest_web_page_fetch_error(self, mock_fetch, app_client):
+        from app.services.web_page_fetcher import FetchError
+
+        mock_fetch.side_effect = FetchError("Connection timed out fetching 'example.com'")
+        cid = await _create_collection(app_client, "Web Page Error Col")
+        resp = await app_client.post(
+            "/internal/admin/shared/sources",
+            headers=HEADERS,
+            json={
+                "collection_id": cid,
+                "title": "Unreachable Page",
+                "source_type": "web_page",
+                "source_url": "https://example.com/timeout",
                 "created_by": "user-ingest",
             },
         )
         assert resp.status_code == 422
-        assert "not yet supported" in resp.json()["detail"].lower()
+        assert "timed out" in resp.json()["detail"].lower()
+
+    async def test_ingest_web_page_missing_url(self, app_client):
+        cid = await _create_collection(app_client, "Web Page No URL Col")
+        resp = await app_client.post(
+            "/internal/admin/shared/sources",
+            headers=HEADERS,
+            json={
+                "collection_id": cid,
+                "title": "No URL",
+                "source_type": "web_page",
+                "created_by": "user-ingest",
+            },
+        )
+        assert resp.status_code == 422
+        assert "source_url" in resp.json()["detail"].lower()
 
 
 class TestContentHashDedup:

--- a/services/knowledge/tests/integration/test_shared_ingest.py
+++ b/services/knowledge/tests/integration/test_shared_ingest.py
@@ -127,7 +127,8 @@ class TestIngestWebPage:
                 "created_by": "user-ingest",
             },
         )
-        assert resp.status_code == 422
+        # Fetch failures create source/job in error state (500), not bare 422
+        assert resp.status_code == 500
         assert "timed out" in resp.json()["detail"].lower()
 
     async def test_ingest_web_page_missing_url(self, app_client):

--- a/services/knowledge/tests/unit/test_web_page_fetcher.py
+++ b/services/knowledge/tests/unit/test_web_page_fetcher.py
@@ -5,7 +5,7 @@ Tests cover the full Fetch Safety Contract:
 - DNS resolution check against blocked CIDR ranges
 - Redirect re-validation on every hop
 - Error message information leak prevention
-- Response size limits
+- Response size limits (Content-Length header + streaming body enforcement)
 """
 
 from __future__ import annotations
@@ -19,10 +19,62 @@ import pytest
 from app.services.web_page_fetcher import (
     BLOCKED_HOSTNAMES,
     FetchError,
+    MAX_RESPONSE_BYTES,
     _is_blocked_ip,
     _validate_url,
     fetch_and_extract,
 )
+
+
+# ---------------------------------------------------------------------------
+# Helper: build mock streaming client + response
+# ---------------------------------------------------------------------------
+
+
+def _make_streaming_response(
+    *,
+    status_code: int = 200,
+    headers: dict[str, str] | None = None,
+    body: bytes = b"",
+    is_redirect: bool = False,
+    charset_encoding: str | None = "utf-8",
+) -> MagicMock:
+    """Build a mock httpx response compatible with streaming (send + aiter_bytes)."""
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.is_redirect = is_redirect
+    resp.headers = headers or {}
+    resp.charset_encoding = charset_encoding
+    resp.aclose = AsyncMock()
+
+    # Create an async generator for aiter_bytes
+    _body = body
+
+    async def _aiter_bytes(chunk_size: int = 65536):
+        for i in range(0, len(_body), chunk_size):
+            yield _body[i : i + chunk_size]
+
+    resp.aiter_bytes = _aiter_bytes
+    return resp
+
+
+def _make_mock_client(response: MagicMock | Exception) -> AsyncMock:
+    """Build a mock httpx.AsyncClient with send + build_request."""
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client.build_request = MagicMock(return_value=MagicMock())
+
+    if isinstance(response, Exception):
+        mock_client.send = AsyncMock(side_effect=response)
+    else:
+        mock_client.send = AsyncMock(return_value=response)
+
+    return mock_client
+
+
+# DNS mock that returns a public IP (passes all checks)
+PUBLIC_DNS = [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", 443))]
 
 
 # ---------------------------------------------------------------------------
@@ -202,22 +254,14 @@ class TestRedirectRevalidation:
             patch("app.services.web_page_fetcher.socket.getaddrinfo") as mock_dns,
             patch("app.services.web_page_fetcher.httpx.AsyncClient") as mock_client_cls,
         ):
-            # First DNS check passes (public IP)
-            mock_dns.return_value = [
-                (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", 443))
-            ]
+            mock_dns.return_value = PUBLIC_DNS
 
-            # First request returns redirect to loopback
-            mock_response = MagicMock()
-            mock_response.status_code = 301
-            mock_response.headers = {"location": "http://127.0.0.1/secret"}
-            mock_response.is_redirect = True
-
-            mock_client = AsyncMock()
-            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-            mock_client.__aexit__ = AsyncMock(return_value=False)
-            mock_client.get = AsyncMock(return_value=mock_response)
-            mock_client_cls.return_value = mock_client
+            redirect_resp = _make_streaming_response(
+                status_code=301,
+                headers={"location": "http://127.0.0.1/secret"},
+                is_redirect=True,
+            )
+            mock_client_cls.return_value = _make_mock_client(redirect_resp)
 
             with pytest.raises(FetchError, match="blocked|internal"):
                 await fetch_and_extract("https://redirect.example.com/go")
@@ -229,20 +273,14 @@ class TestRedirectRevalidation:
             patch("app.services.web_page_fetcher.socket.getaddrinfo") as mock_dns,
             patch("app.services.web_page_fetcher.httpx.AsyncClient") as mock_client_cls,
         ):
-            mock_dns.return_value = [
-                (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", 443))
-            ]
+            mock_dns.return_value = PUBLIC_DNS
 
-            mock_response = MagicMock()
-            mock_response.status_code = 302
-            mock_response.headers = {"location": "ftp://files.example.com/data"}
-            mock_response.is_redirect = True
-
-            mock_client = AsyncMock()
-            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-            mock_client.__aexit__ = AsyncMock(return_value=False)
-            mock_client.get = AsyncMock(return_value=mock_response)
-            mock_client_cls.return_value = mock_client
+            redirect_resp = _make_streaming_response(
+                status_code=302,
+                headers={"location": "ftp://files.example.com/data"},
+                is_redirect=True,
+            )
+            mock_client_cls.return_value = _make_mock_client(redirect_resp)
 
             with pytest.raises(FetchError, match="scheme"):
                 await fetch_and_extract("https://redirect.example.com/go")
@@ -254,21 +292,14 @@ class TestRedirectRevalidation:
             patch("app.services.web_page_fetcher.socket.getaddrinfo") as mock_dns,
             patch("app.services.web_page_fetcher.httpx.AsyncClient") as mock_client_cls,
         ):
-            mock_dns.return_value = [
-                (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", 443))
-            ]
+            mock_dns.return_value = PUBLIC_DNS
 
-            # Every request returns a redirect
-            mock_response = MagicMock()
-            mock_response.status_code = 302
-            mock_response.headers = {"location": "https://example.com/next"}
-            mock_response.is_redirect = True
-
-            mock_client = AsyncMock()
-            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-            mock_client.__aexit__ = AsyncMock(return_value=False)
-            mock_client.get = AsyncMock(return_value=mock_response)
-            mock_client_cls.return_value = mock_client
+            redirect_resp = _make_streaming_response(
+                status_code=302,
+                headers={"location": "https://example.com/next"},
+                is_redirect=True,
+            )
+            mock_client_cls.return_value = _make_mock_client(redirect_resp)
 
             with pytest.raises(FetchError, match="redirect"):
                 await fetch_and_extract("https://loop.example.com/start")
@@ -296,37 +327,91 @@ class TestErrorMessageNoIpLeak:
 
 
 # ---------------------------------------------------------------------------
-# Response size limit
+# Response size limit — Content-Length header + streaming enforcement
 # ---------------------------------------------------------------------------
 
 
 class TestResponseSizeLimit:
     @pytest.mark.asyncio
-    async def test_response_size_limit(self) -> None:
-        """Responses exceeding 2MB must be rejected."""
+    async def test_rejects_oversized_content_length_header(self) -> None:
+        """Response with Content-Length > 2MB must be rejected before reading body."""
         with (
             patch("app.services.web_page_fetcher.socket.getaddrinfo") as mock_dns,
             patch("app.services.web_page_fetcher.httpx.AsyncClient") as mock_client_cls,
         ):
-            mock_dns.return_value = [
-                (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", 443))
-            ]
+            mock_dns.return_value = PUBLIC_DNS
 
-            # Return a response with Content-Length > 2MB
-            mock_response = MagicMock()
-            mock_response.status_code = 200
-            mock_response.is_redirect = False
-            mock_response.headers = {"content-length": str(3 * 1024 * 1024), "content-type": "text/html"}
-            mock_response.text = "<html><body>big</body></html>"
-
-            mock_client = AsyncMock()
-            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-            mock_client.__aexit__ = AsyncMock(return_value=False)
-            mock_client.get = AsyncMock(return_value=mock_response)
+            resp = _make_streaming_response(
+                headers={
+                    "content-length": str(3 * 1024 * 1024),
+                    "content-type": "text/html",
+                },
+            )
+            mock_client = _make_mock_client(resp)
             mock_client_cls.return_value = mock_client
 
             with pytest.raises(FetchError, match="size"):
                 await fetch_and_extract("https://big.example.com/huge-page")
+
+            # aclose must be called even on rejection
+            resp.aclose.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_rejects_oversized_body_without_content_length(self) -> None:
+        """Response without Content-Length that exceeds 2MB during streaming must be rejected."""
+        with (
+            patch("app.services.web_page_fetcher.socket.getaddrinfo") as mock_dns,
+            patch("app.services.web_page_fetcher.httpx.AsyncClient") as mock_client_cls,
+        ):
+            mock_dns.return_value = PUBLIC_DNS
+
+            # No content-length header — server streams without advertising size
+            oversized_body = b"x" * (MAX_RESPONSE_BYTES + 1)
+            resp = _make_streaming_response(
+                headers={"content-type": "text/html"},
+                body=oversized_body,
+            )
+            mock_client_cls.return_value = _make_mock_client(resp)
+
+            with pytest.raises(FetchError, match="size limit"):
+                await fetch_and_extract("https://big.example.com/no-content-length")
+
+            # aclose must be called via finally block
+            resp.aclose.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_streaming_aborts_mid_read(self) -> None:
+        """Body exceeding 2MB is rejected during streaming, not after full buffering."""
+        with (
+            patch("app.services.web_page_fetcher.socket.getaddrinfo") as mock_dns,
+            patch("app.services.web_page_fetcher.httpx.AsyncClient") as mock_client_cls,
+        ):
+            mock_dns.return_value = PUBLIC_DNS
+
+            # Build a response that yields many 64KB chunks exceeding the limit
+            chunk_count = (MAX_RESPONSE_BYTES // 65536) + 2  # enough to exceed limit
+            chunks_yielded: list[int] = []
+
+            async def _tracked_aiter_bytes(chunk_size: int = 65536):
+                for i in range(chunk_count):
+                    chunks_yielded.append(i)
+                    yield b"x" * 65536
+
+            resp = MagicMock()
+            resp.status_code = 200
+            resp.is_redirect = False
+            resp.headers = {"content-type": "text/html"}
+            resp.charset_encoding = "utf-8"
+            resp.aclose = AsyncMock()
+            resp.aiter_bytes = _tracked_aiter_bytes
+
+            mock_client_cls.return_value = _make_mock_client(resp)
+
+            with pytest.raises(FetchError, match="size limit"):
+                await fetch_and_extract("https://big.example.com/streaming")
+
+            # Verify streaming aborted before all chunks were read
+            assert len(chunks_yielded) < chunk_count
 
 
 # ---------------------------------------------------------------------------
@@ -344,21 +429,13 @@ class TestFetchAndExtract:
             patch("app.services.web_page_fetcher.httpx.AsyncClient") as mock_client_cls,
             patch("app.services.web_page_fetcher.trafilatura") as mock_traf,
         ):
-            mock_dns.return_value = [
-                (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", 443))
-            ]
+            mock_dns.return_value = PUBLIC_DNS
 
-            mock_response = MagicMock()
-            mock_response.status_code = 200
-            mock_response.is_redirect = False
-            mock_response.headers = {"content-length": "200", "content-type": "text/html"}
-            mock_response.text = html
-
-            mock_client = AsyncMock()
-            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-            mock_client.__aexit__ = AsyncMock(return_value=False)
-            mock_client.get = AsyncMock(return_value=mock_response)
-            mock_client_cls.return_value = mock_client
+            resp = _make_streaming_response(
+                headers={"content-length": "200", "content-type": "text/html"},
+                body=html.encode(),
+            )
+            mock_client_cls.return_value = _make_mock_client(resp)
 
             mock_traf.extract.return_value = "Hello world paragraph."
 
@@ -374,15 +451,11 @@ class TestFetchAndExtract:
             patch("app.services.web_page_fetcher.socket.getaddrinfo") as mock_dns,
             patch("app.services.web_page_fetcher.httpx.AsyncClient") as mock_client_cls,
         ):
-            mock_dns.return_value = [
-                (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", 443))
-            ]
+            mock_dns.return_value = PUBLIC_DNS
 
-            mock_client = AsyncMock()
-            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-            mock_client.__aexit__ = AsyncMock(return_value=False)
-            mock_client.get = AsyncMock(side_effect=httpx.ConnectTimeout("timed out"))
-            mock_client_cls.return_value = mock_client
+            mock_client_cls.return_value = _make_mock_client(
+                httpx.ConnectTimeout("timed out")
+            )
 
             with pytest.raises(FetchError, match="timed out|timeout"):
                 await fetch_and_extract("https://slow.example.com/page")
@@ -395,21 +468,13 @@ class TestFetchAndExtract:
             patch("app.services.web_page_fetcher.httpx.AsyncClient") as mock_client_cls,
             patch("app.services.web_page_fetcher.trafilatura") as mock_traf,
         ):
-            mock_dns.return_value = [
-                (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", 443))
-            ]
+            mock_dns.return_value = PUBLIC_DNS
 
-            mock_response = MagicMock()
-            mock_response.status_code = 200
-            mock_response.is_redirect = False
-            mock_response.headers = {"content-length": "200", "content-type": "text/html"}
-            mock_response.text = "<html></html>"
-
-            mock_client = AsyncMock()
-            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-            mock_client.__aexit__ = AsyncMock(return_value=False)
-            mock_client.get = AsyncMock(return_value=mock_response)
-            mock_client_cls.return_value = mock_client
+            resp = _make_streaming_response(
+                headers={"content-length": "200", "content-type": "text/html"},
+                body=b"<html></html>",
+            )
+            mock_client_cls.return_value = _make_mock_client(resp)
 
             mock_traf.extract.return_value = None
 

--- a/services/knowledge/tests/unit/test_web_page_fetcher.py
+++ b/services/knowledge/tests/unit/test_web_page_fetcher.py
@@ -1,0 +1,417 @@
+"""Unit tests for web page fetcher with SSRF protection.
+
+Tests cover the full Fetch Safety Contract:
+- URL validation (scheme, credentials, port, internal hostnames)
+- DNS resolution check against blocked CIDR ranges
+- Redirect re-validation on every hop
+- Error message information leak prevention
+- Response size limits
+"""
+
+from __future__ import annotations
+
+import socket
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from app.services.web_page_fetcher import (
+    BLOCKED_HOSTNAMES,
+    FetchError,
+    _is_blocked_ip,
+    _validate_url,
+    fetch_and_extract,
+)
+
+
+# ---------------------------------------------------------------------------
+# URL Validation — scheme, credentials, port, hostnames
+# ---------------------------------------------------------------------------
+
+
+class TestValidateUrl:
+    def test_accepts_https_url(self) -> None:
+        _validate_url("https://example.com/page")
+
+    def test_accepts_http_url(self) -> None:
+        _validate_url("http://example.com/page")
+
+    def test_rejects_ftp_scheme(self) -> None:
+        with pytest.raises(FetchError, match="scheme"):
+            _validate_url("ftp://example.com/file.txt")
+
+    def test_rejects_file_scheme(self) -> None:
+        with pytest.raises(FetchError, match="scheme"):
+            _validate_url("file:///etc/passwd")
+
+    def test_rejects_data_scheme(self) -> None:
+        with pytest.raises(FetchError, match="scheme"):
+            _validate_url("data:text/html,<h1>hi</h1>")
+
+    def test_rejects_javascript_scheme(self) -> None:
+        with pytest.raises(FetchError, match="scheme"):
+            _validate_url("javascript:alert(1)")
+
+    def test_rejects_url_with_userinfo(self) -> None:
+        with pytest.raises(FetchError, match="credentials"):
+            _validate_url("https://user:pass@example.com/")
+
+    def test_rejects_url_with_username_only(self) -> None:
+        with pytest.raises(FetchError, match="credentials"):
+            _validate_url("https://admin@example.com/")
+
+    def test_rejects_non_standard_port(self) -> None:
+        with pytest.raises(FetchError, match="port"):
+            _validate_url("https://example.com:8080/page")
+
+    def test_accepts_port_80(self) -> None:
+        _validate_url("http://example.com:80/page")
+
+    def test_accepts_port_443(self) -> None:
+        _validate_url("https://example.com:443/page")
+
+    def test_rejects_empty_hostname(self) -> None:
+        with pytest.raises(FetchError, match="hostname"):
+            _validate_url("https:///path")
+
+    def test_rejects_internal_service_hostname_postgres(self) -> None:
+        with pytest.raises(FetchError, match="internal service"):
+            _validate_url("http://postgres:5432/")
+
+    def test_rejects_internal_service_hostname_api(self) -> None:
+        with pytest.raises(FetchError, match="internal service"):
+            _validate_url("http://api/health")
+
+    def test_rejects_internal_service_hostname_keycloak(self) -> None:
+        with pytest.raises(FetchError, match="internal service"):
+            _validate_url("http://keycloak:8080/auth")
+
+    def test_rejects_internal_service_hostname_litellm(self) -> None:
+        with pytest.raises(FetchError, match="internal service"):
+            _validate_url("http://litellm/v1/models")
+
+    def test_rejects_internal_service_hostname_openbao(self) -> None:
+        with pytest.raises(FetchError, match="internal service"):
+            _validate_url("http://openbao:8200/v1/sys/health")
+
+    def test_rejects_internal_service_hostname_knowledge(self) -> None:
+        with pytest.raises(FetchError, match="internal service"):
+            _validate_url("http://knowledge:8002/health")
+
+    def test_rejects_ip_literal_loopback(self) -> None:
+        with pytest.raises(FetchError, match="blocked"):
+            _validate_url("http://127.0.0.1/")
+
+    def test_rejects_ip_literal_private(self) -> None:
+        with pytest.raises(FetchError, match="blocked"):
+            _validate_url("http://10.0.0.1/")
+
+
+# ---------------------------------------------------------------------------
+# Blocked IP ranges — all 7 CIDR categories
+# ---------------------------------------------------------------------------
+
+
+class TestIsBlockedIp:
+    def test_blocks_loopback_127(self) -> None:
+        assert _is_blocked_ip("127.0.0.1") is True
+        assert _is_blocked_ip("127.255.255.255") is True
+
+    def test_blocks_rfc1918_class_a(self) -> None:
+        assert _is_blocked_ip("10.0.0.1") is True
+        assert _is_blocked_ip("10.255.255.255") is True
+
+    def test_blocks_rfc1918_class_b_docker(self) -> None:
+        assert _is_blocked_ip("172.16.0.1") is True
+        assert _is_blocked_ip("172.31.255.255") is True
+        # 172.32.x should NOT be blocked
+        assert _is_blocked_ip("172.32.0.1") is False
+
+    def test_blocks_rfc1918_class_c(self) -> None:
+        assert _is_blocked_ip("192.168.0.1") is True
+        assert _is_blocked_ip("192.168.255.255") is True
+
+    def test_blocks_link_local(self) -> None:
+        assert _is_blocked_ip("169.254.0.1") is True
+        assert _is_blocked_ip("169.254.169.254") is True  # AWS metadata
+
+    def test_blocks_tailscale_cgnat(self) -> None:
+        assert _is_blocked_ip("100.64.0.1") is True
+        assert _is_blocked_ip("100.100.100.100") is True
+        assert _is_blocked_ip("100.127.255.255") is True
+
+    def test_blocks_unspecified(self) -> None:
+        assert _is_blocked_ip("0.0.0.0") is True
+
+    def test_blocks_broadcast(self) -> None:
+        assert _is_blocked_ip("255.255.255.255") is True
+
+    def test_allows_public_ip(self) -> None:
+        assert _is_blocked_ip("8.8.8.8") is False
+        assert _is_blocked_ip("1.1.1.1") is False
+        assert _is_blocked_ip("93.184.216.34") is False  # example.com
+
+    def test_blocks_ipv6_loopback(self) -> None:
+        assert _is_blocked_ip("::1") is True
+
+    def test_blocks_ipv6_link_local(self) -> None:
+        assert _is_blocked_ip("fe80::1") is True
+
+    def test_blocks_ipv6_unique_local(self) -> None:
+        assert _is_blocked_ip("fc00::1") is True
+        assert _is_blocked_ip("fd00::1") is True
+
+
+# ---------------------------------------------------------------------------
+# DNS resolution → blocked IP detection
+# ---------------------------------------------------------------------------
+
+
+class TestDnsResolutionBlocking:
+    @pytest.mark.asyncio
+    async def test_blocks_dns_resolving_to_private_ip(self) -> None:
+        """A public hostname that resolves to a private IP must be rejected."""
+        with patch("app.services.web_page_fetcher.socket.getaddrinfo") as mock_dns:
+            mock_dns.return_value = [
+                (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("10.0.0.5", 80))
+            ]
+            with pytest.raises(FetchError, match="blocked"):
+                await fetch_and_extract("https://evil.example.com/page")
+
+    @pytest.mark.asyncio
+    async def test_blocks_dns_resolving_to_loopback(self) -> None:
+        with patch("app.services.web_page_fetcher.socket.getaddrinfo") as mock_dns:
+            mock_dns.return_value = [
+                (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("127.0.0.1", 80))
+            ]
+            with pytest.raises(FetchError, match="blocked"):
+                await fetch_and_extract("https://evil.example.com/page")
+
+
+# ---------------------------------------------------------------------------
+# Redirect re-validation
+# ---------------------------------------------------------------------------
+
+
+class TestRedirectRevalidation:
+    @pytest.mark.asyncio
+    async def test_blocks_redirect_to_private_ip(self) -> None:
+        """Redirect to http://127.0.0.1/ must be caught and rejected."""
+        with (
+            patch("app.services.web_page_fetcher.socket.getaddrinfo") as mock_dns,
+            patch("app.services.web_page_fetcher.httpx.AsyncClient") as mock_client_cls,
+        ):
+            # First DNS check passes (public IP)
+            mock_dns.return_value = [
+                (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", 443))
+            ]
+
+            # First request returns redirect to loopback
+            mock_response = MagicMock()
+            mock_response.status_code = 301
+            mock_response.headers = {"location": "http://127.0.0.1/secret"}
+            mock_response.is_redirect = True
+
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.get = AsyncMock(return_value=mock_response)
+            mock_client_cls.return_value = mock_client
+
+            with pytest.raises(FetchError, match="blocked|internal"):
+                await fetch_and_extract("https://redirect.example.com/go")
+
+    @pytest.mark.asyncio
+    async def test_redirect_revalidates_scheme(self) -> None:
+        """Redirect to ftp:// must be rejected."""
+        with (
+            patch("app.services.web_page_fetcher.socket.getaddrinfo") as mock_dns,
+            patch("app.services.web_page_fetcher.httpx.AsyncClient") as mock_client_cls,
+        ):
+            mock_dns.return_value = [
+                (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", 443))
+            ]
+
+            mock_response = MagicMock()
+            mock_response.status_code = 302
+            mock_response.headers = {"location": "ftp://files.example.com/data"}
+            mock_response.is_redirect = True
+
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.get = AsyncMock(return_value=mock_response)
+            mock_client_cls.return_value = mock_client
+
+            with pytest.raises(FetchError, match="scheme"):
+                await fetch_and_extract("https://redirect.example.com/go")
+
+    @pytest.mark.asyncio
+    async def test_max_redirects_enforced(self) -> None:
+        """More than 3 redirects must be rejected."""
+        with (
+            patch("app.services.web_page_fetcher.socket.getaddrinfo") as mock_dns,
+            patch("app.services.web_page_fetcher.httpx.AsyncClient") as mock_client_cls,
+        ):
+            mock_dns.return_value = [
+                (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", 443))
+            ]
+
+            # Every request returns a redirect
+            mock_response = MagicMock()
+            mock_response.status_code = 302
+            mock_response.headers = {"location": "https://example.com/next"}
+            mock_response.is_redirect = True
+
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.get = AsyncMock(return_value=mock_response)
+            mock_client_cls.return_value = mock_client
+
+            with pytest.raises(FetchError, match="redirect"):
+                await fetch_and_extract("https://loop.example.com/start")
+
+
+# ---------------------------------------------------------------------------
+# Error message information leak prevention
+# ---------------------------------------------------------------------------
+
+
+class TestErrorMessageNoIpLeak:
+    @pytest.mark.asyncio
+    async def test_error_message_no_ip_leak(self) -> None:
+        """Error messages must not include the resolved IP address."""
+        with patch("app.services.web_page_fetcher.socket.getaddrinfo") as mock_dns:
+            mock_dns.return_value = [
+                (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("10.42.99.7", 80))
+            ]
+            with pytest.raises(FetchError) as exc_info:
+                await fetch_and_extract("https://sneaky.example.com/data")
+
+            error_msg = str(exc_info.value)
+            assert "10.42.99.7" not in error_msg
+            assert "blocked" in error_msg.lower() or "private" in error_msg.lower()
+
+
+# ---------------------------------------------------------------------------
+# Response size limit
+# ---------------------------------------------------------------------------
+
+
+class TestResponseSizeLimit:
+    @pytest.mark.asyncio
+    async def test_response_size_limit(self) -> None:
+        """Responses exceeding 2MB must be rejected."""
+        with (
+            patch("app.services.web_page_fetcher.socket.getaddrinfo") as mock_dns,
+            patch("app.services.web_page_fetcher.httpx.AsyncClient") as mock_client_cls,
+        ):
+            mock_dns.return_value = [
+                (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", 443))
+            ]
+
+            # Return a response with Content-Length > 2MB
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.is_redirect = False
+            mock_response.headers = {"content-length": str(3 * 1024 * 1024), "content-type": "text/html"}
+            mock_response.text = "<html><body>big</body></html>"
+
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.get = AsyncMock(return_value=mock_response)
+            mock_client_cls.return_value = mock_client
+
+            with pytest.raises(FetchError, match="size"):
+                await fetch_and_extract("https://big.example.com/huge-page")
+
+
+# ---------------------------------------------------------------------------
+# Successful fetch and extract
+# ---------------------------------------------------------------------------
+
+
+class TestFetchAndExtract:
+    @pytest.mark.asyncio
+    async def test_web_page_fetcher_extracts_content(self) -> None:
+        """Successful fetch returns title and extracted text."""
+        html = "<html><head><title>Test Page</title></head><body><p>Hello world paragraph.</p></body></html>"
+        with (
+            patch("app.services.web_page_fetcher.socket.getaddrinfo") as mock_dns,
+            patch("app.services.web_page_fetcher.httpx.AsyncClient") as mock_client_cls,
+            patch("app.services.web_page_fetcher.trafilatura") as mock_traf,
+        ):
+            mock_dns.return_value = [
+                (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", 443))
+            ]
+
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.is_redirect = False
+            mock_response.headers = {"content-length": "200", "content-type": "text/html"}
+            mock_response.text = html
+
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.get = AsyncMock(return_value=mock_response)
+            mock_client_cls.return_value = mock_client
+
+            mock_traf.extract.return_value = "Hello world paragraph."
+
+            result = await fetch_and_extract("https://example.com/page")
+
+            assert result["content"] == "Hello world paragraph."
+            assert result["url"] == "https://example.com/page"
+
+    @pytest.mark.asyncio
+    async def test_web_page_fetcher_timeout(self) -> None:
+        """Connection timeout raises FetchError."""
+        with (
+            patch("app.services.web_page_fetcher.socket.getaddrinfo") as mock_dns,
+            patch("app.services.web_page_fetcher.httpx.AsyncClient") as mock_client_cls,
+        ):
+            mock_dns.return_value = [
+                (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", 443))
+            ]
+
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.get = AsyncMock(side_effect=httpx.ConnectTimeout("timed out"))
+            mock_client_cls.return_value = mock_client
+
+            with pytest.raises(FetchError, match="timed out|timeout"):
+                await fetch_and_extract("https://slow.example.com/page")
+
+    @pytest.mark.asyncio
+    async def test_web_page_fetcher_extraction_fails(self) -> None:
+        """When trafilatura returns None, raise FetchError."""
+        with (
+            patch("app.services.web_page_fetcher.socket.getaddrinfo") as mock_dns,
+            patch("app.services.web_page_fetcher.httpx.AsyncClient") as mock_client_cls,
+            patch("app.services.web_page_fetcher.trafilatura") as mock_traf,
+        ):
+            mock_dns.return_value = [
+                (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", 443))
+            ]
+
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.is_redirect = False
+            mock_response.headers = {"content-length": "200", "content-type": "text/html"}
+            mock_response.text = "<html></html>"
+
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.get = AsyncMock(return_value=mock_response)
+            mock_client_cls.return_value = mock_client
+
+            mock_traf.extract.return_value = None
+
+            with pytest.raises(FetchError, match="extract"):
+                await fetch_and_extract("https://empty.example.com/page")

--- a/services/ui/src/__tests__/SharedKnowledgeClient.test.tsx
+++ b/services/ui/src/__tests__/SharedKnowledgeClient.test.tsx
@@ -1,0 +1,446 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+
+// Mock global fetch
+const mockFetch = vi.fn()
+vi.stubGlobal('fetch', mockFetch)
+
+import SharedKnowledgeClient from '@/app/harness/shared-knowledge/SharedKnowledgeClient'
+
+const MOCK_COLLECTIONS = [
+  {
+    id: 'col-1',
+    name: 'Engineering Docs',
+    description: 'Internal engineering documentation',
+    visibility: 'shared',
+    created_by: 'user-1',
+    created_at: '2026-02-28T12:00:00Z',
+  },
+  {
+    id: 'col-2',
+    name: 'Personal Notes',
+    description: '',
+    visibility: 'private',
+    created_by: 'user-1',
+    created_at: '2026-02-27T12:00:00Z',
+  },
+]
+
+const MOCK_SOURCES = [
+  {
+    id: 'src-1',
+    collection_id: 'col-1',
+    title: 'Setup Guide',
+    source_type: 'text',
+    source_url: null,
+    status: 'active',
+    error_message: null,
+    content_hash: 'abc123',
+    created_at: '2026-02-28T12:00:00Z',
+  },
+  {
+    id: 'src-2',
+    collection_id: 'col-1',
+    title: 'Architecture Overview',
+    source_type: 'web_page',
+    source_url: 'https://example.com/arch',
+    status: 'active',
+    error_message: null,
+    content_hash: 'def456',
+    created_at: '2026-02-28T13:00:00Z',
+  },
+  {
+    id: 'src-3',
+    collection_id: 'col-1',
+    title: 'Failed Import',
+    source_type: 'web_page',
+    source_url: 'https://example.com/broken',
+    status: 'error',
+    error_message: 'Connection timed out',
+    content_hash: '',
+    created_at: '2026-02-28T14:00:00Z',
+  },
+]
+
+const MOCK_SEARCH_RESULTS = {
+  query: 'setup guide',
+  results: [
+    {
+      chunk_id: 'chunk-1',
+      content: 'This is the setup guide content.',
+      headline: 'This is the <b>setup</b> <b>guide</b> content.',
+      score: 0.8765,
+      chunk_index: 0,
+      source_title: 'Setup Guide',
+      source_url: null,
+      collection_name: 'Engineering Docs',
+    },
+    {
+      chunk_id: 'chunk-2',
+      content: 'Architecture setup instructions.',
+      headline: 'Architecture <b>setup</b> instructions.',
+      score: 0.5432,
+      chunk_index: 1,
+      source_title: 'Architecture Overview',
+      source_url: 'https://example.com/arch',
+      collection_name: 'Engineering Docs',
+    },
+  ],
+  count: 2,
+  search_type: 'fts',
+  score_type: 'ts_rank',
+}
+
+function mockFetchDefaults() {
+  mockFetch.mockImplementation((url: string) => {
+    if (url === '/api/shared-knowledge/collections') {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_COLLECTIONS) })
+    }
+    if (typeof url === 'string' && url.startsWith('/api/shared-knowledge/sources?')) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_SOURCES) })
+    }
+    if (typeof url === 'string' && url.startsWith('/api/shared-knowledge/search?')) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_SEARCH_RESULTS) })
+    }
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+  })
+}
+
+describe('SharedKnowledgeClient', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockFetchDefaults()
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('renders page title and tabs', async () => {
+    render(<SharedKnowledgeClient />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Shared Knowledge')).toBeInTheDocument()
+    })
+
+    expect(screen.getByText('Collections & Sources')).toBeInTheDocument()
+    expect(screen.getByText('Search')).toBeInTheDocument()
+  })
+
+  it('renders collections list', async () => {
+    render(<SharedKnowledgeClient />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Engineering Docs')).toBeInTheDocument()
+      expect(screen.getByText('Personal Notes')).toBeInTheDocument()
+    })
+
+    // Visibility badges
+    expect(screen.getByText('shared')).toBeInTheDocument()
+    expect(screen.getByText('private')).toBeInTheDocument()
+  })
+
+  it('shows empty state when no collection selected', async () => {
+    render(<SharedKnowledgeClient />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Select a collection to view its sources')).toBeInTheDocument()
+    })
+  })
+
+  it('fetches and displays sources when collection clicked', async () => {
+    render(<SharedKnowledgeClient />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Engineering Docs')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByText('Engineering Docs'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Setup Guide')).toBeInTheDocument()
+      expect(screen.getByText('Architecture Overview')).toBeInTheDocument()
+    })
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('/api/shared-knowledge/sources?collection_id=col-1')
+    )
+  })
+
+  it('shows source type badges', async () => {
+    render(<SharedKnowledgeClient />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Engineering Docs')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByText('Engineering Docs'))
+
+    await waitFor(() => {
+      expect(screen.getByText('text')).toBeInTheDocument()
+      expect(screen.getAllByText('web_page').length).toBeGreaterThanOrEqual(1)
+    })
+  })
+
+  it('shows source status badges', async () => {
+    render(<SharedKnowledgeClient />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Engineering Docs')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByText('Engineering Docs'))
+
+    await waitFor(() => {
+      expect(screen.getAllByText('active').length).toBeGreaterThanOrEqual(1)
+      expect(screen.getByText('error')).toBeInTheDocument()
+    })
+  })
+
+  it('shows error message for failed sources', async () => {
+    render(<SharedKnowledgeClient />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Engineering Docs')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByText('Engineering Docs'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Connection timed out')).toBeInTheDocument()
+    })
+  })
+
+  it('shows source URL for web_page sources', async () => {
+    render(<SharedKnowledgeClient />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Engineering Docs')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByText('Engineering Docs'))
+
+    await waitFor(() => {
+      const link = screen.getByText('https://example.com/arch')
+      expect(link).toBeInTheDocument()
+      expect(link.closest('a')).toHaveAttribute('href', 'https://example.com/arch')
+    })
+  })
+
+  it('shows create collection form when New button clicked', async () => {
+    render(<SharedKnowledgeClient />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Engineering Docs')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByText('New'))
+
+    expect(screen.getByText('New Collection')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('Collection name')).toBeInTheDocument()
+  })
+
+  it('submits create collection form', async () => {
+    mockFetch.mockImplementation((url: string, opts?: RequestInit) => {
+      if (url === '/api/shared-knowledge/collections' && opts?.method === 'POST') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ id: 'col-new', name: 'New Col' }) })
+      }
+      if (url === '/api/shared-knowledge/collections') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_COLLECTIONS) })
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+    })
+
+    render(<SharedKnowledgeClient />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Engineering Docs')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByText('New'))
+    fireEvent.change(screen.getByPlaceholderText('Collection name'), { target: { value: 'New Col' } })
+    fireEvent.click(screen.getByText('Create'))
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        '/api/shared-knowledge/collections',
+        expect.objectContaining({ method: 'POST' })
+      )
+    })
+  })
+
+  it('shows add source form with type selector', async () => {
+    render(<SharedKnowledgeClient />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Engineering Docs')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByText('Engineering Docs'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Add Source')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByText('Add Source'))
+
+    expect(screen.getByPlaceholderText('Source title')).toBeInTheDocument()
+    // Type selector should have options
+    const typeSelect = screen.getAllByRole('combobox').find(
+      s => (s as HTMLSelectElement).value === 'text'
+    )
+    expect(typeSelect).toBeTruthy()
+  })
+
+  it('shows URL field when web_page type selected', async () => {
+    render(<SharedKnowledgeClient />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Engineering Docs')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByText('Engineering Docs'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Add Source')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByText('Add Source'))
+
+    // Change type to web_page
+    const typeSelect = screen.getAllByRole('combobox').find(
+      s => (s as HTMLSelectElement).value === 'text'
+    )!
+    fireEvent.change(typeSelect, { target: { value: 'web_page' } })
+
+    expect(screen.getByPlaceholderText('https://example.com/article')).toBeInTheDocument()
+  })
+
+  it('shows textarea when text type selected', async () => {
+    render(<SharedKnowledgeClient />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Engineering Docs')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByText('Engineering Docs'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Add Source')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByText('Add Source'))
+
+    expect(screen.getByPlaceholderText('Paste text content here...')).toBeInTheDocument()
+  })
+
+  it('searches and displays results', async () => {
+    render(<SharedKnowledgeClient />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Shared Knowledge')).toBeInTheDocument()
+    })
+
+    // Switch to search tab
+    fireEvent.click(screen.getByText('Search'))
+
+    const searchInput = screen.getByPlaceholderText('Search shared knowledge...')
+    fireEvent.change(searchInput, { target: { value: 'setup guide' } })
+
+    // Trigger search via Enter key (avoids ambiguity with Search tab button)
+    fireEvent.keyDown(searchInput, { key: 'Enter' })
+
+    await waitFor(() => {
+      expect(screen.getByText('Setup Guide')).toBeInTheDocument()
+      expect(screen.getByText('Architecture Overview')).toBeInTheDocument()
+    })
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('/api/shared-knowledge/search?')
+    )
+  })
+
+  it('search results show source attribution', async () => {
+    render(<SharedKnowledgeClient />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Shared Knowledge')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByText('Search'))
+
+    const searchInput = screen.getByPlaceholderText('Search shared knowledge...')
+    fireEvent.change(searchInput, { target: { value: 'setup' } })
+    fireEvent.keyDown(searchInput, { key: 'Enter' })
+
+    await waitFor(() => {
+      expect(screen.getAllByText('in Engineering Docs').length).toBeGreaterThanOrEqual(1)
+    })
+  })
+
+  it('search results show source URL link for web pages', async () => {
+    render(<SharedKnowledgeClient />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Shared Knowledge')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByText('Search'))
+
+    const searchInput = screen.getByPlaceholderText('Search shared knowledge...')
+    fireEvent.change(searchInput, { target: { value: 'setup' } })
+    fireEvent.keyDown(searchInput, { key: 'Enter' })
+
+    await waitFor(() => {
+      const sourceLinks = screen.getAllByText('Source')
+      expect(sourceLinks.length).toBeGreaterThanOrEqual(1)
+      expect(sourceLinks[0].closest('a')).toHaveAttribute('href', 'https://example.com/arch')
+    })
+  })
+
+  it('shows empty search state', async () => {
+    render(<SharedKnowledgeClient />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Shared Knowledge')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByText('Search'))
+
+    expect(screen.getByText('Enter a query to search shared knowledge')).toBeInTheDocument()
+  })
+
+  it('shows empty collections state', async () => {
+    mockFetch.mockImplementation((url: string) => {
+      if (url === '/api/shared-knowledge/collections') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve([]) })
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+    })
+
+    render(<SharedKnowledgeClient />)
+
+    await waitFor(() => {
+      expect(screen.getByText('No collections yet')).toBeInTheDocument()
+    })
+  })
+
+  it('shows collection filter in search tab', async () => {
+    render(<SharedKnowledgeClient />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Shared Knowledge')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByText('Search'))
+
+    // Collection filter dropdown
+    const selects = screen.getAllByRole('combobox')
+    const collectionFilter = selects.find(
+      s => Array.from((s as HTMLSelectElement).options).some(o => o.text === 'All collections')
+    )
+    expect(collectionFilter).toBeTruthy()
+  })
+})

--- a/services/ui/src/__tests__/Sidebar.test.tsx
+++ b/services/ui/src/__tests__/Sidebar.test.tsx
@@ -129,7 +129,8 @@ describe('Sidebar', () => {
     expect(screen.getByRole('link', { name: /models/i })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /policies/i })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /usage/i })).toBeInTheDocument()
-    expect(screen.getByRole('link', { name: /knowledge/i })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /^knowledge$/i })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /shared knowledge/i })).toBeInTheDocument()
   })
 
   it('highlights active harness route', () => {

--- a/services/ui/src/app/api/shared-knowledge/[...path]/route.ts
+++ b/services/ui/src/app/api/shared-knowledge/[...path]/route.ts
@@ -1,0 +1,13 @@
+import { NextRequest } from 'next/server'
+import { proxyToApi } from '@/utils/api-proxy'
+
+async function proxyRequest(req: NextRequest, { params }: { params: Promise<{ path: string[] }> }) {
+  const { path } = await params
+  const pathStr = path.join('/')
+  return proxyToApi(req, `/shared-knowledge/${pathStr}`, { label: 'shared-knowledge-proxy' })
+}
+
+export const GET = proxyRequest
+export const POST = proxyRequest
+export const PUT = proxyRequest
+export const DELETE = proxyRequest

--- a/services/ui/src/app/harness/shared-knowledge/SharedKnowledgeClient.tsx
+++ b/services/ui/src/app/harness/shared-knowledge/SharedKnowledgeClient.tsx
@@ -1,0 +1,661 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+
+interface Collection {
+  id: string
+  name: string
+  description: string
+  visibility: string
+  created_by: string
+  created_at: string
+}
+
+interface Source {
+  id: string
+  collection_id: string
+  title: string
+  source_type: string
+  source_url: string | null
+  status: string
+  error_message: string | null
+  content_hash: string
+  created_at: string
+  chunk_count?: number
+}
+
+interface SearchResult {
+  chunk_id: string
+  content: string
+  headline: string
+  score: number
+  chunk_index: number
+  source_title: string
+  source_url: string | null
+  collection_name: string
+}
+
+type Tab = 'collections' | 'search'
+
+export default function SharedKnowledgeClient() {
+  // Data state
+  const [collections, setCollections] = useState<Collection[]>([])
+  const [sources, setSources] = useState<Source[]>([])
+  const [selectedCollection, setSelectedCollection] = useState<Collection | null>(null)
+  const [searchResults, setSearchResults] = useState<SearchResult[]>([])
+
+  // UI state
+  const [loading, setLoading] = useState(true)
+  const [activeTab, setActiveTab] = useState<Tab>('collections')
+  const [showCollectionForm, setShowCollectionForm] = useState(false)
+  const [editingCollectionId, setEditingCollectionId] = useState<string | null>(null)
+  const [showSourceForm, setShowSourceForm] = useState(false)
+  const [actionLoading, setActionLoading] = useState<string | null>(null)
+  const [searchQuery, setSearchQuery] = useState('')
+  const [searchCollectionFilter, setSearchCollectionFilter] = useState('')
+  const [searching, setSearching] = useState(false)
+
+  // Form state
+  const [collectionForm, setCollectionForm] = useState({ name: '', description: '', visibility: 'private' })
+  const [collectionFormError, setCollectionFormError] = useState('')
+  const [sourceForm, setSourceForm] = useState({ title: '', source_type: 'text', raw_content: '', source_url: '' })
+  const [sourceFormError, setSourceFormError] = useState('')
+
+  // Fetch collections
+  const fetchCollections = useCallback(async () => {
+    try {
+      const res = await fetch('/api/shared-knowledge/collections')
+      if (res.ok) {
+        setCollections(await res.json())
+      }
+    } catch {
+      // silent
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  // Fetch sources for a collection
+  const fetchSources = useCallback(async (collectionId: string) => {
+    try {
+      const res = await fetch(`/api/shared-knowledge/sources?collection_id=${collectionId}`)
+      if (res.ok) {
+        setSources(await res.json())
+      }
+    } catch {
+      // silent
+    }
+  }, [])
+
+  useEffect(() => {
+    fetchCollections()
+  }, [fetchCollections])
+
+  // When a collection is selected, fetch its sources
+  useEffect(() => {
+    if (selectedCollection) {
+      fetchSources(selectedCollection.id)
+    } else {
+      setSources([])
+    }
+  }, [selectedCollection, fetchSources])
+
+  // --- Collection CRUD ---
+
+  const resetCollectionForm = () => {
+    setCollectionForm({ name: '', description: '', visibility: 'private' })
+    setCollectionFormError('')
+    setShowCollectionForm(false)
+    setEditingCollectionId(null)
+  }
+
+  const handleCollectionSubmit = async () => {
+    setCollectionFormError('')
+    if (!collectionForm.name.trim()) {
+      setCollectionFormError('Name is required')
+      return
+    }
+
+    try {
+      const url = editingCollectionId
+        ? `/api/shared-knowledge/collections/${editingCollectionId}`
+        : '/api/shared-knowledge/collections'
+      const method = editingCollectionId ? 'PUT' : 'POST'
+
+      const res = await fetch(url, {
+        method,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(collectionForm),
+      })
+
+      if (res.ok) {
+        resetCollectionForm()
+        await fetchCollections()
+      } else {
+        const data = await res.json()
+        setCollectionFormError(data.error || 'Failed to save collection')
+      }
+    } catch {
+      setCollectionFormError('Request failed')
+    }
+  }
+
+  const handleEditCollection = (col: Collection) => {
+    setCollectionForm({ name: col.name, description: col.description, visibility: col.visibility })
+    setEditingCollectionId(col.id)
+    setShowCollectionForm(true)
+  }
+
+  const handleDeleteCollection = async (col: Collection) => {
+    if (!confirm(`Delete collection "${col.name}"? This will remove all sources and chunks.`)) return
+    setActionLoading(col.id)
+    try {
+      const res = await fetch(`/api/shared-knowledge/collections/${col.id}`, { method: 'DELETE' })
+      if (res.ok) {
+        if (selectedCollection?.id === col.id) {
+          setSelectedCollection(null)
+        }
+        await fetchCollections()
+      } else {
+        const data = await res.json()
+        alert(data.error || 'Failed to delete collection')
+      }
+    } catch {
+      alert('Failed to delete collection')
+    } finally {
+      setActionLoading(null)
+    }
+  }
+
+  // --- Source CRUD ---
+
+  const resetSourceForm = () => {
+    setSourceForm({ title: '', source_type: 'text', raw_content: '', source_url: '' })
+    setSourceFormError('')
+    setShowSourceForm(false)
+  }
+
+  const handleSourceSubmit = async () => {
+    setSourceFormError('')
+    if (!sourceForm.title.trim()) {
+      setSourceFormError('Title is required')
+      return
+    }
+    if (sourceForm.source_type === 'web_page') {
+      if (!sourceForm.source_url.trim()) {
+        setSourceFormError('URL is required for web page sources')
+        return
+      }
+    } else {
+      if (!sourceForm.raw_content.trim()) {
+        setSourceFormError('Content is required')
+        return
+      }
+    }
+
+    if (!selectedCollection) return
+
+    try {
+      const body: Record<string, string> = {
+        collection_id: selectedCollection.id,
+        title: sourceForm.title,
+        source_type: sourceForm.source_type,
+      }
+      if (sourceForm.source_type === 'web_page') {
+        body.source_url = sourceForm.source_url
+      } else {
+        body.raw_content = sourceForm.raw_content
+      }
+
+      const res = await fetch('/api/shared-knowledge/sources', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      })
+
+      if (res.ok) {
+        resetSourceForm()
+        await fetchSources(selectedCollection.id)
+      } else {
+        const data = await res.json()
+        setSourceFormError(data.error || data.detail || 'Failed to create source')
+      }
+    } catch {
+      setSourceFormError('Request failed')
+    }
+  }
+
+  const handleDeleteSource = async (src: Source) => {
+    if (!confirm(`Delete source "${src.title}"?`)) return
+    setActionLoading(src.id)
+    try {
+      const res = await fetch(`/api/shared-knowledge/sources/${src.id}`, { method: 'DELETE' })
+      if (res.ok && selectedCollection) {
+        await fetchSources(selectedCollection.id)
+      } else if (!res.ok) {
+        const data = await res.json()
+        alert(data.error || 'Failed to delete source')
+      }
+    } catch {
+      alert('Failed to delete source')
+    } finally {
+      setActionLoading(null)
+    }
+  }
+
+  // --- Search ---
+
+  const handleSearch = async () => {
+    if (!searchQuery.trim()) return
+    setSearching(true)
+    try {
+      const params = new URLSearchParams({ q: searchQuery })
+      if (searchCollectionFilter) {
+        params.set('collection_id', searchCollectionFilter)
+      }
+      const res = await fetch(`/api/shared-knowledge/search?${params}`)
+      if (res.ok) {
+        const data = await res.json()
+        setSearchResults(data.results || [])
+      }
+    } catch {
+      // silent
+    } finally {
+      setSearching(false)
+    }
+  }
+
+  // --- Render ---
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-24">
+        <div className="h-8 w-8 rounded-full border-2 border-brand-500 border-t-transparent animate-spin" />
+      </div>
+    )
+  }
+
+  const statusBadge = (status: string) => {
+    const colors: Record<string, string> = {
+      active: 'bg-green-900/40 text-green-400 border-green-700',
+      pending: 'bg-yellow-900/40 text-yellow-400 border-yellow-700',
+      error: 'bg-red-900/40 text-red-400 border-red-700',
+    }
+    return (
+      <span className={`px-2 py-0.5 text-xs font-medium rounded border ${colors[status] || 'bg-navy-700 text-mountain-400 border-navy-600'}`}>
+        {status}
+      </span>
+    )
+  }
+
+  const visibilityBadge = (v: string) => (
+    <span className={`px-2 py-0.5 text-xs font-medium rounded border ${
+      v === 'shared' ? 'bg-brand-900/30 text-brand-400 border-brand-700' : 'bg-navy-700 text-mountain-400 border-navy-600'
+    }`}>
+      {v}
+    </span>
+  )
+
+  return (
+    <div>
+      {/* Header */}
+      <div className="flex items-center justify-between mb-8">
+        <div>
+          <h1 className="text-2xl font-bold">Shared Knowledge</h1>
+          <p className="text-sm text-mountain-400 mt-1">Manage collections, sources, and search across shared knowledge</p>
+        </div>
+      </div>
+
+      {/* Tabs */}
+      <div className="flex gap-1 mb-6 border-b border-navy-700">
+        <button
+          onClick={() => setActiveTab('collections')}
+          className={`px-4 py-2 text-sm font-medium transition-colors cursor-pointer ${
+            activeTab === 'collections'
+              ? 'text-brand-400 border-b-2 border-brand-500'
+              : 'text-mountain-400 hover:text-white'
+          }`}
+        >
+          Collections & Sources
+        </button>
+        <button
+          onClick={() => setActiveTab('search')}
+          className={`px-4 py-2 text-sm font-medium transition-colors cursor-pointer ${
+            activeTab === 'search'
+              ? 'text-brand-400 border-b-2 border-brand-500'
+              : 'text-mountain-400 hover:text-white'
+          }`}
+        >
+          Search
+        </button>
+      </div>
+
+      {/* Collections & Sources Tab */}
+      {activeTab === 'collections' && (
+        <div className="flex gap-6">
+          {/* Collections sidebar */}
+          <div className="w-72 shrink-0">
+            <div className="flex items-center justify-between mb-3">
+              <h2 className="text-sm font-medium text-mountain-400 uppercase tracking-wider">Collections</h2>
+              <button
+                onClick={() => { resetCollectionForm(); setShowCollectionForm(true) }}
+                className="px-3 py-1 text-xs font-medium rounded-md bg-brand-600 hover:bg-brand-500 text-white transition-colors cursor-pointer"
+              >
+                New
+              </button>
+            </div>
+
+            {/* Collection form */}
+            {showCollectionForm && (
+              <div className="rounded-lg border border-navy-700 bg-navy-800 p-4 mb-3">
+                <h3 className="text-sm font-semibold text-white mb-3">
+                  {editingCollectionId ? 'Edit Collection' : 'New Collection'}
+                </h3>
+                <div className="space-y-3">
+                  <div>
+                    <label className="block text-xs text-mountain-400 mb-1">Name</label>
+                    <input
+                      type="text"
+                      value={collectionForm.name}
+                      onChange={e => setCollectionForm(f => ({ ...f, name: e.target.value }))}
+                      className="w-full rounded-md border border-navy-600 bg-navy-900 px-3 py-1.5 text-sm text-white placeholder-mountain-500 focus:border-brand-500 focus:outline-none"
+                      placeholder="Collection name"
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-xs text-mountain-400 mb-1">Description</label>
+                    <input
+                      type="text"
+                      value={collectionForm.description}
+                      onChange={e => setCollectionForm(f => ({ ...f, description: e.target.value }))}
+                      className="w-full rounded-md border border-navy-600 bg-navy-900 px-3 py-1.5 text-sm text-white placeholder-mountain-500 focus:border-brand-500 focus:outline-none"
+                      placeholder="Optional description"
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-xs text-mountain-400 mb-1">Visibility</label>
+                    <select
+                      value={collectionForm.visibility}
+                      onChange={e => setCollectionForm(f => ({ ...f, visibility: e.target.value }))}
+                      className="w-full rounded-md border border-navy-600 bg-navy-900 px-3 py-1.5 text-sm text-white focus:border-brand-500 focus:outline-none"
+                    >
+                      <option value="private">Private</option>
+                      <option value="shared">Shared</option>
+                    </select>
+                  </div>
+                  {collectionFormError && <p className="text-xs text-red-400">{collectionFormError}</p>}
+                  <div className="flex gap-2">
+                    <button onClick={handleCollectionSubmit} className="px-3 py-1.5 text-xs font-medium rounded-md bg-brand-600 hover:bg-brand-500 text-white transition-colors cursor-pointer">
+                      {editingCollectionId ? 'Update' : 'Create'}
+                    </button>
+                    <button onClick={resetCollectionForm} className="px-3 py-1.5 text-xs font-medium rounded-md border border-navy-600 text-mountain-400 hover:text-white hover:border-navy-500 transition-colors cursor-pointer">
+                      Cancel
+                    </button>
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {/* Collection list */}
+            {collections.length === 0 ? (
+              <div className="rounded-lg border border-navy-700 bg-navy-800 p-6 text-center">
+                <p className="text-sm text-mountain-400">No collections yet</p>
+              </div>
+            ) : (
+              <div className="space-y-1">
+                {collections.map(col => (
+                  <div
+                    key={col.id}
+                    onClick={() => setSelectedCollection(col)}
+                    className={`rounded-lg border p-3 cursor-pointer transition-colors ${
+                      selectedCollection?.id === col.id
+                        ? 'border-brand-600 bg-navy-800'
+                        : 'border-navy-700 bg-navy-900 hover:bg-navy-800'
+                    }`}
+                  >
+                    <div className="flex items-center justify-between">
+                      <span className="text-sm font-medium text-white truncate">{col.name}</span>
+                      {visibilityBadge(col.visibility)}
+                    </div>
+                    {col.description && (
+                      <p className="text-xs text-mountain-500 mt-1 truncate">{col.description}</p>
+                    )}
+                    <div className="flex items-center gap-2 mt-2">
+                      <button
+                        onClick={e => { e.stopPropagation(); handleEditCollection(col) }}
+                        className="px-2 py-0.5 text-xs font-medium rounded border border-navy-600 text-mountain-400 hover:text-white hover:border-navy-500 transition-colors cursor-pointer"
+                      >
+                        Edit
+                      </button>
+                      <button
+                        onClick={e => { e.stopPropagation(); handleDeleteCollection(col) }}
+                        disabled={actionLoading === col.id}
+                        className="px-2 py-0.5 text-xs font-medium rounded border border-red-700 text-red-400 hover:bg-red-900/30 transition-colors disabled:opacity-50 cursor-pointer disabled:cursor-not-allowed"
+                      >
+                        Delete
+                      </button>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* Sources panel */}
+          <div className="flex-1 min-w-0">
+            {!selectedCollection ? (
+              <div className="rounded-lg border border-navy-700 bg-navy-800 p-12 text-center">
+                <p className="text-mountain-400">Select a collection to view its sources</p>
+              </div>
+            ) : (
+              <>
+                <div className="flex items-center justify-between mb-4">
+                  <h2 className="text-lg font-semibold text-white">
+                    {selectedCollection.name}
+                    <span className="text-sm text-mountain-400 font-normal ml-2">
+                      {sources.length} source{sources.length !== 1 ? 's' : ''}
+                    </span>
+                  </h2>
+                  <button
+                    onClick={() => { resetSourceForm(); setShowSourceForm(true) }}
+                    className="px-4 py-2 text-sm font-medium rounded-lg bg-brand-600 hover:bg-brand-500 text-white transition-colors cursor-pointer"
+                  >
+                    Add Source
+                  </button>
+                </div>
+
+                {/* Source form */}
+                {showSourceForm && (
+                  <div className="rounded-lg border border-navy-700 bg-navy-800 p-5 mb-4">
+                    <h3 className="text-lg font-semibold text-white mb-4">Add Source</h3>
+                    <div className="space-y-4">
+                      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                        <div>
+                          <label className="block text-sm text-mountain-400 mb-1">Title</label>
+                          <input
+                            type="text"
+                            value={sourceForm.title}
+                            onChange={e => setSourceForm(f => ({ ...f, title: e.target.value }))}
+                            className="w-full rounded-md border border-navy-600 bg-navy-900 px-3 py-2 text-sm text-white placeholder-mountain-500 focus:border-brand-500 focus:outline-none"
+                            placeholder="Source title"
+                          />
+                        </div>
+                        <div>
+                          <label className="block text-sm text-mountain-400 mb-1">Type</label>
+                          <select
+                            value={sourceForm.source_type}
+                            onChange={e => setSourceForm(f => ({ ...f, source_type: e.target.value }))}
+                            className="w-full rounded-md border border-navy-600 bg-navy-900 px-3 py-2 text-sm text-white focus:border-brand-500 focus:outline-none"
+                          >
+                            <option value="text">Text</option>
+                            <option value="markdown">Markdown</option>
+                            <option value="web_page">Web Page</option>
+                          </select>
+                        </div>
+                      </div>
+                      {sourceForm.source_type === 'web_page' ? (
+                        <div>
+                          <label className="block text-sm text-mountain-400 mb-1">URL</label>
+                          <input
+                            type="url"
+                            value={sourceForm.source_url}
+                            onChange={e => setSourceForm(f => ({ ...f, source_url: e.target.value }))}
+                            className="w-full rounded-md border border-navy-600 bg-navy-900 px-3 py-2 text-sm text-white placeholder-mountain-500 focus:border-brand-500 focus:outline-none"
+                            placeholder="https://example.com/article"
+                          />
+                        </div>
+                      ) : (
+                        <div>
+                          <label className="block text-sm text-mountain-400 mb-1">Content</label>
+                          <textarea
+                            value={sourceForm.raw_content}
+                            onChange={e => setSourceForm(f => ({ ...f, raw_content: e.target.value }))}
+                            rows={6}
+                            className="w-full rounded-md border border-navy-600 bg-navy-900 px-3 py-2 text-sm text-white placeholder-mountain-500 focus:border-brand-500 focus:outline-none resize-y"
+                            placeholder={sourceForm.source_type === 'markdown' ? '# Heading\n\nContent...' : 'Paste text content here...'}
+                          />
+                        </div>
+                      )}
+                      {sourceFormError && <p className="text-sm text-red-400">{sourceFormError}</p>}
+                      <div className="flex gap-3">
+                        <button onClick={handleSourceSubmit} className="px-4 py-2 text-sm font-medium rounded-lg bg-brand-600 hover:bg-brand-500 text-white transition-colors cursor-pointer">
+                          Create Source
+                        </button>
+                        <button onClick={resetSourceForm} className="px-4 py-2 text-sm font-medium rounded-lg border border-navy-600 text-mountain-400 hover:text-white hover:border-navy-500 transition-colors cursor-pointer">
+                          Cancel
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                )}
+
+                {/* Sources list */}
+                {sources.length === 0 ? (
+                  <div className="rounded-lg border border-navy-700 bg-navy-800 p-12 text-center">
+                    <p className="text-mountain-400 mb-2">No sources in this collection</p>
+                    <p className="text-sm text-mountain-500">Add text, markdown, or web page sources to build your knowledge base</p>
+                  </div>
+                ) : (
+                  <div className="rounded-lg border border-navy-700 overflow-hidden">
+                    <table className="w-full text-sm">
+                      <thead className="bg-navy-800 text-mountain-400 text-left">
+                        <tr>
+                          <th className="px-4 py-3 font-medium">Title</th>
+                          <th className="px-4 py-3 font-medium">Type</th>
+                          <th className="px-4 py-3 font-medium">Status</th>
+                          <th className="px-4 py-3 font-medium">Created</th>
+                          <th className="px-4 py-3 font-medium text-right">Actions</th>
+                        </tr>
+                      </thead>
+                      <tbody className="divide-y divide-navy-700">
+                        {sources.map(src => (
+                          <tr key={src.id} className="bg-navy-900 hover:bg-navy-800 transition-colors">
+                            <td className="px-4 py-3">
+                              <div className="text-white font-medium">{src.title}</div>
+                              {src.source_url && (
+                                <a href={src.source_url} target="_blank" rel="noopener noreferrer" className="text-xs text-brand-400 hover:text-brand-300 truncate block max-w-xs">
+                                  {src.source_url}
+                                </a>
+                              )}
+                              {src.error_message && (
+                                <p className="text-xs text-red-400 mt-0.5">{src.error_message}</p>
+                              )}
+                            </td>
+                            <td className="px-4 py-3">
+                              <span className="px-2 py-0.5 text-xs font-medium rounded border bg-navy-700 text-mountain-300 border-navy-600">
+                                {src.source_type}
+                              </span>
+                            </td>
+                            <td className="px-4 py-3">{statusBadge(src.status)}</td>
+                            <td className="px-4 py-3 text-mountain-400">
+                              {new Date(src.created_at).toLocaleDateString()}
+                            </td>
+                            <td className="px-4 py-3">
+                              <div className="flex items-center gap-2 justify-end">
+                                <button
+                                  onClick={() => handleDeleteSource(src)}
+                                  disabled={actionLoading === src.id}
+                                  className="px-2.5 py-1 text-xs font-medium rounded-md border border-red-700 text-red-400 hover:bg-red-900/30 transition-colors disabled:opacity-50 cursor-pointer disabled:cursor-not-allowed"
+                                >
+                                  Delete
+                                </button>
+                              </div>
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                )}
+              </>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Search Tab */}
+      {activeTab === 'search' && (
+        <div>
+          <div className="flex gap-3 mb-6">
+            <input
+              type="text"
+              value={searchQuery}
+              onChange={e => setSearchQuery(e.target.value)}
+              onKeyDown={e => e.key === 'Enter' && handleSearch()}
+              className="flex-1 rounded-md border border-navy-600 bg-navy-900 px-4 py-2 text-sm text-white placeholder-mountain-500 focus:border-brand-500 focus:outline-none"
+              placeholder="Search shared knowledge..."
+            />
+            <select
+              value={searchCollectionFilter}
+              onChange={e => setSearchCollectionFilter(e.target.value)}
+              className="rounded-md border border-navy-600 bg-navy-900 px-3 py-2 text-sm text-white focus:border-brand-500 focus:outline-none"
+            >
+              <option value="">All collections</option>
+              {collections.map(c => (
+                <option key={c.id} value={c.id}>{c.name}</option>
+              ))}
+            </select>
+            <button
+              onClick={handleSearch}
+              disabled={searching || !searchQuery.trim()}
+              className="px-4 py-2 text-sm font-medium rounded-lg bg-brand-600 hover:bg-brand-500 text-white transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {searching ? 'Searching...' : 'Search'}
+            </button>
+          </div>
+
+          {searchResults.length === 0 ? (
+            <div className="rounded-lg border border-navy-700 bg-navy-800 p-12 text-center">
+              <p className="text-mountain-400">
+                {searchQuery ? 'No results found' : 'Enter a query to search shared knowledge'}
+              </p>
+            </div>
+          ) : (
+            <div className="space-y-3">
+              {searchResults.map((r, i) => (
+                <div key={`${r.chunk_id}-${i}`} className="rounded-lg border border-navy-700 bg-navy-800 p-4">
+                  <div className="flex items-center gap-2 mb-2">
+                    <span className="text-sm font-medium text-white">{r.source_title}</span>
+                    <span className="text-xs text-mountain-500">in {r.collection_name}</span>
+                    {r.source_url && (
+                      <a href={r.source_url} target="_blank" rel="noopener noreferrer" className="text-xs text-brand-400 hover:text-brand-300">
+                        Source
+                      </a>
+                    )}
+                    <span className="text-xs text-mountain-500 ml-auto">
+                      Score: {Number(r.score).toFixed(4)}
+                    </span>
+                  </div>
+                  <p
+                    className="text-sm text-mountain-300 leading-relaxed"
+                    dangerouslySetInnerHTML={{ __html: r.headline || r.content }}
+                  />
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/services/ui/src/app/harness/shared-knowledge/page.tsx
+++ b/services/ui/src/app/harness/shared-knowledge/page.tsx
@@ -1,0 +1,20 @@
+import { redirect } from 'next/navigation'
+import { auth } from '@/auth'
+import AppShell from '@/components/AppShell'
+import SharedKnowledgeClient from './SharedKnowledgeClient'
+
+export default async function SharedKnowledgePage() {
+  const session = await auth()
+
+  if (!session) {
+    redirect('/api/auth/signin')
+  }
+
+  return (
+    <AppShell>
+      <main className="flex-1 px-6 py-12 max-w-6xl mx-auto w-full">
+        <SharedKnowledgeClient />
+      </main>
+    </AppShell>
+  )
+}

--- a/services/ui/src/components/nav-items.ts
+++ b/services/ui/src/components/nav-items.ts
@@ -1,4 +1,4 @@
-import { Home, LayoutDashboard, Bot, FileText, Book, ExternalLink, KeyRound, Cpu, Shield, BarChart3, BookOpen, Layers } from 'lucide-react'
+import { Home, LayoutDashboard, Bot, FileText, Book, ExternalLink, KeyRound, Cpu, Shield, BarChart3, BookOpen, Library, Layers } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
 
 export interface NavLink {
@@ -36,6 +36,7 @@ export const NAV_ITEMS: NavItem[] = [
       { type: 'link', id: 'policies', label: 'Policies', href: '/harness/policies', icon: Shield },
       { type: 'link', id: 'usage', label: 'Usage', href: '/harness/usage', icon: BarChart3 },
       { type: 'link', id: 'knowledge', label: 'Knowledge', href: '/harness/knowledge', icon: BookOpen },
+      { type: 'link', id: 'shared-knowledge', label: 'Shared Knowledge', href: '/harness/shared-knowledge', icon: Library },
     ],
   },
   {


### PR DESCRIPTION
## Summary
- Adds harness UI page at `/harness/shared-knowledge` with collections sidebar, sources table (text/markdown/web_page), and full-text search with provenance citations
- Lifts `web_page` source type restriction with SSRF-protected fetch pipeline (`trafilatura` for HTML extraction)
- Web page fetcher implements full Fetch Safety Contract: URL validation, DNS resolution pre-check against 7 blocked CIDR categories, manual redirect following with re-validation per hop, error messages that omit resolved IPs
- Adds `GET /shared-knowledge/sources/:id` route handler (proxy function existed, route was missing)
- Adds UI API proxy catch-all route + "Shared Knowledge" nav item under Harness group

## Changes by service

**Knowledge service:**
- `web_page_fetcher.py` — SSRF-protected URL fetch + trafilatura extraction (250 lines)
- `ingest.py` — remove web_page rejection, add fetch+extract branch
- `pyproject.toml` — add `trafilatura ^2.0.0` dependency
- 42 unit tests covering all SSRF categories (loopback, RFC1918×3, link-local, Tailscale/CGNAT, internal hostnames, DNS rebinding, redirect chains, info leak prevention)
- 3 integration tests (web_page success with mock, fetch error, missing URL)

**API service:**
- `shared-knowledge.ts` — add `GET /sources/:id` route with ownership check
- OpenAPI spec updated + synced to `docs/site/openapi.yaml`

**UI service:**
- `SharedKnowledgeClient.tsx` — client component with collections panel, sources panel, search panel
- `page.tsx` — server component with auth guard + AppShell
- `shared-knowledge/[...path]/route.ts` — UI API proxy
- `nav-items.ts` — add "Shared Knowledge" with Library icon
- 19 vitest tests for SharedKnowledgeClient
- Fix Sidebar test regex to handle "Knowledge" vs "Shared Knowledge" ambiguity

## Test plan
- [x] Knowledge unit tests: 89 passed (42 web_page_fetcher + 47 existing)
- [x] Knowledge integration tests: compile-checked (require DB for runtime)
- [x] SSRF blocked ranges: all 7 CIDR categories covered with ≥1 test each
- [x] SSRF redirect re-validation: redirect to 127.0.0.1 rejected
- [x] SSRF DNS rebind: public hostname → private IP rejected
- [x] Error message leak check: resolved IP not in error string
- [x] UI vitest: 217 passed (19 new + 198 existing, including Sidebar fix)
- [x] API TypeScript compile: clean (no new errors)
- [x] OpenAPI drift: no diff between API spec and docs/site
- [x] No AKM changes or regressions

## Risks
- trafilatura extraction quality varies by page — users can retry or paste text manually
- Synchronous fetch could slow for very large/slow pages (30s timeout, async-ready for future)

🤖 Generated with [Claude Code](https://claude.com/claude-code)