### PR TITLE
feat: tool presets — CRUD API, migration, and agent preset assignment

### DIFF
--- a/.claude/plans/curious-dazzling-nest.md
+++ b/.claude/plans/curious-dazzling-nest.md
@@ -1,0 +1,373 @@
+# Tool Presets — Phase 1
+
+## Context
+
+Agents have tools_config (JSONB), policies, and runtime containers. The current UX requires users to configure low-level fields (`allowed_binaries`, `denied_patterns`, path lists) per agent. This phase introduces **Tool Presets** — named, reusable tool configurations. The design reuses the general route/table/FK pattern established by `model_policies` / `model_policy_id`, but intentionally diverges: presets have no ownership scoping in Phase 1 (all are shared platform resources), add `is_platform` immutability enforcement (platform seeds cannot be mutated or deleted), and use resolve-on-save semantics (preset config is copied into the agent at assignment time rather than referenced dynamically).
+
+**Plan artifact**: This plan will be committed into the repo at `.claude/plans/curious-dazzling-nest.md` as a changed file in PR 1, satisfying the `check_plan_closed_loop.py` detection rule (`f.startswith(".claude/plans/") and f.endswith(".md")`).
+
+**Product concept decision**: "Tool Presets" not "Skills." The current system is a policy layer — `tools_config` controls what's *allowed*, not what's *installed*. Enabling `allowed_binaries: [git]` permits access to already-installed git; it doesn't install it. "Preset" accurately describes a predefined policy configuration. Skills (implying installable, composable capabilities) are premature until the runtime supports capability extension.
+
+**Naming**: DB/API = `tool_presets` / `tool_preset_id`. UI = "Tool Profiles." URL = `/harness/tool-profiles`.
+
+---
+
+## 1. Goal / Signal
+
+After this lands:
+- **Observable signal**: `GET /tool-presets` returns 4 platform presets. Agents can be created/updated with `tool_preset_id`. Agent form shows a preset dropdown. `/harness/tool-profiles` page is live.
+- **User-facing impact**: Users pick a named tool profile (Minimal, Developer, Research, Operator) instead of manually configuring `allowed_binaries` and path lists. Custom configuration remains available.
+
+---
+
+## 2. Scope
+
+**In scope:**
+- `tool_presets` table + `tool_preset_id` FK on agents
+- CRUD API for tool presets (admin-only create/update/delete)
+- 4 seed platform presets (Minimal, Developer, Research, Operator)
+- Resolve-on-save: assigning a preset copies its `tools_config` to the agent at that moment
+- Agent form: preset dropdown with two-mode switching (preset vs custom)
+- Agent detail: preset name badge in capability summary
+- `/harness/tool-profiles` management page
+- OpenAPI spec update (both `services/api/src/openapi/openapi.yaml` AND `docs/site/openapi.yaml`)
+- "No preset selected by default" on new agents — user must explicitly choose a profile or Custom
+
+**Out of scope:**
+- "Skills" as first-class entity
+- Container image variants / installable packages
+- MCP client connections for agents
+- User-created presets (Phase 2)
+- Preset validation against container image
+- Binary inventory / introspection endpoint
+- Preset reapply/sync action
+- Agent usage count per preset in the Tool Profiles page (removed from scope — adds a cross-table query and UI for minimal Phase 1 value; revisit in Phase 2)
+
+**Product decision — "no preset selected by default"**: New agents have `tool_preset_id = NULL` and the existing default `tools_config` (shell disabled, filesystem disabled, health enabled). The form shows an empty dropdown prompting the user to choose. This is a deliberate UX change: it forces awareness of tool profiles without breaking backward compatibility. Agents created via API without `tool_preset_id` still work identically to today.
+
+---
+
+## 3. Preset Visibility & Assignment Rules
+
+### Visibility (GET /tool-presets)
+
+| Preset type | `is_platform` | `created_by` | Admin sees | User sees |
+|-------------|---------------|--------------|------------|-----------|
+| Platform seed | `true` | `NULL` | Yes | Yes |
+| Admin-created | `false` | `NULL` | Yes | Yes |
+
+Phase 1 has only admin-created and platform presets. Both are visible to all authenticated users (both admin and non-admin). The GET query for non-admins:
+```sql
+SELECT * FROM tool_presets ORDER BY is_platform DESC, name ASC
+```
+No ownership scoping needed in Phase 1 because all presets are shared resources (no user-owned presets until Phase 2).
+
+### Mutation (POST/PUT/DELETE /tool-presets)
+
+| Operation | Admin | Non-admin |
+|-----------|-------|-----------|
+| Create | Allowed (`created_by = NULL`) | 403 Forbidden |
+| Update | Allowed (except `is_platform = true` presets) | 403 Forbidden |
+| Delete | Allowed (except `is_platform = true` presets, and not if assigned to agents) | 403 Forbidden |
+
+Platform presets (`is_platform = true`) are immutable and undeletable. Admin-created presets (`is_platform = false`) can be updated/deleted by admins only.
+
+### Assignment (agents create/update with tool_preset_id)
+
+| Caller | Can assign? | Validation |
+|--------|-------------|------------|
+| Admin | Any preset | Preset must exist |
+| Non-admin user | Any preset | Preset must exist |
+
+All presets are assignable by any authenticated user. This matches the model where presets are shared platform resources. The agent create/update handler validates:
+1. If `tool_preset_id` is provided, query `SELECT tools_config FROM tool_presets WHERE id = $1`
+2. If not found → 400 "Tool preset not found"
+3. If found → overwrite agent's `tools_config` with preset's value (resolve-on-save)
+
+### Enforcement locations
+
+- **GET /tool-presets**: `requireRole('user')` — all authenticated users see all presets
+- **POST/PUT/DELETE /tool-presets**: `requireRole('admin')` — admin check at route level
+- **PUT /DELETE immutability**: Check `is_platform` column in handler — return 403 if true
+- **Agent create/update**: Validate preset existence via DB lookup in `agents.ts`
+
+---
+
+## 4. TDD Matrix
+
+| # | Requirement | Test name | File | Type |
+|---|-------------|-----------|------|------|
+| T1 | List presets returns platform seeds | `returns 4 platform presets` | routes-tool-presets.test.ts | unit |
+| T2 | List presets requires auth | `rejects unauthenticated requests` | routes-tool-presets.test.ts | unit |
+| T3 | Create preset requires admin | `rejects non-admin create` | routes-tool-presets.test.ts | unit |
+| T4 | Create preset validates name required | `rejects create without name` | routes-tool-presets.test.ts | unit |
+| T5 | Create preset validates tools_config required | `rejects create without tools_config` | routes-tool-presets.test.ts | unit |
+| T6 | Create preset succeeds for admin | `admin creates preset` | routes-tool-presets.test.ts | unit |
+| T7 | Update preset requires admin | `rejects non-admin update` | routes-tool-presets.test.ts | unit |
+| T8 | Update platform preset blocked | `rejects update of platform preset` | routes-tool-presets.test.ts | unit |
+| T9 | Delete preset requires admin | `rejects non-admin delete` | routes-tool-presets.test.ts | unit |
+| T10 | Delete platform preset blocked | `rejects delete of platform preset` | routes-tool-presets.test.ts | unit |
+| T11 | Delete assigned preset blocked | `rejects delete of preset assigned to agent` | routes-tool-presets.test.ts | unit |
+| T12 | Delete unassigned preset succeeds | `admin deletes unassigned preset` | routes-tool-presets.test.ts | unit |
+| T13 | Agent create with preset resolves tools_config | `create agent with tool_preset_id copies preset config` | routes-agents-preset.test.ts | unit |
+| T14 | Agent create with invalid preset rejected | `create agent with nonexistent preset returns 400` | routes-agents-preset.test.ts | unit |
+| T15 | Agent update with preset resolves tools_config | `update agent tool_preset_id copies preset config` | routes-agents-preset.test.ts | unit |
+| T16 | Agent create without preset uses default tools_config | `create agent without preset uses default` | routes-agents-preset.test.ts | unit |
+| T17 | Agent update clears preset (set null) | `update agent tool_preset_id to null preserves tools_config` | routes-agents-preset.test.ts | unit |
+| T18 | Preset dropdown renders options | `renders preset dropdown with options` | AgentFormClient.test.tsx | vitest |
+| T19 | Selecting preset shows summary | `selecting preset shows summary card` | AgentFormClient.test.tsx | vitest |
+| T20 | Selecting Custom reveals manual config | `selecting Custom shows tool toggles` | AgentFormClient.test.tsx | vitest |
+| T21 | Preset→Custom populates fields | `switching to Custom populates from preset` | AgentFormClient.test.tsx | vitest |
+| T22 | Agent detail shows preset badge | `shows preset name badge when assigned` | AgentDetailClient.test.tsx | vitest |
+| T23 | Agent detail shows Custom when no preset | `shows Custom when no preset assigned` | AgentDetailClient.test.tsx | vitest |
+| T24 | Tool Profiles page lists presets | `renders preset list with badges` | ToolProfilesClient.test.tsx | vitest |
+| T25 | Tool Profiles platform badge | `platform presets show Platform badge` | ToolProfilesClient.test.tsx | vitest |
+| T26 | Tool Profiles expand shows config | `expanding preset shows tools_config detail` | ToolProfilesClient.test.tsx | vitest |
+| T27 | Tool Profiles create form (admin) | `admin can create new preset` | ToolProfilesClient.test.tsx | vitest |
+| T28 | Nav includes Tool Profiles | `nav items include tool-profiles entry` | nav-items.test.tsx (or inline) | vitest |
+
+---
+
+## 5. Implementation Steps
+
+### PR 1: Database + API (backend)
+
+**Red:**
+1. Create `services/api/src/__tests__/routes-tool-presets.test.ts` — tests T1-T12 (CRUD, auth, platform immutability, delete protection)
+2. Create `services/api/src/__tests__/routes-agents-preset.test.ts` — tests T13-T17 (preset assignment, resolve-on-save)
+3. Run `npm test --prefix services/api` — confirm all new tests fail
+
+**Green:**
+4. Create `services/api/src/db/migrations/016_create_tool_presets.sql`:
+   - `tool_presets` table (id UUID PK, name VARCHAR(128) UNIQUE NOT NULL, description TEXT, tools_config JSONB NOT NULL, is_platform BOOLEAN DEFAULT false, created_by VARCHAR(255), created_at TIMESTAMPTZ, updated_at TIMESTAMPTZ)
+   - `ALTER TABLE agents ADD COLUMN IF NOT EXISTS tool_preset_id UUID REFERENCES tool_presets(id)`
+   - INSERT 4 seed presets with `is_platform = true, created_by = NULL`
+5. Create `services/api/src/routes/tool-presets.ts` — CRUD routes reusing the general `model-policies.ts` route/table/FK structure but diverging on visibility (no ownership scoping) and immutability (`is_platform` guard):
+   - GET / — `requireRole('user')`, return all presets ordered by `is_platform DESC, name ASC`
+   - GET /:id — `requireRole('user')`, return single preset
+   - POST / — `requireRole('admin')`, validate name + tools_config, insert with `created_by = NULL`
+   - PUT /:id — `requireRole('admin')`, check `is_platform` → 403 if true, update
+   - DELETE /:id — `requireRole('admin')`, check `is_platform` → 403, check agent assignment → 409, delete
+6. Register route in `services/api/src/app.ts`: `app.use('/tool-presets', toolPresetsRouter)`
+7. Modify `services/api/src/routes/agents.ts`:
+   - In POST/PUT handlers: if `tool_preset_id` provided, query preset, copy `tools_config` to agent, store both `tool_preset_id` and resolved `tools_config`
+   - If `tool_preset_id` is explicitly `null`, clear it but preserve current `tools_config`
+8. Update `services/api/src/openapi/openapi.yaml`: add ToolPreset schema, CRUD paths, `tool_preset_id` field on Agent schema
+9. Copy updated spec: `cp services/api/src/openapi/openapi.yaml docs/site/openapi.yaml`
+10. Copy plan into repo: `cp ~/.claude/plans/curious-dazzling-nest.md .claude/plans/curious-dazzling-nest.md` — satisfies CI closed-loop detection
+11. Run `npm test --prefix services/api` — confirm all tests pass
+
+**Refactor:**
+12. Review route code for duplication with model-policies, extract shared helpers if warranted (likely not worth it for Phase 1)
+
+### PR 2: Agent form + preset picker (UI)
+
+**Red:**
+13. Add tests T18-T23 to existing `AgentFormClient.test.tsx` and `AgentDetailClient.test.tsx`
+14. Run `npm test --prefix services/ui` — confirm new tests fail
+
+**Green:**
+15. Create `services/ui/src/app/api/tool-presets/route.ts` — proxy (same pattern as model-policies proxy)
+16. Create `services/ui/src/app/api/tool-presets/[...path]/route.ts` — proxy
+17. Modify `services/ui/src/app/agents/new/AgentFormClient.tsx`:
+    - Add `presets` state, fetch from `/api/tool-presets` on mount
+    - Add dropdown above existing tools section: "Tool Profile" with options from presets + "Custom"
+    - When preset selected: show read-only summary card (enabled tools, binaries, fs mode), hide manual config
+    - When "Custom" selected: show existing tool toggles, populate from preset values if switching from a preset
+    - On submit: include `tool_preset_id` in payload (null if Custom)
+18. Modify `services/ui/src/app/agents/[id]/AgentDetailClient.tsx`:
+    - Fetch preset name if `tool_preset_id` is set
+    - Show preset badge in Overview tab alongside tool icons
+19. Modify `services/ui/src/app/agents/[id]/edit/AgentEditClient.tsx` — pass preset data
+20. Run `npm test --prefix services/ui` — confirm all tests pass
+
+### PR 3: Tool Profiles harness page (UI)
+
+**Red:**
+21. Create `services/ui/src/app/harness/tool-profiles/__tests__/ToolProfilesClient.test.tsx` — tests T24-T28
+22. Run `npm test --prefix services/ui` — confirm new tests fail
+
+**Green:**
+23. Create `services/ui/src/app/harness/tool-profiles/page.tsx` — server page (auth + AppShell)
+24. Create `services/ui/src/app/harness/tool-profiles/ToolProfilesClient.tsx` — follows PoliciesClient.tsx pattern:
+    - List presets with name, description, tool summary badges (Terminal/Folder/Heart icons)
+    - Click row to expand → show full tools_config detail
+    - Platform presets: "Platform" badge, no edit/delete buttons
+    - Admin-created: edit/delete buttons (admin only)
+    - Create form for admins: name, description, tools_config editor (reuse existing tool toggle pattern from AgentFormClient)
+25. Modify `services/ui/src/components/nav-items.ts`:
+    - Add `Wrench` to lucide-react imports
+    - Add `{ type: 'link', id: 'tool-profiles', label: 'Tool Profiles', href: '/harness/tool-profiles', icon: Wrench }` after Policies, before Usage
+26. Run `npm test --prefix services/ui` — confirm all tests pass
+
+---
+
+## 6. Seed Preset Definitions
+
+**Minimal** — _Health monitoring only. No shell or filesystem access._
+```json
+{
+  "shell": { "enabled": false, "allowed_binaries": [], "denied_patterns": [], "max_timeout": 300 },
+  "filesystem": { "enabled": false, "read_only": false, "allowed_paths": ["/workspace"], "denied_paths": ["/etc/shadow", "/etc/passwd", "/root"] },
+  "health": { "enabled": true }
+}
+```
+
+**Developer** — _Full dev environment: bash, git, make, curl, jq. Read-write workspace and data._
+```json
+{
+  "shell": { "enabled": true, "allowed_binaries": ["bash", "git", "make", "curl", "jq"], "denied_patterns": ["rm -rf /", ":(){ :|:& };:"], "max_timeout": 300 },
+  "filesystem": { "enabled": true, "read_only": false, "allowed_paths": ["/workspace", "/data"], "denied_paths": ["/etc/shadow", "/etc/passwd", "/root"] },
+  "health": { "enabled": true }
+}
+```
+
+**Research** — _Read-only with networking tools. Can fetch data but cannot modify filesystem._
+```json
+{
+  "shell": { "enabled": true, "allowed_binaries": ["bash", "curl", "wget", "jq"], "denied_patterns": ["rm ", "mv ", "dd ", "mkfs", "> /", ">> /"], "max_timeout": 120 },
+  "filesystem": { "enabled": true, "read_only": true, "allowed_paths": ["/workspace", "/data"], "denied_paths": ["/etc/shadow", "/etc/passwd", "/root"] },
+  "health": { "enabled": true }
+}
+```
+
+**Operator** — _All pre-installed tools including rsync and ssh. Extended timeout._
+```json
+{
+  "shell": { "enabled": true, "allowed_binaries": ["bash", "git", "curl", "wget", "jq", "rsync", "ssh", "make", "vim"], "denied_patterns": ["rm -rf /", ":(){ :|:& };:"], "max_timeout": 600 },
+  "filesystem": { "enabled": true, "read_only": false, "allowed_paths": ["/workspace", "/data", "/var/log/agentbox"], "denied_paths": ["/etc/shadow", "/etc/passwd", "/root"] },
+  "health": { "enabled": true }
+}
+```
+
+---
+
+## 7. Verification Matrix
+
+| # | Check | Command | Expected result | Category |
+|---|-------|---------|-----------------|----------|
+| V1 | API unit tests pass | `npm test --prefix services/api` | All tests pass including routes-tool-presets and routes-agents-preset | Tests |
+| V2 | UI unit tests pass | `npm test --prefix services/ui` | All tests pass including AgentForm preset tests and ToolProfilesClient tests | Tests |
+| V3 | OpenAPI spec valid | `npx --yes @redocly/cli lint services/api/src/openapi/openapi.yaml --skip-rule no-unused-components` | No errors | Static |
+| V4 | OpenAPI spec synced | `diff services/api/src/openapi/openapi.yaml docs/site/openapi.yaml` | No diff | Static |
+| V5 | TypeScript compiles (API) | `npx tsc --noEmit --project services/api/tsconfig.json` | No errors | Static |
+| V6 | TypeScript compiles (UI) | `npx tsc --noEmit --project services/ui/tsconfig.json` | No errors | Static |
+| V7 | Migration SQL valid | Review `016_create_tool_presets.sql` — table, FK, 4 seed inserts | DDL is syntactically correct, seeds match definitions in section 6 | Code review |
+| V8 | CI pipeline green | `gh pr checks <number> --watch` | All required checks pass | CI |
+| V9 | Closed-loop plan detected by CI | Plan file committed at `.claude/plans/curious-dazzling-nest.md` as a changed file in PR 1. CI rule: `check_plan_closed_loop.py` reads changed files matching `.claude/plans/*.md` and validates all 9 section headings are present. | `check_plan_closed_loop.py` finds all 9 sections and passes | CI |
+| V10 | Preset resolves to agent config on disk | After PR 1 merge + deploy: (1) create agent with `tool_preset_id` set to Developer preset via API, (2) start agent, (3) inspect generated config: `ssh deploy@100.65.232.75 "cat /opt/hill90/agentbox-configs/<agent_id>/agent.yml"`, (4) confirm `tools.shell.allowed_binaries` contains `[bash, git, make, curl, jq]` matching the Developer preset definition | YAML `tools:` section matches the Developer preset's `tools_config` exactly | Runtime |
+
+---
+
+## 8. CI / Drift Gates
+
+**Existing gates preserved (no changes):**
+- `ci.yml` → TypeScript compile, Jest (API), Vitest (UI), ESLint, OpenAPI lint, OpenAPI sync diff
+- `agent-loop-gate.yml` → Advisory plan check, infra enforced check (not triggered — no infra paths changed)
+- `check_plan_closed_loop.py` → Validates plan sections in PR body
+
+**OpenAPI sync enforcement**: `diff services/api/src/openapi/openapi.yaml docs/site/openapi.yaml` in CI. Both files must be updated in the same PR. Failing this check blocks merge.
+
+**New drift risk**: If seed preset tools_config values reference binaries not in the agentbox Dockerfile, agents using those presets will have binaries in their allowlist that don't resolve at runtime. **Phase 1 mitigation**: Seed presets are manually curated against the current Dockerfile (bash, git, curl, wget, jq, openssh-client, rsync, vim, make). No automated enforcement in Phase 1. **Phase 2**: Add a CI check or runtime validation.
+
+**No new CI gates added** in this phase.
+
+---
+
+## 9. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| Preset updates don't propagate to existing agents | Expected behavior | Low — documented | Resolve-on-save is the design. Document in UI ("Profile applied at assignment time"). Phase 2 adds explicit reapply action. |
+| Custom config lost on preset assignment | Medium | Medium — user frustration | Confirmation dialog in UI before overwriting. Switching preset→Custom populates fields from preset as starting point. |
+| Seed preset binaries don't match Dockerfile | Low | Low — allowlist contains non-existent binary, shell tool resolves via `shutil.which()` and rejects | Curate seed presets against current Dockerfile. Phase 2 adds validation. |
+| tools_config default change breaks existing agents | N/A | N/A | No default change. Existing agents without `tool_preset_id` keep their current `tools_config` unchanged. API without `tool_preset_id` parameter behaves identically to today. |
+| Migration 016 conflicts with concurrent work | Low | Low | Check for migration files before implementing. Next available is 016. |
+
+---
+
+## 10. Definition of Done
+
+- [ ] Migration 016 creates `tool_presets` table with 4 platform seeds and `tool_preset_id` FK on agents
+- [ ] GET/POST/PUT/DELETE /tool-presets routes work with correct auth/visibility rules
+- [ ] Platform presets cannot be updated or deleted (403)
+- [ ] Assigned presets cannot be deleted (409)
+- [ ] Agent create/update with `tool_preset_id` resolves preset's `tools_config` into agent (resolve-on-save)
+- [ ] Agent create/update without `tool_preset_id` works identically to today
+- [ ] Agent form shows preset dropdown with two-mode switching
+- [ ] Agent detail shows preset name badge
+- [ ] `/harness/tool-profiles` page lists presets with expand, platform badge, admin CRUD
+- [ ] Nav includes "Tool Profiles" in Harness group (Wrench icon, after Policies, before Usage)
+- [ ] Both `services/api/src/openapi/openapi.yaml` and `docs/site/openapi.yaml` updated and synced
+- [ ] All API tests pass (T1-T17)
+- [ ] All UI tests pass (T18-T28)
+- [ ] `npx @redocly/cli lint` passes
+- [ ] CI green on all PRs
+- [ ] Runtime: agent created with preset → started → generated `agent.yml` contains resolved preset tools_config (V10)
+
+---
+
+## 11. Stop Conditions / Out-of-Scope
+
+**Stop if:**
+- Migration numbering conflicts with concurrent work (resequence before continuing)
+- Seed preset binary lists prove controversial (resolve before PR 1 merge)
+- Phase 1 scope expands beyond 3 PRs
+
+**Out of scope (do not implement):**
+- "Skills" as first-class entity — premature, revisit when runtime supports capability extension
+- Container image variants / installable packages
+- MCP client connections for agents
+- User-created presets (Phase 2 — adds ownership scoping)
+- Preset validation against container image contents
+- Binary inventory / introspection endpoint
+- Preset reapply/sync action (Phase 2 — explicit "sync agents to latest preset")
+- Agent usage count per preset on the Tool Profiles page (Phase 2)
+- Preset composition / merging multiple presets
+
+---
+
+## Plan Checklist
+
+- [x] Goal / Signal
+- [x] Scope
+- [x] TDD Matrix
+- [x] Implementation Steps
+- [x] Verification Matrix
+- [x] CI / Drift Gates
+- [x] Risks & Mitigations
+- [x] Definition of Done
+- [x] Stop Conditions
+
+---
+
+## Key Files
+
+| File | Action |
+|------|--------|
+| `services/api/src/db/migrations/016_create_tool_presets.sql` | Create |
+| `services/api/src/routes/tool-presets.ts` | Create |
+| `services/api/src/__tests__/routes-tool-presets.test.ts` | Create |
+| `services/api/src/__tests__/routes-agents-preset.test.ts` | Create |
+| `services/api/src/routes/agents.ts` | Modify — add `tool_preset_id` handling |
+| `services/api/src/app.ts` | Modify — register tool-presets route |
+| `services/api/src/openapi/openapi.yaml` | Modify — add ToolPreset schema + paths |
+| `docs/site/openapi.yaml` | Modify — sync copy |
+| `services/ui/src/app/api/tool-presets/route.ts` | Create |
+| `services/ui/src/app/api/tool-presets/[...path]/route.ts` | Create |
+| `services/ui/src/app/agents/new/AgentFormClient.tsx` | Modify — preset dropdown + two-mode |
+| `services/ui/src/app/agents/[id]/AgentDetailClient.tsx` | Modify — preset badge |
+| `services/ui/src/app/agents/[id]/edit/AgentEditClient.tsx` | Modify — pass preset data |
+| `services/ui/src/app/harness/tool-profiles/page.tsx` | Create |
+| `services/ui/src/app/harness/tool-profiles/ToolProfilesClient.tsx` | Create |
+| `services/ui/src/components/nav-items.ts` | Modify — add Wrench + entry |
+| `.claude/plans/curious-dazzling-nest.md` | Create (copy from ~/.claude/plans/) — CI closed-loop evidence |
+
+### Pattern references (read-only, do not modify):
+| File | Why |
+|------|-----|
+| `services/api/src/routes/model-policies.ts` | CRUD route pattern, visibility logic, delete protection |
+| `services/api/src/__tests__/routes-model-policies.test.ts` | Test pattern (supertest, mock pool, JWT helpers) |
+| `services/api/src/helpers/scope.ts` | `scopeToOwner` helper (not used for presets in Phase 1, but referenced) |
+| `services/ui/src/app/harness/policies/PoliciesClient.tsx` | UI list/expand/CRUD pattern |
+| `services/agentbox/app/config.py` | ToolsConfig Pydantic model (validates preset configs are valid) |

