### PR TITLE
feat: multi-skill runtime semantics (Phase 4)

### DIFF
--- a/docs/site/openapi.yaml
+++ b/docs/site/openapi.yaml
@@ -643,8 +643,7 @@ paths:
                   items:
                     type: string
                     format: uuid
-                  maxItems: 1
-                  description: Skill IDs to assign (max 1). Config is copied into agent at save time (resolve-on-save).
+                  description: Skill IDs to assign. Config is merged from all skills at save time (resolve-on-save).
       responses:
         "201":
           description: Agent created
@@ -727,8 +726,7 @@ paths:
                   items:
                     type: string
                     format: uuid
-                  maxItems: 1
-                  description: Skill IDs to assign (max 1). Config is copied into agent at save time. Empty array to detach skill.
+                  description: Skill IDs to assign. Empty array to detach all skills (Custom mode). Config is merged from all skills at save time.
       responses:
         "200":
           description: Agent updated

--- a/services/api/src/__tests__/merge-tools-config.test.ts
+++ b/services/api/src/__tests__/merge-tools-config.test.ts
@@ -1,0 +1,252 @@
+import { mergeToolsConfigs, DEFAULT_TOOLS_CONFIG, ToolsConfig } from '../services/merge-tools-config';
+
+describe('mergeToolsConfigs', () => {
+  // M1: Empty array returns no-skills default config
+  it('returns default config for empty array', () => {
+    const result = mergeToolsConfigs([]);
+    expect(result).toEqual(DEFAULT_TOOLS_CONFIG);
+    expect(result.shell.enabled).toBe(false);
+    expect(result.filesystem.enabled).toBe(false);
+    expect(result.health.enabled).toBe(true);
+    expect(result.shell.max_timeout).toBe(300);
+    expect(result.filesystem.read_only).toBe(false);
+    expect(result.filesystem.allowed_paths).toEqual(['/workspace']);
+    expect(result.filesystem.denied_paths).toEqual(['/etc/shadow', '/etc/passwd', '/root']);
+  });
+
+  // M2: Single config returns itself
+  it('returns single config unchanged', () => {
+    const single: ToolsConfig = {
+      shell: { enabled: true, allowed_binaries: ['bash'], denied_patterns: ['rm -rf'], max_timeout: 600 },
+      filesystem: { enabled: true, read_only: true, allowed_paths: ['/data'], denied_paths: ['/root'] },
+      health: { enabled: false },
+    };
+    const result = mergeToolsConfigs([single]);
+    expect(result).toBe(single); // Same reference
+  });
+
+  // M3: shell.enabled OR
+  it('shell.enabled uses OR', () => {
+    const a: ToolsConfig = {
+      shell: { enabled: false, allowed_binaries: [], denied_patterns: [], max_timeout: 300 },
+      filesystem: { enabled: false, read_only: false, allowed_paths: [], denied_paths: [] },
+      health: { enabled: false },
+    };
+    const b: ToolsConfig = {
+      shell: { enabled: true, allowed_binaries: [], denied_patterns: [], max_timeout: 300 },
+      filesystem: { enabled: false, read_only: false, allowed_paths: [], denied_paths: [] },
+      health: { enabled: false },
+    };
+    expect(mergeToolsConfigs([a, b]).shell.enabled).toBe(true);
+  });
+
+  // M4: shell.allowed_binaries UNION
+  it('shell.allowed_binaries uses UNION', () => {
+    const a: ToolsConfig = {
+      shell: { enabled: true, allowed_binaries: ['bash'], denied_patterns: [], max_timeout: 300 },
+      filesystem: { enabled: false, read_only: false, allowed_paths: [], denied_paths: [] },
+      health: { enabled: true },
+    };
+    const b: ToolsConfig = {
+      shell: { enabled: true, allowed_binaries: ['git'], denied_patterns: [], max_timeout: 300 },
+      filesystem: { enabled: false, read_only: false, allowed_paths: [], denied_paths: [] },
+      health: { enabled: true },
+    };
+    const result = mergeToolsConfigs([a, b]);
+    expect(result.shell.allowed_binaries.sort()).toEqual(['bash', 'git']);
+  });
+
+  // M5: shell.allowed_binaries empty-means-unrestricted
+  it('shell.allowed_binaries empty array means unrestricted', () => {
+    const a: ToolsConfig = {
+      shell: { enabled: true, allowed_binaries: ['bash'], denied_patterns: [], max_timeout: 300 },
+      filesystem: { enabled: false, read_only: false, allowed_paths: [], denied_paths: [] },
+      health: { enabled: true },
+    };
+    const b: ToolsConfig = {
+      shell: { enabled: true, allowed_binaries: [], denied_patterns: [], max_timeout: 300 },
+      filesystem: { enabled: false, read_only: false, allowed_paths: [], denied_paths: [] },
+      health: { enabled: true },
+    };
+    const result = mergeToolsConfigs([a, b]);
+    expect(result.shell.allowed_binaries).toEqual([]);
+  });
+
+  // M6: shell.denied_patterns UNION
+  it('shell.denied_patterns uses UNION', () => {
+    const a: ToolsConfig = {
+      shell: { enabled: true, allowed_binaries: [], denied_patterns: ['rm -rf'], max_timeout: 300 },
+      filesystem: { enabled: false, read_only: false, allowed_paths: [], denied_paths: [] },
+      health: { enabled: true },
+    };
+    const b: ToolsConfig = {
+      shell: { enabled: true, allowed_binaries: [], denied_patterns: ['dd'], max_timeout: 300 },
+      filesystem: { enabled: false, read_only: false, allowed_paths: [], denied_paths: [] },
+      health: { enabled: true },
+    };
+    const result = mergeToolsConfigs([a, b]);
+    expect(result.shell.denied_patterns.sort()).toEqual(['dd', 'rm -rf']);
+  });
+
+  // M7: shell.max_timeout MAX
+  it('shell.max_timeout uses MAX', () => {
+    const a: ToolsConfig = {
+      shell: { enabled: true, allowed_binaries: [], denied_patterns: [], max_timeout: 300 },
+      filesystem: { enabled: false, read_only: false, allowed_paths: [], denied_paths: [] },
+      health: { enabled: true },
+    };
+    const b: ToolsConfig = {
+      shell: { enabled: true, allowed_binaries: [], denied_patterns: [], max_timeout: 600 },
+      filesystem: { enabled: false, read_only: false, allowed_paths: [], denied_paths: [] },
+      health: { enabled: true },
+    };
+    expect(mergeToolsConfigs([a, b]).shell.max_timeout).toBe(600);
+  });
+
+  // M8: filesystem.enabled OR
+  it('filesystem.enabled uses OR', () => {
+    const a: ToolsConfig = {
+      shell: { enabled: false, allowed_binaries: [], denied_patterns: [], max_timeout: 300 },
+      filesystem: { enabled: false, read_only: false, allowed_paths: [], denied_paths: [] },
+      health: { enabled: true },
+    };
+    const b: ToolsConfig = {
+      shell: { enabled: false, allowed_binaries: [], denied_patterns: [], max_timeout: 300 },
+      filesystem: { enabled: true, read_only: false, allowed_paths: [], denied_paths: [] },
+      health: { enabled: true },
+    };
+    expect(mergeToolsConfigs([a, b]).filesystem.enabled).toBe(true);
+  });
+
+  // M9: filesystem.read_only AND
+  it('filesystem.read_only uses AND', () => {
+    const a: ToolsConfig = {
+      shell: { enabled: false, allowed_binaries: [], denied_patterns: [], max_timeout: 300 },
+      filesystem: { enabled: true, read_only: true, allowed_paths: [], denied_paths: [] },
+      health: { enabled: true },
+    };
+    const b: ToolsConfig = {
+      shell: { enabled: false, allowed_binaries: [], denied_patterns: [], max_timeout: 300 },
+      filesystem: { enabled: true, read_only: false, allowed_paths: [], denied_paths: [] },
+      health: { enabled: true },
+    };
+    // false if any is false
+    expect(mergeToolsConfigs([a, b]).filesystem.read_only).toBe(false);
+
+    // true only if all are true
+    const c: ToolsConfig = { ...a, filesystem: { ...a.filesystem, read_only: true } };
+    const d: ToolsConfig = { ...b, filesystem: { ...b.filesystem, read_only: true } };
+    expect(mergeToolsConfigs([c, d]).filesystem.read_only).toBe(true);
+  });
+
+  // M10: filesystem.allowed_paths UNION
+  it('filesystem.allowed_paths uses UNION', () => {
+    const a: ToolsConfig = {
+      shell: { enabled: false, allowed_binaries: [], denied_patterns: [], max_timeout: 300 },
+      filesystem: { enabled: true, read_only: false, allowed_paths: ['/workspace'], denied_paths: [] },
+      health: { enabled: true },
+    };
+    const b: ToolsConfig = {
+      shell: { enabled: false, allowed_binaries: [], denied_patterns: [], max_timeout: 300 },
+      filesystem: { enabled: true, read_only: false, allowed_paths: ['/data'], denied_paths: [] },
+      health: { enabled: true },
+    };
+    const result = mergeToolsConfigs([a, b]);
+    expect(result.filesystem.allowed_paths.sort()).toEqual(['/data', '/workspace']);
+  });
+
+  // M11: filesystem.denied_paths UNION
+  it('filesystem.denied_paths uses UNION', () => {
+    const a: ToolsConfig = {
+      shell: { enabled: false, allowed_binaries: [], denied_patterns: [], max_timeout: 300 },
+      filesystem: { enabled: true, read_only: false, allowed_paths: [], denied_paths: ['/etc/shadow'] },
+      health: { enabled: true },
+    };
+    const b: ToolsConfig = {
+      shell: { enabled: false, allowed_binaries: [], denied_patterns: [], max_timeout: 300 },
+      filesystem: { enabled: true, read_only: false, allowed_paths: [], denied_paths: ['/root'] },
+      health: { enabled: true },
+    };
+    const result = mergeToolsConfigs([a, b]);
+    expect(result.filesystem.denied_paths.sort()).toEqual(['/etc/shadow', '/root']);
+  });
+
+  // M12: health.enabled OR
+  it('health.enabled uses OR', () => {
+    const a: ToolsConfig = {
+      shell: { enabled: false, allowed_binaries: [], denied_patterns: [], max_timeout: 300 },
+      filesystem: { enabled: false, read_only: false, allowed_paths: [], denied_paths: [] },
+      health: { enabled: false },
+    };
+    const b: ToolsConfig = {
+      shell: { enabled: false, allowed_binaries: [], denied_patterns: [], max_timeout: 300 },
+      filesystem: { enabled: false, read_only: false, allowed_paths: [], denied_paths: [] },
+      health: { enabled: true },
+    };
+    expect(mergeToolsConfigs([a, b]).health.enabled).toBe(true);
+  });
+
+  // M13: Full 3-config merge
+  it('merges 3 configs with all fields correctly', () => {
+    const a: ToolsConfig = {
+      shell: { enabled: true, allowed_binaries: ['bash'], denied_patterns: ['rm -rf'], max_timeout: 300 },
+      filesystem: { enabled: true, read_only: true, allowed_paths: ['/workspace'], denied_paths: ['/etc/shadow'] },
+      health: { enabled: true },
+    };
+    const b: ToolsConfig = {
+      shell: { enabled: false, allowed_binaries: ['git'], denied_patterns: ['dd'], max_timeout: 600 },
+      filesystem: { enabled: false, read_only: true, allowed_paths: ['/data'], denied_paths: ['/root'] },
+      health: { enabled: false },
+    };
+    const c: ToolsConfig = {
+      shell: { enabled: true, allowed_binaries: ['make', 'bash'], denied_patterns: ['rm -rf'], max_timeout: 120 },
+      filesystem: { enabled: true, read_only: false, allowed_paths: ['/workspace', '/tmp'], denied_paths: [] },
+      health: { enabled: true },
+    };
+
+    const result = mergeToolsConfigs([a, b, c]);
+
+    // shell: OR → true; UNION binaries; UNION denied; MAX timeout
+    expect(result.shell.enabled).toBe(true);
+    expect(result.shell.allowed_binaries.sort()).toEqual(['bash', 'git', 'make']);
+    expect(result.shell.denied_patterns.sort()).toEqual(['dd', 'rm -rf']);
+    expect(result.shell.max_timeout).toBe(600);
+
+    // filesystem: OR → true; AND read_only → false (c is false); UNION paths
+    expect(result.filesystem.enabled).toBe(true);
+    expect(result.filesystem.read_only).toBe(false);
+    expect(result.filesystem.allowed_paths.sort()).toEqual(['/data', '/tmp', '/workspace']);
+    expect(result.filesystem.denied_paths.sort()).toEqual(['/etc/shadow', '/root']);
+
+    // health: OR → true
+    expect(result.health.enabled).toBe(true);
+  });
+
+  // M14: Deduplication
+  it('UNION lists have no duplicates', () => {
+    const a: ToolsConfig = {
+      shell: { enabled: true, allowed_binaries: ['bash', 'git'], denied_patterns: ['rm -rf'], max_timeout: 300 },
+      filesystem: { enabled: true, read_only: false, allowed_paths: ['/workspace'], denied_paths: ['/etc/shadow'] },
+      health: { enabled: true },
+    };
+    const b: ToolsConfig = {
+      shell: { enabled: true, allowed_binaries: ['bash', 'make'], denied_patterns: ['rm -rf', 'dd'], max_timeout: 300 },
+      filesystem: { enabled: true, read_only: false, allowed_paths: ['/workspace', '/data'], denied_paths: ['/etc/shadow', '/root'] },
+      health: { enabled: true },
+    };
+
+    const result = mergeToolsConfigs([a, b]);
+
+    // No duplicate entries
+    expect(result.shell.allowed_binaries.filter((v, i, arr) => arr.indexOf(v) !== i)).toEqual([]);
+    expect(result.shell.denied_patterns.filter((v, i, arr) => arr.indexOf(v) !== i)).toEqual([]);
+    expect(result.filesystem.allowed_paths.filter((v, i, arr) => arr.indexOf(v) !== i)).toEqual([]);
+    expect(result.filesystem.denied_paths.filter((v, i, arr) => arr.indexOf(v) !== i)).toEqual([]);
+
+    // Correct values
+    expect(result.shell.allowed_binaries.sort()).toEqual(['bash', 'git', 'make']);
+    expect(result.shell.denied_patterns.sort()).toEqual(['dd', 'rm -rf']);
+    expect(result.filesystem.allowed_paths.sort()).toEqual(['/data', '/workspace']);
+    expect(result.filesystem.denied_paths.sort()).toEqual(['/etc/shadow', '/root']);
+  });
+});

