### PR TITLE
feat: show skill instructions on agent detail page

### DIFF
--- a/services/ui/src/__tests__/AgentDetailClient.test.tsx
+++ b/services/ui/src/__tests__/AgentDetailClient.test.tsx
@@ -70,6 +70,7 @@ const MOCK_PRESETS = [
     description: 'Full dev environment',
     tools_config: {},
     is_platform: true,
+    instructions_md: 'Always write tests before implementation.\nFollow TDD red-green-refactor.',
   },
 ]
 
@@ -344,5 +345,31 @@ describe('AgentDetailClient', () => {
     await waitFor(() => {
       expect(screen.getByText(/Skill:\s*Developer/i)).toBeInTheDocument()
     })
+  })
+
+  it('shows skill instructions when preset has instructions_md', async () => {
+    mockFetchDefaults(MOCK_AGENT_WITH_PRESET as any)
+
+    render(<AgentDetailClient agentId="uuid-1" session={ADMIN_SESSION as any} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('ResearchBot')).toBeInTheDocument()
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('Skill Instructions')).toBeInTheDocument()
+    })
+    expect(screen.getByText(/Always write tests before implementation/)).toBeInTheDocument()
+    expect(screen.getByText(/Follow TDD red-green-refactor/)).toBeInTheDocument()
+  })
+
+  it('does not show skill instructions section when no preset assigned', async () => {
+    render(<AgentDetailClient agentId="uuid-1" session={ADMIN_SESSION as any} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('ResearchBot')).toBeInTheDocument()
+    })
+
+    expect(screen.queryByText('Skill Instructions')).not.toBeInTheDocument()
   })
 })

--- a/services/ui/src/app/agents/[id]/AgentDetailClient.tsx
+++ b/services/ui/src/app/agents/[id]/AgentDetailClient.tsx
@@ -41,6 +41,7 @@ interface ToolPreset {
   name: string
   description: string
   is_platform: boolean
+  instructions_md?: string
 }
 
 type TabId = 'overview' | 'configuration' | 'model-access' | 'knowledge' | 'activity'
@@ -365,6 +366,14 @@ export default function AgentDetailClient({
               <ToolBadge label="Health" enabled={tc.health?.enabled} />
             </div>
           </div>
+
+          {/* Skill Instructions */}
+          {currentPreset?.instructions_md && (
+            <div className="rounded-lg border border-navy-700 bg-navy-800 p-5">
+              <h2 className="text-lg font-semibold text-white mb-2">Skill Instructions</h2>
+              <pre className="text-sm text-mountain-300 whitespace-pre-wrap bg-navy-900 rounded-md p-3 max-h-64 overflow-y-auto">{currentPreset.instructions_md}</pre>
+            </div>
+          )}
 
           {/* Resource Grid */}
           <div className="rounded-lg border border-navy-700 bg-navy-800 p-5">


### PR DESCRIPTION
## Summary
- Surface the assigned skill's `instructions_md` on the agent detail Overview tab
- Adds `instructions_md?: string` to the local `ToolPreset` interface (field already returned by `GET /api/tool-presets`)
- Renders a "Skill Instructions" card below Tool Access when a skill with instructions is assigned
- No backend, API, migration, or OpenAPI changes

## Files Changed
| File | Change |
|------|--------|
| `services/ui/src/app/agents/[id]/AgentDetailClient.tsx` | Add `instructions_md` to interface + display section |
| `services/ui/src/__tests__/AgentDetailClient.test.tsx` | Add `instructions_md` to mock + 2 new tests |

## Test Plan
- [x] T1: Preset with `instructions_md` assigned → instructions section renders (heading + text visible)
- [x] T2: No preset assigned (Custom) → instructions section absent (no "Skill Instructions" heading)
- [x] Full UI test suite: 287/287 tests pass (33 files)
- [x] TypeScript: 9 errors, all pre-existing (middleware.test.ts x8, UsageClient.test.tsx x1), zero introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>