--- a/docs/site/openapi.yaml
+++ b/docs/site/openapi.yaml
@@ -56,6 +56,11 @@ components:
           format: uuid
           nullable: true
           description: ID of the model policy controlling LLM access. Users can assign own or platform policies to own agents; admins can assign any.
+        tool_preset_id:
+          type: string
+          format: uuid
+          nullable: true
+          description: ID of the tool preset applied at assignment time. Config is copied (resolve-on-save).
         error_message:
           type: string
           nullable: true
@@ -224,6 +229,33 @@ components:
           type: string
           nullable: true
           description: Owner (user sub). NULL for platform policies.
+
+    ToolPreset:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        description:
+          type: string
+        tools_config:
+          type: object
+          description: JSONB tool configuration (shell, filesystem, health settings)
+        is_platform:
+          type: boolean
+          description: Platform presets are immutable and undeletable.
+        created_by:
+          type: string
+          nullable: true
+          description: Always NULL in Phase 1 (admin-created shared resources).
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
 
     UsageSummary:
       type: object
@@ -484,6 +516,11 @@ paths:
                   format: uuid
                   nullable: true
                   description: ID of a model policy to assign at creation. Users can assign own or platform policies; admins can assign any.
+                tool_preset_id:
+                  type: string
+                  format: uuid
+                  nullable: true
+                  description: ID of a tool preset. Config is copied into agent at save time (resolve-on-save).
       responses:
         "201":
           description: Agent created
