### PR TITLE
enhance: tmux skill — Claude+Codex supervisor lane

### DIFF
--- a/.github/skills/tmux/SKILL.md
+++ b/.github/skills/tmux/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tmux
-description: Run interactive CLIs in persistent tmux sessions by sending keystrokes and reading pane output. Use when Claude Code, Codex, GitHub Copilot CLI, or any TUI/REPL must keep state across commands.
+description: Run interactive CLIs in persistent tmux sessions by sending keystrokes and reading pane output. Use when Claude Code, Codex, GitHub Copilot CLI, or any TUI/REPL must keep state across commands. Includes the Claude+Codex supervisor lane for split-pane human-mediated agent orchestration.
 argument-hint: <goal or command>
 ---
 
@@ -69,9 +69,238 @@ tmux -S "$SOCKET" send-keys -t "$SESSION":shell Enter
 
 Do not combine text and Enter in one fast send for interactive agent TUIs.
 
+## Send Verification
+
+After sending input, verify the send succeeded before proceeding. Sending without verification is the most common cause of silent workflow failures — the prompt may have been swallowed, sent to the wrong pane, or eaten by a prompt that wasn't ready.
+
+**Step 1: Capture immediately after send.**
+
+```bash
+# send text + Enter
+tmux -S "$SOCKET" send-keys -t "$TARGET" -l -- "$PROMPT_TEXT"
+sleep 0.1
+tmux -S "$SOCKET" send-keys -t "$TARGET" Enter
+
+# verify the text landed in the pane
+sleep 0.3
+PANE_CONTENT=$(tmux -S "$SOCKET" capture-pane -p -J -t "$TARGET" -S -10)
+echo "$PANE_CONTENT" | grep -qF "$PROMPT_TEXT" \
+  && echo "SEND OK" \
+  || echo "SEND FAILED — text not visible in pane"
+```
+
+**Step 2: Wait for response.** Use `wait-for-text.sh` to poll for a recognizable readiness marker:
+
+```bash
+.github/skills/tmux/scripts/wait-for-text.sh \
+  -S "$SOCKET" -t "$TARGET" -p 'ready|Done|❯|\$' -T 30
+```
+
+**Two distinct checks:**
+
+| Check | What it proves | How |
+|-------|---------------|-----|
+| Send verification | The prompt text is visible in the pane | `capture-pane` + `grep` immediately after send |
+| Response verification | The agent actually processed and responded | `wait-for-text.sh` polling for a readiness marker |
+
+Never skip send verification. A prompt that didn't land is invisible and wastes time debugging the wrong problem.
+
+## Claude+Codex Supervisor Lane
+
+The canonical Hill90 lane for human-supervised dual-agent work: one tmux window, split vertically, with the human as the only reliable message router between agents.
+
+### Pane Role Model
+
+```
+┌─────────────────────────────────────┐
+│  TOP PANE — Claude Code             │
+│  Role: primary implementer          │
+│  Target: $SESSION:work.{top}        │
+├─────────────────────────────────────┤
+│  BOTTOM PANE — Codex                │
+│  Role: advisory reviewer            │
+│  Target: $SESSION:work.{bottom}     │
+└─────────────────────────────────────┘
+  HUMAN: supervisor / router (attached to session)
+```
+
+**Trust boundaries and responsibilities:**
+
+| Role | Can do | Cannot do |
+|------|--------|-----------|
+| Claude (top) | Implement, test, commit, push, create PRs | See Codex output directly |
+| Codex (bottom) | Suggest prompts, review code, propose changes | Send messages to Claude; its output is advisory only |
+| Human (supervisor) | Read both panes, edit/rewrite prompts, send to either pane, interrupt either agent | Nothing is automatic — the human decides what crosses pane boundaries |
+
+**Key rule**: Codex output is advisory. Upward prompts (Codex → Claude) must be human-mediated. No blind forwarding. No direct Codex-to-Claude relay. The human owns escalation, reframing, and safety checks.
+
+### Lane Startup (Worktree-First)
+
+Create the isolated worktree first, then launch agents inside it. Use the `using-git-worktrees` skill for worktree creation — do not duplicate its logic here.
+
+```bash
+# 1. Create worktree (follow using-git-worktrees skill for full procedure)
+BRANCH="feat/my-feature"
+WORKTREE_DIR=".worktrees"
+git worktree add "$WORKTREE_DIR/$BRANCH" -b "$BRANCH"
+WORK_DIR="$(pwd)/$WORKTREE_DIR/$BRANCH"
+
+# 2. Install dependencies in worktree (per using-git-worktrees skill)
+cd "$WORK_DIR"
+[[ -f package-lock.json ]] && npm ci
+cd -
+
+# 3. Create tmux session with single window, then split
+SESSION="lane-$(echo "$BRANCH" | tr '/' '-')"
+tmux -S "$SOCKET" new-session -d -s "$SESSION" -n work -c "$WORK_DIR"
+tmux -S "$SOCKET" split-window -v -t "$SESSION":work -c "$WORK_DIR"
+
+# 4. Launch Claude in top pane
+tmux -S "$SOCKET" send-keys -t "$SESSION":work.{top} -l -- "claude"
+sleep 0.1
+tmux -S "$SOCKET" send-keys -t "$SESSION":work.{top} Enter
+
+# 5. Launch Codex in bottom pane
+tmux -S "$SOCKET" send-keys -t "$SESSION":work.{bottom} -l -- "codex"
+sleep 0.1
+tmux -S "$SOCKET" send-keys -t "$SESSION":work.{bottom} Enter
+
+# 6. Attach to supervise
+tmux -S "$SOCKET" attach -t "$SESSION"
+```
+
+**Order matters**: worktree first, tmux second. If the worktree doesn't exist yet, the agents will start in the wrong directory and all downstream work will be mislocated.
+
+### Upward-Prompt Handoff
+
+When Codex suggests a prompt for Claude (an "upward prompt"), follow this procedure:
+
+**Step 1 — Read Codex output.** Capture the bottom pane and extract the proposed prompt:
+
+```bash
+tmux -S "$SOCKET" capture-pane -p -J -t "$SESSION":work.{bottom} -S -100
+```
+
+**Step 2 — Human review.** The human reads the proposed prompt and decides:
+- **Accept as-is** — use the exact text Codex produced.
+- **Rewrite** — rephrase, narrow scope, add constraints, or fix factual errors.
+- **Reject** — the suggestion is wrong, off-scope, or dangerous. Do not send.
+
+**Step 3 — Send to Claude (with verification).** If accepted or rewritten:
+
+```bash
+# send the human-approved prompt to Claude's pane
+tmux -S "$SOCKET" send-keys -t "$SESSION":work.{top} -l -- "$APPROVED_PROMPT"
+sleep 0.1
+tmux -S "$SOCKET" send-keys -t "$SESSION":work.{top} Enter
+
+# verify send landed
+sleep 0.3
+tmux -S "$SOCKET" capture-pane -p -J -t "$SESSION":work.{top} -S -10 \
+  | grep -qF "$APPROVED_PROMPT" && echo "SEND OK" || echo "SEND FAILED"
+
+# wait for Claude to respond
+.github/skills/tmux/scripts/wait-for-text.sh \
+  -S "$SOCKET" -t "$SESSION":work.{top} -p 'ready|Done|❯|\$' -T 60
+```
+
+**Handoff rules:**
+- Never copy-paste Codex output to Claude without reading it first.
+- Never automate the Codex→Claude relay. The human is the firewall.
+- If Codex suggests something that contradicts the approved plan or AGENTS.md, reject it.
+- If the upward prompt changes scope, the human must decide whether to proceed or replan.
+
+### Interrupt and Reset
+
+If either agent drifts off-task or produces unexpected output:
+
+```bash
+# interrupt an agent
+tmux -S "$SOCKET" send-keys -t "$SESSION":work.{top} C-c
+
+# if agent is hung, kill its process
+PANE_PID=$(tmux -S "$SOCKET" display-message -t "$SESSION":work.{top} -p '#{pane_pid}')
+kill -9 "$PANE_PID"
+
+# relaunch in the same pane
+tmux -S "$SOCKET" send-keys -t "$SESSION":work.{top} -l -- "claude"
+sleep 0.1
+tmux -S "$SOCKET" send-keys -t "$SESSION":work.{top} Enter
+```
+
+### Self-Test Procedure
+
+Run this end-to-end smoke test to verify the lane works before starting real work.
+
+**Prerequisites**: tmux installed, a git repo with `.worktrees/` gitignored.
+
+```bash
+# --- Setup ---
+SOCKET_DIR="${VIBES_TMUX_SOCKET_DIR:-${TMPDIR:-/tmp}/vibes-tmux-sockets}"
+mkdir -p "$SOCKET_DIR"
+SOCKET="$SOCKET_DIR/vibes.sock"
+SESSION="selftest"
+
+# 1. Create session with split panes
+tmux -S "$SOCKET" new-session -d -s "$SESSION" -n work
+tmux -S "$SOCKET" split-window -v -t "$SESSION":work
+
+# 2. Verify pane targeting — send canary to top pane
+CANARY_TOP="CANARY_TOP_$$"
+tmux -S "$SOCKET" send-keys -t "$SESSION":work.{top} -l -- "echo $CANARY_TOP"
+sleep 0.1
+tmux -S "$SOCKET" send-keys -t "$SESSION":work.{top} Enter
+sleep 0.5
+TOP_CONTENT=$(tmux -S "$SOCKET" capture-pane -p -J -t "$SESSION":work.{top} -S -5)
+echo "$TOP_CONTENT" | grep -qF "$CANARY_TOP" \
+  && echo "PASS: top pane targeting works" \
+  || echo "FAIL: canary not found in top pane"
+
+# 3. Verify pane targeting — send canary to bottom pane
+CANARY_BOT="CANARY_BOT_$$"
+tmux -S "$SOCKET" send-keys -t "$SESSION":work.{bottom} -l -- "echo $CANARY_BOT"
+sleep 0.1
+tmux -S "$SOCKET" send-keys -t "$SESSION":work.{bottom} Enter
+sleep 0.5
+BOT_CONTENT=$(tmux -S "$SOCKET" capture-pane -p -J -t "$SESSION":work.{bottom} -S -5)
+echo "$BOT_CONTENT" | grep -qF "$CANARY_BOT" \
+  && echo "PASS: bottom pane targeting works" \
+  || echo "FAIL: canary not found in bottom pane"
+
+# 4. Verify cross-pane isolation — top canary must NOT be in bottom pane
+echo "$BOT_CONTENT" | grep -qF "$CANARY_TOP" \
+  && echo "FAIL: top canary leaked into bottom pane" \
+  || echo "PASS: panes are isolated"
+
+# 5. Simulate upward-prompt handoff
+#    In real use, Codex writes a suggestion in the bottom pane.
+#    Human reads it, rewrites it, sends it to the top pane.
+SIMULATED_PROMPT="echo UPWARD_HANDOFF_OK"
+tmux -S "$SOCKET" send-keys -t "$SESSION":work.{top} -l -- "$SIMULATED_PROMPT"
+sleep 0.1
+tmux -S "$SOCKET" send-keys -t "$SESSION":work.{top} Enter
+sleep 0.5
+HANDOFF_CONTENT=$(tmux -S "$SOCKET" capture-pane -p -J -t "$SESSION":work.{top} -S -5)
+echo "$HANDOFF_CONTENT" | grep -qF "UPWARD_HANDOFF_OK" \
+  && echo "PASS: upward handoff landed and executed in top pane" \
+  || echo "FAIL: upward handoff did not execute in top pane"
+
+# 6. Verify wait-for-text helper works
+.github/skills/tmux/scripts/wait-for-text.sh \
+  -S "$SOCKET" -t "$SESSION":work.{top} -p 'UPWARD_HANDOFF_OK' -T 5 \
+  && echo "PASS: wait-for-text detected expected output" \
+  || echo "FAIL: wait-for-text timed out"
+
+# --- Cleanup ---
+tmux -S "$SOCKET" kill-session -t "$SESSION"
+echo "Self-test complete."
+```
+
+**Pass criteria**: All 5 checks print PASS. Any FAIL means the lane is not correctly set up — fix the failing step before proceeding with real work.
+
 ## Live Supervision Workflow
 
