### PR TITLE
fix: use system CA store instead of certifi for web page fetcher

### DIFF
--- a/services/knowledge/app/services/web_page_fetcher.py
+++ b/services/knowledge/app/services/web_page_fetcher.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import ipaddress
 import socket
+import ssl
 from typing import Any
 from urllib.parse import urlparse
 
@@ -170,6 +171,7 @@ async def fetch_and_extract(url: str) -> dict[str, Any]:
         timeout=httpx.Timeout(connect=CONNECT_TIMEOUT, read=READ_TIMEOUT, write=READ_TIMEOUT, pool=READ_TIMEOUT),
         follow_redirects=False,
         headers={"User-Agent": USER_AGENT},
+        verify=ssl.create_default_context(),
     ) as client:
         while True:
             try:


### PR DESCRIPTION
## Summary
- Web page ingestion in the knowledge service failed with `SSL: CERTIFICATE_VERIFY_FAILED` against all HTTPS URLs
- Root cause: httpx defaults to certifi's bundled CA certificates, which was missing the root CA needed for common domains
- Fix: pass `verify=ssl.create_default_context()` to httpx.AsyncClient so it uses the Debian system CA store instead

## Root Cause
The `python:3.12-slim` Docker image includes system CA certificates at `/etc/ssl/certs/ca-certificates.crt` (150 certs, kept current by the base image). However, httpx's default behavior uses the `certifi` Python package's bundled CA file, which had only 137 certs and was missing the issuer chain for `example.com`'s certificate.

Raw Python `ssl.create_default_context()` worked fine (uses system certs). Only httpx's certifi path failed.

## Test plan
- [x] All 44 web_page_fetcher unit tests pass
- [x] All 91 knowledge unit tests pass
- [x] Verified fix against live container: `httpx.AsyncClient(verify=ssl.create_default_context())` successfully fetches https://example.com
- [ ] CI green
- [ ] Deploy knowledge service and re-verify web page ingestion

🤖 Generated with [Claude Code](https://claude.com/claude-code)