--- a/services/api/src/__tests__/routes-agents-skill.test.ts
+++ b/services/api/src/__tests__/routes-agents-skill.test.ts
@@ -45,9 +45,15 @@ function makeToken(sub: string, roles: string[]) {
 const adminToken = makeToken('admin-user', ['admin', 'user']);
 const userToken = makeToken('regular-user', ['user']);
 
-const developerSkillConfig = {
+const devToolsConfig = {
   shell: { enabled: true, allowed_binaries: ['bash', 'git', 'make', 'curl', 'jq'], denied_patterns: ['rm -rf /'], max_timeout: 300 },
   filesystem: { enabled: true, read_only: false, allowed_paths: ['/workspace', '/data'], denied_paths: ['/etc/shadow', '/etc/passwd', '/root'] },
+  health: { enabled: true },
+};
+
+const minToolsConfig = {
+  shell: { enabled: false, allowed_binaries: [], denied_patterns: [], max_timeout: 120 },
+  filesystem: { enabled: true, read_only: true, allowed_paths: ['/workspace'], denied_paths: ['/etc/shadow'] },
   health: { enabled: true },
 };
 
@@ -87,17 +93,17 @@ describe('Agent POST skill_ids behavior', () => {
   });
 
   it('create agent with skill_ids resolves tools_config', async () => {
-    // Skill lookup
+    // 1. Skill batch lookup (WHERE id = ANY($1::uuid[]))
     mockQuery.mockResolvedValueOnce({
-      rows: [{ id: 'skill-dev', tools_config: developerSkillConfig }],
+      rows: [{ id: 'skill-dev', tools_config: devToolsConfig, scope: 'container_local' }],
     });
-    // INSERT agent
+    // 2. INSERT agent
     mockQuery.mockResolvedValueOnce({
-      rows: [{ ...agentRow, id: 'uuid-new', tools_config: developerSkillConfig }],
+      rows: [{ ...agentRow, id: 'uuid-new', tools_config: devToolsConfig }],
     });
-    // INSERT agent_skills
+    // 3. INSERT agent_skills (1 skill)
     mockQuery.mockResolvedValueOnce({ rows: [] });
-    // SELECT skills for response
+    // 4. SELECT skills for response
     mockQuery.mockResolvedValueOnce({
       rows: [{ id: 'skill-dev', name: 'Developer', scope: 'container_local' }],
     });
@@ -122,8 +128,31 @@ describe('Agent POST skill_ids behavior', () => {
     expect(parsed.shell.allowed_binaries).toContain('bash');
   });
 
-  // T5: skill_ids > 1 rejected
-  it('create agent with skill_ids > 1 returns 400', async () => {
+  // R6: Create agent with 2 skills — merged tools_config
+  it('create agent with 2 skills merges tools_config', async () => {
+    // 1. Skill batch lookup returns 2 skills
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        { id: 'skill-1', tools_config: devToolsConfig, scope: 'container_local' },
+        { id: 'skill-2', tools_config: minToolsConfig, scope: 'container_local' },
+      ],
+    });
+    // 2. INSERT agent
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ ...agentRow, id: 'uuid-multi' }],
+    });
+    // 3. INSERT agent_skills (skill-1)
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    // 4. INSERT agent_skills (skill-2)
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    // 5. SELECT skills for response
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        { id: 'skill-1', name: 'Developer', scope: 'container_local' },
+        { id: 'skill-2', name: 'Reader', scope: 'container_local' },
+      ],
+    });
+
     const res = await request(app)
       .post('/agents')
       .set('Authorization', `Bearer ${userToken}`)
@@ -133,8 +162,16 @@ describe('Agent POST skill_ids behavior', () => {
         skill_ids: ['skill-1', 'skill-2'],
       });
 
-    expect(res.status).toBe(400);
-    expect(res.body.error).toContain('Maximum 1 skill');
+    expect(res.status).toBe(201);
+    expect(res.body.skills).toHaveLength(2);
+
+    // Verify merged tools_config: shell.enabled OR → true, filesystem.read_only AND → false
+    const insertCall = mockQuery.mock.calls[1];
+    const parsed = JSON.parse(insertCall[1][3]);
+    expect(parsed.shell.enabled).toBe(true); // OR: true || false
+    expect(parsed.filesystem.enabled).toBe(true); // OR: true || true
+    expect(parsed.filesystem.read_only).toBe(false); // AND: false && true → false
+    expect(parsed.shell.max_timeout).toBe(300); // MAX(300, 120)
   });
 
   // T12: tool_preset_id rejected
@@ -153,7 +190,7 @@ describe('Agent POST skill_ids behavior', () => {
   });
 
   it('create agent with nonexistent skill returns 400', async () => {
-    // Skill lookup returns empty
+    // Skill batch lookup returns fewer than requested
     mockQuery.mockResolvedValueOnce({ rows: [] });
 
     const res = await request(app)
@@ -166,16 +203,16 @@ describe('Agent POST skill_ids behavior', () => {
       });
 
     expect(res.status).toBe(400);
-    expect(res.body.error).toContain('Skill not found');
+    expect(res.body.error).toContain('not found');
   });
 
   // T11: Agent create without skill uses default tools_config
   it('create agent without skill_ids uses default', async () => {
-    // INSERT agent
+    // 1. INSERT agent
     mockQuery.mockResolvedValueOnce({
       rows: [{ ...agentRow, id: 'uuid-new' }],
     });
-    // SELECT skills for response (empty)
+    // 2. SELECT skills for response (empty)
     mockQuery.mockResolvedValueOnce({ rows: [] });
 
     const res = await request(app)
@@ -209,21 +246,23 @@ describe('Agent PUT skill_ids behavior', () => {
   });
 
   it('update agent skill_ids resolves tools_config', async () => {
-    // Ownership check returns agent
+    // 1. Ownership check returns agent
     mockQuery.mockResolvedValueOnce({ rows: [agentRow] });
-    // Skill lookup
+    // 2. Skill batch lookup
     mockQuery.mockResolvedValueOnce({
-      rows: [{ id: 'skill-dev', tools_config: developerSkillConfig }],
+      rows: [{ id: 'skill-dev', tools_config: devToolsConfig, scope: 'container_local' }],
     });
-    // UPDATE agent
-    mockQuery.mockResolvedValueOnce({
-      rows: [{ ...agentRow, tools_config: developerSkillConfig }],
-    });
-    // DELETE agent_skills
-    mockQuery.mockResolvedValueOnce({ rowCount: 0 });
-    // INSERT agent_skills
+    // 3. Current agent_skills for elevated-removal check (user is non-admin)
     mockQuery.mockResolvedValueOnce({ rows: [] });
-    // SELECT skills for response
+    // 4. UPDATE agent
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ ...agentRow, tools_config: devToolsConfig }],
+    });
+    // 5. DELETE agent_skills
+    mockQuery.mockResolvedValueOnce({ rowCount: 0 });
+    // 6. INSERT agent_skills
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    // 7. SELECT skills for response
     mockQuery.mockResolvedValueOnce({
       rows: [{ id: 'skill-dev', name: 'Developer', scope: 'container_local' }],
     });
@@ -238,14 +277,17 @@ describe('Agent PUT skill_ids behavior', () => {
     expect(res.body.skills[0].id).toBe('skill-dev');
   });
 
+  // R9: PUT agents empty skill_ids clears skills (Custom mode)
   it('update agent skill_ids to empty clears skill', async () => {
-    // Ownership check returns agent
+    // 1. Ownership check returns agent
     mockQuery.mockResolvedValueOnce({ rows: [agentRow] });
-    // UPDATE agent (no skill lookup needed)
+    // 2. Current agent_skills for elevated-removal check (user is non-admin)
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    // 3. UPDATE agent (no skill lookup since skill_ids is empty)
     mockQuery.mockResolvedValueOnce({ rows: [agentRow] });
-    // DELETE agent_skills
+    // 4. DELETE agent_skills
     mockQuery.mockResolvedValueOnce({ rowCount: 1 });
-    // SELECT skills for response (empty)
+    // 5. SELECT skills for response (empty)
     mockQuery.mockResolvedValueOnce({ rows: [] });
 
     const res = await request(app)
@@ -267,25 +309,12 @@ describe('Agent PUT skill_ids behavior', () => {
     expect(res.body.error).toContain('deprecated');
   });
 
-  it('update agent with skill_ids > 1 returns 400', async () => {
-    // Ownership check
-    mockQuery.mockResolvedValueOnce({ rows: [agentRow] });
-
-    const res = await request(app)
-      .put('/agents/uuid-1')
-      .set('Authorization', `Bearer ${userToken}`)
-      .send({ skill_ids: ['skill-1', 'skill-2'] });
-
-    expect(res.status).toBe(400);
-    expect(res.body.error).toContain('Maximum 1 skill');
-  });
-
   it('update agent without skill_ids does not touch skills', async () => {
-    // Ownership check returns agent
+    // 1. Ownership check returns agent
     mockQuery.mockResolvedValueOnce({ rows: [agentRow] });
-    // UPDATE agent
+    // 2. UPDATE agent (no skill lookup since skill_ids not provided)
     mockQuery.mockResolvedValueOnce({ rows: [{ ...agentRow, name: 'Updated Name' }] });
-    // SELECT skills for response
+    // 3. SELECT skills for response
     mockQuery.mockResolvedValueOnce({ rows: [] });
 
     const res = await request(app)
@@ -310,9 +339,9 @@ describe('Agent create/update scope RBAC', () => {
   });
 
   it('create with host_docker skill as non-admin returns 403', async () => {
-    // Skill lookup returns host_docker scope
+    // Skill batch lookup returns host_docker scope
     mockQuery.mockResolvedValueOnce({
-      rows: [{ id: 'skill-docker', tools_config: developerSkillConfig, scope: 'host_docker' }],
+      rows: [{ id: 'skill-docker', tools_config: devToolsConfig, scope: 'host_docker' }],
     });
 
     const res = await request(app)
@@ -330,17 +359,17 @@ describe('Agent create/update scope RBAC', () => {
   });
 
   it('create with host_docker skill as admin succeeds', async () => {
-    // Skill lookup
+    // 1. Skill batch lookup
     mockQuery.mockResolvedValueOnce({
-      rows: [{ id: 'skill-docker', tools_config: developerSkillConfig, scope: 'host_docker' }],
+      rows: [{ id: 'skill-docker', tools_config: devToolsConfig, scope: 'host_docker' }],
     });
-    // INSERT agent
+    // 2. INSERT agent
     mockQuery.mockResolvedValueOnce({
       rows: [{ ...agentRow, id: 'uuid-admin' }],
     });
-    // INSERT agent_skills
+    // 3. INSERT agent_skills
     mockQuery.mockResolvedValueOnce({ rows: [] });
-    // SELECT skills for response
+    // 4. SELECT skills for response
     mockQuery.mockResolvedValueOnce({
       rows: [{ id: 'skill-docker', name: 'Docker Access', scope: 'host_docker' }],
     });
@@ -360,11 +389,11 @@ describe('Agent create/update scope RBAC', () => {
 
   // T16: Update agent with elevated skill_ids rejected for non-admin
   it('update with vps_system skill as non-admin returns 403', async () => {
-    // Ownership check returns agent
+    // 1. Ownership check returns agent
     mockQuery.mockResolvedValueOnce({ rows: [agentRow] });
-    // Skill lookup returns vps_system scope
+    // 2. Skill batch lookup returns vps_system scope
     mockQuery.mockResolvedValueOnce({
-      rows: [{ id: 'skill-vps', tools_config: developerSkillConfig, scope: 'vps_system' }],
+      rows: [{ id: 'skill-vps', tools_config: devToolsConfig, scope: 'vps_system' }],
     });
 
     const res = await request(app)
@@ -378,21 +407,21 @@ describe('Agent create/update scope RBAC', () => {
   });
 
   it('update with vps_system skill as admin succeeds', async () => {
-    // Ownership check (admin sees all — scopeToOwner returns no constraint for admin)
+    // 1. Ownership check (admin sees all)
     mockQuery.mockResolvedValueOnce({ rows: [agentRow] });
-    // Skill lookup
+    // 2. Skill batch lookup
     mockQuery.mockResolvedValueOnce({
-      rows: [{ id: 'skill-vps', tools_config: developerSkillConfig, scope: 'vps_system' }],
+      rows: [{ id: 'skill-vps', tools_config: devToolsConfig, scope: 'vps_system' }],
     });
-    // UPDATE agent
+    // 3. UPDATE agent (admin skips elevated-removal check)
     mockQuery.mockResolvedValueOnce({
-      rows: [{ ...agentRow, tools_config: developerSkillConfig }],
+      rows: [{ ...agentRow, tools_config: devToolsConfig }],
     });
-    // DELETE agent_skills
+    // 4. DELETE agent_skills
     mockQuery.mockResolvedValueOnce({ rowCount: 0 });
-    // INSERT agent_skills
+    // 5. INSERT agent_skills
     mockQuery.mockResolvedValueOnce({ rows: [] });
-    // SELECT skills for response
+    // 6. SELECT skills for response
     mockQuery.mockResolvedValueOnce({
       rows: [{ id: 'skill-vps', name: 'VPS Access', scope: 'vps_system' }],
     });
@@ -405,9 +434,66 @@ describe('Agent create/update scope RBAC', () => {
     expect(res.status).toBe(200);
     expect(res.body.skills[0].scope).toBe('vps_system');
   });
+
+  // R7: PUT removing elevated skill as non-admin → 403
+  it('update removing elevated skill as non-admin returns 403', async () => {
+    // 1. Ownership check returns agent
+    mockQuery.mockResolvedValueOnce({ rows: [agentRow] });
+    // 2. Skill batch lookup for new skill_ids (container_local only)
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: 'skill-basic', tools_config: minToolsConfig, scope: 'container_local' }],
+    });
+    // 3. Current agent_skills — has an elevated skill being removed
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        { skill_id: 'skill-basic', scope: 'container_local' },
+        { skill_id: 'skill-docker', scope: 'host_docker' },
+      ],
+    });
+
+    const res = await request(app)
+      .put('/agents/uuid-1')
+      .set('Authorization', `Bearer ${userToken}`)
+      .send({ skill_ids: ['skill-basic'] }); // implicitly removes skill-docker
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toContain('host_docker');
+    expect(res.body.error).toContain('admin');
+  });
+
+  // R8: PUT removing elevated skill as admin → 200
+  it('update removing elevated skill as admin succeeds', async () => {
+    // 1. Ownership check (admin sees all)
+    mockQuery.mockResolvedValueOnce({ rows: [agentRow] });
+    // 2. Skill batch lookup for new skill_ids
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: 'skill-basic', tools_config: minToolsConfig, scope: 'container_local' }],
+    });
+    // 3. UPDATE agent (admin skips elevated-removal check)
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ ...agentRow, tools_config: minToolsConfig }],
+    });
+    // 4. DELETE agent_skills
+    mockQuery.mockResolvedValueOnce({ rowCount: 2 });
+    // 5. INSERT agent_skills (1 skill)
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    // 6. SELECT skills for response
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: 'skill-basic', name: 'Basic', scope: 'container_local' }],
+    });
+
+    const res = await request(app)
+      .put('/agents/uuid-1')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ skill_ids: ['skill-basic'] }); // implicitly removes elevated skill
+
+    expect(res.status).toBe(200);
+    expect(res.body.skills).toHaveLength(1);
+    expect(res.body.skills[0].id).toBe('skill-basic');
+  });
 });
 
