### PR TITLE
fix: remove leftover vibes naming from using-tmux skill

### DIFF
--- a/.github/skills/using-tmux/SKILL.md
+++ b/.github/skills/using-tmux/SKILL.md
@@ -30,9 +30,9 @@ tmux sessions survive SSH drops, terminal closes, and laptop sleep. This makes t
 Use a dedicated socket directory:
 
 ```bash
-SOCKET_DIR="${VIBES_TMUX_SOCKET_DIR:-${TMPDIR:-/tmp}/vibes-tmux-sockets}"
+SOCKET_DIR="${TMUX_SOCKET_DIR:-${TMPDIR:-/tmp}/tmux-agent-sockets}"
 mkdir -p "$SOCKET_DIR"
-SOCKET="$SOCKET_DIR/vibes.sock"
+SOCKET="$SOCKET_DIR/agent.sock"
 ```
 
 Use short session names with no spaces. Target panes by window name (e.g. `session:shell`) rather than numeric index (e.g. `session:0.0`) — numeric indexes depend on `base-index`/`pane-base-index` settings and are not portable.
@@ -40,7 +40,7 @@ Use short session names with no spaces. Target panes by window name (e.g. `sessi
 ## Quickstart
 
 ```bash
-SESSION="vibes-work"
+SESSION="agent-work"
 tmux -S "$SOCKET" new-session -d -s "$SESSION" -n shell
 tmux -S "$SOCKET" send-keys -t "$SESSION":shell -l -- "echo ready"
 sleep 0.1
@@ -261,9 +261,9 @@ ls -la "$SOCKET"
 # Common fix: socket dir not writable
 chmod 700 "$SOCKET_DIR"
 
-# On shared systems, use VIBES_TMUX_SOCKET_DIR to isolate
-export VIBES_TMUX_SOCKET_DIR="$HOME/.tmux-sockets"
-mkdir -p "$VIBES_TMUX_SOCKET_DIR"
+# On shared systems, use TMUX_SOCKET_DIR to isolate
+export TMUX_SOCKET_DIR="$HOME/.tmux-sockets"
+mkdir -p "$TMUX_SOCKET_DIR"
 ```
 
 ### Hung-process recovery

--- a/.github/skills/using-tmux/scripts/find-sessions.sh
+++ b/.github/skills/using-tmux/scripts/find-sessions.sh
@@ -10,7 +10,7 @@ List tmux sessions on a socket (or scan all sockets in socket dir).
 Options:
   -L, --socket       tmux socket name (passes tmux -L)
   -S, --socket-path  tmux socket path (passes tmux -S)
-  -A, --all          scan all sockets under VIBES_TMUX_SOCKET_DIR
+  -A, --all          scan all sockets under TMUX_SOCKET_DIR
   -q, --query        case-insensitive substring filter
   -h, --help         show this help
 USAGE
@@ -20,7 +20,7 @@ socket_name=""
 socket_path=""
 query=""
 scan_all=false
-socket_dir="${VIBES_TMUX_SOCKET_DIR:-${TMPDIR:-/tmp}/vibes-tmux-sockets}"
+socket_dir="${TMUX_SOCKET_DIR:-${TMPDIR:-/tmp}/tmux-agent-sockets}"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in


### PR DESCRIPTION
## Summary

- Remove all `vibes` naming inherited from upstream template
- `VIBES_TMUX_SOCKET_DIR` -> `TMUX_SOCKET_DIR`
- `vibes-tmux-sockets` -> `tmux-agent-sockets`
- `vibes.sock` -> `agent.sock`
- `vibes-work` -> `agent-work`
- Both `SKILL.md` and `scripts/find-sessions.sh` updated in sync

## Test plan

- [x] `grep -ri vibes .github/skills/using-tmux/` returns 0 matches
- [x] Self-test passes: 7/7 checks PASS
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)