### PR TITLE
feat: skills naming reset — Phase 2

### DIFF
--- a/docs/site/openapi.yaml
+++ b/docs/site/openapi.yaml
@@ -56,11 +56,20 @@ components:
           format: uuid
           nullable: true
           description: ID of the model policy controlling LLM access. Users can assign own or platform policies to own agents; admins can assign any.
-        tool_preset_id:
-          type: string
-          format: uuid
-          nullable: true
-          description: ID of the tool preset applied at assignment time. Config is copied (resolve-on-save).
+        skills:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+                format: uuid
+              name:
+                type: string
+              scope:
+                type: string
+                enum: [container_local, host_docker, vps_system]
+          description: Skills assigned to this agent (max 1 in current phase).
         error_message:
           type: string
           nullable: true
@@ -230,7 +239,7 @@ components:
           nullable: true
           description: Owner (user sub). NULL for platform policies.
 
-    ToolPreset:
+    Skill:
       type: object
       properties:
         id:
@@ -253,11 +262,11 @@ components:
           description: Scope determines assignment authority. container_local — any user. host_docker/vps_system — admin only.
         is_platform:
           type: boolean
-          description: Platform presets are immutable and undeletable.
+          description: Platform skills are immutable and undeletable.
         created_by:
           type: string
           nullable: true
-          description: Always NULL in Phase 1 (admin-created shared resources).
+          description: Always NULL (admin-created shared resources).
         created_at:
           type: string
           format: date-time
@@ -629,11 +638,13 @@ paths:
                   format: uuid
                   nullable: true
                   description: ID of a model policy to assign at creation. Users can assign own or platform policies; admins can assign any.
-                tool_preset_id:
-                  type: string
-                  format: uuid
-                  nullable: true
-                  description: ID of a tool preset. Config is copied into agent at save time (resolve-on-save).
+                skill_ids:
+                  type: array
+                  items:
+                    type: string
+                    format: uuid
+                  maxItems: 1
+                  description: Skill IDs to assign (max 1). Config is copied into agent at save time (resolve-on-save).
       responses:
         "201":
           description: Agent created
@@ -711,11 +722,13 @@ paths:
                   format: uuid
                   nullable: true
                   description: Model policy ID. Users can assign own or platform policies; admins can assign any. Set to null to remove.
-                tool_preset_id:
-                  type: string
-                  format: uuid
-                  nullable: true
-                  description: Tool preset ID. Config is copied into agent at save time. Set to null to detach preset.
+                skill_ids:
+                  type: array
+                  items:
+                    type: string
+                    format: uuid
+                  maxItems: 1
+                  description: Skill IDs to assign (max 1). Config is copied into agent at save time. Empty array to detach skill.
       responses:
         "200":
           description: Agent updated
@@ -2113,29 +2126,29 @@ paths:
         "403":
           description: Requires user role
 
-  /tool-presets:
+  /skills:
     get:
-      summary: List tool presets
-      description: Returns all tool presets. All authenticated users see all presets.
+      summary: List skills
+      description: Returns all skills. All authenticated users see all skills.
       security:
         - bearerAuth: []
       responses:
         "200":
-          description: Preset list
+          description: Skill list
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/ToolPreset"
+                  $ref: "#/components/schemas/Skill"
         "401":
           description: Not authenticated
         "403":
           description: Requires user role
 
     post:
-      summary: Create tool preset
-      description: Creates a new tool preset. Admin only.
+      summary: Create skill
+      description: Creates a new skill. Admin only.
       security:
         - bearerAuth: []
       requestBody:
@@ -2165,11 +2178,11 @@ paths:
                   description: Scope determines assignment authority.
       responses:
         "201":
-          description: Preset created
+          description: Skill created
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ToolPreset"
+                $ref: "#/components/schemas/Skill"
         "400":
           description: Invalid input
         "401":
@@ -2177,9 +2190,9 @@ paths:
         "403":
           description: Requires admin role
         "409":
-          description: Duplicate preset name
+          description: Duplicate skill name
 
-  /tool-presets/{id}:
+  /skills/{id}:
     parameters:
       - name: id
         in: path
@@ -2189,27 +2202,27 @@ paths:
           format: uuid
 
     get:
-      summary: Get tool preset
-      description: Returns a single tool preset. All authenticated users can read.
+      summary: Get skill
+      description: Returns a single skill. All authenticated users can read.
       security:
         - bearerAuth: []
       responses:
         "200":
-          description: Preset detail
+          description: Skill detail
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ToolPreset"
+                $ref: "#/components/schemas/Skill"
         "401":
           description: Not authenticated
         "403":
           description: Requires user role
         "404":
-          description: Preset not found
+          description: Skill not found
 
     put:
-      summary: Update tool preset
-      description: Updates a tool preset. Admin only. Platform presets are immutable (403).
+      summary: Update skill
+      description: Updates a skill. Admin only. Platform skills are immutable (403).
       security:
         - bearerAuth: []
       requestBody:
@@ -2232,28 +2245,28 @@ paths:
                   enum: [container_local, host_docker, vps_system]
       responses:
         "200":
-          description: Preset updated
+          description: Skill updated
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ToolPreset"
+                $ref: "#/components/schemas/Skill"
         "401":
           description: Not authenticated
         "403":
-          description: Requires admin role or platform preset is immutable
+          description: Requires admin role or platform skill is immutable
         "404":
-          description: Preset not found
+          description: Skill not found
         "409":
-          description: Duplicate preset name
+          description: Duplicate skill name
 
     delete:
-      summary: Delete tool preset
-      description: Deletes a tool preset. Admin only. Platform presets cannot be deleted. Presets assigned to agents cannot be deleted.
+      summary: Delete skill
+      description: Deletes a skill. Admin only. Platform skills cannot be deleted. Skills assigned to agents cannot be deleted.
       security:
         - bearerAuth: []
       responses:
         "200":
-          description: Preset deleted
+          description: Skill deleted
           content:
             application/json:
               schema:
@@ -2264,11 +2277,11 @@ paths:
         "401":
           description: Not authenticated
         "403":
-          description: Requires admin role or platform preset is undeletable
+          description: Requires admin role or platform skill is undeletable
         "404":
-          description: Preset not found
+          description: Skill not found
         "409":
-          description: Preset is assigned to agents
+          description: Skill is assigned to agents
 
   /agents/{id}/skills:
     parameters:

--- a/services/api/src/__tests__/docs.test.ts
+++ b/services/api/src/__tests__/docs.test.ts
@@ -170,13 +170,16 @@ const EXPECTED_PATHS = [
   '/shared-knowledge/sources',
   '/shared-knowledge/sources/{id}',
   '/shared-knowledge/search',
-  '/tool-presets',
-  '/tool-presets/{id}',
+  '/skills',
+  '/skills/{id}',
   '/agents/{id}/skills',
   '/agents/{id}/skills/{skillId}',
 ];
 
 const INFRA_PATHS = ['/docs', '/openapi.json', '/internal/delegation-token'];