-// T10b: Agent start reads from agent_skills
+// Agent start with skills
 const { writeAgentFiles } = jest.requireMock('../services/agent-files') as { writeAgentFiles: jest.Mock };
 
 describe('Agent start reads from agent_skills', () => {
@@ -431,9 +517,9 @@ describe('Agent start reads from agent_skills', () => {
 
     // 1. SELECT agent
     mockQuery.mockResolvedValueOnce({ rows: [agentStopped] });
-    // 2. SELECT instructions_md from agent_skills JOIN skills
+    // 2. SELECT skill instructions from agent_skills JOIN skills (single skill)
     mockQuery.mockResolvedValueOnce({
-      rows: [{ instructions_md: 'You have full developer access.' }],
+      rows: [{ name: 'Developer', instructions_md: 'You have full developer access.' }],
     });
     // 3+. UPDATE agent status queries
     mockQuery.mockResolvedValue({ rows: [] });
@@ -445,7 +531,74 @@ describe('Agent start reads from agent_skills', () => {
     expect(res.status).toBe(200);
     expect(writeAgentFiles).toHaveBeenCalledTimes(1);
     const callArgs = writeAgentFiles.mock.calls[0];
-    expect(callArgs[1]).toBe('You have full developer access.');
+    // Single skill: composed with ## Skill: header
+    expect(callArgs[1]).toBe('## Skill: Developer\n\nYou have full developer access.');
+  });
+
+  // R10: Start agent with multiple skills composes instructions
+  it('start agent with 2 skills composes instructions with headers', async () => {
+    const agentStopped = { ...agentRow, status: 'stopped' };
+
+    const { createAndStartContainer } = jest.requireMock('../services/docker') as any;
+    createAndStartContainer.mockResolvedValue('container-multi');
+
+    // 1. SELECT agent
+    mockQuery.mockResolvedValueOnce({ rows: [agentStopped] });
+    // 2. SELECT skill instructions (2 skills, ordered by assigned_at ASC)
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        { name: 'Developer', instructions_md: 'You have shell access.' },
+        { name: 'Data Reader', instructions_md: 'You can read /data.' },
+      ],
+    });
+    // 3+. UPDATE agent status queries
+    mockQuery.mockResolvedValue({ rows: [] });
+
+    const res = await request(app)
+      .post('/agents/uuid-1/start')
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(res.status).toBe(200);
+    expect(writeAgentFiles).toHaveBeenCalledTimes(1);
+    const callArgs = writeAgentFiles.mock.calls[0];
+    const expected = [
+      '## Skill: Developer',
+      '',
+      'You have shell access.',
+      '',
+      '---',
+      '',
+      '## Skill: Data Reader',
+      '',
+      'You can read /data.',
+    ].join('\n');
+    expect(callArgs[1]).toBe(expected);
+  });
+
+  // Start with skill that has no instructions
+  it('start agent with skill having no instructions writes undefined', async () => {
+    const agentStopped = { ...agentRow, status: 'stopped' };
+
+    const { createAndStartContainer } = jest.requireMock('../services/docker') as any;
+    createAndStartContainer.mockResolvedValue('container-no-instr');
+
+    // 1. SELECT agent
+    mockQuery.mockResolvedValueOnce({ rows: [agentStopped] });
+    // 2. SELECT skill instructions (skill with null instructions_md)
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ name: 'Silent', instructions_md: null }],
+    });
+    // 3+. UPDATE agent status queries
+    mockQuery.mockResolvedValue({ rows: [] });
+
+    const res = await request(app)
+      .post('/agents/uuid-1/start')
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(res.status).toBe(200);
+    expect(writeAgentFiles).toHaveBeenCalledTimes(1);
+    const callArgs = writeAgentFiles.mock.calls[0];
+    expect(callArgs[1]).toBeUndefined();
   });
 
   // T11: Start without skill

--- a/services/api/src/__tests__/routes-agents-skills.test.ts
+++ b/services/api/src/__tests__/routes-agents-skills.test.ts
@@ -49,6 +49,7 @@ const AGENT_ID = '00000000-0000-0000-0000-000000000001';
 const SKILL_CONTAINER = '00000000-0000-0000-0000-000000000010';
 const SKILL_HOST_DOCKER = '00000000-0000-0000-0000-000000000020';
 const SKILL_VPS_SYSTEM = '00000000-0000-0000-0000-000000000030';
+const SKILL_CONTAINER_2 = '00000000-0000-0000-0000-000000000040';
 
 const stoppedAgent = { id: AGENT_ID, status: 'stopped' };
 const runningAgent = { id: AGENT_ID, status: 'running' };
@@ -58,7 +59,15 @@ const devToolsConfig = {
   filesystem: { enabled: true, read_only: false, allowed_paths: ['/workspace'], denied_paths: ['/etc/shadow'] },
   health: { enabled: true },
 };
+
+const minToolsConfig = {
+  shell: { enabled: false, allowed_binaries: [], denied_patterns: [], max_timeout: 300 },
+  filesystem: { enabled: false, read_only: false, allowed_paths: ['/workspace'], denied_paths: ['/etc/shadow', '/etc/passwd', '/root'] },
+  health: { enabled: true },
+};
+
 const containerSkill = { id: SKILL_CONTAINER, scope: 'container_local', tools_config: devToolsConfig };
+const containerSkill2 = { id: SKILL_CONTAINER_2, scope: 'container_local', tools_config: minToolsConfig };
 const hostDockerSkill = { id: SKILL_HOST_DOCKER, scope: 'host_docker', tools_config: devToolsConfig };
 const vpsSystemSkill = { id: SKILL_VPS_SYSTEM, scope: 'vps_system', tools_config: devToolsConfig };
 
@@ -80,17 +89,17 @@ describe('Agent skill assignment endpoints', () => {
   });
 
   // -----------------------------------------------------------------------
-  // POST /agents/:id/skills
+  // POST /agents/:id/skills — additive semantics
   // -----------------------------------------------------------------------
 