@@ -561,6 +598,11 @@ paths:
                   format: uuid
                   nullable: true
                   description: Model policy ID. Users can assign own or platform policies; admins can assign any. Set to null to remove.
+                tool_preset_id:
+                  type: string
+                  format: uuid
+                  nullable: true
+                  description: Tool preset ID. Config is copied into agent at save time. Set to null to detach preset.
       responses:
         "200":
           description: Agent updated
@@ -1878,3 +1920,147 @@ paths:
           description: Not authenticated
         "403":
           description: Requires user role
+
+  /tool-presets:
+    get:
+      summary: List tool presets
+      description: Returns all tool presets. All authenticated users see all presets.
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Preset list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/ToolPreset"
+        "401":
+          description: Not authenticated
+        "403":
+          description: Requires user role
+
+    post:
+      summary: Create tool preset
+      description: Creates a new tool preset. Admin only.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - name
+                - tools_config
+              properties:
+                name:
+                  type: string
+                description:
+                  type: string
+                tools_config:
+                  type: object
+                  description: Tool configuration (shell, filesystem, health settings)
+      responses:
+        "201":
+          description: Preset created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ToolPreset"
+        "400":
+          description: Invalid input
+        "401":
+          description: Not authenticated
+        "403":
+          description: Requires admin role
+        "409":
+          description: Duplicate preset name
+
+  /tool-presets/{id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+
+    get:
+      summary: Get tool preset
+      description: Returns a single tool preset. All authenticated users can read.
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Preset detail
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ToolPreset"
+        "401":
+          description: Not authenticated
+        "403":
+          description: Requires user role
+        "404":
+          description: Preset not found
+
+    put:
+      summary: Update tool preset
+      description: Updates a tool preset. Admin only. Platform presets are immutable (403).
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                description:
+                  type: string
+                tools_config:
+                  type: object
+      responses:
+        "200":
+          description: Preset updated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ToolPreset"
+        "401":
+          description: Not authenticated
+        "403":
+          description: Requires admin role or platform preset is immutable
+        "404":
+          description: Preset not found
+        "409":
+          description: Duplicate preset name
+
+    delete:
+      summary: Delete tool preset
+      description: Deletes a tool preset. Admin only. Platform presets cannot be deleted. Presets assigned to agents cannot be deleted.
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Preset deleted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  deleted:
+                    type: boolean
+        "401":
+          description: Not authenticated
+        "403":
+          description: Requires admin role or platform preset is undeletable
+        "404":
+          description: Preset not found
+        "409":
+          description: Preset is assigned to agents

--- a/services/api/src/__tests__/docs.test.ts
+++ b/services/api/src/__tests__/docs.test.ts
@@ -167,6 +167,8 @@ const EXPECTED_PATHS = [
   '/shared-knowledge/sources',
   '/shared-knowledge/sources/{id}',
   '/shared-knowledge/search',
+  '/tool-presets',
+  '/tool-presets/{id}',
 ];
 
 const INFRA_PATHS = ['/docs', '/openapi.json', '/internal/delegation-token'];

--- a/services/api/src/__tests__/routes-agents-preset.test.ts
+++ b/services/api/src/__tests__/routes-agents-preset.test.ts
@@ -1,0 +1,266 @@
+import request from 'supertest';
+import * as crypto from 'crypto';
+import * as jwt from 'jsonwebtoken';
+import { createApp } from '../app';
+
+const { privateKey, publicKey } = crypto.generateKeyPairSync('rsa', {
+  modulusLength: 2048,
+  publicKeyEncoding: { type: 'spki', format: 'pem' },
+  privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+});
+
+const TEST_ISSUER = 'https://auth.hill90.com/realms/hill90';
+
+const mockQuery = jest.fn();
+jest.mock('../db/pool', () => ({
+  getPool: () => ({ query: mockQuery }),
+}));
+
+jest.mock('../services/docker', () => ({
+  createAndStartContainer: jest.fn(),
+  stopAndRemoveContainer: jest.fn(),
+  inspectContainer: jest.fn(),
+  getContainerLogs: jest.fn(),
+  removeAgentVolumes: jest.fn(),
+  reconcileAgentStatuses: jest.fn(),
+}));
+jest.mock('../services/agent-files', () => ({
+  writeAgentFiles: jest.fn(),
+  removeAgentFiles: jest.fn(),
+}));
+
+const app = createApp({
+  issuer: TEST_ISSUER,
+  getSigningKey: async () => publicKey,
+});
+
+function makeToken(sub: string, roles: string[]) {
+  return jwt.sign(
+    { sub, realm_roles: roles },
+    privateKey,
+    { algorithm: 'RS256', issuer: TEST_ISSUER, expiresIn: '5m' }
+  );
+}
+
+const adminToken = makeToken('admin-user', ['admin', 'user']);
+const userToken = makeToken('regular-user', ['user']);
+
+const developerPresetConfig = {
+  shell: { enabled: true, allowed_binaries: ['bash', 'git', 'make', 'curl', 'jq'], denied_patterns: ['rm -rf /'], max_timeout: 300 },
+  filesystem: { enabled: true, read_only: false, allowed_paths: ['/workspace', '/data'], denied_paths: ['/etc/shadow', '/etc/passwd', '/root'] },
+  health: { enabled: true },
+};
+
+const defaultToolsConfig = {
+  shell: { enabled: false },
+  filesystem: { enabled: false },
+  health: { enabled: true },
+};
+
+const agentRow = {
+  id: 'uuid-1',
+  agent_id: 'test-agent',
+  name: 'Test Agent',
+  description: '',
+  status: 'stopped',
+  tools_config: JSON.stringify(defaultToolsConfig),
+  cpus: '1.0',
+  mem_limit: '1g',
+  pids_limit: 200,
+  soul_md: '',
+  rules_md: '',
+  model_policy_id: null,
+  tool_preset_id: null,
+  created_by: 'regular-user',
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+};
+
+describe('Agent POST tool_preset_id behavior', () => {
+  beforeEach(() => {
+    mockQuery.mockReset();
+    process.env.DATABASE_URL = 'postgresql://test:test@localhost:5432/test';
+  });
+
+  afterEach(() => {
+    delete process.env.DATABASE_URL;
+  });
+
+  // T13: Agent create with preset resolves tools_config
+  it('create agent with tool_preset_id copies preset config', async () => {
+    // Preset lookup
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: 'preset-dev', tools_config: developerPresetConfig }],
+    });
+    // INSERT
+    mockQuery.mockResolvedValueOnce({
+      rows: [{
+        ...agentRow,
+        id: 'uuid-new',
+        tool_preset_id: 'preset-dev',
+        tools_config: developerPresetConfig,
+      }],
+    });
+
+    const res = await request(app)
+      .post('/agents')
+      .set('Authorization', `Bearer ${userToken}`)
+      .send({
+        agent_id: 'test-agent',
+        name: 'Test Agent',
+        tool_preset_id: 'preset-dev',
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body.tool_preset_id).toBe('preset-dev');
+    // Verify the INSERT used the preset's tools_config, not the default
+    const insertCall = mockQuery.mock.calls[1];
+    const toolsConfigParam = insertCall[1][3]; // tools_config is 4th param ($4)
+    const parsed = JSON.parse(toolsConfigParam);
+    expect(parsed.shell.enabled).toBe(true);
+    expect(parsed.shell.allowed_binaries).toContain('bash');
+    expect(parsed.shell.allowed_binaries).toContain('git');
+  });
+
+  // T14: Agent create with invalid preset rejected
+  it('create agent with nonexistent preset returns 400', async () => {
+    // Preset lookup returns empty
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    const res = await request(app)
+      .post('/agents')
+      .set('Authorization', `Bearer ${userToken}`)
+      .send({
+        agent_id: 'test-agent',
+        name: 'Test Agent',
+        tool_preset_id: 'nonexistent-preset',
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain('Tool preset not found');
+  });
+
+  // T16: Agent create without preset uses default tools_config
+  it('create agent without preset uses default', async () => {
+    // No preset lookup needed — just INSERT
+    mockQuery.mockResolvedValueOnce({
+      rows: [{
+        ...agentRow,
+        id: 'uuid-new',
+        tool_preset_id: null,
+      }],
+    });
+
+    const res = await request(app)
+      .post('/agents')
+      .set('Authorization', `Bearer ${userToken}`)
+      .send({
+        agent_id: 'test-agent',
+        name: 'Test Agent',
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body.tool_preset_id).toBeNull();
+    // Verify default tools_config was used in INSERT
+    const insertCall = mockQuery.mock.calls[0];
+    const toolsConfigParam = insertCall[1][3];
+    const parsed = JSON.parse(toolsConfigParam);
+    expect(parsed.shell.enabled).toBe(false);
+    expect(parsed.filesystem.enabled).toBe(false);
+    expect(parsed.health.enabled).toBe(true);
+  });
+});
+
+describe('Agent PUT tool_preset_id behavior', () => {
+  beforeEach(() => {
+    mockQuery.mockReset();
+    process.env.DATABASE_URL = 'postgresql://test:test@localhost:5432/test';
+  });
+
+  afterEach(() => {
+    delete process.env.DATABASE_URL;
+  });
+
+  // T15: Agent update with preset resolves tools_config
+  it('update agent tool_preset_id copies preset config', async () => {
+    // Ownership check returns agent
+    mockQuery.mockResolvedValueOnce({ rows: [agentRow] });
+    // Preset lookup
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: 'preset-dev', tools_config: developerPresetConfig }],
+    });
+    // UPDATE
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ ...agentRow, tool_preset_id: 'preset-dev', tools_config: developerPresetConfig }],
+    });
+
+    const res = await request(app)
+      .put('/agents/uuid-1')
+      .set('Authorization', `Bearer ${userToken}`)
+      .send({ tool_preset_id: 'preset-dev' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.tool_preset_id).toBe('preset-dev');
+    // Verify the UPDATE set both tool_preset_id and tools_config from preset
+    const updateCall = mockQuery.mock.calls[2];
+    // tools_config param should be the preset's config (not null/COALESCE)
+    const toolsConfigParam = updateCall[1][2]; // $3 is tools_config
+    const parsed = JSON.parse(toolsConfigParam);
+    expect(parsed.shell.enabled).toBe(true);
+    expect(parsed.shell.allowed_binaries).toContain('bash');
+  });
+
+  // T17: Agent update clears preset (set null)
+  it('update agent tool_preset_id to null preserves tools_config', async () => {
+    const agentWithPreset = {
+      ...agentRow,
+      tool_preset_id: 'preset-dev',
+      tools_config: developerPresetConfig,
+    };
+    // Ownership check returns agent with preset
+    mockQuery.mockResolvedValueOnce({ rows: [agentWithPreset] });
+    // UPDATE — no preset lookup needed when clearing
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ ...agentWithPreset, tool_preset_id: null }],
+    });
+
+    const res = await request(app)
+      .put('/agents/uuid-1')
+      .set('Authorization', `Bearer ${userToken}`)
+      .send({ tool_preset_id: null });
+
+    expect(res.status).toBe(200);
+    // tool_preset_id should be cleared but tools_config should be preserved
+    // (no tools_config in body means COALESCE keeps existing)
+  });
+
+  it('update agent with nonexistent preset returns 400', async () => {
+    // Ownership check returns agent
+    mockQuery.mockResolvedValueOnce({ rows: [agentRow] });
+    // Preset lookup returns empty
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    const res = await request(app)
+      .put('/agents/uuid-1')
+      .set('Authorization', `Bearer ${userToken}`)
+      .send({ tool_preset_id: 'nonexistent-preset' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain('Tool preset not found');
+  });
+
+  it('update agent without tool_preset_id does not touch it', async () => {
+    // Ownership check returns agent
+    mockQuery.mockResolvedValueOnce({ rows: [agentRow] });
+    // UPDATE
+    mockQuery.mockResolvedValueOnce({ rows: [{ ...agentRow, name: 'Updated Name' }] });
+
+    const res = await request(app)
+      .put('/agents/uuid-1')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ name: 'Updated Name' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.name).toBe('Updated Name');
+  });
+});