+
+// Compat alias paths — same handler as canonical /skills routes, not in OpenAPI spec
+const COMPAT_PATHS = ['/tool-presets', '/tool-presets/{id}'];
 
 /**
  * Introspect Express app._router.stack to extract all registered route paths.
@@ -244,7 +247,7 @@ describe('Spec contract enforcement', () => {
 
   it('every registered Express route maps to EXPECTED_PATHS or INFRA_PATHS', () => {
     const registered = getRegisteredRoutes(app);
-    const allKnown = [...EXPECTED_PATHS, ...INFRA_PATHS];
+    const allKnown = [...EXPECTED_PATHS, ...INFRA_PATHS, ...COMPAT_PATHS];
     for (const route of registered) {
       expect(allKnown).toContain(route);
     }

--- a/services/api/src/__tests__/routes-agents-policy.test.ts
+++ b/services/api/src/__tests__/routes-agents-policy.test.ts
@@ -72,6 +72,8 @@ describe('Agent PUT model_policy_id behavior', () => {
     mockQuery.mockResolvedValueOnce({ rows: [{ id: 'policy-1', created_by: 'regular-user' }] });
     // UPDATE
     mockQuery.mockResolvedValueOnce({ rows: [{ ...agentRow, model_policy_id: 'policy-1' }] });
+    // SELECT skills for response
+    mockQuery.mockResolvedValueOnce({ rows: [] });
 
     const res = await request(app)
       .put('/agents/uuid-1')
@@ -89,6 +91,8 @@ describe('Agent PUT model_policy_id behavior', () => {
     mockQuery.mockResolvedValueOnce({ rows: [{ id: 'platform-policy', created_by: null }] });
     // UPDATE
     mockQuery.mockResolvedValueOnce({ rows: [{ ...agentRow, model_policy_id: 'platform-policy' }] });
+    // SELECT skills for response
+    mockQuery.mockResolvedValueOnce({ rows: [] });
 
     const res = await request(app)
       .put('/agents/uuid-1')
@@ -117,7 +121,8 @@ describe('Agent PUT model_policy_id behavior', () => {
     mockQuery
       .mockResolvedValueOnce({ rows: [agentRow] }) // ownership check
       .mockResolvedValueOnce({ rows: [{ id: 'policy-1', created_by: 'someone' }] }) // FK validation
-      .mockResolvedValueOnce({ rows: [{ ...agentRow, model_policy_id: 'policy-1' }] }); // UPDATE
+      .mockResolvedValueOnce({ rows: [{ ...agentRow, model_policy_id: 'policy-1' }] }) // UPDATE
+      .mockResolvedValueOnce({ rows: [] }); // SELECT skills for response
 
     const res = await request(app)
       .put('/agents/uuid-1')
@@ -149,7 +154,8 @@ describe('Agent PUT model_policy_id behavior', () => {
     const agentWithPolicy = { ...agentRow, model_policy_id: 'policy-1' };
     mockQuery
       .mockResolvedValueOnce({ rows: [agentWithPolicy] }) // ownership check
-      .mockResolvedValueOnce({ rows: [{ ...agentRow, model_policy_id: null }] }); // UPDATE
+      .mockResolvedValueOnce({ rows: [{ ...agentRow, model_policy_id: null }] }) // UPDATE
+      .mockResolvedValueOnce({ rows: [] }); // SELECT skills for response
 
     const res = await request(app)
       .put('/agents/uuid-1')
@@ -166,7 +172,8 @@ describe('Agent PUT model_policy_id behavior', () => {
   it('does not touch model_policy_id when not in body', async () => {
     mockQuery
       .mockResolvedValueOnce({ rows: [agentRow] }) // ownership check
-      .mockResolvedValueOnce({ rows: [agentRow] }); // UPDATE
+      .mockResolvedValueOnce({ rows: [agentRow] }) // UPDATE
+      .mockResolvedValueOnce({ rows: [] }); // SELECT skills for response
 
     const res = await request(app)
       .put('/agents/uuid-1')
@@ -182,7 +189,8 @@ describe('Agent PUT model_policy_id behavior', () => {
   it('allows non-admin to update other fields without model_policy_id', async () => {
     mockQuery
       .mockResolvedValueOnce({ rows: [agentRow] }) // ownership check
-      .mockResolvedValueOnce({ rows: [{ ...agentRow, name: 'New Name' }] }); // UPDATE
+      .mockResolvedValueOnce({ rows: [{ ...agentRow, name: 'New Name' }] }) // UPDATE
+      .mockResolvedValueOnce({ rows: [] }); // SELECT skills for response
 
     const res = await request(app)
       .put('/agents/uuid-1')
@@ -217,6 +225,8 @@ describe('Agent POST model_policy_id behavior', () => {
         created_by: 'regular-user',
       }],
     });
+    // SELECT skills for response
+    mockQuery.mockResolvedValueOnce({ rows: [] });
 
     const res = await request(app)
       .post('/agents')
@@ -253,6 +263,8 @@ describe('Agent POST model_policy_id behavior', () => {
         created_by: 'admin-user',
       }],
     });
+    // SELECT skills for response
+    mockQuery.mockResolvedValueOnce({ rows: [] });
 
     const res = await request(app)
       .post('/agents')
@@ -287,6 +299,8 @@ describe('Agent POST model_policy_id behavior', () => {
         created_by: 'regular-user',
       }],
     });
+    // SELECT skills for response
+    mockQuery.mockResolvedValueOnce({ rows: [] });
 
     const res = await request(app)
       .post('/agents')

--- a/services/api/src/__tests__/routes-agents-skill.test.ts
+++ b/services/api/src/__tests__/routes-agents-skill.test.ts
@@ -45,7 +45,7 @@ function makeToken(sub: string, roles: string[]) {
 const adminToken = makeToken('admin-user', ['admin', 'user']);
 const userToken = makeToken('regular-user', ['user']);
 
-const developerPresetConfig = {
+const developerSkillConfig = {
   shell: { enabled: true, allowed_binaries: ['bash', 'git', 'make', 'curl', 'jq'], denied_patterns: ['rm -rf /'], max_timeout: 300 },
   filesystem: { enabled: true, read_only: false, allowed_paths: ['/workspace', '/data'], denied_paths: ['/etc/shadow', '/etc/passwd', '/root'] },
   health: { enabled: true },
@@ -70,13 +70,13 @@ const agentRow = {
   soul_md: '',
   rules_md: '',
   model_policy_id: null,
-  tool_preset_id: null,
   created_by: 'regular-user',
   created_at: '2026-01-01T00:00:00Z',
   updated_at: '2026-01-01T00:00:00Z',
 };
 
-describe('Agent POST tool_preset_id behavior', () => {
+// T4: Agent create with skill_ids assigns skill
+describe('Agent POST skill_ids behavior', () => {
   beforeEach(() => {
     mockQuery.mockReset();
     process.env.DATABASE_URL = 'postgresql://test:test@localhost:5432/test';
@@ -86,20 +86,20 @@ describe('Agent POST tool_preset_id behavior', () => {
     delete process.env.DATABASE_URL;
   });
 
-  // T13: Agent create with preset resolves tools_config
-  it('create agent with tool_preset_id copies preset config', async () => {
-    // Preset lookup
+  it('create agent with skill_ids resolves tools_config', async () => {
+    // Skill lookup
     mockQuery.mockResolvedValueOnce({
-      rows: [{ id: 'preset-dev', tools_config: developerPresetConfig }],
+      rows: [{ id: 'skill-dev', tools_config: developerSkillConfig }],
     });
-    // INSERT
+    // INSERT agent
     mockQuery.mockResolvedValueOnce({
-      rows: [{
-        ...agentRow,
-        id: 'uuid-new',
-        tool_preset_id: 'preset-dev',
-        tools_config: developerPresetConfig,
-      }],
+      rows: [{ ...agentRow, id: 'uuid-new', tools_config: developerSkillConfig }],
+    });
+    // INSERT agent_skills
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    // SELECT skills for response
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: 'skill-dev', name: 'Developer', scope: 'container_local' }],
     });
 
     const res = await request(app)
@@ -108,23 +108,52 @@ describe('Agent POST tool_preset_id behavior', () => {
       .send({
         agent_id: 'test-agent',
         name: 'Test Agent',
-        tool_preset_id: 'preset-dev',
+        skill_ids: ['skill-dev'],
       });
 
     expect(res.status).toBe(201);
-    expect(res.body.tool_preset_id).toBe('preset-dev');
-    // Verify the INSERT used the preset's tools_config, not the default
+    expect(res.body.skills).toHaveLength(1);
+    expect(res.body.skills[0].id).toBe('skill-dev');
+    // Verify the INSERT used the skill's tools_config
     const insertCall = mockQuery.mock.calls[1];
-    const toolsConfigParam = insertCall[1][3]; // tools_config is 4th param ($4)
+    const toolsConfigParam = insertCall[1][3]; // tools_config is 4th param
     const parsed = JSON.parse(toolsConfigParam);
     expect(parsed.shell.enabled).toBe(true);
     expect(parsed.shell.allowed_binaries).toContain('bash');
-    expect(parsed.shell.allowed_binaries).toContain('git');
   });
 
-  // T14: Agent create with invalid preset rejected
-  it('create agent with nonexistent preset returns 400', async () => {
-    // Preset lookup returns empty
+  // T5: skill_ids > 1 rejected
+  it('create agent with skill_ids > 1 returns 400', async () => {
+    const res = await request(app)
+      .post('/agents')
+      .set('Authorization', `Bearer ${userToken}`)
+      .send({
+        agent_id: 'test-agent',
+        name: 'Test Agent',
+        skill_ids: ['skill-1', 'skill-2'],
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain('Maximum 1 skill');
+  });
+
+  // T12: tool_preset_id rejected
+  it('create agent with tool_preset_id returns 400', async () => {
+    const res = await request(app)
+      .post('/agents')
+      .set('Authorization', `Bearer ${userToken}`)
+      .send({
+        agent_id: 'test-agent',
+        name: 'Test Agent',
+        tool_preset_id: 'some-id',
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain('deprecated');
+  });
+
+  it('create agent with nonexistent skill returns 400', async () => {
+    // Skill lookup returns empty
     mockQuery.mockResolvedValueOnce({ rows: [] });
 
     const res = await request(app)
@@ -133,23 +162,21 @@ describe('Agent POST tool_preset_id behavior', () => {
       .send({
         agent_id: 'test-agent',
         name: 'Test Agent',
-        tool_preset_id: 'nonexistent-preset',
+        skill_ids: ['nonexistent-skill'],
       });
 
     expect(res.status).toBe(400);
-    expect(res.body.error).toContain('Tool preset not found');
+    expect(res.body.error).toContain('Skill not found');
   });
 
-  // T16: Agent create without preset uses default tools_config
-  it('create agent without preset uses default', async () => {
-    // No preset lookup needed — just INSERT
+  // T11: Agent create without skill uses default tools_config
+  it('create agent without skill_ids uses default', async () => {
+    // INSERT agent
     mockQuery.mockResolvedValueOnce({
-      rows: [{
-        ...agentRow,
-        id: 'uuid-new',
-        tool_preset_id: null,
-      }],
+      rows: [{ ...agentRow, id: 'uuid-new' }],
     });
+    // SELECT skills for response (empty)
+    mockQuery.mockResolvedValueOnce({ rows: [] });
 
     const res = await request(app)
       .post('/agents')
@@ -160,18 +187,18 @@ describe('Agent POST tool_preset_id behavior', () => {
       });
 
     expect(res.status).toBe(201);
-    expect(res.body.tool_preset_id).toBeNull();
+    expect(res.body.skills).toHaveLength(0);
     // Verify default tools_config was used in INSERT
     const insertCall = mockQuery.mock.calls[0];
     const toolsConfigParam = insertCall[1][3];
     const parsed = JSON.parse(toolsConfigParam);
     expect(parsed.shell.enabled).toBe(false);
-    expect(parsed.filesystem.enabled).toBe(false);
     expect(parsed.health.enabled).toBe(true);
   });
 });
 
-describe('Agent PUT tool_preset_id behavior', () => {
+// T7: Agent update with skill_ids
+describe('Agent PUT skill_ids behavior', () => {
   beforeEach(() => {
     mockQuery.mockReset();
     process.env.DATABASE_URL = 'postgresql://test:test@localhost:5432/test';
@@ -181,79 +208,85 @@ describe('Agent PUT tool_preset_id behavior', () => {
     delete process.env.DATABASE_URL;
   });
 
-  // T15: Agent update with preset resolves tools_config
-  it('update agent tool_preset_id copies preset config', async () => {
+  it('update agent skill_ids resolves tools_config', async () => {
     // Ownership check returns agent
     mockQuery.mockResolvedValueOnce({ rows: [agentRow] });
-    // Preset lookup
+    // Skill lookup
     mockQuery.mockResolvedValueOnce({
-      rows: [{ id: 'preset-dev', tools_config: developerPresetConfig }],
+      rows: [{ id: 'skill-dev', tools_config: developerSkillConfig }],
     });
-    // UPDATE
+    // UPDATE agent
     mockQuery.mockResolvedValueOnce({
-      rows: [{ ...agentRow, tool_preset_id: 'preset-dev', tools_config: developerPresetConfig }],
+      rows: [{ ...agentRow, tools_config: developerSkillConfig }],
+    });
+    // DELETE agent_skills
+    mockQuery.mockResolvedValueOnce({ rowCount: 0 });
+    // INSERT agent_skills
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    // SELECT skills for response
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: 'skill-dev', name: 'Developer', scope: 'container_local' }],
     });
 
     const res = await request(app)
       .put('/agents/uuid-1')
       .set('Authorization', `Bearer ${userToken}`)
-      .send({ tool_preset_id: 'preset-dev' });
+      .send({ skill_ids: ['skill-dev'] });
 
     expect(res.status).toBe(200);
-    expect(res.body.tool_preset_id).toBe('preset-dev');
-    // Verify the UPDATE set both tool_preset_id and tools_config from preset
-    const updateCall = mockQuery.mock.calls[2];
-    // tools_config param should be the preset's config (not null/COALESCE)
-    const toolsConfigParam = updateCall[1][2]; // $3 is tools_config
-    const parsed = JSON.parse(toolsConfigParam);
-    expect(parsed.shell.enabled).toBe(true);
-    expect(parsed.shell.allowed_binaries).toContain('bash');
+    expect(res.body.skills).toHaveLength(1);
+    expect(res.body.skills[0].id).toBe('skill-dev');
   });
 
-  // T17: Agent update clears preset (set null)
-  it('update agent tool_preset_id to null preserves tools_config', async () => {
-    const agentWithPreset = {
-      ...agentRow,
-      tool_preset_id: 'preset-dev',
-      tools_config: developerPresetConfig,
-    };
-    // Ownership check returns agent with preset
-    mockQuery.mockResolvedValueOnce({ rows: [agentWithPreset] });
-    // UPDATE — no preset lookup needed when clearing
-    mockQuery.mockResolvedValueOnce({
-      rows: [{ ...agentWithPreset, tool_preset_id: null }],
-    });
-
-    const res = await request(app)
-      .put('/agents/uuid-1')
-      .set('Authorization', `Bearer ${userToken}`)
-      .send({ tool_preset_id: null });
-
-    expect(res.status).toBe(200);
-    // tool_preset_id should be cleared but tools_config should be preserved
-    // (no tools_config in body means COALESCE keeps existing)
-  });
-
-  it('update agent with nonexistent preset returns 400', async () => {
+  it('update agent skill_ids to empty clears skill', async () => {
     // Ownership check returns agent
     mockQuery.mockResolvedValueOnce({ rows: [agentRow] });
-    // Preset lookup returns empty
+    // UPDATE agent (no skill lookup needed)
+    mockQuery.mockResolvedValueOnce({ rows: [agentRow] });
+    // DELETE agent_skills
+    mockQuery.mockResolvedValueOnce({ rowCount: 1 });
+    // SELECT skills for response (empty)
     mockQuery.mockResolvedValueOnce({ rows: [] });
 
     const res = await request(app)
       .put('/agents/uuid-1')
       .set('Authorization', `Bearer ${userToken}`)
-      .send({ tool_preset_id: 'nonexistent-preset' });
+      .send({ skill_ids: [] });
 
-    expect(res.status).toBe(400);
-    expect(res.body.error).toContain('Tool preset not found');
+    expect(res.status).toBe(200);
+    expect(res.body.skills).toHaveLength(0);
   });
 
-  it('update agent without tool_preset_id does not touch it', async () => {
+  it('update agent with tool_preset_id returns 400', async () => {
+    const res = await request(app)
+      .put('/agents/uuid-1')
+      .set('Authorization', `Bearer ${userToken}`)
+      .send({ tool_preset_id: 'some-id' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain('deprecated');
+  });
+
+  it('update agent with skill_ids > 1 returns 400', async () => {
+    // Ownership check
+    mockQuery.mockResolvedValueOnce({ rows: [agentRow] });
+
+    const res = await request(app)
+      .put('/agents/uuid-1')
+      .set('Authorization', `Bearer ${userToken}`)
+      .send({ skill_ids: ['skill-1', 'skill-2'] });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain('Maximum 1 skill');
+  });
+
+  it('update agent without skill_ids does not touch skills', async () => {
     // Ownership check returns agent
     mockQuery.mockResolvedValueOnce({ rows: [agentRow] });
-    // UPDATE
+    // UPDATE agent
     mockQuery.mockResolvedValueOnce({ rows: [{ ...agentRow, name: 'Updated Name' }] });
+    // SELECT skills for response
+    mockQuery.mockResolvedValueOnce({ rows: [] });
 
     const res = await request(app)
       .put('/agents/uuid-1')
@@ -265,9 +298,10 @@ describe('Agent PUT tool_preset_id behavior', () => {
   });
 });
 
+// T10b: Agent start reads from agent_skills
 const { writeAgentFiles } = jest.requireMock('../services/agent-files') as { writeAgentFiles: jest.Mock };
 
-describe('Agent start skill instructions merge', () => {
+describe('Agent start reads from agent_skills', () => {
   beforeEach(() => {
     mockQuery.mockReset();
     writeAgentFiles.mockReset();
@@ -280,25 +314,19 @@ describe('Agent start skill instructions merge', () => {
     delete process.env.AGENTBOX_CONFIG_HOST_PATH;
   });
 
-  // T5: Agent start merges skill instructions into RULES.md
-  it('start agent with skill appends instructions to RULES.md', async () => {
-    const agentWithPresetAndRules = {
-      ...agentRow,
-      tool_preset_id: 'preset-dev',
-      rules_md: 'Agent-specific rules here.',
-      status: 'stopped',
-    };
+  it('start agent with skill fetches instructions from agent_skills JOIN', async () => {
+    const agentStopped = { ...agentRow, status: 'stopped' };
 
     const { createAndStartContainer } = jest.requireMock('../services/docker') as any;
     createAndStartContainer.mockResolvedValue('container-123');
 
     // 1. SELECT agent
-    mockQuery.mockResolvedValueOnce({ rows: [agentWithPresetAndRules] });
-    // 2. SELECT instructions_md from tool_presets
+    mockQuery.mockResolvedValueOnce({ rows: [agentStopped] });
+    // 2. SELECT instructions_md from agent_skills JOIN skills
     mockQuery.mockResolvedValueOnce({
-      rows: [{ instructions_md: 'You have full developer access with bash, git, make, curl, and jq available.' }],
+      rows: [{ instructions_md: 'You have full developer access.' }],
     });
-    // 3-5. UPDATE agent status queries
+    // 3+. UPDATE agent status queries
     mockQuery.mockResolvedValue({ rows: [] });
 
     const res = await request(app)
@@ -306,29 +334,23 @@ describe('Agent start skill instructions merge', () => {
       .set('Authorization', `Bearer ${adminToken}`);
 
     expect(res.status).toBe(200);
-
-    // Verify writeAgentFiles was called with merged rules
     expect(writeAgentFiles).toHaveBeenCalledTimes(1);
     const callArgs = writeAgentFiles.mock.calls[0];
-    // First arg is the agent row, second is skillInstructions
-    expect(callArgs[1]).toBe('You have full developer access with bash, git, make, curl, and jq available.');
+    expect(callArgs[1]).toBe('You have full developer access.');
   });
 
-  // T6: Agent start without skill writes only agent rules_md
-  it('start agent without skill writes only agent rules_md', async () => {
-    const agentNoPreset = {
-      ...agentRow,
-      tool_preset_id: null,
-      rules_md: 'Agent-specific rules only.',
-      status: 'stopped',
-    };
+  // T11: Start without skill
+  it('start agent without skill writes no instructions', async () => {
+    const agentStopped = { ...agentRow, status: 'stopped' };
 
     const { createAndStartContainer } = jest.requireMock('../services/docker') as any;
     createAndStartContainer.mockResolvedValue('container-456');
 
-    // 1. SELECT agent (no tool_preset_id)
-    mockQuery.mockResolvedValueOnce({ rows: [agentNoPreset] });
-    // 2-4. UPDATE agent status queries
+    // 1. SELECT agent
+    mockQuery.mockResolvedValueOnce({ rows: [agentStopped] });
+    // 2. SELECT from agent_skills (empty — no skill assigned)
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    // 3+. UPDATE agent status queries
     mockQuery.mockResolvedValue({ rows: [] });
 
     const res = await request(app)
@@ -336,11 +358,8 @@ describe('Agent start skill instructions merge', () => {
       .set('Authorization', `Bearer ${adminToken}`);
 
     expect(res.status).toBe(200);
-
-    // Verify writeAgentFiles was called WITHOUT skillInstructions
     expect(writeAgentFiles).toHaveBeenCalledTimes(1);
     const callArgs = writeAgentFiles.mock.calls[0];
-    // Second arg should be undefined (no skill instructions)
     expect(callArgs[1]).toBeUndefined();
   });
 });

--- a/services/api/src/__tests__/routes-agents-skills.test.ts
+++ b/services/api/src/__tests__/routes-agents-skills.test.ts
@@ -53,9 +53,14 @@ const SKILL_VPS_SYSTEM = '00000000-0000-0000-0000-000000000030';
 const stoppedAgent = { id: AGENT_ID, status: 'stopped' };
 const runningAgent = { id: AGENT_ID, status: 'running' };
 
-const containerSkill = { id: SKILL_CONTAINER, scope: 'container_local' };
-const hostDockerSkill = { id: SKILL_HOST_DOCKER, scope: 'host_docker' };
-const vpsSystemSkill = { id: SKILL_VPS_SYSTEM, scope: 'vps_system' };
+const devToolsConfig = {
+  shell: { enabled: true, allowed_binaries: ['bash', 'git'], denied_patterns: [], max_timeout: 300 },
+  filesystem: { enabled: true, read_only: false, allowed_paths: ['/workspace'], denied_paths: ['/etc/shadow'] },
+  health: { enabled: true },
+};
+const containerSkill = { id: SKILL_CONTAINER, scope: 'container_local', tools_config: devToolsConfig };
+const hostDockerSkill = { id: SKILL_HOST_DOCKER, scope: 'host_docker', tools_config: devToolsConfig };
+const vpsSystemSkill = { id: SKILL_VPS_SYSTEM, scope: 'vps_system', tools_config: devToolsConfig };
 
 const assignmentRecord = {
   agent_id: AGENT_ID,
@@ -84,7 +89,8 @@ describe('Agent skill assignment endpoints', () => {
       .mockResolvedValueOnce({ rows: [stoppedAgent] })  // agent lookup (user scope)
       .mockResolvedValueOnce({ rows: [containerSkill] }) // skill lookup
       .mockResolvedValueOnce({ rowCount: 0 })            // delete existing
-      .mockResolvedValueOnce({ rows: [assignmentRecord] }); // insert
+      .mockResolvedValueOnce({ rows: [assignmentRecord] }) // insert
+      .mockResolvedValueOnce({ rowCount: 1 });            // update agents.tools_config
 
     const res = await request(app)
       .post(`/agents/${AGENT_ID}/skills`)
@@ -99,12 +105,14 @@ describe('Agent skill assignment endpoints', () => {
   // T10: Replace semantics — assigning new skill replaces existing
   it('POST /agents/:id/skills replaces existing skill (max 1)', async () => {
     const newSkillId = '00000000-0000-0000-0000-000000000099';
+    const newToolsConfig = { shell: { enabled: false }, filesystem: { enabled: false }, health: { enabled: true } };
     const newAssignment = { ...assignmentRecord, skill_id: newSkillId };
     mockQuery
       .mockResolvedValueOnce({ rows: [stoppedAgent] })  // agent lookup
-      .mockResolvedValueOnce({ rows: [{ id: newSkillId, scope: 'container_local' }] }) // skill lookup
+      .mockResolvedValueOnce({ rows: [{ id: newSkillId, scope: 'container_local', tools_config: newToolsConfig }] }) // skill lookup
       .mockResolvedValueOnce({ rowCount: 1 })            // delete existing (had one)
-      .mockResolvedValueOnce({ rows: [newAssignment] }); // insert new
+      .mockResolvedValueOnce({ rows: [newAssignment] })  // insert new
+      .mockResolvedValueOnce({ rowCount: 1 });           // update agents.tools_config
 
     const res = await request(app)
       .post(`/agents/${AGENT_ID}/skills`)
@@ -115,13 +123,39 @@ describe('Agent skill assignment endpoints', () => {
     expect(res.body.skill_id).toBe(newSkillId);
   });
 
+  // T10b: POST /agents/:id/skills resolves tools_config on assign
+  it('POST /agents/:id/skills resolves tools_config into agent (resolve-on-save)', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [stoppedAgent] })  // agent lookup
+      .mockResolvedValueOnce({ rows: [containerSkill] }) // skill lookup (includes tools_config)
+      .mockResolvedValueOnce({ rowCount: 0 })            // delete existing
+      .mockResolvedValueOnce({ rows: [assignmentRecord] }) // insert
+      .mockResolvedValueOnce({ rowCount: 1 });            // update agents.tools_config
+
+    const res = await request(app)
+      .post(`/agents/${AGENT_ID}/skills`)
+      .set('Authorization', `Bearer ${userToken}`)
+      .send({ skill_id: SKILL_CONTAINER });
+
+    expect(res.status).toBe(201);
+
+    // Verify the UPDATE agents query was called with the skill's tools_config
+    expect(mockQuery).toHaveBeenCalledTimes(5);
+    const updateCall = mockQuery.mock.calls[4];
+    expect(updateCall[0]).toContain('UPDATE agents');
+    expect(updateCall[0]).toContain('tools_config');
+    expect(updateCall[1][0]).toBe(JSON.stringify(devToolsConfig));
+    expect(updateCall[1][1]).toBe(AGENT_ID);
+  });
+
   // T4: User can assign container_local skill
   it('POST /agents/:id/skills user assigns container_local', async () => {
     mockQuery
       .mockResolvedValueOnce({ rows: [stoppedAgent] })
       .mockResolvedValueOnce({ rows: [containerSkill] })
       .mockResolvedValueOnce({ rowCount: 0 })            // delete existing
-      .mockResolvedValueOnce({ rows: [assignmentRecord] });
+      .mockResolvedValueOnce({ rows: [assignmentRecord] })
+      .mockResolvedValueOnce({ rowCount: 1 });            // update agents.tools_config
 
     const res = await request(app)
       .post(`/agents/${AGENT_ID}/skills`)
@@ -168,7 +202,8 @@ describe('Agent skill assignment endpoints', () => {
       .mockResolvedValueOnce({ rows: [stoppedAgent] })   // agent lookup (admin scope = 1=1)
       .mockResolvedValueOnce({ rows: [hostDockerSkill] }) // skill lookup
       .mockResolvedValueOnce({ rowCount: 0 })             // delete existing
-      .mockResolvedValueOnce({ rows: [adminAssignment] }); // insert
+      .mockResolvedValueOnce({ rows: [adminAssignment] }) // insert
+      .mockResolvedValueOnce({ rowCount: 1 });            // update agents.tools_config
 
     const res = await request(app)
       .post(`/agents/${AGENT_ID}/skills`)
@@ -246,6 +281,28 @@ describe('Agent skill assignment endpoints', () => {
 
     expect(res.status).toBe(200);
     expect(res.body.removed).toBe(true);
+  });
+
+  // T10c: DELETE preserves tools_config — no UPDATE agents query
+  it('DELETE /agents/:id/skills/:skillId preserves tools_config (no mutation)', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [stoppedAgent] })  // agent lookup
+      .mockResolvedValueOnce({ rows: [containerSkill] }) // skill lookup
+      .mockResolvedValueOnce({ rowCount: 1 });           // delete
+
+    const res = await request(app)
+      .delete(`/agents/${AGENT_ID}/skills/${SKILL_CONTAINER}`)
+      .set('Authorization', `Bearer ${userToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.removed).toBe(true);
+
+    // Verify exactly 3 queries — no UPDATE agents for tools_config
+    expect(mockQuery).toHaveBeenCalledTimes(3);
+    // None of the 3 queries should be an UPDATE agents
+    for (const call of mockQuery.mock.calls) {
+      expect(call[0]).not.toContain('UPDATE agents');
+    }
   });
 
   // T9: Non-admin cannot remove host_docker skill

--- a/services/api/src/__tests__/routes-agents-skills.test.ts
+++ b/services/api/src/__tests__/routes-agents-skills.test.ts
@@ -83,6 +83,7 @@ describe('Agent skill assignment endpoints', () => {
     mockQuery
       .mockResolvedValueOnce({ rows: [stoppedAgent] })  // agent lookup (user scope)
       .mockResolvedValueOnce({ rows: [containerSkill] }) // skill lookup
+      .mockResolvedValueOnce({ rowCount: 0 })            // delete existing
       .mockResolvedValueOnce({ rows: [assignmentRecord] }); // insert
 
     const res = await request(app)
@@ -95,20 +96,23 @@ describe('Agent skill assignment endpoints', () => {
     expect(res.body.skill_id).toBe(SKILL_CONTAINER);
   });
 
-  // T2: Duplicate assignment returns 409
-  it('POST /agents/:id/skills duplicate returns 409', async () => {
+  // T10: Replace semantics — assigning new skill replaces existing
+  it('POST /agents/:id/skills replaces existing skill (max 1)', async () => {
+    const newSkillId = '00000000-0000-0000-0000-000000000099';
+    const newAssignment = { ...assignmentRecord, skill_id: newSkillId };
     mockQuery
       .mockResolvedValueOnce({ rows: [stoppedAgent] })  // agent lookup
-      .mockResolvedValueOnce({ rows: [containerSkill] }) // skill lookup
-      .mockRejectedValueOnce({ code: '23505' });         // PK conflict
+      .mockResolvedValueOnce({ rows: [{ id: newSkillId, scope: 'container_local' }] }) // skill lookup
+      .mockResolvedValueOnce({ rowCount: 1 })            // delete existing (had one)
+      .mockResolvedValueOnce({ rows: [newAssignment] }); // insert new
 
     const res = await request(app)
       .post(`/agents/${AGENT_ID}/skills`)
       .set('Authorization', `Bearer ${userToken}`)
-      .send({ skill_id: SKILL_CONTAINER });
+      .send({ skill_id: newSkillId });
 
-    expect(res.status).toBe(409);
-    expect(res.body.error).toContain('already assigned');
+    expect(res.status).toBe(201);
+    expect(res.body.skill_id).toBe(newSkillId);
   });
 
   // T4: User can assign container_local skill
@@ -116,6 +120,7 @@ describe('Agent skill assignment endpoints', () => {
     mockQuery
       .mockResolvedValueOnce({ rows: [stoppedAgent] })
       .mockResolvedValueOnce({ rows: [containerSkill] })
+      .mockResolvedValueOnce({ rowCount: 0 })            // delete existing
       .mockResolvedValueOnce({ rows: [assignmentRecord] });
 
     const res = await request(app)
@@ -162,6 +167,7 @@ describe('Agent skill assignment endpoints', () => {
     mockQuery
       .mockResolvedValueOnce({ rows: [stoppedAgent] })   // agent lookup (admin scope = 1=1)
       .mockResolvedValueOnce({ rows: [hostDockerSkill] }) // skill lookup
+      .mockResolvedValueOnce({ rowCount: 0 })             // delete existing
       .mockResolvedValueOnce({ rows: [adminAssignment] }); // insert
 
     const res = await request(app)

--- a/services/api/src/__tests__/routes-agents.test.ts
+++ b/services/api/src/__tests__/routes-agents.test.ts
@@ -109,9 +109,11 @@ describe('Agent CRUD routes', () => {
       name: 'Test Agent',
       description: 'A test agent',
     };
-    mockQuery.mockResolvedValueOnce({
-      rows: [{ id: 'uuid-1', ...agentData, status: 'stopped', created_by: 'regular-user' }],
-    });
+    mockQuery
+      .mockResolvedValueOnce({
+        rows: [{ id: 'uuid-1', ...agentData, status: 'stopped', created_by: 'regular-user' }],
+      })
+      .mockResolvedValueOnce({ rows: [] }); // SELECT skills for response
 
     const res = await request(app)
       .post('/agents')
@@ -202,6 +204,7 @@ describe('Agent lifecycle routes', () => {
           soul_md: '', rules_md: '', description: '',
         }],
       })
+      .mockResolvedValueOnce({ rows: [] }) // SELECT agent_skills (no skill)
       .mockResolvedValueOnce({ rows: [] });
 
     const res = await request(app)

--- a/services/api/src/__tests__/routes-skills.test.ts
+++ b/services/api/src/__tests__/routes-skills.test.ts
@@ -45,8 +45,8 @@ function makeToken(sub: string, roles: string[]) {
 const adminToken = makeToken('admin-user', ['admin', 'user']);
 const userToken = makeToken('regular-user', ['user']);
 
-const developerPreset = {
-  id: 'preset-dev',
+const developerSkill = {
+  id: 'skill-dev',
   name: 'Developer',
   description: 'Full dev environment',
   tools_config: {
@@ -60,8 +60,8 @@ const developerPreset = {
   updated_at: '2026-01-01T00:00:00Z',
 };
 
-const minimalPreset = {
-  id: 'preset-min',
+const minimalSkill = {
+  id: 'skill-min',
   name: 'Minimal',
   description: 'Health only',
   tools_config: {
@@ -75,10 +75,10 @@ const minimalPreset = {
   updated_at: '2026-01-01T00:00:00Z',
 };
 
-const adminCreatedPreset = {
-  id: 'preset-custom',
-  name: 'Custom Admin Preset',
-  description: 'Admin-created non-platform preset',
+const adminCreatedSkill = {
+  id: 'skill-custom',
+  name: 'Custom Admin Skill',
+  description: 'Admin-created non-platform skill',
   tools_config: {
     shell: { enabled: true, allowed_binaries: ['bash'], denied_patterns: [], max_timeout: 60 },
     filesystem: { enabled: false },
@@ -90,7 +90,8 @@ const adminCreatedPreset = {
   updated_at: '2026-01-01T00:00:00Z',
 };
 
-describe('Tool Preset CRUD routes', () => {
+// T1: Skill CRUD routes
+describe('Skill CRUD routes', () => {
   beforeEach(() => {
     mockQuery.mockReset();
     process.env.DATABASE_URL = 'postgresql://test:test@localhost:5432/test';
@@ -100,217 +101,200 @@ describe('Tool Preset CRUD routes', () => {
     delete process.env.DATABASE_URL;
   });
 
-  // T1: List presets returns platform seeds
-  it('GET /tool-presets returns all presets', async () => {
+  // T1: List skills returns all with scope
+  it('GET /skills returns all skills', async () => {
     mockQuery.mockResolvedValueOnce({
-      rows: [developerPreset, minimalPreset, adminCreatedPreset],
+      rows: [developerSkill, minimalSkill, adminCreatedSkill],
     });
     const res = await request(app)
-      .get('/tool-presets')
+      .get('/skills')
       .set('Authorization', `Bearer ${adminToken}`);
     expect(res.status).toBe(200);
     expect(res.body).toHaveLength(3);
   });
 
-  // T1 continued: user also sees all presets (no ownership scoping in Phase 1)
-  it('GET /tool-presets user sees all presets', async () => {
+  it('GET /skills user sees all skills', async () => {
     mockQuery.mockResolvedValueOnce({
-      rows: [developerPreset, minimalPreset],
+      rows: [developerSkill, minimalSkill],
     });
     const res = await request(app)
-      .get('/tool-presets')
+      .get('/skills')
       .set('Authorization', `Bearer ${userToken}`);
     expect(res.status).toBe(200);
     expect(res.body).toHaveLength(2);
-    // Verify no ownership scoping (no WHERE ... created_by = filter)
     const call = mockQuery.mock.calls[0];
     expect(call[0]).not.toMatch(/WHERE.*created_by/);
   });
 
-  // T2: List presets requires auth
-  it('GET /tool-presets returns 401 without auth', async () => {
-    const res = await request(app).get('/tool-presets');
+  it('GET /skills returns 401 without auth', async () => {
+    const res = await request(app).get('/skills');
     expect(res.status).toBe(401);
   });
 
-  it('GET /tool-presets returns 403 for no-role user', async () => {
+  it('GET /skills returns 403 for no-role user', async () => {
     const noRoleToken = makeToken('no-role', []);
     const res = await request(app)
-      .get('/tool-presets')
+      .get('/skills')
       .set('Authorization', `Bearer ${noRoleToken}`);
     expect(res.status).toBe(403);
   });
 
-  // T3: Create preset requires admin
-  it('POST /tool-presets rejects non-admin create', async () => {
+  // T2: Create skill requires admin
+  it('POST /skills rejects non-admin create', async () => {
     const res = await request(app)
-      .post('/tool-presets')
+      .post('/skills')
       .set('Authorization', `Bearer ${userToken}`)
-      .send({ name: 'user-preset', tools_config: { shell: { enabled: false }, filesystem: { enabled: false }, health: { enabled: true } } });
+      .send({ name: 'user-skill', tools_config: { shell: { enabled: false }, filesystem: { enabled: false }, health: { enabled: true } } });
     expect(res.status).toBe(403);
   });
 
-  // T4: Create preset validates name required
-  it('POST /tool-presets rejects create without name', async () => {
+  it('POST /skills rejects create without name', async () => {
     const res = await request(app)
-      .post('/tool-presets')
+      .post('/skills')
       .set('Authorization', `Bearer ${adminToken}`)
       .send({ tools_config: { shell: { enabled: false }, filesystem: { enabled: false }, health: { enabled: true } } });
     expect(res.status).toBe(400);
     expect(res.body.error).toContain('name');
   });
 
-  // T5: Create preset validates tools_config required
-  it('POST /tool-presets rejects create without tools_config', async () => {
+  it('POST /skills rejects create without tools_config', async () => {
     const res = await request(app)
-      .post('/tool-presets')
+      .post('/skills')
       .set('Authorization', `Bearer ${adminToken}`)
       .send({ name: 'no-config' });
     expect(res.status).toBe(400);
     expect(res.body.error).toContain('tools_config');
   });
 
-  // T6: Create preset succeeds for admin
-  it('POST /tool-presets admin creates preset', async () => {
-    const newPreset = { ...adminCreatedPreset, id: 'new-id' };
-    mockQuery.mockResolvedValueOnce({ rows: [newPreset] });
+  it('POST /skills admin creates skill', async () => {
+    const newSkill = { ...adminCreatedSkill, id: 'new-id' };
+    mockQuery.mockResolvedValueOnce({ rows: [newSkill] });
     const res = await request(app)
-      .post('/tool-presets')
+      .post('/skills')
       .set('Authorization', `Bearer ${adminToken}`)
       .send({
-        name: 'Custom Admin Preset',
-        description: 'Admin-created non-platform preset',
-        tools_config: adminCreatedPreset.tools_config,
+        name: 'Custom Admin Skill',
+        description: 'Admin-created non-platform skill',
+        tools_config: adminCreatedSkill.tools_config,
       });
     expect(res.status).toBe(201);
-    expect(res.body.name).toBe('Custom Admin Preset');
-    // Admin presets get created_by = null, is_platform = false
+    expect(res.body.name).toBe('Custom Admin Skill');
     const insertCall = mockQuery.mock.calls[0];
-    expect(insertCall[0]).toContain('INSERT INTO tool_presets');
+    expect(insertCall[0]).toContain('INSERT INTO skills');
   });
 
-  it('POST /tool-presets returns 409 on duplicate name', async () => {
+  it('POST /skills returns 409 on duplicate name', async () => {
     mockQuery.mockRejectedValueOnce({ code: '23505' });
     const res = await request(app)
-      .post('/tool-presets')
+      .post('/skills')
       .set('Authorization', `Bearer ${adminToken}`)
       .send({ name: 'Developer', tools_config: { shell: { enabled: false }, filesystem: { enabled: false }, health: { enabled: true } } });
     expect(res.status).toBe(409);
   });
 
-  // Get single
-  it('GET /tool-presets/:id returns preset', async () => {
-    mockQuery.mockResolvedValueOnce({ rows: [developerPreset] });
+  it('GET /skills/:id returns skill', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [developerSkill] });
     const res = await request(app)
-      .get('/tool-presets/preset-dev')
+      .get('/skills/skill-dev')
       .set('Authorization', `Bearer ${adminToken}`);
     expect(res.status).toBe(200);
     expect(res.body.name).toBe('Developer');
   });
 
-  it('GET /tool-presets/:id returns 404 for unknown', async () => {
+  it('GET /skills/:id returns 404 for unknown', async () => {
     mockQuery.mockResolvedValueOnce({ rows: [] });
     const res = await request(app)
-      .get('/tool-presets/nonexistent')
+      .get('/skills/nonexistent')
       .set('Authorization', `Bearer ${adminToken}`);
     expect(res.status).toBe(404);
   });
 
-  // T7: Update preset requires admin
-  it('PUT /tool-presets/:id rejects non-admin update', async () => {
+  it('PUT /skills/:id rejects non-admin update', async () => {
     const res = await request(app)
-      .put('/tool-presets/preset-custom')
+      .put('/skills/skill-custom')
       .set('Authorization', `Bearer ${userToken}`)
       .send({ name: 'Renamed' });
     expect(res.status).toBe(403);
   });
 
-  // T8: Update platform preset blocked
-  it('PUT /tool-presets/:id rejects update of platform preset', async () => {
-    mockQuery.mockResolvedValueOnce({ rows: [developerPreset] }); // existence check returns is_platform = true
+  it('PUT /skills/:id rejects update of platform skill', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [developerSkill] });
     const res = await request(app)
-      .put('/tool-presets/preset-dev')
+      .put('/skills/skill-dev')
       .set('Authorization', `Bearer ${adminToken}`)
       .send({ name: 'Renamed Developer' });
     expect(res.status).toBe(403);
     expect(res.body.error).toContain('platform');
   });
 
-  // Update non-platform preset succeeds
-  it('PUT /tool-presets/:id admin updates non-platform preset', async () => {
+  it('PUT /skills/:id admin updates non-platform skill', async () => {
     mockQuery
-      .mockResolvedValueOnce({ rows: [adminCreatedPreset] }) // existence check, is_platform = false
-      .mockResolvedValueOnce({ rows: [{ ...adminCreatedPreset, name: 'Renamed' }] }); // update
+      .mockResolvedValueOnce({ rows: [adminCreatedSkill] })
+      .mockResolvedValueOnce({ rows: [{ ...adminCreatedSkill, name: 'Renamed' }] });
     const res = await request(app)
-      .put('/tool-presets/preset-custom')
+      .put('/skills/skill-custom')
       .set('Authorization', `Bearer ${adminToken}`)
       .send({ name: 'Renamed' });
     expect(res.status).toBe(200);
     expect(res.body.name).toBe('Renamed');
   });
 
-  // T9: Delete preset requires admin
-  it('DELETE /tool-presets/:id rejects non-admin delete', async () => {
+  it('DELETE /skills/:id rejects non-admin delete', async () => {
     const res = await request(app)
-      .delete('/tool-presets/preset-custom')
+      .delete('/skills/skill-custom')
       .set('Authorization', `Bearer ${userToken}`);
     expect(res.status).toBe(403);
   });
 
-  // T10: Delete platform preset blocked
-  it('DELETE /tool-presets/:id rejects delete of platform preset', async () => {
-    mockQuery.mockResolvedValueOnce({ rows: [developerPreset] }); // existence check returns is_platform = true
+  it('DELETE /skills/:id rejects delete of platform skill', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [developerSkill] });
     const res = await request(app)
-      .delete('/tool-presets/preset-dev')
+      .delete('/skills/skill-dev')
       .set('Authorization', `Bearer ${adminToken}`);
     expect(res.status).toBe(403);
     expect(res.body.error).toContain('platform');
   });
 
-  // T11: Delete assigned preset blocked
-  it('DELETE /tool-presets/:id rejects delete of preset assigned to agent', async () => {
+  it('DELETE /skills/:id rejects delete of skill assigned to agent', async () => {
     mockQuery
-      .mockResolvedValueOnce({ rows: [adminCreatedPreset] }) // existence check, is_platform = false
-      .mockResolvedValueOnce({ rows: [{ id: 'agent-1', agent_id: 'my-agent' }] }); // agents using this preset
+      .mockResolvedValueOnce({ rows: [adminCreatedSkill] })
+      .mockResolvedValueOnce({ rows: [{ agent_id: 'agent-1', agent_slug: 'my-agent' }] });
     const res = await request(app)
-      .delete('/tool-presets/preset-custom')
+      .delete('/skills/skill-custom')
       .set('Authorization', `Bearer ${adminToken}`);
     expect(res.status).toBe(409);
     expect(res.body.error).toContain('agents');
   });
 
-  // T12: Delete unassigned preset succeeds
-  it('DELETE /tool-presets/:id admin deletes unassigned preset', async () => {
+  it('DELETE /skills/:id admin deletes unassigned skill', async () => {
     mockQuery
-      .mockResolvedValueOnce({ rows: [adminCreatedPreset] }) // existence check, is_platform = false
-      .mockResolvedValueOnce({ rows: [] }) // no agents assigned
-      .mockResolvedValueOnce({ rowCount: 1 }); // delete succeeds
+      .mockResolvedValueOnce({ rows: [adminCreatedSkill] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rowCount: 1 });
     const res = await request(app)
-      .delete('/tool-presets/preset-custom')
+      .delete('/skills/skill-custom')
       .set('Authorization', `Bearer ${adminToken}`);
     expect(res.status).toBe(200);
     expect(res.body.deleted).toBe(true);
   });
 
-  it('DELETE /tool-presets/:id returns 404 for unknown', async () => {
-    mockQuery.mockResolvedValueOnce({ rows: [] }); // existence check returns nothing
+  it('DELETE /skills/:id returns 404 for unknown', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
     const res = await request(app)
-      .delete('/tool-presets/nonexistent')
+      .delete('/skills/nonexistent')
       .set('Authorization', `Bearer ${adminToken}`);
     expect(res.status).toBe(404);
   });
 
-  // T1: List skills returns instructions_md
-  it('GET /tool-presets returns skills with instructions_md field', async () => {
-    const presetWithInstructions = {
-      ...developerPreset,
+  // instructions_md support
+  it('GET /skills returns skills with instructions_md field', async () => {
+    const skillWithInstructions = {
+      ...developerSkill,
       instructions_md: 'You have full developer access with bash, git, make, curl, and jq available.',
     };
-    mockQuery.mockResolvedValueOnce({
-      rows: [presetWithInstructions],
-    });
+    mockQuery.mockResolvedValueOnce({ rows: [skillWithInstructions] });
     const res = await request(app)
-      .get('/tool-presets')
+      .get('/skills')
       .set('Authorization', `Bearer ${adminToken}`);
     expect(res.status).toBe(200);
     expect(res.body[0].instructions_md).toBe(
@@ -318,124 +302,143 @@ describe('Tool Preset CRUD routes', () => {
     );
   });
 
-  // T2: Create skill with instructions_md
-  it('POST /tool-presets admin creates skill with instructions_md', async () => {
+  it('POST /skills admin creates skill with instructions_md', async () => {
     const created = {
-      ...adminCreatedPreset,
+      ...adminCreatedSkill,
       id: 'new-id',
       instructions_md: 'Custom instructions for this skill.',
     };
     mockQuery.mockResolvedValueOnce({ rows: [created] });
     const res = await request(app)
-      .post('/tool-presets')
+      .post('/skills')
       .set('Authorization', `Bearer ${adminToken}`)
       .send({
         name: 'Custom Skill',
         description: 'A custom skill',
-        tools_config: adminCreatedPreset.tools_config,
+        tools_config: adminCreatedSkill.tools_config,
         instructions_md: 'Custom instructions for this skill.',
       });
     expect(res.status).toBe(201);
-    // Verify instructions_md was included in the INSERT
     const insertCall = mockQuery.mock.calls[0];
     expect(insertCall[0]).toContain('instructions_md');
     expect(insertCall[1]).toContain('Custom instructions for this skill.');
   });
 
-  // T3: Update skill instructions_md
-  it('PUT /tool-presets/:id admin updates skill instructions_md', async () => {
+  it('PUT /skills/:id admin updates skill instructions_md', async () => {
     mockQuery
-      .mockResolvedValueOnce({ rows: [adminCreatedPreset] }) // existence check
+      .mockResolvedValueOnce({ rows: [adminCreatedSkill] })
       .mockResolvedValueOnce({
-        rows: [{ ...adminCreatedPreset, instructions_md: 'Updated instructions.' }],
-      }); // update
+        rows: [{ ...adminCreatedSkill, instructions_md: 'Updated instructions.' }],
+      });
     const res = await request(app)
-      .put('/tool-presets/preset-custom')
+      .put('/skills/skill-custom')
       .set('Authorization', `Bearer ${adminToken}`)
       .send({ instructions_md: 'Updated instructions.' });
     expect(res.status).toBe(200);
-    // Verify instructions_md was included in the UPDATE
     const updateCall = mockQuery.mock.calls[1];
     expect(updateCall[0]).toContain('instructions_md');
   });
 
-  // T11: GET /tool-presets includes scope field
-  it('GET /tool-presets includes scope in response', async () => {
-    const presetWithScope = { ...developerPreset, scope: 'container_local' };
-    mockQuery.mockResolvedValueOnce({ rows: [presetWithScope] });
+  // scope support
+  it('GET /skills includes scope in response', async () => {
+    const skillWithScope = { ...developerSkill, scope: 'container_local' };
+    mockQuery.mockResolvedValueOnce({ rows: [skillWithScope] });
     const res = await request(app)
-      .get('/tool-presets')
+      .get('/skills')
       .set('Authorization', `Bearer ${adminToken}`);
     expect(res.status).toBe(200);
     expect(res.body[0].scope).toBe('container_local');
-    // Verify scope is in the SELECT query
     const selectCall = mockQuery.mock.calls[0];
     expect(selectCall[0]).toContain('scope');
   });
 
-  // T12: POST /tool-presets accepts scope
-  it('POST /tool-presets admin creates preset with scope', async () => {
-    const created = { ...adminCreatedPreset, id: 'new-id', scope: 'host_docker' };
+  it('POST /skills admin creates skill with scope', async () => {
+    const created = { ...adminCreatedSkill, id: 'new-id', scope: 'host_docker' };
     mockQuery.mockResolvedValueOnce({ rows: [created] });
     const res = await request(app)
-      .post('/tool-presets')
+      .post('/skills')
       .set('Authorization', `Bearer ${adminToken}`)
       .send({
         name: 'Docker Operator',
         description: 'Host docker access',
-        tools_config: adminCreatedPreset.tools_config,
+        tools_config: adminCreatedSkill.tools_config,
         scope: 'host_docker',
       });
     expect(res.status).toBe(201);
-    // Verify scope was included in the INSERT
     const insertCall = mockQuery.mock.calls[0];
     expect(insertCall[0]).toContain('scope');
     expect(insertCall[1]).toContain('host_docker');
   });
 
-  // T13: Invalid scope rejected
-  it('POST /tool-presets rejects invalid scope', async () => {
+  it('POST /skills rejects invalid scope', async () => {
     const res = await request(app)
-      .post('/tool-presets')
+      .post('/skills')
       .set('Authorization', `Bearer ${adminToken}`)
       .send({
         name: 'Bad Scope',
-        tools_config: adminCreatedPreset.tools_config,
+        tools_config: adminCreatedSkill.tools_config,
         scope: 'invalid_scope',
       });
     expect(res.status).toBe(400);
     expect(res.body.error).toContain('scope');
   });
 
-  // T13 continued: PUT rejects invalid scope
-  it('PUT /tool-presets/:id rejects invalid scope', async () => {
-    mockQuery.mockResolvedValueOnce({ rows: [adminCreatedPreset] }); // existence check
+  it('PUT /skills/:id rejects invalid scope', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [adminCreatedSkill] });
     const res = await request(app)
-      .put('/tool-presets/preset-custom')
+      .put('/skills/skill-custom')
       .set('Authorization', `Bearer ${adminToken}`)
       .send({ scope: 'invalid_scope' });
     expect(res.status).toBe(400);
     expect(res.body.error).toContain('scope');
   });
 
-  // T4: Create skill without instructions_md defaults empty
-  it('POST /tool-presets creates skill with empty instructions_md when omitted', async () => {
+  it('POST /skills creates skill with empty instructions_md when omitted', async () => {
     const created = {
-      ...adminCreatedPreset,
+      ...adminCreatedSkill,
       id: 'new-id',
       instructions_md: '',
     };
     mockQuery.mockResolvedValueOnce({ rows: [created] });
     const res = await request(app)
-      .post('/tool-presets')
+      .post('/skills')
       .set('Authorization', `Bearer ${adminToken}`)
       .send({
         name: 'No Instructions Skill',
-        tools_config: adminCreatedPreset.tools_config,
+        tools_config: adminCreatedSkill.tools_config,
       });
     expect(res.status).toBe(201);
-    // Verify empty string was passed for instructions_md
     const insertCall = mockQuery.mock.calls[0];
     expect(insertCall[1]).toContain('');
+  });
+
+  // T3: /tool-presets compat alias serves same data as /skills
+  it('GET /tool-presets compat alias returns same data as /skills', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [developerSkill, minimalSkill],
+    });
+    const res = await request(app)
+      .get('/tool-presets')
+      .set('Authorization', `Bearer ${adminToken}`);
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(2);
+    expect(res.body[0].name).toBe('Developer');
+  });
+
+  it('POST /tool-presets compat alias creates skill', async () => {
+    const newSkill = { ...adminCreatedSkill, id: 'new-id' };
+    mockQuery.mockResolvedValueOnce({ rows: [newSkill] });
+    const res = await request(app)
+      .post('/tool-presets')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({
+        name: 'Custom Admin Skill',
+        description: 'Admin-created non-platform skill',
+        tools_config: adminCreatedSkill.tools_config,
+      });
+    expect(res.status).toBe(201);
+    // Verify query hits the skills table (not tool_presets)
+    const insertCall = mockQuery.mock.calls[0];
+    expect(insertCall[0]).toContain('INSERT INTO skills');
   });
 });

--- a/services/api/src/app.ts
+++ b/services/api/src/app.ts
@@ -5,7 +5,7 @@ import agentsRouter from './routes/agents';
 import knowledgeRouter from './routes/knowledge';
 import sharedKnowledgeRouter from './routes/shared-knowledge';
 import modelPoliciesRouter from './routes/model-policies';
-import toolPresetsRouter from './routes/tool-presets';
+import skillsRouter from './routes/skills';
 import providerConnectionsRouter from './routes/provider-connections';
 import userModelsRouter from './routes/user-models';
 import profileRouter from './routes/profile';
@@ -51,8 +51,9 @@ export function createApp(opts: AppOptions = {}): Application {
   // Model policy management routes (admin-only, enforced in router)
   app.use('/model-policies', requireAuth, modelPoliciesRouter);
 
-  // Tool preset management routes (admin-only mutations, enforced in router)
-  app.use('/tool-presets', requireAuth, toolPresetsRouter);
+  // Skill management routes (admin-only mutations, enforced in router)
+  app.use('/skills', requireAuth, skillsRouter);
+  app.use('/tool-presets', requireAuth, skillsRouter); // compat alias
 
   // Provider connections (user-scoped BYOK credentials)
   app.use('/provider-connections', requireAuth, providerConnectionsRouter);

--- a/services/api/src/db/migrations/019_rename_skills_and_migrate.sql
+++ b/services/api/src/db/migrations/019_rename_skills_and_migrate.sql
@@ -1,0 +1,18 @@
+-- Migration 019: Rename tool_presets to skills and migrate agent assignments
+-- Phase 2 of Skills Architecture Reset
+
+-- Rename the table
+ALTER TABLE tool_presets RENAME TO skills;
+
+-- Rename the CHECK constraint
+ALTER TABLE skills RENAME CONSTRAINT chk_skill_scope TO chk_scope;
+
+-- Migrate tool_preset_id data into agent_skills join table
+INSERT INTO agent_skills (agent_id, skill_id, assigned_by)
+SELECT id, tool_preset_id, created_by
+FROM agents
+WHERE tool_preset_id IS NOT NULL
+ON CONFLICT (agent_id, skill_id) DO NOTHING;
+
+-- Drop the old FK column (cascade drops the FK constraint too)
+ALTER TABLE agents DROP COLUMN IF EXISTS tool_preset_id;

--- a/services/api/src/openapi/openapi.yaml
+++ b/services/api/src/openapi/openapi.yaml
@@ -56,11 +56,20 @@ components:
           format: uuid
           nullable: true
           description: ID of the model policy controlling LLM access. Users can assign own or platform policies to own agents; admins can assign any.
-        tool_preset_id:
-          type: string
-          format: uuid
-          nullable: true
-          description: ID of the tool preset applied at assignment time. Config is copied (resolve-on-save).
+        skills:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+                format: uuid
+              name:
+                type: string
+              scope:
+                type: string
+                enum: [container_local, host_docker, vps_system]
+          description: Skills assigned to this agent (max 1 in current phase).
         error_message:
           type: string
           nullable: true
@@ -230,7 +239,7 @@ components:
           nullable: true
           description: Owner (user sub). NULL for platform policies.
 
-    ToolPreset:
+    Skill:
       type: object
       properties:
         id:
@@ -253,11 +262,11 @@ components:
           description: Scope determines assignment authority. container_local — any user. host_docker/vps_system — admin only.
         is_platform:
           type: boolean
-          description: Platform presets are immutable and undeletable.
+          description: Platform skills are immutable and undeletable.
         created_by:
           type: string
           nullable: true
-          description: Always NULL in Phase 1 (admin-created shared resources).
+          description: Always NULL (admin-created shared resources).
         created_at:
           type: string
           format: date-time
@@ -629,11 +638,13 @@ paths:
                   format: uuid
                   nullable: true
                   description: ID of a model policy to assign at creation. Users can assign own or platform policies; admins can assign any.
-                tool_preset_id:
-                  type: string
-                  format: uuid
-                  nullable: true
-                  description: ID of a tool preset. Config is copied into agent at save time (resolve-on-save).
+                skill_ids:
+                  type: array
+                  items:
+                    type: string
+                    format: uuid
+                  maxItems: 1
+                  description: Skill IDs to assign (max 1). Config is copied into agent at save time (resolve-on-save).
       responses:
         "201":
           description: Agent created
@@ -711,11 +722,13 @@ paths:
                   format: uuid
                   nullable: true
                   description: Model policy ID. Users can assign own or platform policies; admins can assign any. Set to null to remove.
-                tool_preset_id:
-                  type: string
-                  format: uuid
-                  nullable: true
-                  description: Tool preset ID. Config is copied into agent at save time. Set to null to detach preset.
+                skill_ids:
+                  type: array
+                  items:
+                    type: string
+                    format: uuid
+                  maxItems: 1
+                  description: Skill IDs to assign (max 1). Config is copied into agent at save time. Empty array to detach skill.
       responses:
         "200":
           description: Agent updated
@@ -2113,29 +2126,29 @@ paths:
         "403":
           description: Requires user role
 
-  /tool-presets:
+  /skills:
     get:
-      summary: List tool presets
-      description: Returns all tool presets. All authenticated users see all presets.
+      summary: List skills
+      description: Returns all skills. All authenticated users see all skills.
       security:
         - bearerAuth: []
       responses:
         "200":
-          description: Preset list
+          description: Skill list
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/ToolPreset"
+                  $ref: "#/components/schemas/Skill"
         "401":
           description: Not authenticated
         "403":
           description: Requires user role
 
     post:
-      summary: Create tool preset
-      description: Creates a new tool preset. Admin only.
+      summary: Create skill
+      description: Creates a new skill. Admin only.
       security:
         - bearerAuth: []
       requestBody:
@@ -2165,11 +2178,11 @@ paths:
                   description: Scope determines assignment authority.
       responses:
         "201":
-          description: Preset created
+          description: Skill created
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ToolPreset"
+                $ref: "#/components/schemas/Skill"
         "400":
           description: Invalid input
         "401":
@@ -2177,9 +2190,9 @@ paths:
         "403":
           description: Requires admin role
         "409":
-          description: Duplicate preset name
+          description: Duplicate skill name
 
-  /tool-presets/{id}:
+  /skills/{id}:
     parameters:
       - name: id
         in: path
@@ -2189,27 +2202,27 @@ paths:
           format: uuid
 
     get:
-      summary: Get tool preset
-      description: Returns a single tool preset. All authenticated users can read.
+      summary: Get skill
+      description: Returns a single skill. All authenticated users can read.
       security:
         - bearerAuth: []
       responses:
         "200":
-          description: Preset detail
+          description: Skill detail
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ToolPreset"
+                $ref: "#/components/schemas/Skill"
         "401":
           description: Not authenticated
         "403":
           description: Requires user role
         "404":
-          description: Preset not found
+          description: Skill not found
 
     put:
-      summary: Update tool preset
-      description: Updates a tool preset. Admin only. Platform presets are immutable (403).
+      summary: Update skill
+      description: Updates a skill. Admin only. Platform skills are immutable (403).
       security:
         - bearerAuth: []
       requestBody:
@@ -2232,28 +2245,28 @@ paths:
                   enum: [container_local, host_docker, vps_system]
       responses:
         "200":
-          description: Preset updated
+          description: Skill updated
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ToolPreset"
+                $ref: "#/components/schemas/Skill"
         "401":
           description: Not authenticated
         "403":
-          description: Requires admin role or platform preset is immutable
+          description: Requires admin role or platform skill is immutable
         "404":
-          description: Preset not found
+          description: Skill not found
         "409":
-          description: Duplicate preset name
+          description: Duplicate skill name
 
     delete:
-      summary: Delete tool preset
-      description: Deletes a tool preset. Admin only. Platform presets cannot be deleted. Presets assigned to agents cannot be deleted.
+      summary: Delete skill
+      description: Deletes a skill. Admin only. Platform skills cannot be deleted. Skills assigned to agents cannot be deleted.
       security:
         - bearerAuth: []
       responses:
         "200":
-          description: Preset deleted
+          description: Skill deleted
           content:
             application/json:
               schema:
@@ -2264,11 +2277,11 @@ paths:
         "401":
           description: Not authenticated
         "403":
-          description: Requires admin role or platform preset is undeletable
+          description: Requires admin role or platform skill is undeletable
         "404":
-          description: Preset not found
+          description: Skill not found
         "409":
-          description: Preset is assigned to agents
+          description: Skill is assigned to agents
 
   /agents/{id}/skills:
     parameters:

--- a/services/api/src/routes/agents.ts
+++ b/services/api/src/routes/agents.ts
@@ -832,7 +832,7 @@ router.post('/:id/skills', requireRole('user'), async (req: Request, res: Respon
 
     // Look up skill and check scope-based RBAC
     const { rows: skillRows } = await getPool().query(
-      'SELECT id, scope FROM skills WHERE id = $1',
+      'SELECT id, scope, tools_config FROM skills WHERE id = $1',
       [skill_id]
     );
     if (skillRows.length === 0) {
@@ -857,6 +857,12 @@ router.post('/:id/skills', requireRole('user'), async (req: Request, res: Respon
        VALUES ($1, $2, $3)
        RETURNING *`,
       [req.params.id, skill_id, user.sub]
+    );
+
+    // Resolve-on-save: update agent's tools_config to match the assigned skill
+    await getPool().query(
+      'UPDATE agents SET tools_config = $1 WHERE id = $2',
+      [JSON.stringify(skillRows[0].tools_config), req.params.id]
     );
 
     res.status(201).json(rows[0]);

--- a/services/api/src/routes/agents.ts
+++ b/services/api/src/routes/agents.ts
@@ -55,10 +55,20 @@ router.use(dbHealthCheck);
 router.get('/', requireRole('user'), async (req: Request, res: Response) => {
   try {
     const scope = scopeToOwner(req);
-    const paramOffset = scope.params.length;
     const { rows } = await getPool().query(
-      `SELECT id, agent_id, name, description, status, tools_config, cpus, mem_limit, pids_limit, model_policy_id, tool_preset_id, created_at, updated_at, created_by
-       FROM agents WHERE ${scope.where} ORDER BY created_at DESC`,
+      `SELECT a.id, a.agent_id, a.name, a.description, a.status, a.tools_config,
+              a.cpus, a.mem_limit, a.pids_limit, a.model_policy_id,
+              a.created_at, a.updated_at, a.created_by,
+              COALESCE(
+                json_agg(json_build_object('id', s.id, 'name', s.name, 'scope', s.scope))
+                FILTER (WHERE s.id IS NOT NULL), '[]'
+              ) AS skills
+       FROM agents a
+       LEFT JOIN agent_skills asks ON asks.agent_id = a.id
+       LEFT JOIN skills s ON s.id = asks.skill_id
+       WHERE ${scope.where.replace(/created_by/g, 'a.created_by')}
+       GROUP BY a.id
+       ORDER BY a.created_at DESC`,
       scope.params
     );
     res.json(rows);
@@ -72,7 +82,13 @@ router.get('/', requireRole('user'), async (req: Request, res: Response) => {
 router.post('/', requireRole('user'), async (req: Request, res: Response) => {
   try {
     const user = (req as any).user;
-    const { agent_id, name, description, tools_config, cpus, mem_limit, pids_limit, soul_md, rules_md, model_policy_id, tool_preset_id } = req.body;
+    const { agent_id, name, description, tools_config, cpus, mem_limit, pids_limit, soul_md, rules_md, model_policy_id, skill_ids } = req.body;
+
+    // Reject legacy field
+    if (req.body.tool_preset_id !== undefined) {
+      res.status(400).json({ error: 'tool_preset_id is deprecated. Use skill_ids instead.' });
+      return;
+    }
 
     if (!agent_id || !name) {
       res.status(400).json({ error: 'agent_id and name are required' });
@@ -83,6 +99,18 @@ router.post('/', requireRole('user'), async (req: Request, res: Response) => {
     if (!/^[a-z0-9][a-z0-9-]{0,61}[a-z0-9]$/.test(agent_id) && !/^[a-z0-9]$/.test(agent_id)) {
       res.status(400).json({ error: 'agent_id must be a lowercase slug (a-z, 0-9, hyphens, 1-63 chars)' });
       return;
+    }
+
+    // Validate skill_ids (max 1 in Phase 2)
+    if (skill_ids !== undefined) {
+      if (!Array.isArray(skill_ids)) {
+        res.status(400).json({ error: 'skill_ids must be an array' });
+        return;
+      }
+      if (skill_ids.length > 1) {
+        res.status(400).json({ error: 'Maximum 1 skill per agent (multi-skill support coming in a future phase)' });
+        return;
+      }
     }
 
     // Validate model_policy_id ownership (same logic as PUT handler)
@@ -108,25 +136,25 @@ router.post('/', requireRole('user'), async (req: Request, res: Response) => {
       validatedPolicyId = model_policy_id;
     }
 
-    // Resolve tool preset: if tool_preset_id provided, use preset's tools_config (resolve-on-save)
+    // Resolve skill: if skill_ids provided, use skill's tools_config (resolve-on-save)
     let resolvedToolsConfig = tools_config || { shell: { enabled: false }, filesystem: { enabled: false }, health: { enabled: true } };
-    let validatedPresetId: string | null = null;
-    if (tool_preset_id) {
-      const { rows: presetRows } = await getPool().query(
-        'SELECT id, tools_config FROM tool_presets WHERE id = $1',
-        [tool_preset_id]
+    let validatedSkillId: string | null = null;
+    if (skill_ids && skill_ids.length === 1) {
+      const { rows: skillRows } = await getPool().query(
+        'SELECT id, tools_config FROM skills WHERE id = $1',
+        [skill_ids[0]]
       );
-      if (presetRows.length === 0) {
-        res.status(400).json({ error: 'Tool preset not found' });
+      if (skillRows.length === 0) {
+        res.status(400).json({ error: 'Skill not found' });
         return;
       }
-      resolvedToolsConfig = presetRows[0].tools_config;
-      validatedPresetId = tool_preset_id;
+      resolvedToolsConfig = skillRows[0].tools_config;
+      validatedSkillId = skill_ids[0];
     }
 
     const { rows } = await getPool().query(
-      `INSERT INTO agents (agent_id, name, description, tools_config, cpus, mem_limit, pids_limit, soul_md, rules_md, model_policy_id, tool_preset_id, created_by)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+      `INSERT INTO agents (agent_id, name, description, tools_config, cpus, mem_limit, pids_limit, soul_md, rules_md, model_policy_id, created_by)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
        RETURNING *`,
       [
         agent_id,
@@ -139,12 +167,30 @@ router.post('/', requireRole('user'), async (req: Request, res: Response) => {
         soul_md || '',
         rules_md || '',
         validatedPolicyId,
-        validatedPresetId,
         user.sub,
       ]
     );
 
-    res.status(201).json(rows[0]);
+    const createdAgent = rows[0];
+
+    // Insert skill assignment into agent_skills
+    if (validatedSkillId) {
+      await getPool().query(
+        'INSERT INTO agent_skills (agent_id, skill_id, assigned_by) VALUES ($1, $2, $3)',
+        [createdAgent.id, validatedSkillId, user.sub]
+      );
+    }
+
+    // Fetch the skills array for response
+    const { rows: skillRows } = await getPool().query(
+      `SELECT s.id, s.name, s.scope FROM agent_skills asks
+       JOIN skills s ON s.id = asks.skill_id
+       WHERE asks.agent_id = $1`,
+      [createdAgent.id]
+    );
+    createdAgent.skills = skillRows;
+
+    res.status(201).json(createdAgent);
   } catch (err: any) {
     if (err.code === '23505') {
       res.status(409).json({ error: 'An agent with this agent_id already exists' });
@@ -168,7 +214,19 @@ router.get('/:id', requireRole('user'), async (req: Request, res: Response) => {
       res.status(404).json({ error: 'Agent not found' });
       return;
     }
-    res.json(rows[0]);
+
+    const agent = rows[0];
+
+    // Fetch skills for this agent
+    const { rows: skillRows } = await getPool().query(
+      `SELECT s.id, s.name, s.scope FROM agent_skills asks
+       JOIN skills s ON s.id = asks.skill_id
+       WHERE asks.agent_id = $1`,
+      [agent.id]
+    );
+    agent.skills = skillRows;
+
+    res.json(agent);
   } catch (err) {
     console.error('[agents] Get error:', err);
     res.status(500).json({ error: 'Failed to get agent' });
@@ -180,6 +238,12 @@ router.put('/:id', requireRole('user'), async (req: Request, res: Response) => {
   try {
     const scope = scopeToOwner(req);
     const paramOffset = scope.params.length + 1;
+
+    // Reject legacy field
+    if (req.body.tool_preset_id !== undefined) {
+      res.status(400).json({ error: 'tool_preset_id is deprecated. Use skill_ids instead.' });
+      return;
+    }
 
     // Check agent exists and is owned
     const { rows: existing } = await getPool().query(
@@ -195,11 +259,23 @@ router.put('/:id', requireRole('user'), async (req: Request, res: Response) => {
       return;
     }
 
-    const { name, description, tools_config, cpus, mem_limit, pids_limit, soul_md, rules_md, model_policy_id, tool_preset_id } = req.body;
+    const user = (req as any).user;
+    const { name, description, tools_config, cpus, mem_limit, pids_limit, soul_md, rules_md, model_policy_id, skill_ids } = req.body;
+
+    // Validate skill_ids (max 1 in Phase 2)
+    if (skill_ids !== undefined) {
+      if (!Array.isArray(skill_ids)) {
+        res.status(400).json({ error: 'skill_ids must be an array' });
+        return;
+      }
+      if (skill_ids.length > 1) {
+        res.status(400).json({ error: 'Maximum 1 skill per agent (multi-skill support coming in a future phase)' });
+        return;
+      }
+    }
 
     // model_policy_id assignment: admins can assign any, users can assign own or platform
     if (model_policy_id !== undefined) {
-      const user = (req as any).user;
       const roles: string[] = user.realm_roles || [];
       const admin = roles.includes('admin');
 
@@ -225,23 +301,25 @@ router.put('/:id', requireRole('user'), async (req: Request, res: Response) => {
       }
     }
 
-    // Resolve tool preset: if tool_preset_id provided and non-null, look up and resolve
+    // Resolve skill: if skill_ids provided, look up and resolve tools_config
     let resolvedToolsConfig = tools_config ? JSON.stringify(tools_config) : null;
-    if (tool_preset_id !== undefined && tool_preset_id !== null) {
-      const { rows: presetRows } = await getPool().query(
-        'SELECT id, tools_config FROM tool_presets WHERE id = $1',
-        [tool_preset_id]
-      );
-      if (presetRows.length === 0) {
-        res.status(400).json({ error: 'Tool preset not found' });
-        return;
+    if (skill_ids !== undefined) {
+      if (skill_ids.length === 1) {
+        const { rows: skillRows } = await getPool().query(
+          'SELECT id, tools_config FROM skills WHERE id = $1',
+          [skill_ids[0]]
+        );
+        if (skillRows.length === 0) {
+          res.status(400).json({ error: 'Skill not found' });
+          return;
+        }
+        resolvedToolsConfig = JSON.stringify(skillRows[0].tools_config);
       }
-      resolvedToolsConfig = JSON.stringify(presetRows[0].tools_config);
+      // skill_ids.length === 0 means clear the skill — tools_config stays as-is or from body
     }
 
-    // Build SET clause: model_policy_id and tool_preset_id use explicit flags to allow clearing to NULL
+    // Build SET clause: model_policy_id uses explicit flag to allow clearing to NULL
     const modelPolicyProvided = model_policy_id !== undefined;
-    const toolPresetProvided = tool_preset_id !== undefined;
     const { rows } = await getPool().query(
       `UPDATE agents SET
         name = COALESCE($1, name),
@@ -253,9 +331,8 @@ router.put('/:id', requireRole('user'), async (req: Request, res: Response) => {
         soul_md = COALESCE($7, soul_md),
         rules_md = COALESCE($8, rules_md),
         model_policy_id = CASE WHEN $9::boolean THEN $10::uuid ELSE model_policy_id END,
-        tool_preset_id = CASE WHEN $11::boolean THEN $12::uuid ELSE tool_preset_id END,
         updated_at = NOW()
-       WHERE id = $13
+       WHERE id = $11
        RETURNING *`,
       [
         name || null,
@@ -268,13 +345,35 @@ router.put('/:id', requireRole('user'), async (req: Request, res: Response) => {
         rules_md ?? null,
         modelPolicyProvided,
         modelPolicyProvided ? (model_policy_id ?? null) : null,
-        toolPresetProvided,
-        toolPresetProvided ? (tool_preset_id ?? null) : null,
         req.params.id,
       ]
     );
 
-    res.json(rows[0]);
+    const updatedAgent = rows[0];
+
+    // Update agent_skills if skill_ids provided
+    if (skill_ids !== undefined) {
+      // Clear existing assignments
+      await getPool().query('DELETE FROM agent_skills WHERE agent_id = $1', [req.params.id]);
+      // Insert new assignment
+      if (skill_ids.length === 1) {
+        await getPool().query(
+          'INSERT INTO agent_skills (agent_id, skill_id, assigned_by) VALUES ($1, $2, $3)',
+          [req.params.id, skill_ids[0], user.sub]
+        );
+      }
+    }
+
+    // Fetch skills for response
+    const { rows: agentSkills } = await getPool().query(
+      `SELECT s.id, s.name, s.scope FROM agent_skills asks
+       JOIN skills s ON s.id = asks.skill_id
+       WHERE asks.agent_id = $1`,
+      [req.params.id]
+    );
+    updatedAgent.skills = agentSkills;
+
+    res.json(updatedAgent);
   } catch (err) {
     console.error('[agents] Update error:', err);
     res.status(500).json({ error: 'Failed to update agent' });
@@ -347,14 +446,14 @@ router.post('/:id/start', requireRole('admin'), async (req: Request, res: Respon
 
     // Fetch skill instructions at start time (fresh-at-start, not resolve-on-save)
     let skillInstructions: string | undefined;
-    if (agent.tool_preset_id) {
-      const { rows: presetRows } = await getPool().query(
-        'SELECT instructions_md FROM tool_presets WHERE id = $1',
-        [agent.tool_preset_id]
-      );
-      if (presetRows.length > 0 && presetRows[0].instructions_md) {
-        skillInstructions = presetRows[0].instructions_md;
-      }
+    const { rows: skillRows } = await getPool().query(
+      `SELECT s.instructions_md FROM agent_skills asks
+       JOIN skills s ON s.id = asks.skill_id
+       WHERE asks.agent_id = $1`,
+      [agent.id]
+    );
+    if (skillRows.length > 0 && skillRows[0].instructions_md) {
+      skillInstructions = skillRows[0].instructions_md;
     }
 
     // Write config files to disk
@@ -733,7 +832,7 @@ router.post('/:id/skills', requireRole('user'), async (req: Request, res: Respon
 
     // Look up skill and check scope-based RBAC
     const { rows: skillRows } = await getPool().query(
-      'SELECT id, scope FROM tool_presets WHERE id = $1',
+      'SELECT id, scope FROM skills WHERE id = $1',
       [skill_id]
     );
     if (skillRows.length === 0) {
@@ -747,7 +846,12 @@ router.post('/:id/skills', requireRole('user'), async (req: Request, res: Respon
       return;
     }
 
-    // Insert assignment
+    // Max 1 skill per agent: replace existing assignment (delete old, insert new)
+    await getPool().query(
+      'DELETE FROM agent_skills WHERE agent_id = $1',
+      [req.params.id]
+    );
+
     const { rows } = await getPool().query(
       `INSERT INTO agent_skills (agent_id, skill_id, assigned_by)
        VALUES ($1, $2, $3)
@@ -757,10 +861,6 @@ router.post('/:id/skills', requireRole('user'), async (req: Request, res: Respon
 
     res.status(201).json(rows[0]);
   } catch (err: any) {
-    if (err.code === '23505') {
-      res.status(409).json({ error: 'Skill is already assigned to this agent' });
-      return;
-    }
     console.error('[agents] Assign skill error:', err);
     res.status(500).json({ error: 'Failed to assign skill' });
   }
@@ -787,7 +887,7 @@ router.delete('/:id/skills/:skillId', requireRole('user'), async (req: Request, 
 
     // Look up skill to check scope-based RBAC
     const { rows: skillRows } = await getPool().query(
-      'SELECT id, scope FROM tool_presets WHERE id = $1',
+      'SELECT id, scope FROM skills WHERE id = $1',
       [req.params.skillId]
     );
     if (skillRows.length === 0) {

--- a/services/api/src/routes/skills.ts
+++ b/services/api/src/routes/skills.ts
@@ -22,40 +22,40 @@ function isAdmin(req: Request): boolean {
   return roles.includes('admin');
 }
 
-// List all presets — all authenticated users see all presets (no ownership scoping in Phase 1)
+// List all skills — all authenticated users see all skills
 router.get('/', requireRole('user'), async (_req: Request, res: Response) => {
   try {
     const { rows } = await getPool().query(
       `SELECT id, name, description, tools_config, instructions_md, scope, is_platform, created_by, created_at, updated_at
-       FROM tool_presets ORDER BY is_platform DESC, name ASC`
+       FROM skills ORDER BY is_platform DESC, name ASC`
     );
     res.json(rows);
   } catch (err) {
-    console.error('[tool-presets] List error:', err);
-    res.status(500).json({ error: 'Failed to list tool presets' });
+    console.error('[skills] List error:', err);
+    res.status(500).json({ error: 'Failed to list skills' });
   }
 });
 
-// Get single preset
+// Get single skill
 router.get('/:id', requireRole('user'), async (req: Request, res: Response) => {
   try {
     const { rows } = await getPool().query(
       `SELECT id, name, description, tools_config, instructions_md, scope, is_platform, created_by, created_at, updated_at
-       FROM tool_presets WHERE id = $1`,
+       FROM skills WHERE id = $1`,
       [req.params.id]
     );
     if (rows.length === 0) {
-      res.status(404).json({ error: 'Tool preset not found' });
+      res.status(404).json({ error: 'Skill not found' });
       return;
     }
     res.json(rows[0]);
   } catch (err) {
-    console.error('[tool-presets] Get error:', err);
-    res.status(500).json({ error: 'Failed to get tool preset' });
+    console.error('[skills] Get error:', err);
+    res.status(500).json({ error: 'Failed to get skill' });
   }
 });
 
-// Create preset — admin only
+// Create skill — admin only
 router.post('/', requireRole('admin'), async (req: Request, res: Response) => {
   try {
     const { name, description, tools_config, instructions_md, scope } = req.body;
@@ -74,7 +74,7 @@ router.post('/', requireRole('admin'), async (req: Request, res: Response) => {
     }
 
     const { rows } = await getPool().query(
-      `INSERT INTO tool_presets (name, description, tools_config, instructions_md, scope, is_platform, created_by)
+      `INSERT INTO skills (name, description, tools_config, instructions_md, scope, is_platform, created_by)
        VALUES ($1, $2, $3, $4, $5, false, NULL)
        RETURNING *`,
       [name, description || '', JSON.stringify(tools_config), instructions_md || '', scope || 'container_local']
@@ -83,27 +83,27 @@ router.post('/', requireRole('admin'), async (req: Request, res: Response) => {
     res.status(201).json(rows[0]);
   } catch (err: any) {
     if (err.code === '23505') {
-      res.status(409).json({ error: 'A tool preset with this name already exists' });
+      res.status(409).json({ error: 'A skill with this name already exists' });
       return;
     }
-    console.error('[tool-presets] Create error:', err);
-    res.status(500).json({ error: 'Failed to create tool preset' });
+    console.error('[skills] Create error:', err);
+    res.status(500).json({ error: 'Failed to create skill' });
   }
 });
 
-// Update preset — admin only, platform presets immutable
+// Update skill — admin only, platform skills immutable
 router.put('/:id', requireRole('admin'), async (req: Request, res: Response) => {
   try {
     const { rows: existing } = await getPool().query(
-      'SELECT id, is_platform FROM tool_presets WHERE id = $1',
+      'SELECT id, is_platform FROM skills WHERE id = $1',
       [req.params.id]
     );
     if (existing.length === 0) {
-      res.status(404).json({ error: 'Tool preset not found' });
+      res.status(404).json({ error: 'Skill not found' });
       return;
     }
     if (existing[0].is_platform) {
-      res.status(403).json({ error: 'Cannot modify a platform preset' });
+      res.status(403).json({ error: 'Cannot modify a platform skill' });
       return;
     }
 
@@ -115,7 +115,7 @@ router.put('/:id', requireRole('admin'), async (req: Request, res: Response) => 
     }
 
     const { rows } = await getPool().query(
-      `UPDATE tool_presets SET
+      `UPDATE skills SET
         name = COALESCE($1, name),
         description = COALESCE($2, description),
         tools_config = COALESCE($3, tools_config),
@@ -137,48 +137,51 @@ router.put('/:id', requireRole('admin'), async (req: Request, res: Response) => 
     res.json(rows[0]);
   } catch (err: any) {
     if (err.code === '23505') {
-      res.status(409).json({ error: 'A tool preset with this name already exists' });
+      res.status(409).json({ error: 'A skill with this name already exists' });
       return;
     }
-    console.error('[tool-presets] Update error:', err);
-    res.status(500).json({ error: 'Failed to update tool preset' });
+    console.error('[skills] Update error:', err);
+    res.status(500).json({ error: 'Failed to update skill' });
   }
 });
 
-// Delete preset — admin only, platform presets undeletable, assigned presets undeletable
+// Delete skill — admin only, platform skills undeletable, assigned skills undeletable
 router.delete('/:id', requireRole('admin'), async (req: Request, res: Response) => {
   try {
     const { rows: existing } = await getPool().query(
-      'SELECT id, is_platform FROM tool_presets WHERE id = $1',
+      'SELECT id, is_platform FROM skills WHERE id = $1',
       [req.params.id]
     );
     if (existing.length === 0) {
-      res.status(404).json({ error: 'Tool preset not found' });
+      res.status(404).json({ error: 'Skill not found' });
       return;
     }
     if (existing[0].is_platform) {
-      res.status(403).json({ error: 'Cannot delete a platform preset' });
+      res.status(403).json({ error: 'Cannot delete a platform skill' });
       return;
     }
 
-    // Check for agents using this preset
-    const { rows: agents } = await getPool().query(
-      'SELECT id, agent_id FROM agents WHERE tool_preset_id = $1 LIMIT 1',
+    // Check for agents using this skill via agent_skills join table
+    const { rows: assignments } = await getPool().query(
+      `SELECT as2.agent_id, a.agent_id AS agent_slug
+       FROM agent_skills as2
+       JOIN agents a ON a.id = as2.agent_id
+       WHERE as2.skill_id = $1 LIMIT 1`,
       [req.params.id]
     );
-    if (agents.length > 0) {
+    if (assignments.length > 0) {
       res.status(409).json({
-        error: 'Cannot delete preset while agents are assigned to it',
-        agent_id: agents[0].agent_id,
+        error: 'Cannot delete skill while agents are assigned to it',
+        agent_id: assignments[0].agent_slug,
       });
       return;
     }
 
-    await getPool().query('DELETE FROM tool_presets WHERE id = $1', [req.params.id]);
+    await getPool().query('DELETE FROM skills WHERE id = $1', [req.params.id]);
     res.json({ deleted: true });
   } catch (err) {
-    console.error('[tool-presets] Delete error:', err);
-    res.status(500).json({ error: 'Failed to delete tool preset' });
+    console.error('[skills] Delete error:', err);
+    res.status(500).json({ error: 'Failed to delete skill' });
   }
 });
 

--- a/services/ui/src/__tests__/AgentDetailClient.test.tsx
+++ b/services/ui/src/__tests__/AgentDetailClient.test.tsx
@@ -51,28 +51,24 @@ const MOCK_AGENT = {
   rules_md: 'Always cite sources.',
   container_id: null,
   model_policy_id: 'policy-1',
-  tool_preset_id: null,
+  skills: [],
   error_message: null,
   created_at: '2026-01-01T00:00:00Z',
   updated_at: '2026-01-15T00:00:00Z',
   created_by: 'admin',
 }
 
-const MOCK_AGENT_WITH_PRESET = {
+const MOCK_AGENT_WITH_SKILL = {
   ...MOCK_AGENT,
-  tool_preset_id: 'preset-dev',
+  skills: [
+    {
+      id: 'preset-dev',
+      name: 'Developer',
+      scope: 'container_local',
+      instructions_md: 'Always write tests before implementation.\nFollow TDD red-green-refactor.',
+    },
+  ],
 }
-
-const MOCK_PRESETS = [
-  {
-    id: 'preset-dev',
-    name: 'Developer',
-    description: 'Full dev environment',
-    tools_config: {},
-    is_platform: true,
-    instructions_md: 'Always write tests before implementation.\nFollow TDD red-green-refactor.',
-  },
-]
 
 const MOCK_POLICIES = [
   {
@@ -113,9 +109,6 @@ function mockFetchDefaults(agentOverride?: typeof MOCK_AGENT) {
     }
     if (url === '/api/model-policies') {
       return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_POLICIES) })
-    }
-    if (url === '/api/tool-presets') {
-      return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_PRESETS) })
     }
     if (typeof url === 'string' && url.includes('/api/usage')) {
       return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_USAGE) })
@@ -303,9 +296,9 @@ describe('AgentDetailClient', () => {
     expect(screen.getByText('claude-sonnet-4-5-20250929')).toBeInTheDocument()
   })
 
-  // T22: Agent detail shows preset badge when assigned
-  it('shows preset name badge when tool_preset_id is set', async () => {
-    mockFetchDefaults(MOCK_AGENT_WITH_PRESET as any)
+  // T22: Agent detail shows skill badge when assigned
+  it('shows skill name badge when skill is assigned', async () => {
+    mockFetchDefaults(MOCK_AGENT_WITH_SKILL as any)
 
     render(<AgentDetailClient agentId="uuid-1" session={ADMIN_SESSION as any} />)
 
@@ -313,27 +306,25 @@ describe('AgentDetailClient', () => {
       expect(screen.getByText('ResearchBot')).toBeInTheDocument()
     })
 
-    // Should show the preset name in the Tool Access section (now prefixed with "Skill:")
     await waitFor(() => {
       expect(screen.getByText('Skill: Developer')).toBeInTheDocument()
     })
   })
 
-  // T23: Agent detail shows Custom when no preset
-  it('shows Custom when no preset assigned', async () => {
+  // T23: Agent detail shows Custom when no skill
+  it('shows Custom when no skill assigned', async () => {
     render(<AgentDetailClient agentId="uuid-1" session={ADMIN_SESSION as any} />)
 
     await waitFor(() => {
       expect(screen.getByText('ResearchBot')).toBeInTheDocument()
     })
 
-    // Should show "Custom" label in Tool Access since tool_preset_id is null
     expect(screen.getByText('Custom')).toBeInTheDocument()
   })
 
-  // T14: Agent detail badge says "Skill: Developer" when preset assigned
+  // T14: Agent detail badge says "Skill: Developer" when skill assigned
   it('agent detail shows skill badge with Skill label', async () => {
-    mockFetchDefaults(MOCK_AGENT_WITH_PRESET as any)
+    mockFetchDefaults(MOCK_AGENT_WITH_SKILL as any)
 
     render(<AgentDetailClient agentId="uuid-1" session={ADMIN_SESSION as any} />)
 
@@ -341,14 +332,13 @@ describe('AgentDetailClient', () => {
       expect(screen.getByText('ResearchBot')).toBeInTheDocument()
     })
 
-    // Badge should say "Skill:" prefix
     await waitFor(() => {
       expect(screen.getByText(/Skill:\s*Developer/i)).toBeInTheDocument()
     })
   })
 
-  it('shows skill instructions when preset has instructions_md', async () => {
-    mockFetchDefaults(MOCK_AGENT_WITH_PRESET as any)
+  it('shows skill instructions when skill has instructions_md', async () => {
+    mockFetchDefaults(MOCK_AGENT_WITH_SKILL as any)
 
     render(<AgentDetailClient agentId="uuid-1" session={ADMIN_SESSION as any} />)
 
@@ -363,7 +353,7 @@ describe('AgentDetailClient', () => {
     expect(screen.getByText(/Follow TDD red-green-refactor/)).toBeInTheDocument()
   })
 
-  it('does not show skill instructions section when no preset assigned', async () => {
+  it('does not show skill instructions section when no skill assigned', async () => {
     render(<AgentDetailClient agentId="uuid-1" session={ADMIN_SESSION as any} />)
 
     await waitFor(() => {

--- a/services/ui/src/__tests__/AgentFormClient.test.tsx
+++ b/services/ui/src/__tests__/AgentFormClient.test.tsx
@@ -57,7 +57,7 @@ function mockFetchDefaults() {
     if (url === '/api/model-policies') {
       return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_POLICIES) })
     }
-    if (url === '/api/tool-presets') {
+    if (url === '/api/skills') {
       return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_PRESETS) })
     }
     if (url === '/api/agents' && opts?.method === 'POST') {
@@ -485,8 +485,8 @@ describe('AgentFormClient', () => {
     expect(fsCheckbox.checked).toBe(true)
   })
 
-  // Submit body includes tool_preset_id when preset selected
-  it('submit body includes tool_preset_id when preset selected', async () => {
+  // Submit body includes skill_ids when skill selected
+  it('submit body includes skill_ids when skill selected', async () => {
     render(<AgentFormClient />)
 
     await waitFor(() => {
@@ -497,7 +497,7 @@ describe('AgentFormClient', () => {
     fireEvent.change(screen.getByLabelText('Agent ID (slug)'), { target: { value: 'test-agent' } })
     fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Test Agent' } })
 
-    // Select Developer preset
+    // Select Developer skill
     const profileSelect = screen.getByRole('combobox', { name: /skill/i })
     fireEvent.change(profileSelect, { target: { value: 'preset-dev' } })
 
@@ -514,11 +514,11 @@ describe('AgentFormClient', () => {
       (c: any[]) => c[0] === '/api/agents' && c[1]?.method === 'POST'
     )!
     const body = JSON.parse(postCall[1].body)
-    expect(body.tool_preset_id).toBe('preset-dev')
+    expect(body.skill_ids).toEqual(['preset-dev'])
   })
 
-  // Submit body sends tool_preset_id = null when Custom selected
-  it('submit body sends tool_preset_id null when Custom selected', async () => {
+  // Submit body sends skill_ids empty when Custom selected
+  it('submit body sends skill_ids empty when Custom selected', async () => {
     render(<AgentFormClient />)
     await selectCustomMode()
 
@@ -539,11 +539,11 @@ describe('AgentFormClient', () => {
       (c: any[]) => c[0] === '/api/agents' && c[1]?.method === 'POST'
     )!
     const body = JSON.parse(postCall[1].body)
-    expect(body.tool_preset_id).toBeNull()
+    expect(body.skill_ids).toEqual([])
   })
 
-  // Edit form pre-selects preset when initial has tool_preset_id
-  it('pre-selects preset when initial has tool_preset_id', async () => {
+  // Edit form pre-selects skill when initial has skills array
+  it('pre-selects skill when initial has skills array', async () => {
     const initial = {
       agent_id: 'existing',
       name: 'Existing Agent',
@@ -559,7 +559,7 @@ describe('AgentFormClient', () => {
       soul_md: '',
       rules_md: '',
       model_policy_id: null,
-      tool_preset_id: 'preset-dev',
+      skills: [{ id: 'preset-dev', name: 'Developer', scope: 'container_local' }],
     }
 
     render(<AgentFormClient initial={initial} agentUuid="uuid-1" />)

--- a/services/ui/src/__tests__/SkillsClient.test.tsx
+++ b/services/ui/src/__tests__/SkillsClient.test.tsx
@@ -70,16 +70,16 @@ const MOCK_SKILLS = [
 
 function mockFetchDefaults(skills = MOCK_SKILLS) {
   mockFetch.mockImplementation((url: string, opts?: any) => {
-    if (url === '/api/tool-presets' && (!opts || !opts.method || opts.method === 'GET')) {
+    if (url === '/api/skills' && (!opts || !opts.method || opts.method === 'GET')) {
       return Promise.resolve({ ok: true, json: () => Promise.resolve(skills) })
     }
-    if (url === '/api/tool-presets' && opts?.method === 'POST') {
+    if (url === '/api/skills' && opts?.method === 'POST') {
       return Promise.resolve({ ok: true, json: () => Promise.resolve({ id: 'new-preset', ...JSON.parse(opts.body) }) })
     }
-    if (typeof url === 'string' && url.startsWith('/api/tool-presets/') && opts?.method === 'PUT') {
+    if (typeof url === 'string' && url.startsWith('/api/skills/') && opts?.method === 'PUT') {
       return Promise.resolve({ ok: true, json: () => Promise.resolve({ id: url.split('/').pop(), ...JSON.parse(opts.body) }) })
     }
-    if (typeof url === 'string' && url.startsWith('/api/tool-presets/') && opts?.method === 'DELETE') {
+    if (typeof url === 'string' && url.startsWith('/api/skills/') && opts?.method === 'DELETE') {
       return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
     }
     return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })

--- a/services/ui/src/app/agents/[id]/AgentDetailClient.tsx
+++ b/services/ui/src/app/agents/[id]/AgentDetailClient.tsx
@@ -20,7 +20,7 @@ interface Agent {
   rules_md: string
   container_id: string | null
   model_policy_id: string | null
-  tool_preset_id: string | null
+  skills: Array<{ id: string; name: string; scope: string; instructions_md?: string }>
   error_message: string | null
   created_at: string
   updated_at: string
@@ -36,14 +36,6 @@ interface ModelPolicy {
   created_by: string | null
 }
 
-interface ToolPreset {
-  id: string
-  name: string
-  description: string
-  is_platform: boolean
-  instructions_md?: string
-}
-
 type TabId = 'overview' | 'configuration' | 'model-access' | 'knowledge' | 'activity'
 
 export default function AgentDetailClient({
@@ -56,7 +48,6 @@ export default function AgentDetailClient({
   const router = useRouter()
   const [agent, setAgent] = useState<Agent | null>(null)
   const [policies, setPolicies] = useState<ModelPolicy[]>([])
-  const [presets, setPresets] = useState<ToolPreset[]>([])
   const [loading, setLoading] = useState(true)
   const [actionLoading, setActionLoading] = useState(false)
   const [activeTab, setActiveTab] = useState<TabId>('overview')
@@ -106,22 +97,10 @@ export default function AgentDetailClient({
     }
   }, [])
 
-  const fetchPresets = useCallback(async () => {
-    try {
-      const res = await fetch('/api/tool-presets')
-      if (res.ok) {
-        setPresets(await res.json())
-      }
-    } catch (err) {
-      console.error('Failed to fetch presets:', err)
-    }
-  }, [])
-
   useEffect(() => {
     fetchAgent()
     fetchPolicies()
-    fetchPresets()
-  }, [fetchAgent, fetchPolicies, fetchPresets])
+  }, [fetchAgent, fetchPolicies])
 
   // Poll status while running
   useEffect(() => {
@@ -231,7 +210,7 @@ export default function AgentDetailClient({
   if (!agent) return null
 
   const currentPolicy = policies.find((p) => p.id === agent.model_policy_id)
-  const currentPreset = presets.find((p) => p.id === agent.tool_preset_id)
+  const currentSkill = agent.skills?.[0] || null
   const tc = agent.tools_config || {}
 
   const tabs: { id: TabId; label: string; adminOnly?: boolean }[] = [
@@ -353,11 +332,11 @@ export default function AgentDetailClient({
             <div className="flex items-center justify-between mb-3">
               <h2 className="text-lg font-semibold text-white">Tool Access</h2>
               <span className={`px-2.5 py-1 text-xs rounded-md ${
-                currentPreset
+                currentSkill
                   ? 'bg-brand-900/50 text-brand-400 border border-brand-700'
                   : 'bg-navy-900 text-mountain-400 border border-navy-700'
               }`}>
-                {currentPreset ? `Skill: ${currentPreset.name}` : 'Custom'}
+                {currentSkill ? `Skill: ${currentSkill.name}` : 'Custom'}
               </span>
             </div>
             <div className="flex flex-wrap gap-2">
@@ -368,10 +347,10 @@ export default function AgentDetailClient({
           </div>
 
           {/* Skill Instructions */}