-  // T1: Assign skill to agent
-  it('POST /agents/:id/skills assigns skill to agent', async () => {
+  // R1: Assign skill to agent (additive, no DELETE all)
+  it('POST /agents/:id/skills assigns skill additively', async () => {
     mockQuery
       .mockResolvedValueOnce({ rows: [stoppedAgent] })  // agent lookup (user scope)
       .mockResolvedValueOnce({ rows: [containerSkill] }) // skill lookup
-      .mockResolvedValueOnce({ rowCount: 0 })            // delete existing
-      .mockResolvedValueOnce({ rows: [assignmentRecord] }) // insert
-      .mockResolvedValueOnce({ rowCount: 1 });            // update agents.tools_config
+      .mockResolvedValueOnce({ rows: [assignmentRecord] }) // INSERT (additive)
+      .mockResolvedValueOnce({ rows: [{ tools_config: devToolsConfig }] }) // SELECT all skills for merge
+      .mockResolvedValueOnce({ rowCount: 1 });            // UPDATE agents.tools_config
 
     const res = await request(app)
       .post(`/agents/${AGENT_ID}/skills`)
@@ -100,37 +109,45 @@ describe('Agent skill assignment endpoints', () => {
     expect(res.status).toBe(201);
     expect(res.body.agent_id).toBe(AGENT_ID);
     expect(res.body.skill_id).toBe(SKILL_CONTAINER);
+
+    // Verify no DELETE FROM agent_skills was called
+    for (const call of mockQuery.mock.calls) {
+      expect(call[0]).not.toContain('DELETE FROM agent_skills');
+    }
   });
 
-  // T10: Replace semantics — assigning new skill replaces existing
-  it('POST /agents/:id/skills replaces existing skill (max 1)', async () => {
-    const newSkillId = '00000000-0000-0000-0000-000000000099';
-    const newToolsConfig = { shell: { enabled: false }, filesystem: { enabled: false }, health: { enabled: true } };
-    const newAssignment = { ...assignmentRecord, skill_id: newSkillId };
+  // R2: POST duplicate skill returns 409
+  it('POST /agents/:id/skills duplicate returns 409', async () => {
+    const pkError = new Error('duplicate key value violates unique constraint') as any;
+    pkError.code = '23505';
+
     mockQuery
       .mockResolvedValueOnce({ rows: [stoppedAgent] })  // agent lookup
-      .mockResolvedValueOnce({ rows: [{ id: newSkillId, scope: 'container_local', tools_config: newToolsConfig }] }) // skill lookup
-      .mockResolvedValueOnce({ rowCount: 1 })            // delete existing (had one)
-      .mockResolvedValueOnce({ rows: [newAssignment] })  // insert new
-      .mockResolvedValueOnce({ rowCount: 1 });           // update agents.tools_config
+      .mockResolvedValueOnce({ rows: [containerSkill] }) // skill lookup
+      .mockRejectedValueOnce(pkError);                    // INSERT fails with PK violation
 
     const res = await request(app)
       .post(`/agents/${AGENT_ID}/skills`)
       .set('Authorization', `Bearer ${userToken}`)
-      .send({ skill_id: newSkillId });
+      .send({ skill_id: SKILL_CONTAINER });
 
-    expect(res.status).toBe(201);
-    expect(res.body.skill_id).toBe(newSkillId);
+    expect(res.status).toBe(409);
+    expect(res.body.error).toContain('already assigned');
   });
 
-  // T10b: POST /agents/:id/skills resolves tools_config on assign
-  it('POST /agents/:id/skills resolves tools_config into agent (resolve-on-save)', async () => {
+  // R3: POST merges tools_config from ALL skills for agent
+  it('POST /agents/:id/skills merges tools_config from all skills', async () => {
     mockQuery
       .mockResolvedValueOnce({ rows: [stoppedAgent] })  // agent lookup
-      .mockResolvedValueOnce({ rows: [containerSkill] }) // skill lookup (includes tools_config)
-      .mockResolvedValueOnce({ rowCount: 0 })            // delete existing
-      .mockResolvedValueOnce({ rows: [assignmentRecord] }) // insert
-      .mockResolvedValueOnce({ rowCount: 1 });            // update agents.tools_config
+      .mockResolvedValueOnce({ rows: [containerSkill] }) // skill lookup
+      .mockResolvedValueOnce({ rows: [assignmentRecord] }) // INSERT
+      .mockResolvedValueOnce({                            // SELECT all skills for merge (2 skills now)
+        rows: [
+          { tools_config: devToolsConfig },
+          { tools_config: minToolsConfig },
+        ],
+      })
+      .mockResolvedValueOnce({ rowCount: 1 });            // UPDATE agents.tools_config
 
     const res = await request(app)
       .post(`/agents/${AGENT_ID}/skills`)
@@ -139,13 +156,14 @@ describe('Agent skill assignment endpoints', () => {
 
     expect(res.status).toBe(201);
 
-    // Verify the UPDATE agents query was called with the skill's tools_config
-    expect(mockQuery).toHaveBeenCalledTimes(5);
+    // Verify the UPDATE used a merged config
     const updateCall = mockQuery.mock.calls[4];
     expect(updateCall[0]).toContain('UPDATE agents');
-    expect(updateCall[0]).toContain('tools_config');
-    expect(updateCall[1][0]).toBe(JSON.stringify(devToolsConfig));
-    expect(updateCall[1][1]).toBe(AGENT_ID);
+    const mergedConfig = JSON.parse(updateCall[1][0]);
+    // OR: shell enabled because devToolsConfig has shell.enabled=true
+    expect(mergedConfig.shell.enabled).toBe(true);
+    // UNION allowed_paths: ['/workspace'] from both (deduped)
+    expect(mergedConfig.filesystem.allowed_paths).toContain('/workspace');
   });
 
   // T4: User can assign container_local skill
@@ -153,9 +171,9 @@ describe('Agent skill assignment endpoints', () => {
     mockQuery
       .mockResolvedValueOnce({ rows: [stoppedAgent] })
       .mockResolvedValueOnce({ rows: [containerSkill] })
-      .mockResolvedValueOnce({ rowCount: 0 })            // delete existing
-      .mockResolvedValueOnce({ rows: [assignmentRecord] })
-      .mockResolvedValueOnce({ rowCount: 1 });            // update agents.tools_config
+      .mockResolvedValueOnce({ rows: [assignmentRecord] }) // INSERT
+      .mockResolvedValueOnce({ rows: [{ tools_config: devToolsConfig }] }) // SELECT all skills
+      .mockResolvedValueOnce({ rowCount: 1 });            // UPDATE agents.tools_config
 
     const res = await request(app)
       .post(`/agents/${AGENT_ID}/skills`)
@@ -201,9 +219,9 @@ describe('Agent skill assignment endpoints', () => {
     mockQuery
       .mockResolvedValueOnce({ rows: [stoppedAgent] })   // agent lookup (admin scope = 1=1)
       .mockResolvedValueOnce({ rows: [hostDockerSkill] }) // skill lookup
-      .mockResolvedValueOnce({ rowCount: 0 })             // delete existing
-      .mockResolvedValueOnce({ rows: [adminAssignment] }) // insert
-      .mockResolvedValueOnce({ rowCount: 1 });            // update agents.tools_config
+      .mockResolvedValueOnce({ rows: [adminAssignment] }) // INSERT
+      .mockResolvedValueOnce({ rows: [{ tools_config: devToolsConfig }] }) // SELECT all skills
+      .mockResolvedValueOnce({ rowCount: 1 });            // UPDATE agents.tools_config
 
     const res = await request(app)
       .post(`/agents/${AGENT_ID}/skills`)
@@ -265,15 +283,17 @@ describe('Agent skill assignment endpoints', () => {
   });
 
   // -----------------------------------------------------------------------
-  // DELETE /agents/:id/skills/:skillId
+  // DELETE /agents/:id/skills/:skillId — recomputes tools_config
   // -----------------------------------------------------------------------
 
-  // T3: Remove assignment
-  it('DELETE /agents/:id/skills/:skillId removes assignment', async () => {
+  // R4: DELETE recomputes tools_config from remaining skills
+  it('DELETE /agents/:id/skills/:skillId recomputes tools_config from remaining', async () => {
     mockQuery
       .mockResolvedValueOnce({ rows: [stoppedAgent] })  // agent lookup
       .mockResolvedValueOnce({ rows: [containerSkill] }) // skill lookup
-      .mockResolvedValueOnce({ rowCount: 1 });           // delete
+      .mockResolvedValueOnce({ rowCount: 1 })            // DELETE
+      .mockResolvedValueOnce({ rows: [{ tools_config: minToolsConfig }] }) // remaining skills
+      .mockResolvedValueOnce({ rowCount: 1 });           // UPDATE agents.tools_config
 
     const res = await request(app)
       .delete(`/agents/${AGENT_ID}/skills/${SKILL_CONTAINER}`)
@@ -281,28 +301,37 @@ describe('Agent skill assignment endpoints', () => {
 
     expect(res.status).toBe(200);
     expect(res.body.removed).toBe(true);
+
+    // Verify UPDATE agents was called with remaining skill's config
+    const updateCall = mockQuery.mock.calls[4];
+    expect(updateCall[0]).toContain('UPDATE agents');
+    const updatedConfig = JSON.parse(updateCall[1][0]);
+    expect(updatedConfig.shell.enabled).toBe(false);
+    expect(updatedConfig.health.enabled).toBe(true);
   });
 
-  // T10c: DELETE preserves tools_config — no UPDATE agents query
-  it('DELETE /agents/:id/skills/:skillId preserves tools_config (no mutation)', async () => {
+  // R5: DELETE last skill resets to no-skills default
+  it('DELETE /agents/:id/skills/:skillId last skill resets to default', async () => {
     mockQuery
       .mockResolvedValueOnce({ rows: [stoppedAgent] })  // agent lookup
       .mockResolvedValueOnce({ rows: [containerSkill] }) // skill lookup
-      .mockResolvedValueOnce({ rowCount: 1 });           // delete
+      .mockResolvedValueOnce({ rowCount: 1 })            // DELETE
+      .mockResolvedValueOnce({ rows: [] })               // no remaining skills
+      .mockResolvedValueOnce({ rowCount: 1 });           // UPDATE agents.tools_config
 
     const res = await request(app)
       .delete(`/agents/${AGENT_ID}/skills/${SKILL_CONTAINER}`)
       .set('Authorization', `Bearer ${userToken}`);
 
     expect(res.status).toBe(200);
-    expect(res.body.removed).toBe(true);
 
-    // Verify exactly 3 queries — no UPDATE agents for tools_config
-    expect(mockQuery).toHaveBeenCalledTimes(3);
-    // None of the 3 queries should be an UPDATE agents
-    for (const call of mockQuery.mock.calls) {
-      expect(call[0]).not.toContain('UPDATE agents');
-    }
+    // Verify UPDATE used default config (shell/fs disabled, health enabled)
+    const updateCall = mockQuery.mock.calls[4];
+    expect(updateCall[0]).toContain('UPDATE agents');
+    const defaultConfig = JSON.parse(updateCall[1][0]);
+    expect(defaultConfig.shell.enabled).toBe(false);
+    expect(defaultConfig.filesystem.enabled).toBe(false);
+    expect(defaultConfig.health.enabled).toBe(true);
   });
 
   // T9: Non-admin cannot remove host_docker skill
@@ -319,12 +348,14 @@ describe('Agent skill assignment endpoints', () => {
     expect(res.body.error).toContain('host_docker');
   });
 
-  // T10: Non-admin can remove container_local skill
+  // Non-admin can remove container_local skill
   it('DELETE /agents/:id/skills/:skillId user remove container_local OK', async () => {
     mockQuery
       .mockResolvedValueOnce({ rows: [stoppedAgent] })
       .mockResolvedValueOnce({ rows: [containerSkill] })
-      .mockResolvedValueOnce({ rowCount: 1 });
+      .mockResolvedValueOnce({ rowCount: 1 })             // DELETE
+      .mockResolvedValueOnce({ rows: [] })                 // remaining skills (empty)
+      .mockResolvedValueOnce({ rowCount: 1 });             // UPDATE agents.tools_config
 
     const res = await request(app)
       .delete(`/agents/${AGENT_ID}/skills/${SKILL_CONTAINER}`)
@@ -366,7 +397,9 @@ describe('Agent skill assignment endpoints', () => {
     mockQuery
       .mockResolvedValueOnce({ rows: [stoppedAgent] })
       .mockResolvedValueOnce({ rows: [vpsSystemSkill] })
-      .mockResolvedValueOnce({ rowCount: 1 });
+      .mockResolvedValueOnce({ rowCount: 1 })             // DELETE
+      .mockResolvedValueOnce({ rows: [] })                 // remaining skills (empty)
+      .mockResolvedValueOnce({ rowCount: 1 });             // UPDATE agents.tools_config
 
     const res = await request(app)
       .delete(`/agents/${AGENT_ID}/skills/${SKILL_VPS_SYSTEM}`)

--- a/services/api/src/openapi/openapi.yaml
+++ b/services/api/src/openapi/openapi.yaml
@@ -643,8 +643,7 @@ paths:
                   items:
                     type: string
                     format: uuid
-                  maxItems: 1
-                  description: Skill IDs to assign (max 1). Config is copied into agent at save time (resolve-on-save).
+                  description: Skill IDs to assign. Config is merged from all skills at save time (resolve-on-save).
       responses:
         "201":
           description: Agent created
@@ -727,8 +726,7 @@ paths:
                   items:
                     type: string
                     format: uuid
-                  maxItems: 1
-                  description: Skill IDs to assign (max 1). Config is copied into agent at save time. Empty array to detach skill.
+                  description: Skill IDs to assign. Empty array to detach all skills (Custom mode). Config is merged from all skills at save time.
       responses:
         "200":
           description: Agent updated

--- a/services/api/src/routes/agents.ts
+++ b/services/api/src/routes/agents.ts
@@ -3,6 +3,7 @@ import { getPool } from '../db/pool';
 import { requireRole } from '../middleware/role';
 import { scopeToOwner } from '../helpers/scope';
 import { writeAgentFiles, removeAgentFiles } from '../services/agent-files';
+import { mergeToolsConfigs, DEFAULT_TOOLS_CONFIG } from '../services/merge-tools-config';
 import {
   createAndStartContainer,
   stopAndRemoveContainer,
@@ -101,14 +102,10 @@ router.post('/', requireRole('user'), async (req: Request, res: Response) => {
       return;
     }
 
-    // Validate skill_ids (max 1 in Phase 2)
+    // Validate skill_ids
     if (skill_ids !== undefined) {
       if (!Array.isArray(skill_ids)) {
         res.status(400).json({ error: 'skill_ids must be an array' });
-        return;
-      }
-      if (skill_ids.length > 1) {
-        res.status(400).json({ error: 'Maximum 1 skill per agent (multi-skill support coming in a future phase)' });
         return;
       }
     }
@@ -136,24 +133,25 @@ router.post('/', requireRole('user'), async (req: Request, res: Response) => {
       validatedPolicyId = model_policy_id;
     }
 
-    // Resolve skill: if skill_ids provided, use skill's tools_config (resolve-on-save)
-    let resolvedToolsConfig = tools_config || { shell: { enabled: false }, filesystem: { enabled: false }, health: { enabled: true } };
-    let validatedSkillId: string | null = null;
-    if (skill_ids && skill_ids.length === 1) {
+    // Resolve skills: if skill_ids provided, batch-lookup and merge tools_configs
+    let resolvedToolsConfig = tools_config || DEFAULT_TOOLS_CONFIG;
+    let validatedSkillIds: string[] = [];
+    if (skill_ids && skill_ids.length > 0) {
       const { rows: skillRows } = await getPool().query(
-        'SELECT id, tools_config, scope FROM skills WHERE id = $1',
-        [skill_ids[0]]
+        'SELECT id, tools_config, scope FROM skills WHERE id = ANY($1::uuid[])',
+        [skill_ids]
       );
-      if (skillRows.length === 0) {
-        res.status(400).json({ error: 'Skill not found' });
+      if (skillRows.length !== skill_ids.length) {
+        res.status(400).json({ error: 'One or more skills not found' });
         return;
       }
-      if (ELEVATED_SCOPES.includes(skillRows[0].scope) && !isAdmin(req)) {
-        res.status(403).json({ error: `Assigning ${skillRows[0].scope} skills requires admin role` });
+      if (skillRows.some((s: any) => ELEVATED_SCOPES.includes(s.scope)) && !isAdmin(req)) {
+        const elevatedScope = skillRows.find((s: any) => ELEVATED_SCOPES.includes(s.scope))!.scope;
+        res.status(403).json({ error: `Assigning ${elevatedScope} skills requires admin role` });
         return;
       }
-      resolvedToolsConfig = skillRows[0].tools_config;
-      validatedSkillId = skill_ids[0];
+      resolvedToolsConfig = mergeToolsConfigs(skillRows.map((r: any) => r.tools_config));
+      validatedSkillIds = skill_ids;
     }
 
     const { rows } = await getPool().query(
@@ -177,11 +175,11 @@ router.post('/', requireRole('user'), async (req: Request, res: Response) => {
 
     const createdAgent = rows[0];
 
-    // Insert skill assignment into agent_skills
-    if (validatedSkillId) {
+    // Insert skill assignments into agent_skills
+    for (const skillId of validatedSkillIds) {
       await getPool().query(
         'INSERT INTO agent_skills (agent_id, skill_id, assigned_by) VALUES ($1, $2, $3)',
-        [createdAgent.id, validatedSkillId, user.sub]
+        [createdAgent.id, skillId, user.sub]
       );
     }
 
@@ -266,14 +264,10 @@ router.put('/:id', requireRole('user'), async (req: Request, res: Response) => {
     const user = (req as any).user;
     const { name, description, tools_config, cpus, mem_limit, pids_limit, soul_md, rules_md, model_policy_id, skill_ids } = req.body;
 
-    // Validate skill_ids (max 1 in Phase 2)
+    // Validate skill_ids
     if (skill_ids !== undefined) {
       if (!Array.isArray(skill_ids)) {
         res.status(400).json({ error: 'skill_ids must be an array' });
-        return;
-      }
-      if (skill_ids.length > 1) {
-        res.status(400).json({ error: 'Maximum 1 skill per agent (multi-skill support coming in a future phase)' });
         return;
       }
     }
@@ -305,25 +299,42 @@ router.put('/:id', requireRole('user'), async (req: Request, res: Response) => {
       }
     }
 
-    // Resolve skill: if skill_ids provided, look up and resolve tools_config
+    // Resolve skills: if skill_ids provided, batch-lookup and merge tools_configs
     let resolvedToolsConfig = tools_config ? JSON.stringify(tools_config) : null;
     if (skill_ids !== undefined) {
-      if (skill_ids.length === 1) {
+      if (skill_ids.length > 0) {
         const { rows: skillRows } = await getPool().query(
-          'SELECT id, tools_config, scope FROM skills WHERE id = $1',
-          [skill_ids[0]]
+          'SELECT id, tools_config, scope FROM skills WHERE id = ANY($1::uuid[])',
+          [skill_ids]
         );
-        if (skillRows.length === 0) {
-          res.status(400).json({ error: 'Skill not found' });
+        if (skillRows.length !== skill_ids.length) {
+          res.status(400).json({ error: 'One or more skills not found' });
           return;
         }
-        if (ELEVATED_SCOPES.includes(skillRows[0].scope) && !isAdmin(req)) {
-          res.status(403).json({ error: `Assigning ${skillRows[0].scope} skills requires admin role` });
+        if (skillRows.some((s: any) => ELEVATED_SCOPES.includes(s.scope)) && !isAdmin(req)) {
+          const elevatedScope = skillRows.find((s: any) => ELEVATED_SCOPES.includes(s.scope))!.scope;
+          res.status(403).json({ error: `Assigning ${elevatedScope} skills requires admin role` });
           return;
         }
-        resolvedToolsConfig = JSON.stringify(skillRows[0].tools_config);
+        resolvedToolsConfig = JSON.stringify(mergeToolsConfigs(skillRows.map((r: any) => r.tools_config)));
       }
-      // skill_ids.length === 0 means clear the skill — tools_config stays as-is or from body
+
+      // Check for implicit elevated-skill removal (non-admin removing elevated skills via PUT)
+      if (!isAdmin(req)) {
+        const { rows: currentSkills } = await getPool().query(
+          `SELECT asks.skill_id, s.scope FROM agent_skills asks
+           JOIN skills s ON s.id = asks.skill_id
+           WHERE asks.agent_id = $1`,
+          [req.params.id]
+        );
+        const removedIds = currentSkills
+          .filter((cs: any) => !skill_ids.includes(cs.skill_id))
+          .filter((cs: any) => ELEVATED_SCOPES.includes(cs.scope));
+        if (removedIds.length > 0) {
+          res.status(403).json({ error: `Cannot remove ${removedIds[0].scope} skills without admin role` });
+          return;
+        }
+      }
     }
 
     // Build SET clause: model_policy_id uses explicit flag to allow clearing to NULL
@@ -363,11 +374,11 @@ router.put('/:id', requireRole('user'), async (req: Request, res: Response) => {
     if (skill_ids !== undefined) {
       // Clear existing assignments
       await getPool().query('DELETE FROM agent_skills WHERE agent_id = $1', [req.params.id]);
-      // Insert new assignment
-      if (skill_ids.length === 1) {
+      // Insert new assignments
+      for (const skillId of skill_ids) {
         await getPool().query(
           'INSERT INTO agent_skills (agent_id, skill_id, assigned_by) VALUES ($1, $2, $3)',
-          [req.params.id, skill_ids[0], user.sub]
+          [req.params.id, skillId, user.sub]
         );
       }
     }
@@ -453,15 +464,20 @@ router.post('/:id/start', requireRole('admin'), async (req: Request, res: Respon
     const agent = rows[0];
 
     // Fetch skill instructions at start time (fresh-at-start, not resolve-on-save)
+    // Multi-skill: compose all skill instructions with per-skill headers, ordered by assigned_at
     let skillInstructions: string | undefined;
     const { rows: skillRows } = await getPool().query(
-      `SELECT s.instructions_md FROM agent_skills asks
+      `SELECT s.name, s.instructions_md FROM agent_skills asks
        JOIN skills s ON s.id = asks.skill_id
-       WHERE asks.agent_id = $1`,
+       WHERE asks.agent_id = $1
+       ORDER BY asks.assigned_at ASC`,
       [agent.id]
     );
-    if (skillRows.length > 0 && skillRows[0].instructions_md) {
-      skillInstructions = skillRows[0].instructions_md;
+    const instructionParts = skillRows
+      .filter((r: any) => r.instructions_md)
+      .map((r: any) => `## Skill: ${r.name}\n\n${r.instructions_md}`);
+    if (instructionParts.length > 0) {
+      skillInstructions = instructionParts.join('\n\n---\n\n');
     }
 
     // Write config files to disk
@@ -854,26 +870,38 @@ router.post('/:id/skills', requireRole('user'), async (req: Request, res: Respon
       return;
     }
 
-    // Max 1 skill per agent: replace existing assignment (delete old, insert new)
-    await getPool().query(
-      'DELETE FROM agent_skills WHERE agent_id = $1',
+    // Additive: INSERT only, catch PK violation as 409
+    let assignmentRow;
+    try {
+      const { rows } = await getPool().query(
+        `INSERT INTO agent_skills (agent_id, skill_id, assigned_by)
+         VALUES ($1, $2, $3)
+         RETURNING *`,
+        [req.params.id, skill_id, user.sub]
+      );
+      assignmentRow = rows[0];
+    } catch (insertErr: any) {
+      if (insertErr.code === '23505') {
+        res.status(409).json({ error: 'Skill already assigned to this agent' });
+        return;
+      }
+      throw insertErr;
+    }
+
+    // Resolve-on-save: merge tools_config from ALL skills for this agent
+    const { rows: allSkillConfigs } = await getPool().query(
+      `SELECT s.tools_config FROM agent_skills asks
+       JOIN skills s ON s.id = asks.skill_id
+       WHERE asks.agent_id = $1`,
       [req.params.id]
     );
-
-    const { rows } = await getPool().query(
-      `INSERT INTO agent_skills (agent_id, skill_id, assigned_by)
-       VALUES ($1, $2, $3)
-       RETURNING *`,
-      [req.params.id, skill_id, user.sub]
-    );
-
-    // Resolve-on-save: update agent's tools_config to match the assigned skill
+    const mergedConfig = mergeToolsConfigs(allSkillConfigs.map((r: any) => r.tools_config));
     await getPool().query(
       'UPDATE agents SET tools_config = $1 WHERE id = $2',
-      [JSON.stringify(skillRows[0].tools_config), req.params.id]
+      [JSON.stringify(mergedConfig), req.params.id]
     );
 
-    res.status(201).json(rows[0]);
+    res.status(201).json(assignmentRow);
   } catch (err: any) {
     console.error('[agents] Assign skill error:', err);
     res.status(500).json({ error: 'Failed to assign skill' });
@@ -924,6 +952,21 @@ router.delete('/:id/skills/:skillId', requireRole('user'), async (req: Request, 
       res.status(404).json({ error: 'Skill assignment not found' });
       return;
     }
+
+    // Recompute tools_config from remaining skills
+    const { rows: remainingConfigs } = await getPool().query(
+      `SELECT s.tools_config FROM agent_skills asks
+       JOIN skills s ON s.id = asks.skill_id
+       WHERE asks.agent_id = $1`,
+      [req.params.id]
+    );
+    const mergedConfig = remainingConfigs.length > 0
+      ? mergeToolsConfigs(remainingConfigs.map((r: any) => r.tools_config))
+      : DEFAULT_TOOLS_CONFIG;
+    await getPool().query(
+      'UPDATE agents SET tools_config = $1 WHERE id = $2',
+      [JSON.stringify(mergedConfig), req.params.id]
+    );
 
     res.json({ removed: true });
   } catch (err) {

--- a/services/api/src/services/merge-tools-config.ts
+++ b/services/api/src/services/merge-tools-config.ts
@@ -1,0 +1,79 @@
+export interface ShellConfig {
+  enabled: boolean;
+  allowed_binaries: string[];
+  denied_patterns: string[];
+  max_timeout: number;
+}
+
+export interface FilesystemConfig {
+  enabled: boolean;
+  read_only: boolean;
+  allowed_paths: string[];
+  denied_paths: string[];
+}
+
+export interface HealthConfig {
+  enabled: boolean;
+}
+
+export interface ToolsConfig {
+  shell: ShellConfig;
+  filesystem: FilesystemConfig;
+  health: HealthConfig;
+}
+
+// No-skills default: matches routes/agents.ts:140 and agentbox config.py Pydantic defaults.
+// Shell disabled, filesystem disabled, health enabled.
+// Sub-field defaults from agentbox Pydantic: allowed_binaries=[], denied_patterns=[],
+// max_timeout=300, read_only=false, allowed_paths=['/workspace'],
+// denied_paths=['/etc/shadow','/etc/passwd','/root'].
+export const DEFAULT_TOOLS_CONFIG: ToolsConfig = {
+  shell: { enabled: false, allowed_binaries: [], denied_patterns: [], max_timeout: 300 },
+  filesystem: { enabled: false, read_only: false, allowed_paths: ['/workspace'], denied_paths: ['/etc/shadow', '/etc/passwd', '/root'] },
+  health: { enabled: true },
+};
+
+/**
+ * Merge multiple ToolsConfig objects into one using deterministic, order-independent rules.
+ *
+ * | Field                      | Rule                              |
+ * |----------------------------|-----------------------------------|
+ * | shell.enabled              | OR — any skill needs shell → on   |
+ * | shell.allowed_binaries     | UNION, but empty [] = unrestricted (policy.py:41) |
+ * | shell.denied_patterns      | UNION — denials accumulate        |
+ * | shell.max_timeout          | MAX — most permissive wins        |
+ * | filesystem.enabled         | OR                                |
+ * | filesystem.read_only       | AND — false if any skill needs write |
+ * | filesystem.allowed_paths   | UNION                             |
+ * | filesystem.denied_paths    | UNION — denials accumulate        |
+ * | health.enabled             | OR                                |
+ */
+export function mergeToolsConfigs(configs: ToolsConfig[]): ToolsConfig {
+  if (configs.length === 0) return DEFAULT_TOOLS_CONFIG;
+  if (configs.length === 1) return configs[0];
+
+  const dedupe = (arr: string[]) => [...new Set(arr)];
+  // Empty array in allowed_binaries means unrestricted (agentbox policy.py line 41:
+  // `if self.allowed:` — empty set is falsy, so everything is allowed).
+  const anyUnrestricted = configs.some(c => c.shell.allowed_binaries.length === 0);
+
+  return {
+    shell: {
+      enabled: configs.some(c => c.shell.enabled),
+      allowed_binaries: anyUnrestricted
+        ? []
+        : dedupe(configs.flatMap(c => c.shell.allowed_binaries)),
+      denied_patterns: dedupe(configs.flatMap(c => c.shell.denied_patterns)),
+      max_timeout: Math.max(...configs.map(c => c.shell.max_timeout)),
+    },
+    filesystem: {
+      enabled: configs.some(c => c.filesystem.enabled),
+      read_only: configs.every(c => c.filesystem.read_only),
+      allowed_paths: dedupe(configs.flatMap(c => c.filesystem.allowed_paths)),
+      denied_paths: dedupe(configs.flatMap(c => c.filesystem.denied_paths)),
+    },
+    health: {
+      enabled: configs.some(c => c.health.enabled),
+    },
+  };
+}

--- a/services/ui/src/__tests__/AgentDetailClient.test.tsx
+++ b/services/ui/src/__tests__/AgentDetailClient.test.tsx
@@ -108,6 +108,24 @@ const MOCK_ALL_SKILLS = [
   { id: 'skill-vps', name: 'VPS Admin', scope: 'vps_system', instructions_md: 'VPS instructions' },
 ]
 
+const MOCK_AGENT_WITH_MULTI_SKILLS = {
+  ...MOCK_AGENT,
+  skills: [
+    {
+      id: 'preset-dev',
+      name: 'Developer',
+      scope: 'container_local',
+      instructions_md: 'Dev instructions.',
+    },
+    {
+      id: 'skill-docker',
+      name: 'Docker Access',
+      scope: 'host_docker',
+      instructions_md: 'Docker instructions here.',
+    },
+  ],
+}
+
 const MOCK_AGENT_WITH_ELEVATED_SKILL = {
   ...MOCK_AGENT,
   skills: [
@@ -445,6 +463,50 @@ describe('AgentDetailClient', () => {
     })
     expect(screen.queryByText('Docker Access')).not.toBeInTheDocument()
     expect(screen.queryByText('VPS Admin')).not.toBeInTheDocument()
+  })
+
+  // U7: Assign picker excludes already-assigned skills
+  it('assign picker excludes already-assigned skills', async () => {
+    mockFetchDefaults(MOCK_AGENT_WITH_SKILL as any)
+
+    render(<AgentDetailClient agentId="uuid-1" session={ADMIN_SESSION as any} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Developer')).toBeInTheDocument()
+    })
+
+    // Click "Assign Skill" to open picker
+    fireEvent.click(screen.getByText('Assign Skill'))
+
+    // Developer is already assigned — should NOT appear in picker
+    // But Docker Access and VPS Admin should appear (admin sees all)
+    await waitFor(() => {
+      expect(screen.getByText('Docker Access')).toBeInTheDocument()
+    })
+    expect(screen.getByText('VPS Admin')).toBeInTheDocument()
+
+    // The picker should have items for Docker Access and VPS Admin but not Developer
+    // Developer already appears in the skills list above, so we verify the picker
+    // doesn't have a second clickable button for Developer
+    const pickerButtons = screen.getAllByRole('button').filter(
+      btn => btn.textContent?.includes('Developer') && btn.closest('[class*="navy-900"]')
+    )
+    // The picker is inside a navy-900 div — should not have Developer there
+    expect(pickerButtons).toHaveLength(0)
+  })
+
+  // U8: Detail shows multiple skill cards
+  it('shows multiple skill cards', async () => {
+    mockFetchDefaults(MOCK_AGENT_WITH_MULTI_SKILLS as any)
+
+    render(<AgentDetailClient agentId="uuid-1" session={ADMIN_SESSION as any} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Developer')).toBeInTheDocument()
+    })
+
+    // Both skills should appear
+    expect(screen.getByText('Docker Access')).toBeInTheDocument()
   })
 
   // T8: Skill instructions toggle

--- a/services/ui/src/__tests__/AgentFormClient.test.tsx
+++ b/services/ui/src/__tests__/AgentFormClient.test.tsx
@@ -85,13 +85,12 @@ function mockFetchDefaults() {
   })
 }
 
-/** Helper: wait for presets to load then select Custom mode */
+/** Helper: switch to Custom mode via radio toggle */
 async function selectCustomMode() {
   await waitFor(() => {
-    expect(screen.getByRole('combobox', { name: /skill/i })).toBeInTheDocument()
+    expect(screen.getByLabelText('Custom')).toBeInTheDocument()
   })
-  const profileSelect = screen.getByRole('combobox', { name: /skill/i })
-  fireEvent.change(profileSelect, { target: { value: '' } })
+  fireEvent.click(screen.getByLabelText('Custom'))
 }
 
 describe('AgentFormClient', () => {
@@ -126,7 +125,6 @@ describe('AgentFormClient', () => {
     })
 
     expect(screen.getByText('Restricted Policy')).toBeInTheDocument()
-    // "None" option should exist
     const selectEl = screen.getByRole('combobox', { name: /model policy/i })
     expect(selectEl).toBeInTheDocument()
     const noneOption = screen.getByRole('option', { name: 'None' })
@@ -137,11 +135,9 @@ describe('AgentFormClient', () => {
     render(<AgentFormClient />)
     await selectCustomMode()
 
-    // Enable shell
     const shellCheckbox = screen.getByLabelText('Shell access')
     fireEvent.click(shellCheckbox)
 
-    // Click "Advanced settings" to expand
     const advancedLink = screen.getByText('Advanced settings', { selector: 'button' })
     fireEvent.click(advancedLink)
 
@@ -154,11 +150,9 @@ describe('AgentFormClient', () => {
     render(<AgentFormClient />)
     await selectCustomMode()
 
-    // Enable filesystem
     const fsCheckbox = screen.getByLabelText('Filesystem access')
     fireEvent.click(fsCheckbox)
 
-    // Click "Advanced settings" for filesystem
     const advancedLinks = screen.getAllByText('Advanced settings', { selector: 'button' })
     fireEvent.click(advancedLinks[0])
 
@@ -174,15 +168,12 @@ describe('AgentFormClient', () => {
       expect(screen.getByText('Default Policy')).toBeInTheDocument()
     })
 
-    // Fill required fields
     fireEvent.change(screen.getByLabelText('Agent ID (slug)'), { target: { value: 'test-agent' } })
     fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Test Agent' } })
 
-    // Select a policy
     const policySelect = screen.getByRole('combobox', { name: /model policy/i })
     fireEvent.change(policySelect, { target: { value: 'policy-1' } })
 
-    // Submit
     fireEvent.click(screen.getByRole('button', { name: /create agent/i }))
 
     await waitFor(() => {
@@ -202,14 +193,11 @@ describe('AgentFormClient', () => {
     render(<AgentFormClient />)
     await selectCustomMode()
 
-    // Fill required fields
     fireEvent.change(screen.getByLabelText('Agent ID (slug)'), { target: { value: 'test-agent' } })
     fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Test Agent' } })
 
-    // Enable shell
     fireEvent.click(screen.getByLabelText('Shell access'))
 
-    // Submit
     fireEvent.click(screen.getByRole('button', { name: /create agent/i }))
 
     await waitFor(() => {
@@ -232,23 +220,18 @@ describe('AgentFormClient', () => {
     render(<AgentFormClient />)
     await selectCustomMode()
 
-    // Fill required fields
     fireEvent.change(screen.getByLabelText('Agent ID (slug)'), { target: { value: 'test-agent' } })
     fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Test Agent' } })
 
-    // Enable shell and open advanced
     fireEvent.click(screen.getByLabelText('Shell access'))
     fireEvent.click(screen.getByText('Advanced settings', { selector: 'button' }))
 
-    // Set invalid timeout
     const timeoutInput = screen.getByLabelText('Max Timeout (seconds)')
     fireEvent.change(timeoutInput, { target: { value: '0' } })
 
-    // Submit via form submit event to bypass native validation
     const form = screen.getByRole('button', { name: /create agent/i }).closest('form')!
     fireEvent.submit(form)
 
-    // Should show validation error, not send request
     await waitFor(() => {
       expect(screen.getByText(/timeout must be at least 1/i)).toBeInTheDocument()
     })
@@ -263,14 +246,11 @@ describe('AgentFormClient', () => {
     render(<AgentFormClient />)
     await selectCustomMode()
 
-    // Enable filesystem and open advanced
     fireEvent.click(screen.getByLabelText('Filesystem access'))
     const advancedLinks = screen.getAllByText('Advanced settings', { selector: 'button' })
     fireEvent.click(advancedLinks[0])
 
-    // Try to add invalid path via TagInput
     const pathInputs = screen.getAllByPlaceholderText(/add/i)
-    // The first TagInput under filesystem advanced should be allowed_paths
     fireEvent.change(pathInputs[0], { target: { value: 'nope' } })
     fireEvent.keyDown(pathInputs[0], { key: 'Enter' })
 
@@ -301,14 +281,13 @@ describe('AgentFormClient', () => {
       expect(screen.getByText('Tools')).toBeInTheDocument()
     })
 
-    // Edit mode with no preset → Custom mode, tool toggles visible
+    // Edit mode with no skills → Custom mode, tool toggles visible
     const shellCheckbox = screen.getByLabelText('Shell access') as HTMLInputElement
     expect(shellCheckbox.checked).toBe(true)
 
     const fsCheckbox = screen.getByLabelText('Filesystem access') as HTMLInputElement
     expect(fsCheckbox.checked).toBe(true)
 
-    // Policy selector should have policy-1 selected
     await waitFor(() => {
       const policySelect = screen.getByRole('combobox', { name: /model policy/i }) as HTMLSelectElement
       expect(policySelect.value).toBe('policy-1')
@@ -338,7 +317,6 @@ describe('AgentFormClient', () => {
       expect(screen.getByText('This agent is running. Stop it before making changes.')).toBeInTheDocument()
     })
 
-    // Submit button should be disabled
     const submitBtn = screen.getByRole('button', { name: /update agent/i })
     expect(submitBtn).toBeDisabled()
   })
@@ -356,107 +334,35 @@ describe('AgentFormClient', () => {
     expect(screen.getByText('11 characters')).toBeInTheDocument()
   })
 
-  // T18: New agent starts in unselected prompt state
-  it('new agent starts with unselected prompt, not Custom', async () => {
+  // U1: Form renders radio toggle and checkboxes (not dropdown) for skills
+  it('renders radio toggle for Custom/Skills mode', async () => {
     render(<AgentFormClient />)
 
     await waitFor(() => {
-      expect(screen.getByRole('combobox', { name: /skill/i })).toBeInTheDocument()
+      expect(screen.getByLabelText('Skills')).toBeInTheDocument()
     })
 
-    // The select should show "Select a profile..." prompt
-    const profileSelect = screen.getByRole('combobox', { name: /skill/i }) as HTMLSelectElement
-    expect(profileSelect.value).toBe('__unselected__')
-
-    // Prompt message should be visible
-    expect(screen.getByText(/choose a skill/i)).toBeInTheDocument()
-
-    // Tool checkboxes should NOT be visible (neither preset summary nor custom toggles)
-    expect(screen.queryByLabelText('Shell access')).not.toBeInTheDocument()
+    expect(screen.getByLabelText('Custom')).toBeInTheDocument()
+    // No dropdown (combobox) for skills
+    expect(screen.queryByRole('combobox', { name: /skill/i })).not.toBeInTheDocument()
   })
 
-  // T18: Preset dropdown renders options
-  it('renders preset dropdown with preset options and Custom', async () => {
-    render(<AgentFormClient isAdmin />)
+  // U2: Form Custom/Skills toggle switches mode
+  it('Custom/Skills toggle switches mode', async () => {
+    render(<AgentFormClient />)
 
+    await waitFor(() => {
+      expect(screen.getByLabelText('Skills')).toBeInTheDocument()
+    })
+
+    // Default: Skills mode — skill checkboxes visible
     await waitFor(() => {
       expect(screen.getByText(/Minimal/)).toBeInTheDocument()
     })
 
-    expect(screen.getByText(/Developer/)).toBeInTheDocument()
+    // Switch to Custom — manual tool editors visible
+    fireEvent.click(screen.getByLabelText('Custom'))
 
-    // "Custom" option should exist in the tool profile selector
-    const profileSelect = screen.getByRole('combobox', { name: /skill/i })
-    expect(profileSelect).toBeInTheDocument()
-    const customOption = screen.getByRole('option', { name: /custom/i })
-    expect(customOption).toBeInTheDocument()
-  })
-
-  // T18: Submit blocked when still in unselected state
-  it('submit blocked when no profile selected', async () => {
-    render(<AgentFormClient />)
-
-    await waitFor(() => {
-      expect(screen.getByRole('combobox', { name: /skill/i })).toBeInTheDocument()
-    })
-
-    // Fill required fields
-    fireEvent.change(screen.getByLabelText('Agent ID (slug)'), { target: { value: 'test-agent' } })
-    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Test Agent' } })
-
-    // Submit without selecting a profile
-    const form = screen.getByRole('button', { name: /create agent/i }).closest('form')!
-    fireEvent.submit(form)
-
-    await waitFor(() => {
-      expect(screen.getByText(/please select a skill/i)).toBeInTheDocument()
-    })
-
-    // Should NOT have sent a POST request
-    const postCalls = mockFetch.mock.calls.filter(
-      (c: any[]) => c[0] === '/api/agents' && c[1]?.method === 'POST'
-    )
-    expect(postCalls).toHaveLength(0)
-  })
-
-  // T19: Selecting preset shows summary card
-  it('selecting preset shows summary card with tool details', async () => {
-    render(<AgentFormClient isAdmin />)
-
-    await waitFor(() => {
-      expect(screen.getByText(/Developer/)).toBeInTheDocument()
-    })
-
-    // Select the Developer preset
-    const profileSelect = screen.getByRole('combobox', { name: /skill/i })
-    fireEvent.change(profileSelect, { target: { value: 'preset-dev' } })
-
-    // Should show summary with enabled tools info (may match in both summary and instructions)
-    await waitFor(() => {
-      expect(screen.getAllByText(/shell/i).length).toBeGreaterThan(0)
-      expect(screen.getAllByText(/bash/i).length).toBeGreaterThan(0)
-    })
-
-    // Manual tool checkboxes (Shell access, Filesystem access) should NOT be visible
-    expect(screen.queryByLabelText('Shell access')).not.toBeInTheDocument()
-  })
-
-  // T20: Selecting Custom reveals manual config
-  it('selecting Custom shows tool toggles', async () => {
-    render(<AgentFormClient isAdmin />)
-
-    await waitFor(() => {
-      expect(screen.getByText(/Developer/)).toBeInTheDocument()
-    })
-
-    // Select Developer preset first (from unselected)
-    const profileSelect = screen.getByRole('combobox', { name: /skill/i })
-    fireEvent.change(profileSelect, { target: { value: 'preset-dev' } })
-
-    // Now switch to Custom
-    fireEvent.change(profileSelect, { target: { value: '' } })
-
-    // Manual tool checkboxes should be visible again
     await waitFor(() => {
       expect(screen.getByLabelText('Shell access')).toBeInTheDocument()
     })
@@ -464,84 +370,14 @@ describe('AgentFormClient', () => {
     expect(screen.getByLabelText('Health endpoint')).toBeInTheDocument()
   })
 
-  // T20 continued: Selecting Custom from unselected also shows toggles
-  it('selecting Custom from unselected shows tool toggles', async () => {
+  // U3: Form Custom mode: manual tools editors shown, skill_ids: [] submitted
+  it('Custom mode submits skill_ids: [] with tools_config', async () => {
     render(<AgentFormClient />)
     await selectCustomMode()
 
-    expect(screen.getByLabelText('Shell access')).toBeInTheDocument()
-    expect(screen.getByLabelText('Filesystem access')).toBeInTheDocument()
-    expect(screen.getByLabelText('Health endpoint')).toBeInTheDocument()
-  })
-
-  // T21: Preset→Custom populates fields from preset
-  it('switching from preset to Custom populates tool fields from preset', async () => {
-    render(<AgentFormClient isAdmin />)
-
-    await waitFor(() => {
-      expect(screen.getByText(/Developer/)).toBeInTheDocument()
-    })
-
-    // Select Developer preset
-    const profileSelect = screen.getByRole('combobox', { name: /skill/i })
-    fireEvent.change(profileSelect, { target: { value: 'preset-dev' } })
-
-    // Switch to Custom
-    fireEvent.change(profileSelect, { target: { value: '' } })
-
-    // Shell should be enabled (from Developer preset)
-    await waitFor(() => {
-      const shellCheckbox = screen.getByLabelText('Shell access') as HTMLInputElement
-      expect(shellCheckbox.checked).toBe(true)
-    })
-
-    // Filesystem should be enabled (from Developer preset)
-    const fsCheckbox = screen.getByLabelText('Filesystem access') as HTMLInputElement
-    expect(fsCheckbox.checked).toBe(true)
-  })
-
-  // Submit body includes skill_ids when skill selected
-  it('submit body includes skill_ids when skill selected', async () => {
-    render(<AgentFormClient isAdmin />)
-
-    await waitFor(() => {
-      expect(screen.getByText(/Developer/)).toBeInTheDocument()
-    })
-
-    // Fill required fields
     fireEvent.change(screen.getByLabelText('Agent ID (slug)'), { target: { value: 'test-agent' } })
     fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Test Agent' } })
 
-    // Select Developer skill
-    const profileSelect = screen.getByRole('combobox', { name: /skill/i })
-    fireEvent.change(profileSelect, { target: { value: 'preset-dev' } })
-
-    // Submit
-    fireEvent.click(screen.getByRole('button', { name: /create agent/i }))
-
-    await waitFor(() => {
-      expect(mockFetch).toHaveBeenCalledWith('/api/agents', expect.objectContaining({
-        method: 'POST',
-      }))
-    })
-
-    const postCall = mockFetch.mock.calls.find(
-      (c: any[]) => c[0] === '/api/agents' && c[1]?.method === 'POST'
-    )!
-    const body = JSON.parse(postCall[1].body)
-    expect(body.skill_ids).toEqual(['preset-dev'])
-  })
-
-  // Submit body sends skill_ids empty when Custom selected
-  it('submit body sends skill_ids empty when Custom selected', async () => {
-    render(<AgentFormClient />)
-    await selectCustomMode()
-
-    // Fill required fields
-    fireEvent.change(screen.getByLabelText('Agent ID (slug)'), { target: { value: 'test-agent' } })
-    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Test Agent' } })
-
-    // Submit
     fireEvent.click(screen.getByRole('button', { name: /create agent/i }))
 
     await waitFor(() => {
@@ -555,10 +391,134 @@ describe('AgentFormClient', () => {
     )!
     const body = JSON.parse(postCall[1].body)
     expect(body.skill_ids).toEqual([])
+    expect(body.tools_config).toBeDefined()
   })
 
-  // Edit form pre-selects skill when initial has skills array
-  it('pre-selects skill when initial has skills array', async () => {
+  // U4: Form Skills mode: checkboxes shown, skill_ids submitted
+  it('Skills mode submits checked skill_ids', async () => {
+    render(<AgentFormClient isAdmin />)
+
+    await waitFor(() => {
+      expect(screen.getByText(/Minimal/)).toBeInTheDocument()
+    })
+
+    // Fill required fields
+    fireEvent.change(screen.getByLabelText('Agent ID (slug)'), { target: { value: 'test-agent' } })
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Test Agent' } })
+
+    // Check two skills using role query to match partial label text
+    const checkboxes = screen.getAllByRole('checkbox')
+    const minCheckbox = checkboxes.find(cb => cb.closest('label')?.textContent?.includes('Minimal'))!
+    const devCheckbox = checkboxes.find(cb => cb.closest('label')?.textContent?.includes('Developer'))!
+    fireEvent.click(minCheckbox)
+    fireEvent.click(devCheckbox)
+
+    fireEvent.click(screen.getByRole('button', { name: /create agent/i }))
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith('/api/agents', expect.objectContaining({
+        method: 'POST',
+      }))
+    })
+
+    const postCall = mockFetch.mock.calls.find(
+      (c: any[]) => c[0] === '/api/agents' && c[1]?.method === 'POST'
+    )!
+    const body = JSON.parse(postCall[1].body)
+    expect(body.skill_ids).toHaveLength(2)
+    expect(body.skill_ids).toContain('preset-min')
+    expect(body.skill_ids).toContain('preset-dev')
+  })
+
+  // U5: Form non-admin: elevated skills not shown in checkboxes
+  it('non-admin checkboxes exclude elevated skills', async () => {
+    render(<AgentFormClient isAdmin={false} />)
+
+    await waitFor(() => {
+      expect(screen.getByText(/Minimal/)).toBeInTheDocument()
+    })
+
+    // Non-admin should see Minimal and Developer (container_local) but NOT Docker Access (host_docker)
+    const checkboxes = screen.getAllByRole('checkbox')
+    expect(checkboxes.some(cb => cb.closest('label')?.textContent?.includes('Minimal'))).toBe(true)
+    expect(checkboxes.some(cb => cb.closest('label')?.textContent?.includes('Developer'))).toBe(true)
+    expect(checkboxes.some(cb => cb.closest('label')?.textContent?.includes('Docker Access'))).toBe(false)
+  })
+
+  // U6: Overwrite warning when switching from Custom to Skills with dirty tools
+  it('dirty custom state prompts confirmation before switching to Skills', async () => {
+    render(<AgentFormClient />)
+    await selectCustomMode()
+
+    // Make a manual change in Custom mode (enable shell = dirty)
+    fireEvent.click(screen.getByLabelText('Shell access'))
+
+    // Now try to switch back to Skills mode
+    fireEvent.click(screen.getByLabelText('Skills'))
+
+    // confirm() should have been called
+    expect(mockConfirm).toHaveBeenCalledWith(
+      expect.stringMatching(/overwrite/i)
+    )
+  })
+
+  it('cancel on overwrite confirmation keeps Custom mode', async () => {
+    mockConfirm.mockReturnValue(false)
+
+    render(<AgentFormClient />)
+    await selectCustomMode()
+
+    // Make a manual change (enable shell)
+    fireEvent.click(screen.getByLabelText('Shell access'))
+
+    // Try to switch to Skills — user cancels
+    fireEvent.click(screen.getByLabelText('Skills'))
+
+    // Should still be in Custom mode — tool toggles visible
+    expect(screen.getByLabelText('Shell access')).toBeInTheDocument()
+    const shellCheckbox = screen.getByLabelText('Shell access') as HTMLInputElement
+    expect(shellCheckbox.checked).toBe(true)
+  })
+
+  it('no confirmation when switching from unmodified Custom to Skills', async () => {
+    render(<AgentFormClient />)
+    await selectCustomMode()
+
+    // Don't make any changes — just switch back to Skills
+    fireEvent.click(screen.getByLabelText('Skills'))
+
+    // confirm() should NOT have been called
+    expect(mockConfirm).not.toHaveBeenCalled()
+  })
+
+  // Skills mode validation: requires at least one skill selected
+  it('submit blocked when no skills selected in Skills mode', async () => {
+    render(<AgentFormClient />)
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Skills')).toBeInTheDocument()
+    })
+
+    // Fill required fields
+    fireEvent.change(screen.getByLabelText('Agent ID (slug)'), { target: { value: 'test-agent' } })
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Test Agent' } })
+
+    // Submit without selecting any skill
+    const form = screen.getByRole('button', { name: /create agent/i }).closest('form')!
+    fireEvent.submit(form)
+
+    await waitFor(() => {
+      expect(screen.getByText(/please select at least one skill/i)).toBeInTheDocument()
+    })
+
+    const postCalls = mockFetch.mock.calls.filter(
+      (c: any[]) => c[0] === '/api/agents' && c[1]?.method === 'POST'
+    )
+    expect(postCalls).toHaveLength(0)
+  })
+
+  // Edit form pre-selects skills and starts in Skills mode
+  it('pre-selects skills when initial has skills array', async () => {
     const initial = {
       agent_id: 'existing',
       name: 'Existing Agent',
@@ -574,169 +534,36 @@ describe('AgentFormClient', () => {
       soul_md: '',
       rules_md: '',
       model_policy_id: null,
-      skills: [{ id: 'preset-dev', name: 'Developer', scope: 'container_local' }],
+      skills: [
+        { id: 'preset-dev', name: 'Developer', scope: 'container_local' },
+        { id: 'preset-min', name: 'Minimal', scope: 'container_local' },
+      ],
     }
 
     render(<AgentFormClient initial={initial} agentUuid="uuid-1" />)
 
     await waitFor(() => {
-      const profileSelect = screen.getByRole('combobox', { name: /skill/i }) as HTMLSelectElement
-      expect(profileSelect.value).toBe('preset-dev')
+      expect(screen.getByText(/Minimal/)).toBeInTheDocument()
     })
+
+    // Both skills should be checked
+    const checkboxes = screen.getAllByRole('checkbox')
+    const minCheckbox = checkboxes.find(cb => cb.closest('label')?.textContent?.includes('Minimal'))! as HTMLInputElement
+    expect(minCheckbox.checked).toBe(true)
+
+    const devCheckbox = checkboxes.find(cb => cb.closest('label')?.textContent?.includes('Developer'))! as HTMLInputElement
+    expect(devCheckbox.checked).toBe(true)
   })
 
-  // T11: Form dropdown shows scope badge
-  it('skill dropdown shows scope label', async () => {
+  // Scope badges shown on skill checkboxes
+  it('skill checkboxes show scope badges', async () => {
     render(<AgentFormClient isAdmin />)
 
     await waitFor(() => {
       expect(screen.getByText(/Minimal/)).toBeInTheDocument()
     })
 
-    // Scope labels should appear in dropdown options
-    const options = screen.getAllByRole('option')
-    const minimalOption = options.find(o => o.textContent?.includes('Minimal'))
-    expect(minimalOption?.textContent).toContain('Container')
-
-    const dockerOption = options.find(o => o.textContent?.includes('Docker Access'))
-    expect(dockerOption?.textContent).toContain('Host · Docker')
-  })
-
-  // T12: Form dropdown filters elevated scopes for non-admin
-  it('non-admin dropdown excludes elevated skills', async () => {
-    render(<AgentFormClient isAdmin={false} />)
-
-    await waitFor(() => {
-      expect(screen.getByText(/Minimal/)).toBeInTheDocument()
-    })
-
-    // Non-admin should see Minimal and Developer (container_local) but NOT Docker Access (host_docker)
-    const options = screen.getAllByRole('option')
-    const optionTexts = options.map(o => o.textContent)
-    expect(optionTexts.some(t => t?.includes('Minimal'))).toBe(true)
-    expect(optionTexts.some(t => t?.includes('Developer'))).toBe(true)
-    expect(optionTexts.some(t => t?.includes('Docker Access'))).toBe(false)
-  })
-
-  // T13: Form instructions preview
-  it('instructions preview shown when skill selected', async () => {
-    render(<AgentFormClient isAdmin />)
-
-    await waitFor(() => {
-      expect(screen.getByText(/Developer/)).toBeInTheDocument()
-    })
-
-    // Select Developer skill
-    const skillSelect = screen.getByRole('combobox', { name: /skill/i })
-    fireEvent.change(skillSelect, { target: { value: 'preset-dev' } })
-
-    // Instructions should be visible in the summary card
-    await waitFor(() => {
-      expect(screen.getByText(/full developer access with bash/i)).toBeInTheDocument()
-    })
-  })
-
-  // Overwrite protection: dirty custom → preset selection prompts confirmation
-  it('dirty custom state prompts confirmation before switching to preset', async () => {
-    render(<AgentFormClient />)
-    await selectCustomMode()
-
-    // Make a manual change in Custom mode (enable shell = dirty)
-    fireEvent.click(screen.getByLabelText('Shell access'))
-
-    // Now try to switch to Developer preset
-    const profileSelect = screen.getByRole('combobox', { name: /skill/i })
-    fireEvent.change(profileSelect, { target: { value: 'preset-dev' } })
-
-    // confirm() should have been called
-    expect(mockConfirm).toHaveBeenCalledWith(
-      expect.stringMatching(/overwrite/i)
-    )
-  })
-
-  // Overwrite protection: cancel keeps custom state intact
-  it('cancel on overwrite confirmation keeps custom state', async () => {
-    mockConfirm.mockReturnValue(false)
-
-    render(<AgentFormClient />)
-    await selectCustomMode()
-
-    // Make a manual change (enable shell)
-    fireEvent.click(screen.getByLabelText('Shell access'))
-
-    // Try to switch to preset — user cancels
-    const profileSelect = screen.getByRole('combobox', { name: /skill/i })
-    fireEvent.change(profileSelect, { target: { value: 'preset-dev' } })
-
-    // Should still be in Custom mode
-    expect((profileSelect as HTMLSelectElement).value).toBe('')
-
-    // Shell should still be checked (custom state preserved)
-    const shellCheckbox = screen.getByLabelText('Shell access') as HTMLInputElement
-    expect(shellCheckbox.checked).toBe(true)
-  })
-
-  // Overwrite protection: confirm applies the preset
-  it('confirm on overwrite applies preset config', async () => {
-    mockConfirm.mockReturnValue(true)
-
-    render(<AgentFormClient />)
-    await selectCustomMode()
-
-    // Make a manual change (enable shell only, filesystem stays disabled)
-    fireEvent.click(screen.getByLabelText('Shell access'))
-
-    // Switch to Developer preset — user confirms
-    const profileSelect = screen.getByRole('combobox', { name: /skill/i })
-    fireEvent.change(profileSelect, { target: { value: 'preset-dev' } })
-
-    // Should now be in preset mode
-    expect((profileSelect as HTMLSelectElement).value).toBe('preset-dev')
-
-    // Manual tool checkboxes should NOT be visible (preset summary shown instead)
-    expect(screen.queryByLabelText('Shell access')).not.toBeInTheDocument()
-
-    // Preset summary should show Developer description
-    expect(screen.getByText('Full dev environment')).toBeInTheDocument()
-  })
-
-  // No confirmation when switching from clean Custom (no changes) to preset
-  it('no confirmation when switching from unmodified Custom to preset', async () => {
-    render(<AgentFormClient />)
-    await selectCustomMode()
-
-    // Don't make any changes — just switch to preset
-    const profileSelect = screen.getByRole('combobox', { name: /skill/i })
-    fireEvent.change(profileSelect, { target: { value: 'preset-dev' } })
-
-    // confirm() should NOT have been called
-    expect(mockConfirm).not.toHaveBeenCalled()
-  })
-
-  // T12: Agent form dropdown says "Skill"
-  it('agent form shows Skill dropdown label', async () => {
-    render(<AgentFormClient isAdmin />)
-
-    await waitFor(() => {
-      expect(screen.getByRole('combobox', { name: /^skill$/i })).toBeInTheDocument()
-    })
-  })
-
-  // T13: Agent form shows instructions preview when skill selected
-  it('selecting skill shows instructions preview', async () => {
-    render(<AgentFormClient isAdmin />)
-
-    await waitFor(() => {
-      expect(screen.getByText(/Developer/)).toBeInTheDocument()
-    })
-
-    // Select Developer skill
-    const skillSelect = screen.getByRole('combobox', { name: /skill/i })
-    fireEvent.change(skillSelect, { target: { value: 'preset-dev' } })
-
-    // Should show instructions preview
-    await waitFor(() => {
-      expect(screen.getByText(/full developer access with bash/i)).toBeInTheDocument()
-    })
+    // Should show scope labels in checkbox list (multiple skills may have Container scope)
+    expect(screen.getAllByText('Container').length).toBeGreaterThan(0)
   })
 })

--- a/services/ui/src/__tests__/AgentsClient.test.tsx
+++ b/services/ui/src/__tests__/AgentsClient.test.tsx
@@ -82,6 +82,29 @@ const MOCK_AGENTS = [
     updated_at: '2026-03-01T00:00:00Z',
     created_by: 'admin',
   },
+  {
+    id: 'agent-4',
+    agent_id: 'multi-skill-bot',
+    name: 'MultiSkillBot',
+    description: 'Has multiple skills',
+    status: 'stopped',
+    cpus: '2.0',
+    mem_limit: '2g',
+    pids_limit: 200,
+    tools_config: {
+      shell: { enabled: true, allowed_binaries: ['bash', 'git'], denied_patterns: [], max_timeout: 300 },
+      filesystem: { enabled: true, read_only: false, allowed_paths: ['/workspace'], denied_paths: [] },
+      health: { enabled: true },
+    },
+    model_policy_id: null,
+    skills: [
+      { id: 'skill-dev', name: 'Developer', scope: 'container_local' },
+      { id: 'skill-reader', name: 'Data Reader', scope: 'container_local' },
+    ],
+    created_at: '2026-03-02T00:00:00Z',
+    updated_at: '2026-03-02T00:00:00Z',
+    created_by: 'admin',
+  },
 ]
 
 const MOCK_POLICIES = [
@@ -122,7 +145,7 @@ describe('AgentsClient', () => {
     // Status badges + filter buttons both show these texts
     expect(screen.getAllByText('Running').length).toBeGreaterThan(0)
     expect(screen.getAllByText('Stopped').length).toBeGreaterThan(0)
-    expect(screen.getByText('3 agents')).toBeInTheDocument()
+    expect(screen.getByText('4 agents')).toBeInTheDocument()
   })
 
   it('shows policy name badge on agents with assigned policy', async () => {
@@ -237,9 +260,10 @@ describe('AgentsClient', () => {
       expect(screen.getByText('ResearchBot')).toBeInTheDocument()
     })
 
-    // ResearchBot has Developer skill with container_local scope
-    expect(screen.getByText('Developer')).toBeInTheDocument()
-    expect(screen.getByText(/Container/)).toBeInTheDocument()
+    // ResearchBot has Developer skill with container_local scope (MultiSkillBot also has it)
+    expect(screen.getAllByText('Developer').length).toBeGreaterThan(0)
+    // Scope badge "Container" appears on multiple agent cards
+    expect(screen.getAllByText(/Container/).length).toBeGreaterThan(0)
   })
 
   // T10: Agent list card shows Custom when no skill
@@ -253,6 +277,18 @@ describe('AgentsClient', () => {
     // WriterBot has no skills → should show "Custom" badge
     const customBadges = screen.getAllByText('Custom')
     expect(customBadges.length).toBeGreaterThan(0)
+  })
+
+  // U9: Agent list shows multiple skill badges
+  it('agent card shows multiple skill badges', async () => {
+    render(<AgentsClient session={MOCK_SESSION as any} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('MultiSkillBot')).toBeInTheDocument()
+    })
+
+    // MultiSkillBot has Developer and Data Reader skills
+    expect(screen.getByText('Data Reader')).toBeInTheDocument()
   })
 
   it('running agents appear before stopped agents', async () => {

--- a/services/ui/src/app/agents/AgentsClient.tsx
+++ b/services/ui/src/app/agents/AgentsClient.tsx
@@ -199,13 +199,22 @@ export default function AgentsClient({ session }: { session: Session }) {
                   )}
                 </div>
 
-                {/* Skill Badge */}
-                <div className="mb-3">
+                {/* Skill Badges */}
+                <div className="mb-3 flex flex-wrap gap-1">
                   {agent.skills && agent.skills.length > 0 ? (
-                    <span className={`inline-flex items-center gap-1.5 px-2 py-0.5 text-xs font-medium rounded-md ${scopeBadge(agent.skills[0].scope).colorClasses}`}>
-                      {agent.skills[0].name}
-                      <span className="opacity-75">· {scopeBadge(agent.skills[0].scope).label}</span>
-                    </span>
+                    <>
+                      {agent.skills.slice(0, 3).map((skill: { id: string; name: string; scope: string }) => (
+                        <span key={skill.id} className={`inline-flex items-center gap-1.5 px-2 py-0.5 text-xs font-medium rounded-md ${scopeBadge(skill.scope).colorClasses}`}>
+                          {skill.name}
+                          <span className="opacity-75">· {scopeBadge(skill.scope).label}</span>
+                        </span>
+                      ))}
+                      {agent.skills.length > 3 && (
+                        <span className="inline-flex items-center px-2 py-0.5 text-xs font-medium rounded-md bg-navy-900 text-mountain-400 border border-navy-700">
+                          +{agent.skills.length - 3} more
+                        </span>
+                      )}
+                    </>
                   ) : (
                     <span className="inline-flex items-center px-2 py-0.5 text-xs font-medium rounded-md bg-navy-900 text-mountain-400 border border-navy-700">
                       Custom

--- a/services/ui/src/app/agents/[id]/AgentDetailClient.tsx
+++ b/services/ui/src/app/agents/[id]/AgentDetailClient.tsx
@@ -298,9 +298,12 @@ export default function AgentDetailClient({
   }
 
   // For assign picker: admins see all skills, non-admins see only container_local
-  const assignableSkills = isAdmin
+  // Exclude already-assigned skills (additive semantics)
+  const assignedIds = new Set(agentSkills.map(s => s.id))
+  const assignableSkills = (isAdmin
     ? allSkills
     : allSkills.filter(s => !ELEVATED_SCOPES.includes(s.scope))
+  ).filter(s => !assignedIds.has(s.id))
 
   const tabs: { id: TabId; label: string; adminOnly?: boolean }[] = [
     { id: 'overview', label: 'Overview' },

--- a/services/ui/src/app/agents/new/AgentFormClient.tsx
+++ b/services/ui/src/app/agents/new/AgentFormClient.tsx
@@ -11,9 +11,6 @@ interface ToolsConfig {
   health: { enabled: boolean }
 }
 
-// Sentinel value — new agents start here, forcing the user to choose
-const UNSELECTED = '__unselected__'
-
 const defaultTools: ToolsConfig = {
   shell: { enabled: false, allowed_binaries: [], denied_patterns: [], max_timeout: 300 },
   filesystem: { enabled: false, read_only: false, allowed_paths: ['/workspace'], denied_paths: ['/etc/shadow', '/etc/passwd', '/root'] },
@@ -91,9 +88,13 @@ export default function AgentFormClient({
   const [modelPolicyId, setModelPolicyId] = useState(initial?.model_policy_id || '')
   const [policies, setPolicies] = useState<PolicyOption[]>([])
   const [skills, setSkills] = useState<SkillOption[]>([])
-  // New agents: unselected prompt. Edit agents: skill ID or '' (Custom).
-  const [selectedSkillId, setToolPresetId] = useState(
-    initial ? (initial.skills?.[0]?.id || '') : UNSELECTED
+  // Mode: 'custom' = manual tools_config; 'skills' = checkbox multi-select
+  const hasInitialSkills = (initial?.skills?.length ?? 0) > 0
+  const [mode, setMode] = useState<'custom' | 'skills'>(
+    initial ? (hasInitialSkills ? 'skills' : 'custom') : 'skills'
+  )
+  const [selectedSkillIds, setSelectedSkillIds] = useState<Set<string>>(
+    new Set(initial?.skills?.map(s => s.id) || [])
   )
   const toolsCustomDirty = useRef(false)
 
@@ -119,38 +120,40 @@ export default function AgentFormClient({
     toolsCustomDirty.current = true
   }
 
-  const handleSkillChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    const newId = e.target.value
-    const switchingFromCustom = selectedSkillId === ''
+  const handleModeChange = (newMode: 'custom' | 'skills') => {
+    if (newMode === mode) return
 
-    // Overwrite protection: if user has made manual changes in Custom mode
-    if (switchingFromCustom && newId && newId !== UNSELECTED && toolsCustomDirty.current) {
-      if (!confirm('Switching to a skill will overwrite your custom tool configuration. Continue?')) {
+    if (newMode === 'skills' && toolsCustomDirty.current) {
+      if (!confirm('Switching to Skills mode will overwrite your custom tool configuration. Continue?')) {
         return
       }
     }
 
-    if (newId && newId !== UNSELECTED) {
-      // Switching to a skill — copy its tools_config
-      const skill = skills.find((p) => p.id === newId)
-      if (skill) {
-        setTools(skill.tools_config)
-      }
+    if (newMode === 'custom') {
+      setSelectedSkillIds(new Set())
       toolsCustomDirty.current = false
-    } else if (newId === '') {
-      // Switching to Custom — inherited config is the new baseline
+    } else {
       toolsCustomDirty.current = false
     }
 
-    setToolPresetId(newId)
+    setMode(newMode)
+  }
+
+  const handleSkillToggle = (skillId: string) => {
+    setSelectedSkillIds(prev => {
+      const next = new Set(prev)
+      if (next.has(skillId)) next.delete(skillId)
+      else next.add(skillId)
+      return next
+    })
   }
 
   const validateForm = (): boolean => {
-    if (selectedSkillId === UNSELECTED) {
-      setValidationError('Please select a skill or choose Custom')
+    if (mode === 'skills' && selectedSkillIds.size === 0) {
+      setValidationError('Please select at least one skill or switch to Custom mode')
       return false
     }
-    if (tools.shell.enabled && tools.shell.max_timeout < 1) {
+    if (mode === 'custom' && tools.shell.enabled && tools.shell.max_timeout < 1) {
       setValidationError('Timeout must be at least 1 second')
       return false
     }
@@ -169,14 +172,14 @@ export default function AgentFormClient({
       agent_id: agentId,
       name,
       description,
-      tools_config: tools,
+      tools_config: mode === 'custom' ? tools : undefined,
       cpus,
       mem_limit: memLimit,
       pids_limit: pidsLimit,
       soul_md: soulMd,
       rules_md: rulesMd,
       model_policy_id: modelPolicyId || null,
-      skill_ids: selectedSkillId ? [selectedSkillId] : [],
+      skill_ids: mode === 'skills' ? [...selectedSkillIds] : [],
     }
 
     try {
@@ -278,88 +281,71 @@ export default function AgentFormClient({
         </div>
       </fieldset>
 
-      {/* Skill */}
+      {/* Tools — Custom/Skills mode toggle */}
       <fieldset disabled={disabled} className="space-y-4">
         <legend className="text-lg font-semibold text-white mb-4">Tools</legend>
 
-        <div>
-          <label htmlFor="skill" className="block text-xs font-medium text-mountain-500 uppercase tracking-wide mb-1">
-            Skill
+        {/* Mode radio toggle */}
+        <div className="flex items-center gap-4" role="radiogroup" aria-label="Tools mode">
+          <label className="flex items-center gap-2 cursor-pointer">
+            <input
+              type="radio"
+              name="tools-mode"
+              value="skills"
+              checked={mode === 'skills'}
+              onChange={() => handleModeChange('skills')}
+              className="text-brand-500"
+            />
+            <span className="text-sm text-white">Skills</span>
           </label>
-          <select
-            id="skill"
-            value={selectedSkillId}
-            onChange={handleSkillChange}
-            className="rounded-lg border border-navy-600 bg-navy-900 px-3 py-2 text-sm text-white focus:border-brand-500 focus:outline-none disabled:opacity-50"
-          >
-            {selectedSkillId === UNSELECTED && (
-              <option value={UNSELECTED} disabled>Select a skill...</option>
-            )}
-            <option value="">Custom</option>
-            {(isAdmin ? skills : skills.filter(s => !ELEVATED_SCOPES.includes(s.scope))).map((p) => (
-              <option key={p.id} value={p.id}>{p.name} ({scopeBadge(p.scope).label})</option>
-            ))}
-          </select>
-          <p className="text-xs text-mountain-500 mt-1">
-            Select a skill or choose Custom for manual configuration.
-          </p>
+          <label className="flex items-center gap-2 cursor-pointer">
+            <input
+              type="radio"
+              name="tools-mode"
+              value="custom"
+              checked={mode === 'custom'}
+              onChange={() => handleModeChange('custom')}
+              className="text-brand-500"
+            />
+            <span className="text-sm text-white">Custom</span>
+          </label>
         </div>
 
-        {selectedSkillId === UNSELECTED ? (
-          /* No selection yet — prompt user */
-          <div className="rounded-lg border border-navy-700 bg-navy-800 p-4">
-            <p className="text-sm text-mountain-400">
-              Choose a skill above to configure this agent&apos;s capabilities.
-            </p>
-          </div>
-        ) : selectedSkillId ? (
-          /* Preset selected — show read-only summary */
+        {mode === 'skills' ? (
+          /* Skills mode — checkbox multi-select */
           <div className="rounded-lg border border-navy-700 bg-navy-800 p-4 space-y-3">
-            {(() => {
-              const selected = skills.find((p) => p.id === selectedSkillId)
-              if (!selected) return null
-              const tc = selected.tools_config
-              return (
-                <>
-                  {selected.description && (
-                    <p className="text-sm text-mountain-300">{selected.description}</p>
-                  )}
-                  <div className="space-y-2">
-                    <div className="flex items-center gap-2 text-sm">
-                      <span className={`h-2 w-2 rounded-full ${tc.shell.enabled ? 'bg-brand-500' : 'bg-mountain-600'}`} />
-                      <span className="text-white">Shell</span>
-                      {tc.shell.enabled && (
-                        <span className="text-mountain-400">
-                          — {tc.shell.allowed_binaries.join(', ') || 'all binaries'}
-                        </span>
-                      )}
-                    </div>
-                    <div className="flex items-center gap-2 text-sm">
-                      <span className={`h-2 w-2 rounded-full ${tc.filesystem.enabled ? 'bg-brand-500' : 'bg-mountain-600'}`} />
-                      <span className="text-white">Filesystem</span>
-                      {tc.filesystem.enabled && (
-                        <span className="text-mountain-400">
-                          — {tc.filesystem.read_only ? 'Read-only' : 'Read-write'}
-                        </span>
-                      )}
-                    </div>
-                    <div className="flex items-center gap-2 text-sm">
-                      <span className={`h-2 w-2 rounded-full ${tc.health.enabled ? 'bg-brand-500' : 'bg-mountain-600'}`} />
-                      <span className="text-white">Health</span>
-                    </div>
-                  </div>
-                  {selected.instructions_md && (
-                    <div className="border-t border-navy-700 pt-3">
-                      <h4 className="text-xs font-medium text-mountain-400 uppercase tracking-wide mb-1">Instructions</h4>
-                      <p className="text-sm text-mountain-300 whitespace-pre-wrap">{selected.instructions_md}</p>
-                    </div>
-                  )}
-                  <p className="text-xs text-mountain-500">
-                    Skill applied at assignment time. Switch to Custom to edit manually.
-                  </p>
-                </>
-              )
-            })()}
+            <p className="text-xs text-mountain-400 mb-2">
+              Select one or more skills. Tool configurations are merged from all selected skills.
+            </p>
+            <div className="space-y-2">
+              {(isAdmin ? skills : skills.filter(s => !ELEVATED_SCOPES.includes(s.scope))).map((skill) => {
+                const badge = scopeBadge(skill.scope)
+                return (
+                  <label key={skill.id} className="flex items-center gap-3 cursor-pointer py-1">
+                    <input
+                      type="checkbox"
+                      checked={selectedSkillIds.has(skill.id)}
+                      onChange={() => handleSkillToggle(skill.id)}
+                      className="rounded border-navy-600"
+                    />
+                    <span className="text-sm text-white">{skill.name}</span>
+                    <span className={`px-1.5 py-0.5 text-xs rounded-md ${badge.colorClasses}`}>
+                      {badge.label}
+                    </span>
+                  </label>
+                )
+              })}
+              {skills.length === 0 && (
+                <p className="text-xs text-mountain-500">No skills available</p>
+              )}
+            </div>
+            {selectedSkillIds.size > 0 && (
+              <div className="border-t border-navy-700 pt-3">
+                <p className="text-xs text-mountain-500">
+                  {selectedSkillIds.size} skill{selectedSkillIds.size !== 1 ? 's' : ''} selected. Tools config will be merged at save time.
+                </p>
+              </div>
+            )}
           </div>
         ) : (
           /* Custom mode — show manual tool toggles */


### PR DESCRIPTION
## Summary

- Remove max-1 skill cap from all 4 enforcement points (POST create, PUT update, POST assign, POST start)
- Add deterministic `mergeToolsConfigs()` pure function for multi-skill tools_config composition (OR for capability gates, UNION for allowlists, UNION-accumulate for denylists, MAX for timeouts, AND for read_only)
- Make POST /:id/skills additive (no delete-all-first), catch PK violation as 409
- Add DELETE /:id/skills/:skillId tools_config recompute from remaining skills
- Add PUT RBAC: reject non-admin implicitly removing elevated-scope skills (403)
- Compose multi-skill instructions at start time with per-skill headers ordered by assigned_at ASC
- Remove `maxItems: 1` from OpenAPI spec (source + mirror kept identical)
- UI: Replace single-select dropdown with Custom/Skills radio toggle + checkbox multi-select
- UI: Detail assign picker filters already-assigned skills
- UI: Agent list shows multiple skill badges with +N truncation

## Plan

[Phase 4 plan](.claude/plans/curious-dazzling-nest.md)

## Scope Confirmation

- Multi-skill composition: yes
- Max-1 removal: yes (4 locations)
- Additive assign: yes (POST /:id/skills)
- Elevated removal protection on PUT: yes
- No new routes: confirmed
- No dependency-system or Tools-surface work: confirmed
- No schema migrations: confirmed (agent_skills M:N already exists)

## Risks

| Risk | Mitigation |
|------|-----------|
| Merge function edge cases | 14 unit tests (M1-M14) covering all field rules |
| allowed_binaries empty-array semantics | M5 explicitly tests empty-means-unrestricted |
| Existing tests break from additive POST | Updated all mocks in routes-agents-skills.test.ts |
| PUT RBAC adds query overhead | One additional SELECT per PUT with skill_ids |

## Rollback

Revert the single commit. No migration to reverse.

## Validation Evidence

| # | Check | Result |
|---|-------|--------|
| V1 | Merge function unit tests (M1-M14) | 14/14 pass |
| V2 | API route tests (--runInBand) | 294/294 pass |
| V3 | UI tests (vitest run) | 291/291 pass |
| V4 | API TypeScript (`tsc --noEmit`) | Clean |
| V5 | UI TypeScript (`tsc --noEmit`) | 9 pre-existing errors, none introduced |
| V6a | No `maxItems: 1` on skill_ids (source) | Zero matches |
| V6b | No `maxItems: 1` on skill_ids (mirror) | Zero matches |
| V6c | Source/mirror OpenAPI identical (`diff`) | Exit code 0 |
| V7 | No `skill_ids.length > 1` cap in routes | Zero matches |
| V8 | No DELETE-all in POST /:id/skills | Confirmed additive |
| V9 | ELEVATED_SCOPES consistent | All `['host_docker', 'vps_system']` |

## Test plan

- [x] V1: `cd services/api && npx jest merge-tools-config --verbose` — 14/14
- [x] V2: `cd services/api && npx jest --runInBand --verbose` — 294/294
- [x] V3: `cd services/ui && npx vitest run` — 291/291
- [x] V4: `cd services/api && npx tsc --noEmit` — clean
- [x] V5: `cd services/ui && npx tsc --noEmit` — 9 pre-existing only
- [x] V6c: `diff services/api/src/openapi/openapi.yaml docs/site/openapi.yaml` — identical
- [x] V7: `grep -n 'skill_ids.length > 1' services/api/src/routes/agents.ts` — zero
- [x] V8: POST /:id/skills handler (lines 831-909) has no `DELETE FROM agent_skills`
- [x] V9: `grep -rn 'ELEVATED_SCOPES' services/` — all `['host_docker', 'vps_system']`

🤖 Generated with [Claude Code](https://claude.com/claude-code)