### PR TITLE
feat: UI skills awareness + scope RBAC completion (Phase 3)

### DIFF
--- a/services/api/src/__tests__/routes-agents-skill.test.ts
+++ b/services/api/src/__tests__/routes-agents-skill.test.ts
@@ -298,6 +298,115 @@ describe('Agent PUT skill_ids behavior', () => {
   });
 });
 
+// T15: Create agent with elevated skill_ids rejected for non-admin
+describe('Agent create/update scope RBAC', () => {
+  beforeEach(() => {
+    mockQuery.mockReset();
+    process.env.DATABASE_URL = 'postgresql://test:test@localhost:5432/test';
+  });
+
+  afterEach(() => {
+    delete process.env.DATABASE_URL;
+  });
+
+  it('create with host_docker skill as non-admin returns 403', async () => {
+    // Skill lookup returns host_docker scope
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: 'skill-docker', tools_config: developerSkillConfig, scope: 'host_docker' }],
+    });
+
+    const res = await request(app)
+      .post('/agents')
+      .set('Authorization', `Bearer ${userToken}`)
+      .send({
+        agent_id: 'test-agent',
+        name: 'Test Agent',
+        skill_ids: ['skill-docker'],
+      });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toContain('host_docker');
+    expect(res.body.error).toContain('admin');
+  });
+
+  it('create with host_docker skill as admin succeeds', async () => {
+    // Skill lookup
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: 'skill-docker', tools_config: developerSkillConfig, scope: 'host_docker' }],
+    });
+    // INSERT agent
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ ...agentRow, id: 'uuid-admin' }],
+    });
+    // INSERT agent_skills
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    // SELECT skills for response
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: 'skill-docker', name: 'Docker Access', scope: 'host_docker' }],
+    });
+
+    const res = await request(app)
+      .post('/agents')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({
+        agent_id: 'test-agent',
+        name: 'Test Agent',
+        skill_ids: ['skill-docker'],
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body.skills[0].scope).toBe('host_docker');
+  });
+
+  // T16: Update agent with elevated skill_ids rejected for non-admin
+  it('update with vps_system skill as non-admin returns 403', async () => {
+    // Ownership check returns agent
+    mockQuery.mockResolvedValueOnce({ rows: [agentRow] });
+    // Skill lookup returns vps_system scope
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: 'skill-vps', tools_config: developerSkillConfig, scope: 'vps_system' }],
+    });
+
+    const res = await request(app)
+      .put('/agents/uuid-1')
+      .set('Authorization', `Bearer ${userToken}`)
+      .send({ skill_ids: ['skill-vps'] });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toContain('vps_system');
+    expect(res.body.error).toContain('admin');
+  });
+
+  it('update with vps_system skill as admin succeeds', async () => {
+    // Ownership check (admin sees all — scopeToOwner returns no constraint for admin)
+    mockQuery.mockResolvedValueOnce({ rows: [agentRow] });
+    // Skill lookup
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: 'skill-vps', tools_config: developerSkillConfig, scope: 'vps_system' }],
+    });
+    // UPDATE agent
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ ...agentRow, tools_config: developerSkillConfig }],
+    });
+    // DELETE agent_skills
+    mockQuery.mockResolvedValueOnce({ rowCount: 0 });
+    // INSERT agent_skills
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    // SELECT skills for response
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: 'skill-vps', name: 'VPS Access', scope: 'vps_system' }],
+    });
+
+    const res = await request(app)
+      .put('/agents/uuid-1')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ skill_ids: ['skill-vps'] });
+
+    expect(res.status).toBe(200);
+    expect(res.body.skills[0].scope).toBe('vps_system');
+  });
+});
+
 // T10b: Agent start reads from agent_skills
 const { writeAgentFiles } = jest.requireMock('../services/agent-files') as { writeAgentFiles: jest.Mock };
 

--- a/services/api/src/routes/agents.ts
+++ b/services/api/src/routes/agents.ts
@@ -141,11 +141,15 @@ router.post('/', requireRole('user'), async (req: Request, res: Response) => {
     let validatedSkillId: string | null = null;
     if (skill_ids && skill_ids.length === 1) {
       const { rows: skillRows } = await getPool().query(
-        'SELECT id, tools_config FROM skills WHERE id = $1',
+        'SELECT id, tools_config, scope FROM skills WHERE id = $1',
         [skill_ids[0]]
       );
       if (skillRows.length === 0) {
         res.status(400).json({ error: 'Skill not found' });
+        return;
+      }
+      if (ELEVATED_SCOPES.includes(skillRows[0].scope) && !isAdmin(req)) {
+        res.status(403).json({ error: `Assigning ${skillRows[0].scope} skills requires admin role` });
         return;
       }
       resolvedToolsConfig = skillRows[0].tools_config;
@@ -306,11 +310,15 @@ router.put('/:id', requireRole('user'), async (req: Request, res: Response) => {
     if (skill_ids !== undefined) {
       if (skill_ids.length === 1) {
         const { rows: skillRows } = await getPool().query(
-          'SELECT id, tools_config FROM skills WHERE id = $1',
+          'SELECT id, tools_config, scope FROM skills WHERE id = $1',
           [skill_ids[0]]
         );
         if (skillRows.length === 0) {
           res.status(400).json({ error: 'Skill not found' });
+          return;
+        }
+        if (ELEVATED_SCOPES.includes(skillRows[0].scope) && !isAdmin(req)) {
+          res.status(403).json({ error: `Assigning ${skillRows[0].scope} skills requires admin role` });
           return;
         }
         resolvedToolsConfig = JSON.stringify(skillRows[0].tools_config);

--- a/services/ui/src/__tests__/AgentDetailClient.test.tsx
+++ b/services/ui/src/__tests__/AgentDetailClient.test.tsx
@@ -102,19 +102,46 @@ const USER_SESSION = {
   expires: '2026-12-31',
 }
 
+const MOCK_ALL_SKILLS = [
+  { id: 'preset-dev', name: 'Developer', scope: 'container_local', instructions_md: 'Dev instructions' },
+  { id: 'skill-docker', name: 'Docker Access', scope: 'host_docker', instructions_md: 'Docker instructions' },
+  { id: 'skill-vps', name: 'VPS Admin', scope: 'vps_system', instructions_md: 'VPS instructions' },
+]
+
+const MOCK_AGENT_WITH_ELEVATED_SKILL = {
+  ...MOCK_AGENT,
+  skills: [
+    {
+      id: 'skill-docker',
+      name: 'Docker Access',
+      scope: 'host_docker',
+      instructions_md: 'Docker instructions here.',
+    },
+  ],
+}
+
 function mockFetchDefaults(agentOverride?: typeof MOCK_AGENT) {
-  mockFetch.mockImplementation((url: string) => {
-    if (url === `/api/agents/uuid-1`) {
+  mockFetch.mockImplementation((url: string, opts?: any) => {
+    if (url === `/api/agents/uuid-1` && (!opts || !opts.method || opts.method === 'GET')) {
       return Promise.resolve({ ok: true, json: () => Promise.resolve(agentOverride || MOCK_AGENT) })
     }
     if (url === '/api/model-policies') {
       return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_POLICIES) })
+    }
+    if (url === '/api/skills') {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_ALL_SKILLS) })
     }
     if (typeof url === 'string' && url.includes('/api/usage')) {
       return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_USAGE) })
     }
     if (typeof url === 'string' && url.includes('/api/knowledge/entries')) {
       return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_KNOWLEDGE_ENTRIES) })
+    }
+    if (typeof url === 'string' && url.includes('/skills') && opts?.method === 'POST') {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+    }
+    if (typeof url === 'string' && url.includes('/skills/') && opts?.method === 'DELETE') {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
     }
     return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
   })