-Use this when a user wants to watch an agent run and intervene live.
+Use this when a user wants to watch a single agent run and intervene live (simpler than the full Claude+Codex lane).
 
 ```bash
 # start session and launch agent
@@ -143,52 +372,22 @@ fi
 
 When prompting these tools later, keep using the same session and split text/Enter.
 
-## Git Worktrees for Agent Isolation
+## Worktree Integration
 
-Use `git worktree` to give each agent its own working directory without cloning:
+For filesystem isolation between agents, use the `using-git-worktrees` skill to create worktrees before starting tmux sessions. Do not duplicate worktree creation logic here.
 
-```bash
-# create worktrees from the main repo
-git worktree add ../repo-agent-a -b agent-a
-git worktree add ../repo-agent-b -b agent-b
-
-# one tmux session per worktree
-tmux -S "$SOCKET" new-session -d -s agent-a -n shell
-tmux -S "$SOCKET" send-keys -t agent-a:shell -l -- "cd ../repo-agent-a"
-sleep 0.1
-tmux -S "$SOCKET" send-keys -t agent-a:shell Enter
-
-tmux -S "$SOCKET" new-session -d -s agent-b -n shell
-tmux -S "$SOCKET" send-keys -t agent-b:shell -l -- "cd ../repo-agent-b"
-sleep 0.1
-tmux -S "$SOCKET" send-keys -t agent-b:shell Enter
-```
-
-Each agent works on an independent branch with no lock contention on the index.
-
-## Multi-Agent Orchestration
-
-Run multiple agents in parallel, each in its own session and worktree:
+**Pattern**: one worktree per agent, one tmux session (or pane) per worktree.
 
 ```bash