--- a/services/api/src/__tests__/routes-tool-presets.test.ts
+++ b/services/api/src/__tests__/routes-tool-presets.test.ts
@@ -1,0 +1,302 @@
+import request from 'supertest';
+import * as crypto from 'crypto';
+import * as jwt from 'jsonwebtoken';
+import { createApp } from '../app';
+
+const { privateKey, publicKey } = crypto.generateKeyPairSync('rsa', {
+  modulusLength: 2048,
+  publicKeyEncoding: { type: 'spki', format: 'pem' },
+  privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+});
+
+const TEST_ISSUER = 'https://auth.hill90.com/realms/hill90';
+
+const mockQuery = jest.fn();
+jest.mock('../db/pool', () => ({
+  getPool: () => ({ query: mockQuery }),
+}));
+
+jest.mock('../services/docker', () => ({
+  createAndStartContainer: jest.fn(),
+  stopAndRemoveContainer: jest.fn(),
+  inspectContainer: jest.fn(),
+  getContainerLogs: jest.fn(),
+  removeAgentVolumes: jest.fn(),
+  reconcileAgentStatuses: jest.fn(),
+}));
+jest.mock('../services/agent-files', () => ({
+  writeAgentFiles: jest.fn(),
+  removeAgentFiles: jest.fn(),
+}));
+
+const app = createApp({
+  issuer: TEST_ISSUER,
+  getSigningKey: async () => publicKey,
+});
+
+function makeToken(sub: string, roles: string[]) {
+  return jwt.sign(
+    { sub, realm_roles: roles },
+    privateKey,
+    { algorithm: 'RS256', issuer: TEST_ISSUER, expiresIn: '5m' }
+  );
+}
+
+const adminToken = makeToken('admin-user', ['admin', 'user']);
+const userToken = makeToken('regular-user', ['user']);
+
+const developerPreset = {
+  id: 'preset-dev',
+  name: 'Developer',
+  description: 'Full dev environment',
+  tools_config: {
+    shell: { enabled: true, allowed_binaries: ['bash', 'git'], denied_patterns: [], max_timeout: 300 },
+    filesystem: { enabled: true, read_only: false, allowed_paths: ['/workspace'], denied_paths: [] },
+    health: { enabled: true },
+  },
+  is_platform: true,
+  created_by: null,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+};
+
+const minimalPreset = {
+  id: 'preset-min',
+  name: 'Minimal',
+  description: 'Health only',
+  tools_config: {
+    shell: { enabled: false },
+    filesystem: { enabled: false },
+    health: { enabled: true },
+  },
+  is_platform: true,
+  created_by: null,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+};
+
+const adminCreatedPreset = {
+  id: 'preset-custom',
+  name: 'Custom Admin Preset',
+  description: 'Admin-created non-platform preset',
+  tools_config: {
+    shell: { enabled: true, allowed_binaries: ['bash'], denied_patterns: [], max_timeout: 60 },
+    filesystem: { enabled: false },
+    health: { enabled: true },
+  },
+  is_platform: false,
+  created_by: null,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+};
+
+describe('Tool Preset CRUD routes', () => {
+  beforeEach(() => {
+    mockQuery.mockReset();
+    process.env.DATABASE_URL = 'postgresql://test:test@localhost:5432/test';
+  });
+
+  afterEach(() => {
+    delete process.env.DATABASE_URL;
+  });
+
+  // T1: List presets returns platform seeds
+  it('GET /tool-presets returns all presets', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [developerPreset, minimalPreset, adminCreatedPreset],
+    });
+    const res = await request(app)
+      .get('/tool-presets')
+      .set('Authorization', `Bearer ${adminToken}`);
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(3);
+  });
+
+  // T1 continued: user also sees all presets (no ownership scoping in Phase 1)
+  it('GET /tool-presets user sees all presets', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [developerPreset, minimalPreset],
+    });
+    const res = await request(app)
+      .get('/tool-presets')
+      .set('Authorization', `Bearer ${userToken}`);
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(2);
+    // Verify no ownership scoping (no WHERE ... created_by = filter)
+    const call = mockQuery.mock.calls[0];
+    expect(call[0]).not.toMatch(/WHERE.*created_by/);
+  });
+
+  // T2: List presets requires auth
+  it('GET /tool-presets returns 401 without auth', async () => {
+    const res = await request(app).get('/tool-presets');
+    expect(res.status).toBe(401);
+  });
+
+  it('GET /tool-presets returns 403 for no-role user', async () => {
+    const noRoleToken = makeToken('no-role', []);
+    const res = await request(app)
+      .get('/tool-presets')
+      .set('Authorization', `Bearer ${noRoleToken}`);
+    expect(res.status).toBe(403);
+  });
+
+  // T3: Create preset requires admin
+  it('POST /tool-presets rejects non-admin create', async () => {
+    const res = await request(app)
+      .post('/tool-presets')
+      .set('Authorization', `Bearer ${userToken}`)
+      .send({ name: 'user-preset', tools_config: { shell: { enabled: false }, filesystem: { enabled: false }, health: { enabled: true } } });
+    expect(res.status).toBe(403);
+  });
+
+  // T4: Create preset validates name required
+  it('POST /tool-presets rejects create without name', async () => {
+    const res = await request(app)
+      .post('/tool-presets')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ tools_config: { shell: { enabled: false }, filesystem: { enabled: false }, health: { enabled: true } } });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain('name');
+  });
+
+  // T5: Create preset validates tools_config required
+  it('POST /tool-presets rejects create without tools_config', async () => {
+    const res = await request(app)
+      .post('/tool-presets')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ name: 'no-config' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain('tools_config');
+  });
+
+  // T6: Create preset succeeds for admin
+  it('POST /tool-presets admin creates preset', async () => {
+    const newPreset = { ...adminCreatedPreset, id: 'new-id' };
+    mockQuery.mockResolvedValueOnce({ rows: [newPreset] });
+    const res = await request(app)
+      .post('/tool-presets')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({
+        name: 'Custom Admin Preset',
+        description: 'Admin-created non-platform preset',
+        tools_config: adminCreatedPreset.tools_config,
+      });
+    expect(res.status).toBe(201);
+    expect(res.body.name).toBe('Custom Admin Preset');
+    // Admin presets get created_by = null, is_platform = false
+    const insertCall = mockQuery.mock.calls[0];
+    expect(insertCall[0]).toContain('INSERT INTO tool_presets');
+  });
+
+  it('POST /tool-presets returns 409 on duplicate name', async () => {
+    mockQuery.mockRejectedValueOnce({ code: '23505' });
+    const res = await request(app)
+      .post('/tool-presets')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ name: 'Developer', tools_config: { shell: { enabled: false }, filesystem: { enabled: false }, health: { enabled: true } } });
+    expect(res.status).toBe(409);
+  });
+
+  // Get single
+  it('GET /tool-presets/:id returns preset', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [developerPreset] });
+    const res = await request(app)
+      .get('/tool-presets/preset-dev')
+      .set('Authorization', `Bearer ${adminToken}`);
+    expect(res.status).toBe(200);
+    expect(res.body.name).toBe('Developer');
+  });
+
+  it('GET /tool-presets/:id returns 404 for unknown', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    const res = await request(app)
+      .get('/tool-presets/nonexistent')
+      .set('Authorization', `Bearer ${adminToken}`);
+    expect(res.status).toBe(404);
+  });
+
+  // T7: Update preset requires admin
+  it('PUT /tool-presets/:id rejects non-admin update', async () => {
+    const res = await request(app)
+      .put('/tool-presets/preset-custom')
+      .set('Authorization', `Bearer ${userToken}`)
+      .send({ name: 'Renamed' });
+    expect(res.status).toBe(403);
+  });
+
+  // T8: Update platform preset blocked
+  it('PUT /tool-presets/:id rejects update of platform preset', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [developerPreset] }); // existence check returns is_platform = true
+    const res = await request(app)
+      .put('/tool-presets/preset-dev')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ name: 'Renamed Developer' });
+    expect(res.status).toBe(403);
+    expect(res.body.error).toContain('platform');
+  });
+
+  // Update non-platform preset succeeds
+  it('PUT /tool-presets/:id admin updates non-platform preset', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [adminCreatedPreset] }) // existence check, is_platform = false
+      .mockResolvedValueOnce({ rows: [{ ...adminCreatedPreset, name: 'Renamed' }] }); // update
+    const res = await request(app)
+      .put('/tool-presets/preset-custom')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ name: 'Renamed' });
+    expect(res.status).toBe(200);
+    expect(res.body.name).toBe('Renamed');
+  });
+
+  // T9: Delete preset requires admin
+  it('DELETE /tool-presets/:id rejects non-admin delete', async () => {
+    const res = await request(app)
+      .delete('/tool-presets/preset-custom')
+      .set('Authorization', `Bearer ${userToken}`);
+    expect(res.status).toBe(403);
+  });
+
+  // T10: Delete platform preset blocked
+  it('DELETE /tool-presets/:id rejects delete of platform preset', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [developerPreset] }); // existence check returns is_platform = true
+    const res = await request(app)
+      .delete('/tool-presets/preset-dev')
+      .set('Authorization', `Bearer ${adminToken}`);
+    expect(res.status).toBe(403);
+    expect(res.body.error).toContain('platform');
+  });
+
+  // T11: Delete assigned preset blocked
+  it('DELETE /tool-presets/:id rejects delete of preset assigned to agent', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [adminCreatedPreset] }) // existence check, is_platform = false
+      .mockResolvedValueOnce({ rows: [{ id: 'agent-1', agent_id: 'my-agent' }] }); // agents using this preset
+    const res = await request(app)
+      .delete('/tool-presets/preset-custom')
+      .set('Authorization', `Bearer ${adminToken}`);
+    expect(res.status).toBe(409);
+    expect(res.body.error).toContain('agents');
+  });
+
+  // T12: Delete unassigned preset succeeds
+  it('DELETE /tool-presets/:id admin deletes unassigned preset', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [adminCreatedPreset] }) // existence check, is_platform = false
+      .mockResolvedValueOnce({ rows: [] }) // no agents assigned
+      .mockResolvedValueOnce({ rowCount: 1 }); // delete succeeds
+    const res = await request(app)
+      .delete('/tool-presets/preset-custom')
+      .set('Authorization', `Bearer ${adminToken}`);
+    expect(res.status).toBe(200);
+    expect(res.body.deleted).toBe(true);
+  });
+
+  it('DELETE /tool-presets/:id returns 404 for unknown', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] }); // existence check returns nothing
+    const res = await request(app)
+      .delete('/tool-presets/nonexistent')
+      .set('Authorization', `Bearer ${adminToken}`);
+    expect(res.status).toBe(404);
+  });
+});