@@ -296,8 +323,8 @@ describe('AgentDetailClient', () => {
     expect(screen.getByText('claude-sonnet-4-5-20250929')).toBeInTheDocument()
   })
 
-  // T22: Agent detail shows skill badge when assigned
-  it('shows skill name badge when skill is assigned', async () => {
+  // T1: Detail skills card renders each skill with name and scope badge
+  it('renders skills list with scope badges', async () => {
     mockFetchDefaults(MOCK_AGENT_WITH_SKILL as any)
 
     render(<AgentDetailClient agentId="uuid-1" session={ADMIN_SESSION as any} />)
@@ -306,60 +333,139 @@ describe('AgentDetailClient', () => {
       expect(screen.getByText('ResearchBot')).toBeInTheDocument()
     })
 
+    // Skills card should show skill name and scope badge
     await waitFor(() => {
-      expect(screen.getByText('Skill: Developer')).toBeInTheDocument()
+      expect(screen.getByText('Developer')).toBeInTheDocument()
     })
+    // Multiple "Container" badges may appear (skills card + assign picker)
+    expect(screen.getAllByText('Container').length).toBeGreaterThan(0)
   })
 
-  // T23: Agent detail shows Custom when no skill
-  it('shows Custom when no skill assigned', async () => {
+  // T2: Detail skills card empty state
+  it('shows no skills assigned when empty', async () => {
     render(<AgentDetailClient agentId="uuid-1" session={ADMIN_SESSION as any} />)
 
     await waitFor(() => {
       expect(screen.getByText('ResearchBot')).toBeInTheDocument()
     })
 
-    expect(screen.getByText('Custom')).toBeInTheDocument()
+    expect(screen.getByText('No skills assigned')).toBeInTheDocument()
   })
 
-  // T14: Agent detail badge says "Skill: Developer" when skill assigned
-  it('agent detail shows skill badge with Skill label', async () => {
+  // T3: Detail assign skill calls POST
+  it('assign skill calls POST endpoint', async () => {
+    render(<AgentDetailClient agentId="uuid-1" session={ADMIN_SESSION as any} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('ResearchBot')).toBeInTheDocument()
+    })
+
+    // Click "Assign Skill" to open picker
+    fireEvent.click(screen.getByText('Assign Skill'))
+
+    // Select Developer skill from picker
+    await waitFor(() => {
+      expect(screen.getByText('Developer')).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByText('Developer'))
+
+    // Should have called POST /api/agents/uuid-1/skills
+    await waitFor(() => {
+      const postCalls = mockFetch.mock.calls.filter(
+        (c: any[]) => typeof c[0] === 'string' && c[0].includes('/skills') && c[1]?.method === 'POST'
+      )
+      expect(postCalls.length).toBeGreaterThan(0)
+    })
+  })
+
+  // T4: Detail remove skill calls DELETE
+  it('remove skill calls DELETE endpoint', async () => {
     mockFetchDefaults(MOCK_AGENT_WITH_SKILL as any)
 
     render(<AgentDetailClient agentId="uuid-1" session={ADMIN_SESSION as any} />)
 
     await waitFor(() => {
-      expect(screen.getByText('ResearchBot')).toBeInTheDocument()
+      expect(screen.getByText('Developer')).toBeInTheDocument()
     })
 
+    // Click Remove button
+    fireEvent.click(screen.getByText('Remove'))
+
+    // Should have called DELETE
     await waitFor(() => {
-      expect(screen.getByText(/Skill:\s*Developer/i)).toBeInTheDocument()
+      const deleteCalls = mockFetch.mock.calls.filter(
+        (c: any[]) => typeof c[0] === 'string' && c[0].includes('/skills/') && c[1]?.method === 'DELETE'
+      )
+      expect(deleteCalls.length).toBeGreaterThan(0)
     })
   })
 
-  it('shows skill instructions when skill has instructions_md', async () => {
+  // T5: Remove hidden for non-admin on elevated skill
+  it('remove hidden for non-admin on host_docker skill', async () => {
+    mockFetchDefaults(MOCK_AGENT_WITH_ELEVATED_SKILL as any)
+
+    render(<AgentDetailClient agentId="uuid-1" session={USER_SESSION as any} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Docker Access')).toBeInTheDocument()
+    })
+
+    // Non-admin should NOT see Remove button for host_docker skill
+    expect(screen.queryByText('Remove')).not.toBeInTheDocument()
+  })
+
+  // T6: Remove shown for non-admin on container_local skill
+  it('remove shown for non-admin on container_local skill', async () => {
+    mockFetchDefaults(MOCK_AGENT_WITH_SKILL as any)
+
+    render(<AgentDetailClient agentId="uuid-1" session={USER_SESSION as any} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Developer')).toBeInTheDocument()
+    })
+
+    // Non-admin CAN see Remove button for container_local skill
+    expect(screen.getByText('Remove')).toBeInTheDocument()
+  })
+
+  // T7: Assign picker filters elevated scopes for non-admin
+  it('assign picker excludes elevated skills for non-admin', async () => {
+    render(<AgentDetailClient agentId="uuid-1" session={USER_SESSION as any} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('ResearchBot')).toBeInTheDocument()
+    })
+
+    // Click "Assign Skill" to open picker
+    fireEvent.click(screen.getByText('Assign Skill'))
+
+    // Should show container_local skill but NOT elevated ones
+    await waitFor(() => {
+      expect(screen.getByText('Developer')).toBeInTheDocument()
+    })
+    expect(screen.queryByText('Docker Access')).not.toBeInTheDocument()
+    expect(screen.queryByText('VPS Admin')).not.toBeInTheDocument()
+  })
+
+  // T8: Skill instructions toggle
+  it('skill instructions expand on click', async () => {
     mockFetchDefaults(MOCK_AGENT_WITH_SKILL as any)
 
     render(<AgentDetailClient agentId="uuid-1" session={ADMIN_SESSION as any} />)
 
     await waitFor(() => {
-      expect(screen.getByText('ResearchBot')).toBeInTheDocument()
+      expect(screen.getByText('Developer')).toBeInTheDocument()
     })
 
+    // Instructions should NOT be visible initially
+    expect(screen.queryByText(/Always write tests before implementation/)).not.toBeInTheDocument()
+
+    // Click "Show Instructions"
+    fireEvent.click(screen.getByText('Show Instructions'))
+
+    // Instructions should now be visible
     await waitFor(() => {
-      expect(screen.getByText('Skill Instructions')).toBeInTheDocument()
+      expect(screen.getByText(/Always write tests before implementation/)).toBeInTheDocument()
     })
-    expect(screen.getByText(/Always write tests before implementation/)).toBeInTheDocument()
-    expect(screen.getByText(/Follow TDD red-green-refactor/)).toBeInTheDocument()
-  })
-
-  it('does not show skill instructions section when no skill assigned', async () => {
-    render(<AgentDetailClient agentId="uuid-1" session={ADMIN_SESSION as any} />)
-
-    await waitFor(() => {
-      expect(screen.getByText('ResearchBot')).toBeInTheDocument()
-    })
-
-    expect(screen.queryByText('Skill Instructions')).not.toBeInTheDocument()
   })
 })

--- a/services/ui/src/__tests__/AgentFormClient.test.tsx
+++ b/services/ui/src/__tests__/AgentFormClient.test.tsx
@@ -30,6 +30,7 @@ const MOCK_PRESETS = [
     id: 'preset-min',
     name: 'Minimal',
     description: 'Health monitoring only',
+    scope: 'container_local',
     tools_config: {
       shell: { enabled: false, allowed_binaries: [], denied_patterns: [], max_timeout: 300 },
       filesystem: { enabled: false, read_only: false, allowed_paths: ['/workspace'], denied_paths: ['/etc/shadow', '/etc/passwd', '/root'] },
@@ -42,6 +43,7 @@ const MOCK_PRESETS = [
     id: 'preset-dev',
     name: 'Developer',
     description: 'Full dev environment',
+    scope: 'container_local',
     tools_config: {
       shell: { enabled: true, allowed_binaries: ['bash', 'git', 'make', 'curl', 'jq'], denied_patterns: ['rm -rf /', ':(){ :|:& };:'], max_timeout: 300 },
       filesystem: { enabled: true, read_only: false, allowed_paths: ['/workspace', '/data'], denied_paths: ['/etc/shadow', '/etc/passwd', '/root'] },
@@ -49,6 +51,19 @@ const MOCK_PRESETS = [
     },
     instructions_md: 'You have full developer access with bash, git, make, curl, and jq available.',
     is_platform: true,
+  },
+  {
+    id: 'preset-docker',
+    name: 'Docker Access',
+    description: 'Docker socket access',
+    scope: 'host_docker',
+    tools_config: {
+      shell: { enabled: true, allowed_binaries: ['bash', 'docker'], denied_patterns: [], max_timeout: 300 },
+      filesystem: { enabled: true, read_only: false, allowed_paths: ['/workspace'], denied_paths: [] },
+      health: { enabled: true },
+    },
+    instructions_md: 'You have Docker socket access.',
+    is_platform: false,
   },
 ]
 
@@ -362,13 +377,13 @@ describe('AgentFormClient', () => {
 
   // T18: Preset dropdown renders options
   it('renders preset dropdown with preset options and Custom', async () => {
-    render(<AgentFormClient />)
+    render(<AgentFormClient isAdmin />)
 
     await waitFor(() => {
-      expect(screen.getByText('Minimal')).toBeInTheDocument()
+      expect(screen.getByText(/Minimal/)).toBeInTheDocument()
     })
 
-    expect(screen.getByText('Developer')).toBeInTheDocument()
+    expect(screen.getByText(/Developer/)).toBeInTheDocument()
 
     // "Custom" option should exist in the tool profile selector
     const profileSelect = screen.getByRole('combobox', { name: /skill/i })
@@ -406,10 +421,10 @@ describe('AgentFormClient', () => {
 
   // T19: Selecting preset shows summary card
   it('selecting preset shows summary card with tool details', async () => {
-    render(<AgentFormClient />)
+    render(<AgentFormClient isAdmin />)
 
     await waitFor(() => {
-      expect(screen.getByText('Developer')).toBeInTheDocument()
+      expect(screen.getByText(/Developer/)).toBeInTheDocument()
     })
 
     // Select the Developer preset
@@ -428,10 +443,10 @@ describe('AgentFormClient', () => {
 
   // T20: Selecting Custom reveals manual config
   it('selecting Custom shows tool toggles', async () => {
-    render(<AgentFormClient />)
+    render(<AgentFormClient isAdmin />)
 
     await waitFor(() => {
-      expect(screen.getByText('Developer')).toBeInTheDocument()
+      expect(screen.getByText(/Developer/)).toBeInTheDocument()
     })
 
     // Select Developer preset first (from unselected)
@@ -461,10 +476,10 @@ describe('AgentFormClient', () => {
 
   // T21: Preset→Custom populates fields from preset
   it('switching from preset to Custom populates tool fields from preset', async () => {
-    render(<AgentFormClient />)
+    render(<AgentFormClient isAdmin />)
 
     await waitFor(() => {
-      expect(screen.getByText('Developer')).toBeInTheDocument()
+      expect(screen.getByText(/Developer/)).toBeInTheDocument()
     })
 
     // Select Developer preset
@@ -487,10 +502,10 @@ describe('AgentFormClient', () => {
 
   // Submit body includes skill_ids when skill selected
   it('submit body includes skill_ids when skill selected', async () => {
-    render(<AgentFormClient />)
+    render(<AgentFormClient isAdmin />)
 
     await waitFor(() => {
-      expect(screen.getByText('Developer')).toBeInTheDocument()
+      expect(screen.getByText(/Developer/)).toBeInTheDocument()
     })
 
     // Fill required fields
@@ -570,6 +585,57 @@ describe('AgentFormClient', () => {
     })
   })
 
+  // T11: Form dropdown shows scope badge
+  it('skill dropdown shows scope label', async () => {
+    render(<AgentFormClient isAdmin />)
+
+    await waitFor(() => {
+      expect(screen.getByText(/Minimal/)).toBeInTheDocument()
+    })
+
+    // Scope labels should appear in dropdown options
+    const options = screen.getAllByRole('option')
+    const minimalOption = options.find(o => o.textContent?.includes('Minimal'))
+    expect(minimalOption?.textContent).toContain('Container')
+
+    const dockerOption = options.find(o => o.textContent?.includes('Docker Access'))
+    expect(dockerOption?.textContent).toContain('Host · Docker')
+  })
+
+  // T12: Form dropdown filters elevated scopes for non-admin
+  it('non-admin dropdown excludes elevated skills', async () => {
+    render(<AgentFormClient isAdmin={false} />)
+
+    await waitFor(() => {
+      expect(screen.getByText(/Minimal/)).toBeInTheDocument()
+    })
+
+    // Non-admin should see Minimal and Developer (container_local) but NOT Docker Access (host_docker)
+    const options = screen.getAllByRole('option')
+    const optionTexts = options.map(o => o.textContent)
+    expect(optionTexts.some(t => t?.includes('Minimal'))).toBe(true)
+    expect(optionTexts.some(t => t?.includes('Developer'))).toBe(true)
+    expect(optionTexts.some(t => t?.includes('Docker Access'))).toBe(false)
+  })
+
+  // T13: Form instructions preview
+  it('instructions preview shown when skill selected', async () => {
+    render(<AgentFormClient isAdmin />)
+
+    await waitFor(() => {
+      expect(screen.getByText(/Developer/)).toBeInTheDocument()
+    })
+
+    // Select Developer skill
+    const skillSelect = screen.getByRole('combobox', { name: /skill/i })
+    fireEvent.change(skillSelect, { target: { value: 'preset-dev' } })
+
+    // Instructions should be visible in the summary card
+    await waitFor(() => {
+      expect(screen.getByText(/full developer access with bash/i)).toBeInTheDocument()
+    })
+  })
+
   // Overwrite protection: dirty custom → preset selection prompts confirmation
   it('dirty custom state prompts confirmation before switching to preset', async () => {
     render(<AgentFormClient />)
@@ -584,7 +650,7 @@ describe('AgentFormClient', () => {
 
     // confirm() should have been called
     expect(mockConfirm).toHaveBeenCalledWith(
-      expect.stringContaining('overwrite')
+      expect.stringMatching(/overwrite/i)
     )
   })
 
@@ -649,7 +715,7 @@ describe('AgentFormClient', () => {
 
   // T12: Agent form dropdown says "Skill"
   it('agent form shows Skill dropdown label', async () => {
-    render(<AgentFormClient />)
+    render(<AgentFormClient isAdmin />)
 
     await waitFor(() => {
       expect(screen.getByRole('combobox', { name: /^skill$/i })).toBeInTheDocument()
@@ -658,10 +724,10 @@ describe('AgentFormClient', () => {
 
   // T13: Agent form shows instructions preview when skill selected
   it('selecting skill shows instructions preview', async () => {
-    render(<AgentFormClient />)
+    render(<AgentFormClient isAdmin />)
 
     await waitFor(() => {
-      expect(screen.getByText('Developer')).toBeInTheDocument()
+      expect(screen.getByText(/Developer/)).toBeInTheDocument()
     })
 
     // Select Developer skill

--- a/services/ui/src/__tests__/AgentsClient.test.tsx
+++ b/services/ui/src/__tests__/AgentsClient.test.tsx
@@ -37,6 +37,7 @@ const MOCK_AGENTS = [
       health: { enabled: true },
     },
     model_policy_id: 'policy-1',
+    skills: [{ id: 'skill-dev', name: 'Developer', scope: 'container_local' }],
     created_at: '2026-01-01T00:00:00Z',
     updated_at: '2026-01-01T00:00:00Z',
     created_by: 'admin',
@@ -56,6 +57,7 @@ const MOCK_AGENTS = [
       health: { enabled: true },
     },
     model_policy_id: null,
+    skills: [],
     created_at: '2026-02-01T00:00:00Z',
     updated_at: '2026-02-01T00:00:00Z',
     created_by: 'admin',
@@ -75,6 +77,7 @@ const MOCK_AGENTS = [
       health: { enabled: false },
     },
     model_policy_id: null,
+    skills: [],
     created_at: '2026-03-01T00:00:00Z',
     updated_at: '2026-03-01T00:00:00Z',
     created_by: 'admin',
@@ -224,6 +227,32 @@ describe('AgentsClient', () => {
     expect(screen.getByText('ResearchBot')).toBeInTheDocument()
     expect(screen.queryByText('WriterBot')).not.toBeInTheDocument()
     expect(screen.queryByText('ErrorBot')).not.toBeInTheDocument()
+  })
+
+  // T9: Agent list card shows skill badge with scope
+  it('agent card shows skill name and scope', async () => {
+    render(<AgentsClient session={MOCK_SESSION as any} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('ResearchBot')).toBeInTheDocument()
+    })
+
+    // ResearchBot has Developer skill with container_local scope
+    expect(screen.getByText('Developer')).toBeInTheDocument()
+    expect(screen.getByText(/Container/)).toBeInTheDocument()
+  })
+
+  // T10: Agent list card shows Custom when no skill
+  it('agent card shows Custom when no skill', async () => {
+    render(<AgentsClient session={MOCK_SESSION as any} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('WriterBot')).toBeInTheDocument()
+    })
+
+    // WriterBot has no skills → should show "Custom" badge
+    const customBadges = screen.getAllByText('Custom')
+    expect(customBadges.length).toBeGreaterThan(0)
   })
 
   it('running agents appear before stopped agents', async () => {

--- a/services/ui/src/__tests__/SkillsClient.test.tsx
+++ b/services/ui/src/__tests__/SkillsClient.test.tsx
@@ -28,6 +28,7 @@ const MOCK_SKILLS = [
     id: 'preset-minimal',
     name: 'Minimal',
     description: 'Health monitoring only. No shell or filesystem access.',
+    scope: 'container_local',
     tools_config: {
       shell: { enabled: false, allowed_binaries: [], denied_patterns: [], max_timeout: 300 },
       filesystem: { enabled: false, read_only: false, allowed_paths: ['/workspace'], denied_paths: ['/etc/shadow', '/etc/passwd', '/root'] },
@@ -42,6 +43,7 @@ const MOCK_SKILLS = [
     id: 'preset-dev',
     name: 'Developer',
     description: 'Full dev environment: bash, git, make, curl, jq. Read-write workspace and data.',
+    scope: 'host_docker',
     tools_config: {
       shell: { enabled: true, allowed_binaries: ['bash', 'git', 'make', 'curl', 'jq'], denied_patterns: ['rm -rf /', ':(){ :|:& };:'], max_timeout: 300 },
       filesystem: { enabled: true, read_only: false, allowed_paths: ['/workspace', '/data'], denied_paths: ['/etc/shadow', '/etc/passwd', '/root'] },
@@ -56,6 +58,7 @@ const MOCK_SKILLS = [
     id: 'preset-custom',
     name: 'CI Runner',
     description: 'Custom preset for CI pipelines.',
+    scope: 'vps_system',
     tools_config: {
       shell: { enabled: true, allowed_binaries: ['bash', 'git'], denied_patterns: [], max_timeout: 300 },
       filesystem: { enabled: true, read_only: false, allowed_paths: ['/workspace'], denied_paths: [] },
@@ -169,6 +172,22 @@ describe('SkillsClient', () => {
     // Instructions textarea should be pre-filled
     const instructionsTextarea = screen.getByPlaceholderText(/behavioral instructions/i) as HTMLTextAreaElement
     expect(instructionsTextarea.value).toBe('Run CI pipelines in isolated containers.')
+  })
+
+  // T14: Skills admin shows scope badge with correct labels
+  it('skill row shows scope badge with tier-specific label', async () => {
+    render(<SkillsClient />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Minimal')).toBeInTheDocument()
+    })
+
+    // container_local → "Container"
+    expect(screen.getByText('Container')).toBeInTheDocument()
+    // host_docker → "Host · Docker"
+    expect(screen.getByText('Host · Docker')).toBeInTheDocument()
+    // vps_system → "VPS · System"
+    expect(screen.getByText('VPS · System')).toBeInTheDocument()
   })
 
   // T11: Nav says "Skills" with /harness/skills href

--- a/services/ui/src/app/agents/AgentsClient.tsx
+++ b/services/ui/src/app/agents/AgentsClient.tsx
@@ -16,9 +16,23 @@ interface Agent {
   pids_limit: number
   tools_config: Record<string, any> | null
   model_policy_id: string | null
+  skills: Array<{ id: string; name: string; scope: string }>
   created_at: string
   updated_at: string
   created_by: string
+}
+
+function scopeBadge(scope: string): { label: string; colorClasses: string } {
+  switch (scope) {
+    case 'container_local':
+      return { label: 'Container', colorClasses: 'bg-brand-900/50 text-brand-400 border border-brand-700' }
+    case 'host_docker':
+      return { label: 'Host · Docker', colorClasses: 'bg-amber-900/50 text-amber-400 border border-amber-700' }
+    case 'vps_system':
+      return { label: 'VPS · System', colorClasses: 'bg-red-900/50 text-red-400 border border-red-700' }
+    default:
+      return { label: scope, colorClasses: 'bg-navy-900 text-mountain-400 border border-navy-700' }
+  }
 }
 
 interface ModelPolicy {
@@ -181,6 +195,20 @@ export default function AgentsClient({ session }: { session: Session }) {
                   {tc.health?.enabled && (
                     <span aria-label="Health endpoint" className="inline-flex items-center px-1.5 py-0.5 rounded-md bg-navy-900 border border-navy-600" title="Health endpoint">
                       <Heart className="h-3.5 w-3.5 text-mountain-400" />
+                    </span>
+                  )}
+                </div>
+
+                {/* Skill Badge */}
+                <div className="mb-3">
+                  {agent.skills && agent.skills.length > 0 ? (
+                    <span className={`inline-flex items-center gap-1.5 px-2 py-0.5 text-xs font-medium rounded-md ${scopeBadge(agent.skills[0].scope).colorClasses}`}>
+                      {agent.skills[0].name}
+                      <span className="opacity-75">· {scopeBadge(agent.skills[0].scope).label}</span>
+                    </span>
+                  ) : (
+                    <span className="inline-flex items-center px-2 py-0.5 text-xs font-medium rounded-md bg-navy-900 text-mountain-400 border border-navy-700">
+                      Custom
                     </span>
                   )}
                 </div>

--- a/services/ui/src/app/agents/[id]/AgentDetailClient.tsx
+++ b/services/ui/src/app/agents/[id]/AgentDetailClient.tsx
@@ -36,6 +36,28 @@ interface ModelPolicy {
   created_by: string | null
 }
 
+interface SkillRecord {
+  id: string
+  name: string
+  scope: string
+  instructions_md?: string
+}
+
+const ELEVATED_SCOPES = ['host_docker', 'vps_system']
+
+function scopeBadge(scope: string): { label: string; colorClasses: string } {
+  switch (scope) {
+    case 'container_local':
+      return { label: 'Container', colorClasses: 'bg-brand-900/50 text-brand-400 border border-brand-700' }
+    case 'host_docker':
+      return { label: 'Host · Docker', colorClasses: 'bg-amber-900/50 text-amber-400 border border-amber-700' }
+    case 'vps_system':
+      return { label: 'VPS · System', colorClasses: 'bg-red-900/50 text-red-400 border border-red-700' }
+    default:
+      return { label: scope, colorClasses: 'bg-navy-900 text-mountain-400 border border-navy-700' }
+  }
+}
+
 type TabId = 'overview' | 'configuration' | 'model-access' | 'knowledge' | 'activity'
 
 export default function AgentDetailClient({
@@ -65,6 +87,11 @@ export default function AgentDetailClient({
   const [showLogs, setShowLogs] = useState(false)
   const logsEndRef = useRef<HTMLDivElement>(null)
   const eventSourceRef = useRef<EventSource | null>(null)
+
+  // Skills
+  const [allSkills, setAllSkills] = useState<SkillRecord[]>([])
+  const [showAssignPicker, setShowAssignPicker] = useState(false)
+  const [expandedSkillInstructions, setExpandedSkillInstructions] = useState<Set<string>>(new Set())
 
   // Activity sub-view state
   const [activityView, setActivityView] = useState<'events' | 'logs'>('events')
@@ -97,10 +124,22 @@ export default function AgentDetailClient({
     }
   }, [])
 
+  const fetchAllSkills = useCallback(async () => {
+    try {
+      const res = await fetch('/api/skills')
+      if (res.ok) {
+        setAllSkills(await res.json())
+      }
+    } catch (err) {
+      console.error('Failed to fetch skills:', err)
+    }
+  }, [])
+
   useEffect(() => {
     fetchAgent()
     fetchPolicies()
-  }, [fetchAgent, fetchPolicies])
+    fetchAllSkills()
+  }, [fetchAgent, fetchPolicies, fetchAllSkills])
 
   // Poll status while running
   useEffect(() => {
@@ -210,8 +249,58 @@ export default function AgentDetailClient({
   if (!agent) return null
 
   const currentPolicy = policies.find((p) => p.id === agent.model_policy_id)
-  const currentSkill = agent.skills?.[0] || null
+  const agentSkills = agent.skills || []
   const tc = agent.tools_config || {}
+
+  const handleAssignSkill = async (skillId: string) => {
+    try {
+      const res = await fetch(`/api/agents/${agentId}/skills`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ skill_id: skillId }),
+      })
+      if (!res.ok) {
+        const data = await res.json()
+        alert(data.error || 'Failed to assign skill')
+        return
+      }
+      setShowAssignPicker(false)
+      await fetchAgent()
+    } catch (err) {
+      console.error('Failed to assign skill:', err)
+    }
+  }
+
+  const handleRemoveSkill = async (skillId: string) => {
+    if (!confirm('Remove this skill from the agent?')) return
+    try {
+      const res = await fetch(`/api/agents/${agentId}/skills/${skillId}`, {
+        method: 'DELETE',
+      })
+      if (!res.ok) {
+        const data = await res.json()
+        alert(data.error || 'Failed to remove skill')
+        return
+      }
+      await fetchAgent()
+    } catch (err) {
+      console.error('Failed to remove skill:', err)
+    }
+  }
+
+  const toggleSkillInstructions = (skillId: string) => {
+    setExpandedSkillInstructions(prev => {
+      const next = new Set(prev)
+      if (next.has(skillId)) next.delete(skillId)
+      else next.add(skillId)
+      return next
+    })
+  }
+
+  // For assign picker: admins see all skills, non-admins see only container_local
+  const assignableSkills = isAdmin
+    ? allSkills
+    : allSkills.filter(s => !ELEVATED_SCOPES.includes(s.scope))
 
   const tabs: { id: TabId; label: string; adminOnly?: boolean }[] = [
     { id: 'overview', label: 'Overview' },
@@ -327,32 +416,101 @@ export default function AgentDetailClient({
             </div>
           )}
 
-          {/* Quick Tool Summary */}
+          {/* Skills Card */}
           <div className="rounded-lg border border-navy-700 bg-navy-800 p-5">
             <div className="flex items-center justify-between mb-3">
-              <h2 className="text-lg font-semibold text-white">Tool Access</h2>
-              <span className={`px-2.5 py-1 text-xs rounded-md ${
-                currentSkill
-                  ? 'bg-brand-900/50 text-brand-400 border border-brand-700'
-                  : 'bg-navy-900 text-mountain-400 border border-navy-700'
-              }`}>
-                {currentSkill ? `Skill: ${currentSkill.name}` : 'Custom'}
-              </span>
+              <h2 className="text-lg font-semibold text-white">Skills</h2>
+              {agent.status !== 'running' && (
+                <button
+                  onClick={() => setShowAssignPicker(!showAssignPicker)}
+                  className="px-3 py-1.5 text-xs font-medium rounded-md bg-brand-600 hover:bg-brand-500 text-white transition-colors cursor-pointer"
+                >
+                  Assign Skill
+                </button>
+              )}
             </div>
+
+            {/* Assign picker */}
+            {showAssignPicker && (
+              <div className="mb-4 rounded-md border border-navy-600 bg-navy-900 p-3">
+                <p className="text-xs text-mountain-400 mb-2">Select a skill to assign:</p>
+                <div className="space-y-1">
+                  {assignableSkills.map(s => (
+                    <button
+                      key={s.id}
+                      onClick={() => handleAssignSkill(s.id)}
+                      className="w-full text-left px-3 py-2 text-sm rounded-md hover:bg-navy-800 text-white transition-colors flex items-center gap-2 cursor-pointer"
+                    >
+                      <span>{s.name}</span>
+                      <span className={`px-1.5 py-0.5 text-xs rounded-md ${scopeBadge(s.scope).colorClasses}`}>
+                        {scopeBadge(s.scope).label}
+                      </span>
+                    </button>
+                  ))}
+                  {assignableSkills.length === 0 && (
+                    <p className="text-xs text-mountain-500 py-2">No skills available</p>
+                  )}
+                </div>
+              </div>
+            )}
+
+            {agentSkills.length > 0 ? (
+              <div className="space-y-3">
+                {agentSkills.map(skill => {
+                  const badge = scopeBadge(skill.scope)
+                  const canRemove = isAdmin || !ELEVATED_SCOPES.includes(skill.scope)
+                  const instructionsExpanded = expandedSkillInstructions.has(skill.id)
+                  return (
+                    <div key={skill.id} className="rounded-md border border-navy-700 bg-navy-900 p-3">
+                      <div className="flex items-center justify-between">
+                        <div className="flex items-center gap-2">
+                          <span className="text-sm font-medium text-white">{skill.name}</span>
+                          <span className={`px-1.5 py-0.5 text-xs rounded-md ${badge.colorClasses}`}>
+                            {badge.label}
+                          </span>
+                        </div>
+                        <div className="flex items-center gap-2">
+                          {skill.instructions_md && (
+                            <button
+                              onClick={() => toggleSkillInstructions(skill.id)}
+                              className="text-xs text-brand-400 hover:text-brand-300 transition-colors cursor-pointer"
+                            >
+                              {instructionsExpanded ? 'Hide Instructions' : 'Show Instructions'}
+                            </button>
+                          )}
+                          {canRemove && agent.status !== 'running' && (
+                            <button
+                              onClick={() => handleRemoveSkill(skill.id)}
+                              className="px-2 py-1 text-xs font-medium rounded-md border border-red-700 text-red-400 hover:bg-red-900/30 transition-colors cursor-pointer"
+                            >
+                              Remove
+                            </button>
+                          )}
+                        </div>
+                      </div>
+                      {instructionsExpanded && skill.instructions_md && (
+                        <pre className="mt-2 text-sm text-mountain-300 whitespace-pre-wrap bg-navy-800 rounded-md p-3 max-h-64 overflow-y-auto">
+                          {skill.instructions_md}
+                        </pre>
+                      )}
+                    </div>
+                  )
+                })}
+              </div>
+            ) : (
+              <p className="text-sm text-mountain-500">No skills assigned</p>
+            )}
+          </div>
+
+          {/* Quick Tool Summary */}
+          <div className="rounded-lg border border-navy-700 bg-navy-800 p-5">
+            <h2 className="text-lg font-semibold text-white mb-3">Tool Access</h2>
             <div className="flex flex-wrap gap-2">
               <ToolBadge label="Shell" enabled={tc.shell?.enabled} summary={tc.shell?.enabled ? `${tc.shell.allowed_binaries?.length || 0} binaries, ${tc.shell.denied_patterns?.length || 0} patterns` : undefined} />
               <ToolBadge label="Filesystem" enabled={tc.filesystem?.enabled} summary={tc.filesystem?.enabled ? (tc.filesystem.read_only ? 'Read-only' : 'Read-write') : undefined} />
               <ToolBadge label="Health" enabled={tc.health?.enabled} />
             </div>
           </div>
-
-          {/* Skill Instructions */}
-          {currentSkill?.instructions_md && (
-            <div className="rounded-lg border border-navy-700 bg-navy-800 p-5">
-              <h2 className="text-lg font-semibold text-white mb-2">Skill Instructions</h2>
-              <pre className="text-sm text-mountain-300 whitespace-pre-wrap bg-navy-900 rounded-md p-3 max-h-64 overflow-y-auto">{currentSkill.instructions_md}</pre>
-            </div>
-          )}
 
           {/* Resource Grid */}
           <div className="rounded-lg border border-navy-700 bg-navy-800 p-5">

--- a/services/ui/src/app/agents/[id]/edit/AgentEditClient.tsx
+++ b/services/ui/src/app/agents/[id]/edit/AgentEditClient.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import AgentFormClient from '../../new/AgentFormClient'
 
-export default function AgentEditClient({ agentId }: { agentId: string }) {
+export default function AgentEditClient({ agentId, isAdmin = false }: { agentId: string; isAdmin?: boolean }) {
   const router = useRouter()
   const [agent, setAgent] = useState<any>(null)
   const [loading, setLoading] = useState(true)
@@ -54,6 +54,7 @@ export default function AgentEditClient({ agentId }: { agentId: string }) {
       }}
       agentUuid={agent.id}
       disabled={agent.status === 'running'}
+      isAdmin={isAdmin}
     />
   )
 }

--- a/services/ui/src/app/agents/[id]/edit/page.tsx
+++ b/services/ui/src/app/agents/[id]/edit/page.tsx
@@ -9,13 +9,14 @@ export default async function EditAgentPage({ params }: { params: Promise<{ id: 
     redirect('/api/auth/signin')
   }
 
+  const isAdmin = (session.user as any)?.roles?.includes('admin') ?? false
   const { id } = await params
 
   return (
     <AppShell>
       <main className="flex-1 px-6 py-12 max-w-3xl mx-auto w-full">
         <h1 className="text-2xl font-bold mb-8">Edit Agent</h1>
-        <AgentEditClient agentId={id} />
+        <AgentEditClient agentId={id} isAdmin={isAdmin} />
       </main>
     </AppShell>
   )

--- a/services/ui/src/app/agents/new/AgentFormClient.tsx
+++ b/services/ui/src/app/agents/new/AgentFormClient.tsx
@@ -20,13 +20,29 @@ const defaultTools: ToolsConfig = {
   health: { enabled: true },
 }
 
-interface PresetOption {
+interface SkillOption {
   id: string
   name: string
   description: string
+  scope: string
   tools_config: ToolsConfig
   instructions_md?: string
   is_platform: boolean
+}
+
+const ELEVATED_SCOPES = ['host_docker', 'vps_system']
+
+function scopeBadge(scope: string): { label: string; colorClasses: string } {
+  switch (scope) {
+    case 'container_local':
+      return { label: 'Container', colorClasses: 'bg-brand-900/50 text-brand-400 border border-brand-700' }
+    case 'host_docker':
+      return { label: 'Host · Docker', colorClasses: 'bg-amber-900/50 text-amber-400 border border-amber-700' }
+    case 'vps_system':
+      return { label: 'VPS · System', colorClasses: 'bg-red-900/50 text-red-400 border border-red-700' }
+    default:
+      return { label: scope, colorClasses: 'bg-navy-900 text-mountain-400 border border-navy-700' }
+  }
 }
 
 interface PolicyOption {
@@ -38,6 +54,7 @@ export default function AgentFormClient({
   initial,
   agentUuid,
   disabled,
+  isAdmin = false,
 }: {
   initial?: {
     agent_id: string
@@ -54,6 +71,7 @@ export default function AgentFormClient({
   }
   agentUuid?: string
   disabled?: boolean
+  isAdmin?: boolean
 }) {
   const router = useRouter()
   const isEdit = !!agentUuid
@@ -72,9 +90,9 @@ export default function AgentFormClient({
   const [rulesMd, setRulesMd] = useState(initial?.rules_md || '')
   const [modelPolicyId, setModelPolicyId] = useState(initial?.model_policy_id || '')
   const [policies, setPolicies] = useState<PolicyOption[]>([])
-  const [presets, setPresets] = useState<PresetOption[]>([])
+  const [skills, setSkills] = useState<SkillOption[]>([])
   // New agents: unselected prompt. Edit agents: skill ID or '' (Custom).
-  const [toolPresetId, setToolPresetId] = useState(
+  const [selectedSkillId, setToolPresetId] = useState(
     initial ? (initial.skills?.[0]?.id || '') : UNSELECTED
   )
   const toolsCustomDirty = useRef(false)
@@ -91,7 +109,7 @@ export default function AgentFormClient({
       .catch(() => {})
     fetch('/api/skills')
       .then((res) => (res.ok ? res.json() : []))
-      .then((data) => setPresets(data))
+      .then((data) => setSkills(data))
       .catch(() => {})
   }, [])
 
@@ -101,22 +119,22 @@ export default function AgentFormClient({
     toolsCustomDirty.current = true
   }
 
-  const handleProfileChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+  const handleSkillChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     const newId = e.target.value
-    const switchingFromCustom = toolPresetId === ''
+    const switchingFromCustom = selectedSkillId === ''
 
     // Overwrite protection: if user has made manual changes in Custom mode
     if (switchingFromCustom && newId && newId !== UNSELECTED && toolsCustomDirty.current) {
-      if (!confirm('Switching to a preset will overwrite your custom tool configuration. Continue?')) {
+      if (!confirm('Switching to a skill will overwrite your custom tool configuration. Continue?')) {
         return
       }
     }
 
     if (newId && newId !== UNSELECTED) {
-      // Switching to a preset — copy its tools_config
-      const preset = presets.find((p) => p.id === newId)
-      if (preset) {
-        setTools(preset.tools_config)
+      // Switching to a skill — copy its tools_config
+      const skill = skills.find((p) => p.id === newId)
+      if (skill) {
+        setTools(skill.tools_config)
       }
       toolsCustomDirty.current = false
     } else if (newId === '') {
@@ -128,7 +146,7 @@ export default function AgentFormClient({
   }
 
   const validateForm = (): boolean => {
-    if (toolPresetId === UNSELECTED) {
+    if (selectedSkillId === UNSELECTED) {
       setValidationError('Please select a skill or choose Custom')
       return false
     }
@@ -158,7 +176,7 @@ export default function AgentFormClient({
       soul_md: soulMd,
       rules_md: rulesMd,
       model_policy_id: modelPolicyId || null,
-      skill_ids: toolPresetId ? [toolPresetId] : [],
+      skill_ids: selectedSkillId ? [selectedSkillId] : [],
     }
 
     try {
@@ -270,16 +288,16 @@ export default function AgentFormClient({
           </label>
           <select
             id="skill"
-            value={toolPresetId}
-            onChange={handleProfileChange}
+            value={selectedSkillId}
+            onChange={handleSkillChange}
             className="rounded-lg border border-navy-600 bg-navy-900 px-3 py-2 text-sm text-white focus:border-brand-500 focus:outline-none disabled:opacity-50"
           >
-            {toolPresetId === UNSELECTED && (
+            {selectedSkillId === UNSELECTED && (
               <option value={UNSELECTED} disabled>Select a skill...</option>
             )}
             <option value="">Custom</option>
-            {presets.map((p) => (
-              <option key={p.id} value={p.id}>{p.name}</option>
+            {(isAdmin ? skills : skills.filter(s => !ELEVATED_SCOPES.includes(s.scope))).map((p) => (
+              <option key={p.id} value={p.id}>{p.name} ({scopeBadge(p.scope).label})</option>
             ))}
           </select>
           <p className="text-xs text-mountain-500 mt-1">
@@ -287,24 +305,24 @@ export default function AgentFormClient({
           </p>
         </div>
 
-        {toolPresetId === UNSELECTED ? (
+        {selectedSkillId === UNSELECTED ? (
           /* No selection yet — prompt user */
           <div className="rounded-lg border border-navy-700 bg-navy-800 p-4">
             <p className="text-sm text-mountain-400">
               Choose a skill above to configure this agent&apos;s capabilities.
             </p>
           </div>
-        ) : toolPresetId ? (
+        ) : selectedSkillId ? (
           /* Preset selected — show read-only summary */
           <div className="rounded-lg border border-navy-700 bg-navy-800 p-4 space-y-3">
             {(() => {
-              const preset = presets.find((p) => p.id === toolPresetId)
-              if (!preset) return null
-              const tc = preset.tools_config
+              const selected = skills.find((p) => p.id === selectedSkillId)
+              if (!selected) return null
+              const tc = selected.tools_config
               return (
                 <>
-                  {preset.description && (
-                    <p className="text-sm text-mountain-300">{preset.description}</p>
+                  {selected.description && (
+                    <p className="text-sm text-mountain-300">{selected.description}</p>
                   )}
                   <div className="space-y-2">
                     <div className="flex items-center gap-2 text-sm">
@@ -330,10 +348,10 @@ export default function AgentFormClient({
                       <span className="text-white">Health</span>
                     </div>
                   </div>
-                  {preset.instructions_md && (
+                  {selected.instructions_md && (
                     <div className="border-t border-navy-700 pt-3">
                       <h4 className="text-xs font-medium text-mountain-400 uppercase tracking-wide mb-1">Instructions</h4>
-                      <p className="text-sm text-mountain-300 whitespace-pre-wrap">{preset.instructions_md}</p>
+                      <p className="text-sm text-mountain-300 whitespace-pre-wrap">{selected.instructions_md}</p>
                     </div>
                   )}
                   <p className="text-xs text-mountain-500">

--- a/services/ui/src/app/agents/new/page.tsx
+++ b/services/ui/src/app/agents/new/page.tsx
@@ -10,11 +10,13 @@ export default async function NewAgentPage() {
     redirect('/api/auth/signin')
   }
 
+  const isAdmin = (session.user as any)?.roles?.includes('admin') ?? false
+
   return (
     <AppShell>
       <main className="flex-1 px-6 py-12 max-w-3xl mx-auto w-full">
         <h1 className="text-2xl font-bold mb-8">Create Agent</h1>
-        <AgentFormClient />
+        <AgentFormClient isAdmin={isAdmin} />
       </main>
     </AppShell>
   )

--- a/services/ui/src/app/harness/skills/SkillsClient.tsx
+++ b/services/ui/src/app/harness/skills/SkillsClient.tsx
@@ -14,11 +14,25 @@ interface Skill {
   id: string
   name: string
   description: string
+  scope: string
   tools_config: ToolsConfig
   instructions_md: string
   is_platform: boolean
   created_at: string
   updated_at: string
+}
+
+function scopeBadge(scope: string): { label: string; colorClasses: string } {
+  switch (scope) {
+    case 'container_local':
+      return { label: 'Container', colorClasses: 'bg-brand-900/50 text-brand-400 border border-brand-700' }
+    case 'host_docker':
+      return { label: 'Host · Docker', colorClasses: 'bg-amber-900/50 text-amber-400 border border-amber-700' }
+    case 'vps_system':
+      return { label: 'VPS · System', colorClasses: 'bg-red-900/50 text-red-400 border border-red-700' }
+    default:
+      return { label: scope, colorClasses: 'bg-navy-900 text-mountain-400 border border-navy-700' }
+  }
 }
 
 export default function SkillsClient() {
@@ -369,6 +383,11 @@ export default function SkillsClient() {
                       {skill.is_platform && (
                         <span className="px-2 py-0.5 text-xs rounded-md bg-mountain-500/20 text-mountain-300 border border-mountain-500/30">
                           Platform
+                        </span>
+                      )}
+                      {skill.scope && (
+                        <span className={`px-2 py-0.5 text-xs rounded-md ${scopeBadge(skill.scope).colorClasses}`}>
+                          {scopeBadge(skill.scope).label}
                         </span>
                       )}
                       <div className="flex flex-wrap gap-1">


### PR DESCRIPTION
## Summary

- **Close scope RBAC gap**: `POST /agents` and `PUT /agents/:id` now check `ELEVATED_SCOPES` before accepting `skill_ids` — all four assignment paths (create, update, direct assign, direct remove) enforce elevated-skill RBAC in the backend
- **AgentDetailClient**: Replace `skills?.[0]` hardcode with array iteration; dedicated Skills card with scope badges, per-skill instructions toggle, and authority-gated assign/remove actions
- **AgentFormClient**: Rename `toolPresetId` → `selectedSkillId`; scope badge in dropdown; filter elevated scopes for non-admins; instructions preview
- **AgentsClient**: Skill badge with scope on agent cards; "Custom" when no skill assigned
- **SkillsClient**: Three-tier scope badge (Container green / Host · Docker amber / VPS · System red)
- **Prop threading**: `isAdmin` passed from server pages through `AgentEditClient` to `AgentFormClient`

## Phase 3 scope confirmation

- Minimal backend RBAC completion only (~10 lines production code)
- No new API routes or proxy routes
- No multi-select UI — form stays single-select
- No multi-skill merge logic — max-1 enforcement preserved

## Verification evidence

| Check | Result |
|-------|--------|
| V1 UI tests | 33 files, 296 tests passed (vitest) |
| V2 API tests | 26 suites, 277 tests passed (jest) |
| V3 TypeScript API | Clean, zero errors |
| V3 TypeScript UI | 9 pre-existing errors, none introduced by this phase |
| V4 No `skills?.[0]` in AgentDetailClient | 0 matches |
| V5 No `toolPresetId` in AgentFormClient | 0 matches |
| V6 No generic "platform" scope label | 0 matches |
| V7 All three scope labels present | 4 components verified |
| V8 ELEVATED_SCOPES matches backend | Backend + 2 UI files identical |
| V9a Direct assign RBAC | `user host_docker 403` passes |
| V9b Direct remove RBAC | `user remove host_docker 403` passes |
| V9c Create RBAC | `host_docker skill as non-admin returns 403` passes |
| V9d Update RBAC | `vps_system skill as non-admin returns 403` passes |

## Test plan

- [ ] V1: `cd services/ui && npx vitest run` — 33 files, 296 tests pass
- [ ] V2: `cd services/api && npx jest --verbose` — 26 suites, 277 tests pass
- [ ] V3: TypeScript compiles (API clean; UI has 9 pre-existing errors only)
- [ ] V9: All four assignment paths enforce scope RBAC (4 targeted jest runs)
- [ ] V4-V8: Static grep gates pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)