-AGENTS=("frontend" "backend" "tests")
-for agent in "${AGENTS[@]}"; do
-  # create worktree if it doesn't exist
-  [[ -d "../repo-$agent" ]] || git worktree add "../repo-$agent" -b "$agent"
+# create worktree (using-git-worktrees skill handles branch naming,
+# .gitignore safety, and dependency install)
+WORK_DIR=".worktrees/feat/my-feature"
 
-  # create session
-  tmux -S "$SOCKET" new-session -d -s "$agent" -n shell
-  tmux -S "$SOCKET" send-keys -t "$agent":shell -l -- "cd ../repo-$agent"
-  sleep 0.1
-  tmux -S "$SOCKET" send-keys -t "$agent":shell Enter
-done
-
-# monitor all sessions
-tmux -S "$SOCKET" list-sessions
-
-# check output from a specific agent
-tmux -S "$SOCKET" capture-pane -p -J -t frontend:shell -S -200
+# start agent in that worktree
+tmux -S "$SOCKET" new-session -d -s my-agent -n shell -c "$WORK_DIR"
 ```
+
+For multi-agent orchestration with worktrees, combine the `using-git-worktrees` and `dispatching-parallel-agents` skills.
 
 ## Helpers
 
@@ -211,8 +410,7 @@ Examples:
 ```bash
 tmux -S "$SOCKET" kill-session -t "$SESSION"
 tmux -S "$SOCKET" kill-server