-          {currentPreset?.instructions_md && (
+          {currentSkill?.instructions_md && (
             <div className="rounded-lg border border-navy-700 bg-navy-800 p-5">
               <h2 className="text-lg font-semibold text-white mb-2">Skill Instructions</h2>
-              <pre className="text-sm text-mountain-300 whitespace-pre-wrap bg-navy-900 rounded-md p-3 max-h-64 overflow-y-auto">{currentPreset.instructions_md}</pre>
+              <pre className="text-sm text-mountain-300 whitespace-pre-wrap bg-navy-900 rounded-md p-3 max-h-64 overflow-y-auto">{currentSkill.instructions_md}</pre>
             </div>
           )}
 

--- a/services/ui/src/app/agents/[id]/edit/AgentEditClient.tsx
+++ b/services/ui/src/app/agents/[id]/edit/AgentEditClient.tsx
@@ -50,7 +50,7 @@ export default function AgentEditClient({ agentId }: { agentId: string }) {
         soul_md: agent.soul_md,
         rules_md: agent.rules_md,
         model_policy_id: agent.model_policy_id,
-        tool_preset_id: agent.tool_preset_id,
+        skills: agent.skills,
       }}
       agentUuid={agent.id}
       disabled={agent.status === 'running'}

--- a/services/ui/src/app/agents/new/AgentFormClient.tsx
+++ b/services/ui/src/app/agents/new/AgentFormClient.tsx
@@ -50,7 +50,7 @@ export default function AgentFormClient({
     soul_md: string
     rules_md: string
     model_policy_id?: string | null
-    tool_preset_id?: string | null
+    skills?: Array<{ id: string; name: string; scope: string }>
   }
   agentUuid?: string
   disabled?: boolean
@@ -73,9 +73,9 @@ export default function AgentFormClient({
   const [modelPolicyId, setModelPolicyId] = useState(initial?.model_policy_id || '')
   const [policies, setPolicies] = useState<PolicyOption[]>([])
   const [presets, setPresets] = useState<PresetOption[]>([])
-  // New agents: unselected prompt. Edit agents: preset ID or '' (Custom).
+  // New agents: unselected prompt. Edit agents: skill ID or '' (Custom).
   const [toolPresetId, setToolPresetId] = useState(
-    initial ? (initial.tool_preset_id || '') : UNSELECTED
+    initial ? (initial.skills?.[0]?.id || '') : UNSELECTED
   )
   const toolsCustomDirty = useRef(false)
 
@@ -89,7 +89,7 @@ export default function AgentFormClient({
       .then((res) => (res.ok ? res.json() : []))
       .then((data) => setPolicies(data))
       .catch(() => {})
-    fetch('/api/tool-presets')
+    fetch('/api/skills')
       .then((res) => (res.ok ? res.json() : []))
       .then((data) => setPresets(data))
       .catch(() => {})
@@ -158,7 +158,7 @@ export default function AgentFormClient({
       soul_md: soulMd,
       rules_md: rulesMd,
       model_policy_id: modelPolicyId || null,
-      tool_preset_id: toolPresetId || null,
+      skill_ids: toolPresetId ? [toolPresetId] : [],
     }
 
     try {

--- a/services/ui/src/app/api/skills/[...path]/route.ts
+++ b/services/ui/src/app/api/skills/[...path]/route.ts
@@ -4,7 +4,7 @@ import { proxyToApi } from '@/utils/api-proxy'
 async function proxyRequest(req: NextRequest, { params }: { params: Promise<{ path: string[] }> }) {
   const { path } = await params
   const pathStr = path.join('/')
-  return proxyToApi(req, `/tool-presets/${pathStr}`, { label: 'tool-presets-proxy' })
+  return proxyToApi(req, `/skills/${pathStr}`, { label: 'skills-proxy' })
 }
 
 export const GET = proxyRequest

--- a/services/ui/src/app/api/skills/route.ts
+++ b/services/ui/src/app/api/skills/route.ts
@@ -2,7 +2,7 @@ import { NextRequest } from 'next/server'
 import { proxyToApi } from '@/utils/api-proxy'
 
 async function proxyRequest(req: NextRequest) {
-  return proxyToApi(req, '/tool-presets', { label: 'tool-presets-proxy' })
+  return proxyToApi(req, '/skills', { label: 'skills-proxy' })
 }
 
 export const GET = proxyRequest

--- a/services/ui/src/app/harness/skills/SkillsClient.tsx
+++ b/services/ui/src/app/harness/skills/SkillsClient.tsx
@@ -49,7 +49,7 @@ export default function SkillsClient() {
 
   const fetchSkills = useCallback(async () => {
     try {
-      const res = await fetch('/api/tool-presets')
+      const res = await fetch('/api/skills')
       if (res.ok) setSkills(await res.json())
     } catch (err) {
       console.error('Failed to fetch skills:', err)
@@ -118,8 +118,8 @@ export default function SkillsClient() {
 
     try {
       const url = editingId
-        ? `/api/tool-presets/${editingId}`
-        : '/api/tool-presets'
+        ? `/api/skills/${editingId}`
+        : '/api/skills'
       const res = await fetch(url, {
         method: editingId ? 'PUT' : 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -142,7 +142,7 @@ export default function SkillsClient() {
     if (!confirm(`Delete skill "${skill.name}"? Agents using this skill will keep their current tool configuration.`)) return
     setActionLoading(skill.id)
     try {
-      const res = await fetch(`/api/tool-presets/${skill.id}`, { method: 'DELETE' })
+      const res = await fetch(`/api/skills/${skill.id}`, { method: 'DELETE' })
       if (res.ok) {
         await fetchSkills()
       } else {


### PR DESCRIPTION
## Summary

Phase 2 of the skills architecture reset. Makes `agent_skills` the sole authoritative assignment store and migrates the entire API/UI contract from `tool_presets`/`tool_preset_id` to `skills`/`skill_ids`.

- **Migration 019**: Rename `tool_presets` → `skills`, migrate `tool_preset_id` data into `agent_skills`, drop `agents.tool_preset_id` column
- **Canonical `/skills` route** with `/tool-presets` compat alias (same handler, for stale external callers)
- **Agent create/update**: Accept `skill_ids` array (max 1 enforced), reject legacy `tool_preset_id`
- **Agent list/detail**: Return `skills` array via `agent_skills JOIN skills`
- **Agent start**: Read from `agent_skills JOIN skills` (fresh-at-start `instructions_md`)
- **UI fully migrated**: `/api/skills` proxy, `skill_ids` submission, `skills` array display
- **OpenAPI**: `ToolPreset` → `Skill`, Agent schema updated

### What changes at runtime
Runtime *semantics* are preserved (one skill per agent, resolve-on-save for tools_config, fresh-at-start for instructions_md). Runtime *code paths* change: agent start reads from `agent_skills JOIN skills` instead of `tool_preset_id → tool_presets`.

### What survives temporarily
`/tool-presets` compat alias (routed alias, not redirect) — same `skillsRouter` handler at both paths. Shipped UI uses `/api/skills` exclusively. Legacy alias deferred for removal after access logs confirm zero traffic.

### Out of scope
- Multi-skill merge logic (Phase 4)
- Removing max-1 enforcement (Phase 4)
- Multi-select UI picker (Phase 3)

## Verification Evidence

| # | Check | Result |
|---|-------|--------|
| V1 | API tests (jest) | 271/271 pass |
| V2 | TypeScript compile | Clean, no errors |
| V3 | OpenAPI drift check | 13/13 pass |
| V4 | UI tests (vitest) | 287/287 pass |
| V5 | No `tool_preset_id` in routes (except rejection guards) | Confirmed via grep |
| V6 | No `tool_presets` table refs in routes | Zero matches |

## Test plan

- [ ] V7: CI green (jest, vitest, TypeScript, OpenAPI drift, policy gate)
- [ ] V8: `skills` table exists on deploy
- [ ] V9: `tool_presets` table gone
- [ ] V10: `agents.tool_preset_id` column gone
- [ ] V11: `agent_skills` populated from migration
- [ ] V12: `GET /skills` returns data
- [ ] V13: `GET /tool-presets` compat alias works
- [ ] V14: Agent create with `skill_ids`
- [ ] V15: Agent detail has `skills` array
- [ ] V16: UI `/harness/skills` loads
- [ ] V17: UI agent form works with skill picker

## Risks

| Risk | Mitigation |
|------|------------|
| Migration fails mid-way | Single transaction, tested on empty + populated DB |
| agent_skills missing rows | ON CONFLICT DO NOTHING in migration |
| 21 files changed | Naming + authority + contract migration with preserved runtime semantics; T1-T16 test coverage |

## Rollback

Reverse migration: add `tool_preset_id` column back, copy from `agent_skills`, rename table back. Not automated — manual rollback if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)