--- a/services/api/src/app.ts
+++ b/services/api/src/app.ts
@@ -5,6 +5,7 @@ import agentsRouter from './routes/agents';
 import knowledgeRouter from './routes/knowledge';
 import sharedKnowledgeRouter from './routes/shared-knowledge';
 import modelPoliciesRouter from './routes/model-policies';
+import toolPresetsRouter from './routes/tool-presets';
 import providerConnectionsRouter from './routes/provider-connections';
 import userModelsRouter from './routes/user-models';
 import profileRouter from './routes/profile';
@@ -49,6 +50,9 @@ export function createApp(opts: AppOptions = {}): Application {
 
   // Model policy management routes (admin-only, enforced in router)
   app.use('/model-policies', requireAuth, modelPoliciesRouter);
+
+  // Tool preset management routes (admin-only mutations, enforced in router)
+  app.use('/tool-presets', requireAuth, toolPresetsRouter);
 
   // Provider connections (user-scoped BYOK credentials)
   app.use('/provider-connections', requireAuth, providerConnectionsRouter);

--- a/services/api/src/db/migrations/016_create_tool_presets.sql
+++ b/services/api/src/db/migrations/016_create_tool_presets.sql
@@ -1,0 +1,44 @@
+-- Tool presets: named, reusable tool configurations for agents
+-- Platform presets are immutable seed data. Admin-created presets can be modified.
+
+CREATE TABLE IF NOT EXISTS tool_presets (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name VARCHAR(128) NOT NULL UNIQUE,
+    description TEXT DEFAULT '',
+    tools_config JSONB NOT NULL,
+    is_platform BOOLEAN DEFAULT false,
+    created_by VARCHAR(255),
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- FK on agents table: optional preset reference
+ALTER TABLE agents ADD COLUMN IF NOT EXISTS tool_preset_id UUID REFERENCES tool_presets(id);
+
+-- Seed platform presets
+INSERT INTO tool_presets (name, description, tools_config, is_platform) VALUES
+(
+  'Minimal',
+  'Health monitoring only. No shell or filesystem access.',
+  '{"shell":{"enabled":false,"allowed_binaries":[],"denied_patterns":[],"max_timeout":300},"filesystem":{"enabled":false,"read_only":false,"allowed_paths":["/workspace"],"denied_paths":["/etc/shadow","/etc/passwd","/root"]},"health":{"enabled":true}}',
+  true
+),
+(
+  'Developer',
+  'Full dev environment: bash, git, make, curl, jq. Read-write workspace and data.',
+  '{"shell":{"enabled":true,"allowed_binaries":["bash","git","make","curl","jq"],"denied_patterns":["rm -rf /",":(){ :|:& };:"],"max_timeout":300},"filesystem":{"enabled":true,"read_only":false,"allowed_paths":["/workspace","/data"],"denied_paths":["/etc/shadow","/etc/passwd","/root"]},"health":{"enabled":true}}',
+  true
+),
+(
+  'Research',
+  'Read-only with networking tools. Can fetch data but cannot modify filesystem.',
+  '{"shell":{"enabled":true,"allowed_binaries":["bash","curl","wget","jq"],"denied_patterns":["rm ","mv ","dd ","mkfs","> /",">> /"],"max_timeout":120},"filesystem":{"enabled":true,"read_only":true,"allowed_paths":["/workspace","/data"],"denied_paths":["/etc/shadow","/etc/passwd","/root"]},"health":{"enabled":true}}',
+  true
+),
+(
+  'Operator',
+  'All pre-installed tools including rsync and ssh. Extended timeout for operations.',
+  '{"shell":{"enabled":true,"allowed_binaries":["bash","git","curl","wget","jq","rsync","ssh","make","vim"],"denied_patterns":["rm -rf /",":(){ :|:& };:"],"max_timeout":600},"filesystem":{"enabled":true,"read_only":false,"allowed_paths":["/workspace","/data","/var/log/agentbox"],"denied_paths":["/etc/shadow","/etc/passwd","/root"]},"health":{"enabled":true}}',
+  true
+)
+ON CONFLICT (name) DO NOTHING;

--- a/services/api/src/openapi/openapi.yaml
+++ b/services/api/src/openapi/openapi.yaml
@@ -56,6 +56,11 @@ components:
           format: uuid
           nullable: true
           description: ID of the model policy controlling LLM access. Users can assign own or platform policies to own agents; admins can assign any.
+        tool_preset_id:
+          type: string
+          format: uuid
+          nullable: true
+          description: ID of the tool preset applied at assignment time. Config is copied (resolve-on-save).
         error_message:
           type: string
           nullable: true
@@ -224,6 +229,33 @@ components:
           type: string
           nullable: true
           description: Owner (user sub). NULL for platform policies.
+
+    ToolPreset:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        description:
+          type: string
+        tools_config:
+          type: object
+          description: JSONB tool configuration (shell, filesystem, health settings)
+        is_platform:
+          type: boolean
+          description: Platform presets are immutable and undeletable.
+        created_by:
+          type: string
+          nullable: true
+          description: Always NULL in Phase 1 (admin-created shared resources).
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
 
     UsageSummary:
       type: object
@@ -484,6 +516,11 @@ paths:
                   format: uuid
                   nullable: true
                   description: ID of a model policy to assign at creation. Users can assign own or platform policies; admins can assign any.
+                tool_preset_id:
+                  type: string
+                  format: uuid
+                  nullable: true
+                  description: ID of a tool preset. Config is copied into agent at save time (resolve-on-save).
       responses:
         "201":
           description: Agent created
@@ -561,6 +598,11 @@ paths:
                   format: uuid
                   nullable: true
                   description: Model policy ID. Users can assign own or platform policies; admins can assign any. Set to null to remove.
+                tool_preset_id:
+                  type: string
+                  format: uuid
+                  nullable: true
+                  description: Tool preset ID. Config is copied into agent at save time. Set to null to detach preset.
       responses:
         "200":
           description: Agent updated
@@ -1878,3 +1920,147 @@ paths:
           description: Not authenticated
         "403":
           description: Requires user role
+
+  /tool-presets:
+    get:
+      summary: List tool presets
+      description: Returns all tool presets. All authenticated users see all presets.
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Preset list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/ToolPreset"
+        "401":
+          description: Not authenticated
+        "403":
+          description: Requires user role
+
+    post:
+      summary: Create tool preset
+      description: Creates a new tool preset. Admin only.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - name
+                - tools_config
+              properties:
+                name:
+                  type: string
+                description:
+                  type: string
+                tools_config:
+                  type: object
+                  description: Tool configuration (shell, filesystem, health settings)
+      responses:
+        "201":
+          description: Preset created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ToolPreset"
+        "400":
+          description: Invalid input
+        "401":
+          description: Not authenticated
+        "403":
+          description: Requires admin role
+        "409":
+          description: Duplicate preset name
+
+  /tool-presets/{id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+
+    get:
+      summary: Get tool preset
+      description: Returns a single tool preset. All authenticated users can read.
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Preset detail
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ToolPreset"
+        "401":
+          description: Not authenticated
+        "403":
+          description: Requires user role
+        "404":
+          description: Preset not found
+
+    put:
+      summary: Update tool preset
+      description: Updates a tool preset. Admin only. Platform presets are immutable (403).
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                description:
+                  type: string
+                tools_config:
+                  type: object
+      responses:
+        "200":
+          description: Preset updated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ToolPreset"
+        "401":
+          description: Not authenticated
+        "403":
+          description: Requires admin role or platform preset is immutable
+        "404":
+          description: Preset not found
+        "409":
+          description: Duplicate preset name
+
+    delete:
+      summary: Delete tool preset
+      description: Deletes a tool preset. Admin only. Platform presets cannot be deleted. Presets assigned to agents cannot be deleted.
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Preset deleted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  deleted:
+                    type: boolean
+        "401":
+          description: Not authenticated
+        "403":
+          description: Requires admin role or platform preset is undeletable
+        "404":
+          description: Preset not found
+        "409":
+          description: Preset is assigned to agents

--- a/services/api/src/routes/agents.ts
+++ b/services/api/src/routes/agents.ts
@@ -56,7 +56,7 @@ router.get('/', requireRole('user'), async (req: Request, res: Response) => {
     const scope = scopeToOwner(req);
     const paramOffset = scope.params.length;
     const { rows } = await getPool().query(
-      `SELECT id, agent_id, name, description, status, tools_config, cpus, mem_limit, pids_limit, model_policy_id, created_at, updated_at, created_by
+      `SELECT id, agent_id, name, description, status, tools_config, cpus, mem_limit, pids_limit, model_policy_id, tool_preset_id, created_at, updated_at, created_by
        FROM agents WHERE ${scope.where} ORDER BY created_at DESC`,
       scope.params
     );
@@ -71,7 +71,7 @@ router.get('/', requireRole('user'), async (req: Request, res: Response) => {
 router.post('/', requireRole('user'), async (req: Request, res: Response) => {
   try {
     const user = (req as any).user;
-    const { agent_id, name, description, tools_config, cpus, mem_limit, pids_limit, soul_md, rules_md, model_policy_id } = req.body;
+    const { agent_id, name, description, tools_config, cpus, mem_limit, pids_limit, soul_md, rules_md, model_policy_id, tool_preset_id } = req.body;
 
     if (!agent_id || !name) {
       res.status(400).json({ error: 'agent_id and name are required' });
@@ -107,21 +107,38 @@ router.post('/', requireRole('user'), async (req: Request, res: Response) => {
       validatedPolicyId = model_policy_id;
     }
 
+    // Resolve tool preset: if tool_preset_id provided, use preset's tools_config (resolve-on-save)
+    let resolvedToolsConfig = tools_config || { shell: { enabled: false }, filesystem: { enabled: false }, health: { enabled: true } };
+    let validatedPresetId: string | null = null;
+    if (tool_preset_id) {
+      const { rows: presetRows } = await getPool().query(
+        'SELECT id, tools_config FROM tool_presets WHERE id = $1',
+        [tool_preset_id]
+      );
+      if (presetRows.length === 0) {
+        res.status(400).json({ error: 'Tool preset not found' });
+        return;
+      }
+      resolvedToolsConfig = presetRows[0].tools_config;
+      validatedPresetId = tool_preset_id;
+    }
+
     const { rows } = await getPool().query(
-      `INSERT INTO agents (agent_id, name, description, tools_config, cpus, mem_limit, pids_limit, soul_md, rules_md, model_policy_id, created_by)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+      `INSERT INTO agents (agent_id, name, description, tools_config, cpus, mem_limit, pids_limit, soul_md, rules_md, model_policy_id, tool_preset_id, created_by)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
        RETURNING *`,
       [
         agent_id,
         name,
         description || '',
-        JSON.stringify(tools_config || { shell: { enabled: false }, filesystem: { enabled: false }, health: { enabled: true } }),
+        JSON.stringify(resolvedToolsConfig),
         cpus || '1.0',
         mem_limit || '1g',
         pids_limit || 200,
         soul_md || '',
         rules_md || '',
         validatedPolicyId,
+        validatedPresetId,
         user.sub,
       ]
     );
@@ -177,7 +194,7 @@ router.put('/:id', requireRole('user'), async (req: Request, res: Response) => {
       return;
     }
 
-    const { name, description, tools_config, cpus, mem_limit, pids_limit, soul_md, rules_md, model_policy_id } = req.body;
+    const { name, description, tools_config, cpus, mem_limit, pids_limit, soul_md, rules_md, model_policy_id, tool_preset_id } = req.body;
 
     // model_policy_id assignment: admins can assign any, users can assign own or platform
     if (model_policy_id !== undefined) {
@@ -207,8 +224,23 @@ router.put('/:id', requireRole('user'), async (req: Request, res: Response) => {
       }
     }
 
-    // Build SET clause: model_policy_id uses explicit flag to allow clearing to NULL
+    // Resolve tool preset: if tool_preset_id provided and non-null, look up and resolve
+    let resolvedToolsConfig = tools_config ? JSON.stringify(tools_config) : null;
+    if (tool_preset_id !== undefined && tool_preset_id !== null) {
+      const { rows: presetRows } = await getPool().query(
+        'SELECT id, tools_config FROM tool_presets WHERE id = $1',
+        [tool_preset_id]
+      );
+      if (presetRows.length === 0) {
+        res.status(400).json({ error: 'Tool preset not found' });
+        return;
+      }
+      resolvedToolsConfig = JSON.stringify(presetRows[0].tools_config);
+    }
+
+    // Build SET clause: model_policy_id and tool_preset_id use explicit flags to allow clearing to NULL
     const modelPolicyProvided = model_policy_id !== undefined;
+    const toolPresetProvided = tool_preset_id !== undefined;
     const { rows } = await getPool().query(
       `UPDATE agents SET
         name = COALESCE($1, name),
@@ -220,13 +252,14 @@ router.put('/:id', requireRole('user'), async (req: Request, res: Response) => {
         soul_md = COALESCE($7, soul_md),
         rules_md = COALESCE($8, rules_md),
         model_policy_id = CASE WHEN $9::boolean THEN $10::uuid ELSE model_policy_id END,
+        tool_preset_id = CASE WHEN $11::boolean THEN $12::uuid ELSE tool_preset_id END,
         updated_at = NOW()
-       WHERE id = $11
+       WHERE id = $13
        RETURNING *`,
       [
         name || null,
         description ?? null,
-        tools_config ? JSON.stringify(tools_config) : null,
+        resolvedToolsConfig,
         cpus || null,
         mem_limit || null,
         pids_limit ?? null,
@@ -234,6 +267,8 @@ router.put('/:id', requireRole('user'), async (req: Request, res: Response) => {
         rules_md ?? null,
         modelPolicyProvided,
         modelPolicyProvided ? (model_policy_id ?? null) : null,
+        toolPresetProvided,
+        toolPresetProvided ? (tool_preset_id ?? null) : null,
         req.params.id,
       ]
     );

--- a/services/api/src/routes/tool-presets.ts
+++ b/services/api/src/routes/tool-presets.ts
@@ -1,0 +1,170 @@
+import { Router, Request, Response } from 'express';
+import { getPool } from '../db/pool';
+import { requireRole } from '../middleware/role';
+
+const router = Router();
+
+function dbHealthCheck(_req: Request, res: Response, next: () => void) {
+  if (!process.env.DATABASE_URL) {
+    res.status(503).json({ error: 'Database not configured' });
+    return;
+  }
+  next();
+}
+
+router.use(dbHealthCheck);
+
+function isAdmin(req: Request): boolean {
+  const user = (req as any).user;
+  const roles: string[] = user?.realm_roles || [];
+  return roles.includes('admin');
+}
+
+// List all presets — all authenticated users see all presets (no ownership scoping in Phase 1)
+router.get('/', requireRole('user'), async (_req: Request, res: Response) => {
+  try {
+    const { rows } = await getPool().query(
+      `SELECT id, name, description, tools_config, is_platform, created_by, created_at, updated_at
+       FROM tool_presets ORDER BY is_platform DESC, name ASC`
+    );
+    res.json(rows);
+  } catch (err) {
+    console.error('[tool-presets] List error:', err);
+    res.status(500).json({ error: 'Failed to list tool presets' });
+  }
+});
+
+// Get single preset
+router.get('/:id', requireRole('user'), async (req: Request, res: Response) => {
+  try {
+    const { rows } = await getPool().query(
+      `SELECT id, name, description, tools_config, is_platform, created_by, created_at, updated_at
+       FROM tool_presets WHERE id = $1`,
+      [req.params.id]
+    );
+    if (rows.length === 0) {
+      res.status(404).json({ error: 'Tool preset not found' });
+      return;
+    }
+    res.json(rows[0]);
+  } catch (err) {
+    console.error('[tool-presets] Get error:', err);
+    res.status(500).json({ error: 'Failed to get tool preset' });
+  }
+});
+
+// Create preset — admin only
+router.post('/', requireRole('admin'), async (req: Request, res: Response) => {
+  try {
+    const { name, description, tools_config } = req.body;
+
+    if (!name) {
+      res.status(400).json({ error: 'name is required' });
+      return;
+    }
+    if (!tools_config || typeof tools_config !== 'object') {
+      res.status(400).json({ error: 'tools_config is required and must be an object' });
+      return;
+    }
+
+    const { rows } = await getPool().query(
+      `INSERT INTO tool_presets (name, description, tools_config, is_platform, created_by)
+       VALUES ($1, $2, $3, false, NULL)
+       RETURNING *`,
+      [name, description || '', JSON.stringify(tools_config)]
+    );
+
+    res.status(201).json(rows[0]);
+  } catch (err: any) {
+    if (err.code === '23505') {
+      res.status(409).json({ error: 'A tool preset with this name already exists' });
+      return;
+    }
+    console.error('[tool-presets] Create error:', err);
+    res.status(500).json({ error: 'Failed to create tool preset' });
+  }
+});
+
+// Update preset — admin only, platform presets immutable
+router.put('/:id', requireRole('admin'), async (req: Request, res: Response) => {
+  try {
+    const { rows: existing } = await getPool().query(
+      'SELECT id, is_platform FROM tool_presets WHERE id = $1',
+      [req.params.id]
+    );
+    if (existing.length === 0) {
+      res.status(404).json({ error: 'Tool preset not found' });
+      return;
+    }
+    if (existing[0].is_platform) {
+      res.status(403).json({ error: 'Cannot modify a platform preset' });
+      return;
+    }
+
+    const { name, description, tools_config } = req.body;
+
+    const { rows } = await getPool().query(
+      `UPDATE tool_presets SET
+        name = COALESCE($1, name),
+        description = COALESCE($2, description),
+        tools_config = COALESCE($3, tools_config),
+        updated_at = NOW()
+       WHERE id = $4
+       RETURNING *`,
+      [
+        name || null,
+        description ?? null,
+        tools_config ? JSON.stringify(tools_config) : null,
+        req.params.id,
+      ]
+    );
+
+    res.json(rows[0]);
+  } catch (err: any) {
+    if (err.code === '23505') {
+      res.status(409).json({ error: 'A tool preset with this name already exists' });
+      return;
+    }
+    console.error('[tool-presets] Update error:', err);
+    res.status(500).json({ error: 'Failed to update tool preset' });
+  }
+});
+
+// Delete preset — admin only, platform presets undeletable, assigned presets undeletable
+router.delete('/:id', requireRole('admin'), async (req: Request, res: Response) => {
+  try {
+    const { rows: existing } = await getPool().query(
+      'SELECT id, is_platform FROM tool_presets WHERE id = $1',
+      [req.params.id]
+    );
+    if (existing.length === 0) {
+      res.status(404).json({ error: 'Tool preset not found' });
+      return;
+    }
+    if (existing[0].is_platform) {
+      res.status(403).json({ error: 'Cannot delete a platform preset' });
+      return;
+    }
+
+    // Check for agents using this preset
+    const { rows: agents } = await getPool().query(
+      'SELECT id, agent_id FROM agents WHERE tool_preset_id = $1 LIMIT 1',
+      [req.params.id]
+    );
+    if (agents.length > 0) {
+      res.status(409).json({
+        error: 'Cannot delete preset while agents are assigned to it',
+        agent_id: agents[0].agent_id,
+      });
+      return;
+    }
+
+    await getPool().query('DELETE FROM tool_presets WHERE id = $1', [req.params.id]);
+    res.json({ deleted: true });
+  } catch (err) {
+    console.error('[tool-presets] Delete error:', err);
+    res.status(500).json({ error: 'Failed to delete tool preset' });
+  }
+});
+
+export default router;


### PR DESCRIPTION
## Summary

- Introduce **tool presets** as named, reusable tool configurations for agents
- Migration 016: `tool_presets` table + `tool_preset_id` FK on agents + 4 platform seed presets (Minimal, Developer, Research, Operator)
- CRUD routes at `/tool-presets` — admin-only mutations, `is_platform` immutability enforcement, delete protection (cannot delete presets assigned to agents)
- Agent create/update: `tool_preset_id` with **resolve-on-save** semantics — preset `tools_config` is copied into agent at assignment time
- OpenAPI spec updated and synced (both `services/api/src/openapi/openapi.yaml` and `docs/site/openapi.yaml`)

## Plan

`.claude/plans/curious-dazzling-nest.md` — closed-loop plan with all 9 sections. This is PR 1 of 3 (database + API backend).

## Test Plan

- [x] 26 new tests (T1-T17 per plan TDD matrix): routes-tool-presets.test.ts (T1-T12) + routes-agents-preset.test.ts (T13-T17)
- [x] All 227 API tests pass (`npm test --prefix services/api`)
- [x] TypeScript compiles clean (`npx tsc --noEmit`)
- [x] OpenAPI lint passes (`npx @redocly/cli lint` — valid, warnings only, all pre-existing)
- [x] OpenAPI sync verified (`diff` — no diff between API and docs/site copies)
- [x] docs.test.ts updated with new `/tool-presets` and `/tool-presets/{id}` expected paths

## Risks

- Platform seed preset binary lists are manually curated against current Dockerfile — no automated enforcement in Phase 1
- Resolve-on-save means preset updates don't propagate to existing agents — documented behavior, Phase 2 adds explicit reapply

## Validation Evidence

| Check | Result |
|-------|--------|
| API tests | 227/227 pass |
| TypeScript compile | Clean |
| OpenAPI lint | Valid (warnings only) |
| OpenAPI sync | No diff |
| Migration review | DDL correct, 4 seeds match plan section 6 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)