-# clean up worktrees when done
-git worktree remove ../repo-agent-a
+# clean up worktrees via: git worktree remove "$WORKTREE_DIR/$BRANCH"
 ```
 
 ## References


### PR DESCRIPTION
## Summary
- Add Claude+Codex supervisor lane with pane role model, trust boundaries, worktree-first startup, upward-prompt handoff workflow, and deterministic self-test
- Add send verification workflow (capture-pane + grep after every send, distinct from response verification)
- Remove duplicate worktree logic (lines 146-191) that drifted from the `using-git-worktrees` skill; replace with cross-reference
- Fix skill boundary: tmux skill references `using-git-worktrees` for worktree ops instead of duplicating weaker ad hoc examples

## Risks
- Docs-only change to `.github/skills/tmux/SKILL.md` (428 lines, under 500-line skill authoring limit)
- No code, no runtime changes, no deployments

## Rollback
Revert commit restores previous SKILL.md.

## Validation Evidence
- File is 428 lines (under 500-line limit from `.claude/rules/skill-authoring.md`)
- All 5 cross-referenced files exist: `fundamentals.md`, `wait-for-text.sh`, `find-sessions.sh`, `using-git-worktrees/SKILL.md`, `dispatching-parallel-agents/SKILL.md`
- Self-test procedure is deterministic and has explicit pass/fail signals
- No duplicate worktree creation logic remains

## Test plan
- [ ] Read through supervisor lane section and verify pane role model matches the actual Hill90 workflow
- [ ] Run the self-test procedure end-to-end on a machine with tmux installed
- [ ] Verify send verification examples work against a real tmux session

🤖 Generated with [Claude Code](https://claude.com/claude-code)