### PR TITLE
feat: skills concept split — kind discriminator + tool_dependencies (Phase 5)

### DIFF
--- a/docs/site/openapi.yaml
+++ b/docs/site/openapi.yaml
@@ -260,6 +260,22 @@ components:
           enum: [container_local, host_docker, vps_system]
           default: container_local
           description: Scope determines assignment authority. container_local — any user. host_docker/vps_system — admin only.
+        kind:
+          type: string
+          enum: [skill, profile]
+          default: skill
+          description: >-
+            Concept type. 'skill' = capability declaration with tool requirements
+            and behavioral guidance. 'profile' = sandbox environment preset.
+        tool_dependencies:
+          type: array
+          items:
+            type: string
+          default: []
+          description: >-
+            Binary names this skill requires (e.g., ["gh", "git"]).
+            Declarative — not enforced at runtime.
+            Must be empty for kind=profile.
         is_platform:
           type: boolean
           description: Platform skills are immutable and undeletable.

--- a/services/api/src/__tests__/routes-skills.test.ts
+++ b/services/api/src/__tests__/routes-skills.test.ts
@@ -441,4 +441,194 @@ describe('Skill CRUD routes', () => {
     const insertCall = mockQuery.mock.calls[0];
     expect(insertCall[0]).toContain('INSERT INTO skills');
   });
+
+  // kind and tool_dependencies
+  describe('kind and tool_dependencies', () => {
+    // T1: GET /skills returns kind and tool_dependencies
+    it('GET /skills returns kind and tool_dependencies', async () => {
+      const skillWithKind = { ...developerSkill, kind: 'profile', tool_dependencies: [] };
+      const skillWithDeps = { ...adminCreatedSkill, kind: 'skill', tool_dependencies: ['gh', 'git'] };
+      mockQuery.mockResolvedValueOnce({ rows: [skillWithKind, skillWithDeps] });
+      const res = await request(app)
+        .get('/skills')
+        .set('Authorization', `Bearer ${adminToken}`);
+      expect(res.status).toBe(200);
+      expect(res.body[0].kind).toBe('profile');
+      expect(res.body[0].tool_dependencies).toEqual([]);
+      expect(res.body[1].kind).toBe('skill');
+      expect(res.body[1].tool_dependencies).toEqual(['gh', 'git']);
+    });
+
+    // T2: GET /skills?kind=profile returns only profiles
+    it('GET /skills?kind=profile returns only profiles', async () => {
+      const profileSkill = { ...developerSkill, kind: 'profile', tool_dependencies: [] };
+      mockQuery.mockResolvedValueOnce({ rows: [profileSkill] });
+      const res = await request(app)
+        .get('/skills?kind=profile')
+        .set('Authorization', `Bearer ${adminToken}`);
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveLength(1);
+      expect(res.body[0].kind).toBe('profile');
+      const selectCall = mockQuery.mock.calls[0];
+      expect(selectCall[0]).toContain('WHERE kind = $1');
+      expect(selectCall[1]).toContain('profile');
+    });
+
+    // T3: GET /skills?kind=skill returns only skills
+    it('GET /skills?kind=skill returns only skills', async () => {
+      const skillOnly = { ...adminCreatedSkill, kind: 'skill', tool_dependencies: [] };
+      mockQuery.mockResolvedValueOnce({ rows: [skillOnly] });
+      const res = await request(app)
+        .get('/skills?kind=skill')
+        .set('Authorization', `Bearer ${adminToken}`);
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveLength(1);
+      expect(res.body[0].kind).toBe('skill');
+      const selectCall = mockQuery.mock.calls[0];
+      expect(selectCall[0]).toContain('WHERE kind = $1');
+      expect(selectCall[1]).toContain('skill');
+    });
+
+    // T4: POST /skills defaults kind to 'skill'
+    it('POST /skills defaults kind to skill', async () => {
+      const created = { ...adminCreatedSkill, id: 'new-id', kind: 'skill', tool_dependencies: [] };
+      mockQuery.mockResolvedValueOnce({ rows: [created] });
+      const res = await request(app)
+        .post('/skills')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({
+          name: 'Default Kind Skill',
+          tools_config: adminCreatedSkill.tools_config,
+        });
+      expect(res.status).toBe(201);
+      const insertCall = mockQuery.mock.calls[0];
+      expect(insertCall[0]).toContain('INSERT INTO skills');
+      expect(insertCall[1]).toContain('skill');
+    });
+
+    // T5: POST /skills creates profile with kind=profile
+    it('POST /skills creates profile with kind=profile', async () => {
+      const created = { ...adminCreatedSkill, id: 'new-id', kind: 'profile', tool_dependencies: [] };
+      mockQuery.mockResolvedValueOnce({ rows: [created] });
+      const res = await request(app)
+        .post('/skills')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({
+          name: 'My Profile',
+          tools_config: adminCreatedSkill.tools_config,
+          kind: 'profile',
+        });
+      expect(res.status).toBe(201);
+      const insertCall = mockQuery.mock.calls[0];
+      expect(insertCall[1]).toContain('profile');
+    });
+
+    // T6: POST /skills creates skill with tool_dependencies
+    it('POST /skills creates skill with tool_dependencies', async () => {
+      const created = { ...adminCreatedSkill, id: 'new-id', kind: 'skill', tool_dependencies: ['gh', 'git'] };
+      mockQuery.mockResolvedValueOnce({ rows: [created] });
+      const res = await request(app)
+        .post('/skills')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({
+          name: 'Deps Skill',
+          tools_config: adminCreatedSkill.tools_config,
+          tool_dependencies: ['gh', 'git'],
+        });
+      expect(res.status).toBe(201);
+      const insertCall = mockQuery.mock.calls[0];
+      expect(insertCall[0]).toContain('tool_dependencies');
+      expect(insertCall[1]).toContain(JSON.stringify(['gh', 'git']));
+    });
+
+    // T7: POST /skills defaults tool_dependencies to []
+    it('POST /skills defaults tool_dependencies to empty array', async () => {
+      const created = { ...adminCreatedSkill, id: 'new-id', kind: 'skill', tool_dependencies: [] };
+      mockQuery.mockResolvedValueOnce({ rows: [created] });
+      const res = await request(app)
+        .post('/skills')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({
+          name: 'No Deps Skill',
+          tools_config: adminCreatedSkill.tools_config,
+        });
+      expect(res.status).toBe(201);
+      const insertCall = mockQuery.mock.calls[0];
+      expect(insertCall[1]).toContain('[]');
+    });
+
+    // T8: POST /skills rejects profile with non-empty tool_dependencies
+    it('POST /skills rejects profile with non-empty tool_dependencies', async () => {
+      const res = await request(app)
+        .post('/skills')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({
+          name: 'Bad Profile',
+          tools_config: adminCreatedSkill.tools_config,
+          kind: 'profile',
+          tool_dependencies: ['gh'],
+        });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toContain('Profiles cannot have tool_dependencies');
+    });
+
+    // T9: POST /skills rejects invalid kind
+    it('POST /skills rejects invalid kind', async () => {
+      const res = await request(app)
+        .post('/skills')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({
+          name: 'Bad Kind',
+          tools_config: adminCreatedSkill.tools_config,
+          kind: 'banana',
+        });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toContain('kind');
+    });
+
+    // T10: POST /skills rejects non-array tool_dependencies
+    it('POST /skills rejects non-array tool_dependencies', async () => {
+      const res = await request(app)
+        .post('/skills')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({
+          name: 'Bad Deps',
+          tools_config: adminCreatedSkill.tools_config,
+          tool_dependencies: 'not-an-array',
+        });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toContain('tool_dependencies');
+    });
+
+    // T11: POST /skills rejects non-string array entries
+    it('POST /skills rejects non-string array entries in tool_dependencies', async () => {
+      const res = await request(app)
+        .post('/skills')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({
+          name: 'Bad Entries',
+          tools_config: adminCreatedSkill.tools_config,
+          tool_dependencies: [123],
+        });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toContain('tool_dependencies');
+    });
+
+    // T12: PUT /skills/:id updates kind and tool_dependencies
+    it('PUT /skills/:id updates kind and tool_dependencies', async () => {
+      const existingSkill = { ...adminCreatedSkill, kind: 'skill', tool_dependencies: [] };
+      const updatedSkill = { ...adminCreatedSkill, kind: 'skill', tool_dependencies: ['gh', 'git'] };
+      mockQuery
+        .mockResolvedValueOnce({ rows: [existingSkill] })
+        .mockResolvedValueOnce({ rows: [updatedSkill] });
+      const res = await request(app)
+        .put('/skills/skill-custom')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ kind: 'skill', tool_dependencies: ['gh', 'git'] });
+      expect(res.status).toBe(200);
+      const updateCall = mockQuery.mock.calls[1];
+      expect(updateCall[0]).toContain('kind');
+      expect(updateCall[0]).toContain('tool_dependencies');
+    });
+  });
 });

--- a/services/api/src/db/migrations/020_add_kind_and_tool_dependencies.sql
+++ b/services/api/src/db/migrations/020_add_kind_and_tool_dependencies.sql
@@ -1,0 +1,27 @@
+-- Concept split: distinguish skills (capabilities) from profiles (sandbox presets)
+-- and add tool_dependencies for skills to declare binary requirements.
+
+-- kind: 'skill' (default for new entries) or 'profile' (sandbox environment preset)
+ALTER TABLE skills ADD COLUMN IF NOT EXISTS kind VARCHAR(16)
+    NOT NULL DEFAULT 'skill';
+
+-- CHECK constraint for valid kind values
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint WHERE conname = 'chk_skill_kind'
+    ) THEN
+        ALTER TABLE skills ADD CONSTRAINT chk_skill_kind
+            CHECK (kind IN ('skill', 'profile'));
+    END IF;
+END $$;
+
+-- tool_dependencies: JSONB array of binary names a skill requires
+-- Profiles must have [] (enforced in application code, not DB)
+ALTER TABLE skills ADD COLUMN IF NOT EXISTS tool_dependencies JSONB
+    DEFAULT '[]'::jsonb;
+
+-- Reclassify existing platform seeds as profiles
+UPDATE skills SET kind = 'profile'
+    WHERE name IN ('Minimal', 'Developer', 'Research', 'Operator')
+    AND is_platform = true;

--- a/services/api/src/openapi/openapi.yaml
+++ b/services/api/src/openapi/openapi.yaml
@@ -260,6 +260,22 @@ components:
           enum: [container_local, host_docker, vps_system]
           default: container_local
           description: Scope determines assignment authority. container_local — any user. host_docker/vps_system — admin only.
+        kind:
+          type: string
+          enum: [skill, profile]
+          default: skill
+          description: >-
+            Concept type. 'skill' = capability declaration with tool requirements
+            and behavioral guidance. 'profile' = sandbox environment preset.
+        tool_dependencies:
+          type: array
+          items:
+            type: string
+          default: []
+          description: >-
+            Binary names this skill requires (e.g., ["gh", "git"]).
+            Declarative — not enforced at runtime.
+            Must be empty for kind=profile.
         is_platform:
           type: boolean
           description: Platform skills are immutable and undeletable.

--- a/services/api/src/routes/agents.ts
+++ b/services/api/src/routes/agents.ts
@@ -61,7 +61,7 @@ router.get('/', requireRole('user'), async (req: Request, res: Response) => {
               a.cpus, a.mem_limit, a.pids_limit, a.model_policy_id,
               a.created_at, a.updated_at, a.created_by,
               COALESCE(
-                json_agg(json_build_object('id', s.id, 'name', s.name, 'scope', s.scope))
+                json_agg(json_build_object('id', s.id, 'name', s.name, 'scope', s.scope, 'kind', s.kind, 'tool_dependencies', s.tool_dependencies))
                 FILTER (WHERE s.id IS NOT NULL), '[]'
               ) AS skills
        FROM agents a
@@ -185,7 +185,7 @@ router.post('/', requireRole('user'), async (req: Request, res: Response) => {
 
     // Fetch the skills array for response
     const { rows: skillRows } = await getPool().query(
-      `SELECT s.id, s.name, s.scope FROM agent_skills asks
+      `SELECT s.id, s.name, s.scope, s.kind, s.tool_dependencies FROM agent_skills asks
        JOIN skills s ON s.id = asks.skill_id
        WHERE asks.agent_id = $1`,
       [createdAgent.id]
@@ -221,7 +221,7 @@ router.get('/:id', requireRole('user'), async (req: Request, res: Response) => {
 
     // Fetch skills for this agent
     const { rows: skillRows } = await getPool().query(
-      `SELECT s.id, s.name, s.scope FROM agent_skills asks
+      `SELECT s.id, s.name, s.scope, s.kind, s.tool_dependencies FROM agent_skills asks
        JOIN skills s ON s.id = asks.skill_id
        WHERE asks.agent_id = $1`,
       [agent.id]
@@ -385,7 +385,7 @@ router.put('/:id', requireRole('user'), async (req: Request, res: Response) => {
 
     // Fetch skills for response
     const { rows: agentSkills } = await getPool().query(
-      `SELECT s.id, s.name, s.scope FROM agent_skills asks
+      `SELECT s.id, s.name, s.scope, s.kind, s.tool_dependencies FROM agent_skills asks
        JOIN skills s ON s.id = asks.skill_id
        WHERE asks.agent_id = $1`,
       [req.params.id]

--- a/services/api/src/routes/skills.ts
+++ b/services/api/src/routes/skills.ts
@@ -5,6 +5,11 @@ import { requireRole } from '../middleware/role';
 const router = Router();
 
 const VALID_SCOPES = ['container_local', 'host_docker', 'vps_system'] as const;
+const VALID_KINDS = ['skill', 'profile'] as const;
+
+function validateToolDependencies(deps: unknown): deps is string[] {
+  return Array.isArray(deps) && deps.every(d => typeof d === 'string');
+}
 
 function dbHealthCheck(_req: Request, res: Response, next: () => void) {
   if (!process.env.DATABASE_URL) {
@@ -23,12 +28,24 @@ function isAdmin(req: Request): boolean {
 }
 
 // List all skills — all authenticated users see all skills
-router.get('/', requireRole('user'), async (_req: Request, res: Response) => {
+router.get('/', requireRole('user'), async (req: Request, res: Response) => {
   try {
-    const { rows } = await getPool().query(
-      `SELECT id, name, description, tools_config, instructions_md, scope, is_platform, created_by, created_at, updated_at
-       FROM skills ORDER BY is_platform DESC, name ASC`
-    );
+    const kindFilter = req.query.kind as string | undefined;
+    if (kindFilter && !(VALID_KINDS as readonly string[]).includes(kindFilter)) {
+      res.status(400).json({ error: `Invalid kind filter. Must be one of: ${VALID_KINDS.join(', ')}` });
+      return;
+    }
+
+    let query = `SELECT id, name, description, tools_config, instructions_md, scope, kind, tool_dependencies, is_platform, created_by, created_at, updated_at
+       FROM skills`;
+    const params: string[] = [];
+    if (kindFilter) {
+      query += ` WHERE kind = $1`;
+      params.push(kindFilter);
+    }
+    query += ` ORDER BY is_platform DESC, name ASC`;
+
+    const { rows } = await getPool().query(query, params);
     res.json(rows);
   } catch (err) {
     console.error('[skills] List error:', err);
@@ -40,7 +57,7 @@ router.get('/', requireRole('user'), async (_req: Request, res: Response) => {
 router.get('/:id', requireRole('user'), async (req: Request, res: Response) => {
   try {
     const { rows } = await getPool().query(
-      `SELECT id, name, description, tools_config, instructions_md, scope, is_platform, created_by, created_at, updated_at
+      `SELECT id, name, description, tools_config, instructions_md, scope, kind, tool_dependencies, is_platform, created_by, created_at, updated_at
        FROM skills WHERE id = $1`,
       [req.params.id]
     );
@@ -58,7 +75,7 @@ router.get('/:id', requireRole('user'), async (req: Request, res: Response) => {
 // Create skill — admin only
 router.post('/', requireRole('admin'), async (req: Request, res: Response) => {
   try {
-    const { name, description, tools_config, instructions_md, scope } = req.body;
+    const { name, description, tools_config, instructions_md, scope, kind, tool_dependencies } = req.body;
 
     if (!name) {
       res.status(400).json({ error: 'name is required' });
@@ -73,11 +90,27 @@ router.post('/', requireRole('admin'), async (req: Request, res: Response) => {
       return;
     }
 
+    const resolvedKind = kind || 'skill';
+    if (!(VALID_KINDS as readonly string[]).includes(resolvedKind)) {
+      res.status(400).json({ error: `Invalid kind. Must be one of: ${VALID_KINDS.join(', ')}` });
+      return;
+    }
+
+    const resolvedDeps = tool_dependencies ?? [];
+    if (!validateToolDependencies(resolvedDeps)) {
+      res.status(400).json({ error: 'tool_dependencies must be an array of strings' });
+      return;
+    }
+    if (resolvedKind === 'profile' && resolvedDeps.length > 0) {
+      res.status(400).json({ error: 'Profiles cannot have tool_dependencies' });
+      return;
+    }
+
     const { rows } = await getPool().query(
-      `INSERT INTO skills (name, description, tools_config, instructions_md, scope, is_platform, created_by)
-       VALUES ($1, $2, $3, $4, $5, false, NULL)
+      `INSERT INTO skills (name, description, tools_config, instructions_md, scope, kind, tool_dependencies, is_platform, created_by)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, false, NULL)
        RETURNING *`,
-      [name, description || '', JSON.stringify(tools_config), instructions_md || '', scope || 'container_local']
+      [name, description || '', JSON.stringify(tools_config), instructions_md || '', scope || 'container_local', resolvedKind, JSON.stringify(resolvedDeps)]
     );
 
     res.status(201).json(rows[0]);
@@ -95,7 +128,7 @@ router.post('/', requireRole('admin'), async (req: Request, res: Response) => {
 router.put('/:id', requireRole('admin'), async (req: Request, res: Response) => {
   try {
     const { rows: existing } = await getPool().query(
-      'SELECT id, is_platform FROM skills WHERE id = $1',
+      'SELECT id, is_platform, tool_dependencies FROM skills WHERE id = $1',
       [req.params.id]
     );
     if (existing.length === 0) {
@@ -107,11 +140,31 @@ router.put('/:id', requireRole('admin'), async (req: Request, res: Response) => 
       return;
     }
 
-    const { name, description, tools_config, instructions_md, scope } = req.body;
+    const { name, description, tools_config, instructions_md, scope, kind, tool_dependencies } = req.body;
 
     if (scope !== undefined && !VALID_SCOPES.includes(scope)) {
       res.status(400).json({ error: `Invalid scope. Must be one of: ${VALID_SCOPES.join(', ')}` });
       return;
+    }
+
+    if (kind !== undefined && !(VALID_KINDS as readonly string[]).includes(kind)) {
+      res.status(400).json({ error: `Invalid kind. Must be one of: ${VALID_KINDS.join(', ')}` });
+      return;
+    }
+
+    if (tool_dependencies !== undefined && !validateToolDependencies(tool_dependencies)) {
+      res.status(400).json({ error: 'tool_dependencies must be an array of strings' });
+      return;
+    }
+
+    // Cross-validation: if updating kind to 'profile', tool_dependencies must be empty
+    if (kind === 'profile') {
+      const effectiveDeps = tool_dependencies ?? existing[0].tool_dependencies ?? [];
+      const depsArray = Array.isArray(effectiveDeps) ? effectiveDeps : [];
+      if (depsArray.length > 0) {
+        res.status(400).json({ error: 'Profiles cannot have tool_dependencies' });
+        return;
+      }
     }
 
     const { rows } = await getPool().query(
@@ -121,8 +174,10 @@ router.put('/:id', requireRole('admin'), async (req: Request, res: Response) => 
         tools_config = COALESCE($3, tools_config),
         instructions_md = COALESCE($4, instructions_md),
         scope = COALESCE($5, scope),
+        kind = COALESCE($6, kind),
+        tool_dependencies = COALESCE($7, tool_dependencies),
         updated_at = NOW()
-       WHERE id = $6
+       WHERE id = $8
        RETURNING *`,
       [
         name || null,
@@ -130,6 +185,8 @@ router.put('/:id', requireRole('admin'), async (req: Request, res: Response) => 
         tools_config ? JSON.stringify(tools_config) : null,
         instructions_md ?? null,
         scope || null,
+        kind || null,
+        tool_dependencies ? JSON.stringify(tool_dependencies) : null,
         req.params.id,
       ]
     );

--- a/services/ui/src/__tests__/AgentDetailClient.test.tsx
+++ b/services/ui/src/__tests__/AgentDetailClient.test.tsx
@@ -65,6 +65,8 @@ const MOCK_AGENT_WITH_SKILL = {
       id: 'preset-dev',
       name: 'Developer',
       scope: 'container_local',
+      kind: 'skill',
+      tool_dependencies: ['gh', 'git'],
       instructions_md: 'Always write tests before implementation.\nFollow TDD red-green-refactor.',
     },
   ],
@@ -103,9 +105,9 @@ const USER_SESSION = {
 }
 
 const MOCK_ALL_SKILLS = [
-  { id: 'preset-dev', name: 'Developer', scope: 'container_local', instructions_md: 'Dev instructions' },
-  { id: 'skill-docker', name: 'Docker Access', scope: 'host_docker', instructions_md: 'Docker instructions' },
-  { id: 'skill-vps', name: 'VPS Admin', scope: 'vps_system', instructions_md: 'VPS instructions' },
+  { id: 'preset-dev', name: 'Developer', scope: 'container_local', kind: 'skill', tool_dependencies: ['gh', 'git'], instructions_md: 'Dev instructions' },
+  { id: 'skill-docker', name: 'Docker Access', scope: 'host_docker', kind: 'profile', tool_dependencies: [], instructions_md: 'Docker instructions' },
+  { id: 'skill-vps', name: 'VPS Admin', scope: 'vps_system', kind: 'skill', tool_dependencies: [], instructions_md: 'VPS instructions' },
 ]
 
 const MOCK_AGENT_WITH_MULTI_SKILLS = {
@@ -115,12 +117,16 @@ const MOCK_AGENT_WITH_MULTI_SKILLS = {
       id: 'preset-dev',
       name: 'Developer',
       scope: 'container_local',
+      kind: 'skill',
+      tool_dependencies: ['gh', 'git'],
       instructions_md: 'Dev instructions.',
     },
     {
       id: 'skill-docker',
       name: 'Docker Access',
       scope: 'host_docker',
+      kind: 'profile',
+      tool_dependencies: [],
       instructions_md: 'Docker instructions here.',
     },
   ],
@@ -133,6 +139,8 @@ const MOCK_AGENT_WITH_ELEVATED_SKILL = {
       id: 'skill-docker',
       name: 'Docker Access',
       scope: 'host_docker',
+      kind: 'profile',
+      tool_dependencies: [],
       instructions_md: 'Docker instructions here.',
     },
   ],
@@ -529,5 +537,33 @@ describe('AgentDetailClient', () => {
     await waitFor(() => {
       expect(screen.getByText(/Always write tests before implementation/)).toBeInTheDocument()
     })
+  })
+
+  // U5: Detail shows kind badge on cards
+  it('shows kind badge on skill cards', async () => {
+    mockFetchDefaults(MOCK_AGENT_WITH_SKILL as any)
+
+    render(<AgentDetailClient agentId="uuid-1" session={ADMIN_SESSION as any} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Developer')).toBeInTheDocument()
+    })
+
+    // Should show "Skill" kind badge
+    expect(screen.getByText('Skill')).toBeInTheDocument()
+  })
+
+  // U6: Detail shows tool_dependencies on skill cards
+  it('shows tool_dependencies as Requires badges on skill cards', async () => {
+    mockFetchDefaults(MOCK_AGENT_WITH_SKILL as any)
+
+    render(<AgentDetailClient agentId="uuid-1" session={ADMIN_SESSION as any} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Developer')).toBeInTheDocument()
+    })
+
+    // Should show tool dependencies
+    expect(screen.getByText('Requires: gh, git')).toBeInTheDocument()
   })
 })

--- a/services/ui/src/__tests__/AgentFormClient.test.tsx
+++ b/services/ui/src/__tests__/AgentFormClient.test.tsx
@@ -38,6 +38,8 @@ const MOCK_PRESETS = [
     },
     instructions_md: 'You have no shell or filesystem access.',
     is_platform: true,
+    kind: 'profile',
+    tool_dependencies: [],
   },
   {
     id: 'preset-dev',
@@ -51,6 +53,8 @@ const MOCK_PRESETS = [
     },
     instructions_md: 'You have full developer access with bash, git, make, curl, and jq available.',
     is_platform: true,
+    kind: 'profile',
+    tool_dependencies: [],
   },
   {
     id: 'preset-docker',
@@ -64,6 +68,8 @@ const MOCK_PRESETS = [
     },
     instructions_md: 'You have Docker socket access.',
     is_platform: false,
+    kind: 'skill',
+    tool_dependencies: ['docker'],
   },
 ]
 
@@ -565,5 +571,18 @@ describe('AgentFormClient', () => {
 
     // Should show scope labels in checkbox list (multiple skills may have Container scope)
     expect(screen.getAllByText('Container').length).toBeGreaterThan(0)
+  })
+
+  // U4: Form Skills mode shows profiles and skills groups
+  it('Skills mode shows separate profiles and skills group headings', async () => {
+    render(<AgentFormClient isAdmin />)
+
+    await waitFor(() => {
+      expect(screen.getByText(/Minimal/)).toBeInTheDocument()
+    })
+
+    // Both group headings should be present
+    expect(screen.getByText('Profiles (sandbox presets)')).toBeInTheDocument()
+    expect(screen.getByText('Skills (capabilities)')).toBeInTheDocument()
   })
 })

--- a/services/ui/src/__tests__/SkillsClient.test.tsx
+++ b/services/ui/src/__tests__/SkillsClient.test.tsx
@@ -36,6 +36,8 @@ const MOCK_SKILLS = [
     },
     instructions_md: 'You have no shell or filesystem access. You can only monitor your own resource usage via the health endpoint.',
     is_platform: true,
+    kind: 'profile' as const,
+    tool_dependencies: [],
     created_at: '2026-01-01T00:00:00Z',
     updated_at: '2026-01-01T00:00:00Z',
   },
@@ -51,6 +53,8 @@ const MOCK_SKILLS = [
     },
     instructions_md: 'You have full developer access with bash, git, make, curl, and jq available. Use /workspace as your primary working directory.',
     is_platform: true,
+    kind: 'profile' as const,
+    tool_dependencies: [],
     created_at: '2026-01-01T00:00:00Z',
     updated_at: '2026-01-01T00:00:00Z',
   },
@@ -66,6 +70,8 @@ const MOCK_SKILLS = [
     },
     instructions_md: 'Run CI pipelines in isolated containers.',
     is_platform: false,
+    kind: 'skill' as const,
+    tool_dependencies: ['gh', 'git'],
     created_at: '2026-02-15T00:00:00Z',
     updated_at: '2026-02-15T00:00:00Z',
   },
@@ -110,8 +116,8 @@ describe('SkillsClient', () => {
     await waitFor(() => {
       expect(screen.getByText('Skills')).toBeInTheDocument()
     })
-    // Should show skills count, not "profiles" count
-    expect(screen.getByText('3 skills')).toBeInTheDocument()
+    // Should show separate profiles/skills counts
+    expect(screen.getByText('2 profiles, 1 skill')).toBeInTheDocument()
   })
 
   // T8: Skills page shows instructions preview in expanded view
@@ -188,6 +194,40 @@ describe('SkillsClient', () => {
     expect(screen.getByText('Host · Docker')).toBeInTheDocument()
     // vps_system → "VPS · System"
     expect(screen.getByText('VPS · System')).toBeInTheDocument()
+  })
+
+  // U1: Harness shows separate Profiles and Skills sections
+  it('Harness shows separate Profiles and Skills sections', async () => {
+    render(<SkillsClient />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Profiles (sandbox presets)')).toBeInTheDocument()
+      expect(screen.getByText('Skills (capabilities)')).toBeInTheDocument()
+    })
+  })
+
+  // U2: Skill with tool_dependencies shows Requires badges
+  it('Skill with tool_dependencies shows Requires badges', async () => {
+    render(<SkillsClient />)
+
+    await waitFor(() => {
+      expect(screen.getByText('CI Runner')).toBeInTheDocument()
+    })
+
+    expect(screen.getByText('Requires: gh, git')).toBeInTheDocument()
+  })
+
+  // U3: Profile shows no Requires badges for empty tool_dependencies
+  it('Profile shows no Requires badges for empty tool_dependencies', async () => {
+    render(<SkillsClient />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Minimal')).toBeInTheDocument()
+    })
+
+    // Minimal is a profile with empty tool_dependencies — should not show "Requires"
+    const minimalCard = screen.getByText('Minimal').closest('[class*="rounded-lg"]')!
+    expect(minimalCard.textContent).not.toContain('Requires')
   })
 
   // T11: Nav says "Skills" with /harness/skills href

--- a/services/ui/src/app/agents/[id]/AgentDetailClient.tsx
+++ b/services/ui/src/app/agents/[id]/AgentDetailClient.tsx
@@ -20,7 +20,7 @@ interface Agent {
   rules_md: string
   container_id: string | null
   model_policy_id: string | null
-  skills: Array<{ id: string; name: string; scope: string; instructions_md?: string }>
+  skills: Array<{ id: string; name: string; scope: string; kind?: string; tool_dependencies?: string[]; instructions_md?: string }>
   error_message: string | null
   created_at: string
   updated_at: string
@@ -40,6 +40,8 @@ interface SkillRecord {
   id: string
   name: string
   scope: string
+  kind?: string
+  tool_dependencies?: string[]
   instructions_md?: string
 }
 
@@ -466,11 +468,23 @@ export default function AgentDetailClient({
                   return (
                     <div key={skill.id} className="rounded-md border border-navy-700 bg-navy-900 p-3">
                       <div className="flex items-center justify-between">
-                        <div className="flex items-center gap-2">
+                        <div className="flex items-center gap-2 flex-wrap">
                           <span className="text-sm font-medium text-white">{skill.name}</span>
                           <span className={`px-1.5 py-0.5 text-xs rounded-md ${badge.colorClasses}`}>
                             {badge.label}
                           </span>
+                          <span className={`px-1.5 py-0.5 text-xs rounded-md ${
+                            skill.kind === 'profile'
+                              ? 'bg-navy-800 text-blue-400 border border-navy-600'
+                              : 'bg-brand-900/50 text-brand-400 border border-brand-700'
+                          }`}>
+                            {skill.kind === 'profile' ? 'Profile' : 'Skill'}
+                          </span>
+                          {skill.tool_dependencies && skill.tool_dependencies.length > 0 && (
+                            <span className="px-1.5 py-0.5 text-xs rounded-md bg-navy-800 text-mountain-300 border border-navy-600 font-mono">
+                              Requires: {skill.tool_dependencies.join(', ')}
+                            </span>
+                          )}
                         </div>
                         <div className="flex items-center gap-2">
                           {skill.instructions_md && (

--- a/services/ui/src/app/agents/new/AgentFormClient.tsx
+++ b/services/ui/src/app/agents/new/AgentFormClient.tsx
@@ -25,6 +25,8 @@ interface SkillOption {
   tools_config: ToolsConfig
   instructions_md?: string
   is_platform: boolean
+  kind?: 'skill' | 'profile'
+  tool_dependencies?: string[]
 }
 
 const ELEVATED_SCOPES = ['host_docker', 'vps_system']
@@ -317,28 +319,71 @@ export default function AgentFormClient({
             <p className="text-xs text-mountain-400 mb-2">
               Select one or more skills. Tool configurations are merged from all selected skills.
             </p>
-            <div className="space-y-2">
-              {(isAdmin ? skills : skills.filter(s => !ELEVATED_SCOPES.includes(s.scope))).map((skill) => {
-                const badge = scopeBadge(skill.scope)
-                return (
-                  <label key={skill.id} className="flex items-center gap-3 cursor-pointer py-1">
-                    <input
-                      type="checkbox"
-                      checked={selectedSkillIds.has(skill.id)}
-                      onChange={() => handleSkillToggle(skill.id)}
-                      className="rounded border-navy-600"
-                    />
-                    <span className="text-sm text-white">{skill.name}</span>
-                    <span className={`px-1.5 py-0.5 text-xs rounded-md ${badge.colorClasses}`}>
-                      {badge.label}
-                    </span>
-                  </label>
-                )
-              })}
-              {skills.length === 0 && (
-                <p className="text-xs text-mountain-500">No skills available</p>
-              )}
-            </div>
+            {(() => {
+              const visibleSkills = isAdmin ? skills : skills.filter(s => !ELEVATED_SCOPES.includes(s.scope))
+              const profiles = visibleSkills.filter(s => s.kind === 'profile')
+              const skillItems = visibleSkills.filter(s => s.kind !== 'profile')
+              return (
+                <div className="space-y-4">
+                  {profiles.length > 0 && (
+                    <div>
+                      <p className="text-xs font-medium text-mountain-400 uppercase tracking-wide mb-2">Profiles (sandbox presets)</p>
+                      <div className="space-y-2">
+                        {profiles.map((skill) => {
+                          const badge = scopeBadge(skill.scope)
+                          return (
+                            <label key={skill.id} className="flex items-center gap-3 cursor-pointer py-1">
+                              <input
+                                type="checkbox"
+                                checked={selectedSkillIds.has(skill.id)}
+                                onChange={() => handleSkillToggle(skill.id)}
+                                className="rounded border-navy-600"
+                              />
+                              <span className="text-sm text-white">{skill.name}</span>
+                              <span className={`px-1.5 py-0.5 text-xs rounded-md ${badge.colorClasses}`}>
+                                {badge.label}
+                              </span>
+                            </label>
+                          )
+                        })}
+                      </div>
+                    </div>
+                  )}
+                  {skillItems.length > 0 && (
+                    <div>
+                      <p className="text-xs font-medium text-mountain-400 uppercase tracking-wide mb-2">Skills (capabilities)</p>
+                      <div className="space-y-2">
+                        {skillItems.map((skill) => {
+                          const badge = scopeBadge(skill.scope)
+                          return (
+                            <label key={skill.id} className="flex items-center gap-3 cursor-pointer py-1">
+                              <input
+                                type="checkbox"
+                                checked={selectedSkillIds.has(skill.id)}
+                                onChange={() => handleSkillToggle(skill.id)}
+                                className="rounded border-navy-600"
+                              />
+                              <span className="text-sm text-white">{skill.name}</span>
+                              <span className={`px-1.5 py-0.5 text-xs rounded-md ${badge.colorClasses}`}>
+                                {badge.label}
+                              </span>
+                              {skill.tool_dependencies && skill.tool_dependencies.length > 0 && (
+                                <span className="px-1.5 py-0.5 text-xs rounded-md bg-navy-800 text-mountain-300 border border-navy-600 font-mono">
+                                  {skill.tool_dependencies.join(', ')}
+                                </span>
+                              )}
+                            </label>
+                          )
+                        })}
+                      </div>
+                    </div>
+                  )}
+                  {visibleSkills.length === 0 && (
+                    <p className="text-xs text-mountain-500">No skills available</p>
+                  )}
+                </div>
+              )
+            })()}
             {selectedSkillIds.size > 0 && (
               <div className="border-t border-navy-700 pt-3">
                 <p className="text-xs text-mountain-500">

--- a/services/ui/src/app/harness/skills/SkillsClient.tsx
+++ b/services/ui/src/app/harness/skills/SkillsClient.tsx
@@ -18,6 +18,8 @@ interface Skill {
   tools_config: ToolsConfig
   instructions_md: string
   is_platform: boolean
+  kind: 'skill' | 'profile'
+  tool_dependencies: string[]
   created_at: string
   updated_at: string
 }
@@ -49,6 +51,8 @@ export default function SkillsClient() {
     name: '',
     description: '',
     instructions_md: '',
+    kind: 'skill' as 'skill' | 'profile',
+    tool_dependencies: '',
     shellEnabled: false,
     filesystemEnabled: false,
     readOnly: false,
@@ -81,6 +85,8 @@ export default function SkillsClient() {
       name: '',
       description: '',
       instructions_md: '',
+      kind: 'skill',
+      tool_dependencies: '',
       shellEnabled: false,
       filesystemEnabled: false,
       readOnly: false,
@@ -125,6 +131,12 @@ export default function SkillsClient() {
       name: formData.name.trim(),
       tools_config,
       instructions_md: formData.instructions_md,
+    }
+    body.kind = formData.kind
+    if (formData.kind === 'skill' && formData.tool_dependencies.trim()) {
+      body.tool_dependencies = formData.tool_dependencies.split(',').map(s => s.trim()).filter(Boolean)
+    } else {
+      body.tool_dependencies = []
     }
     if (formData.description.trim()) {
       body.description = formData.description.trim()
@@ -176,6 +188,8 @@ export default function SkillsClient() {
       name: skill.name,
       description: skill.description || '',
       instructions_md: skill.instructions_md || '',
+      kind: skill.kind || 'skill',
+      tool_dependencies: skill.tool_dependencies?.join(', ') || '',
       shellEnabled: tc.shell.enabled,
       filesystemEnabled: tc.filesystem.enabled,
       readOnly: tc.filesystem.read_only,
@@ -199,13 +213,16 @@ export default function SkillsClient() {
     )
   }
 
+  const profiles = skills.filter(s => s.kind === 'profile')
+  const skillItems = skills.filter(s => s.kind === 'skill')
+
   return (
     <>
       <div className="flex items-center justify-between mb-8">
         <div>
           <h1 className="text-2xl font-bold">Skills</h1>
           <p className="text-sm text-mountain-400 mt-1">
-            {skills.length} skill{skills.length !== 1 ? 's' : ''}
+            {profiles.length} profile{profiles.length !== 1 ? 's' : ''}, {skillItems.length} skill{skillItems.length !== 1 ? 's' : ''}
           </p>
         </div>
         {isAdmin && (
@@ -249,6 +266,39 @@ export default function SkillsClient() {
                 />
               </div>
             </div>
+
+            {/* Kind selector */}
+            <div>
+              <label className="block text-sm text-mountain-400 mb-1">Kind</label>
+              <div className="flex items-center gap-4">
+                <label className="flex items-center gap-2 text-sm text-white cursor-pointer">
+                  <input type="radio" name="kind" value="skill" checked={formData.kind === 'skill'}
+                    onChange={() => setFormData({ ...formData, kind: 'skill' })} />
+                  Skill
+                </label>
+                <label className="flex items-center gap-2 text-sm text-white cursor-pointer">
+                  <input type="radio" name="kind" value="profile" checked={formData.kind === 'profile'}
+                    onChange={() => setFormData({ ...formData, kind: 'profile' })} />
+                  Profile
+                </label>
+              </div>
+            </div>
+
+            {/* Tool dependencies (skill only) */}
+            {formData.kind === 'skill' && (
+              <div>
+                <label className="block text-sm text-mountain-400 mb-1">
+                  Tool Dependencies <span className="text-mountain-500">(optional, comma-separated)</span>
+                </label>
+                <input
+                  type="text"
+                  value={formData.tool_dependencies}
+                  onChange={(e) => setFormData({ ...formData, tool_dependencies: e.target.value })}
+                  className="w-full rounded-md border border-navy-600 bg-navy-900 px-3 py-2 text-sm text-white font-mono placeholder-mountain-500 focus:border-brand-500 focus:outline-none"
+                  placeholder="gh, git, curl"
+                />
+              </div>
+            )}
 
             {/* Instructions */}
             <div>
@@ -349,17 +399,13 @@ export default function SkillsClient() {
         </div>
       )}
 
-      {/* Skills list */}
-      {skills.length === 0 ? (
-        <div className="rounded-lg border border-navy-700 bg-navy-800 p-12 text-center">
-          <p className="text-mountain-400 mb-4">No skills yet</p>
-          <p className="text-sm text-mountain-500">
-            Create a skill to define reusable tool configurations and instructions for agents.
-          </p>
-        </div>
+      {/* Profiles section */}
+      <h2 className="text-lg font-semibold text-white mb-3">Profiles (sandbox presets)</h2>
+      {profiles.length === 0 ? (
+        <p className="text-sm text-mountain-500 mb-6">No profiles yet</p>
       ) : (
-        <div className="space-y-3">
-          {skills.map((skill) => {
+        <div className="space-y-3 mb-6">
+          {profiles.map((skill) => {
             const isExpanded = expandedId === skill.id
             const tc = skill.tools_config
 
@@ -502,7 +548,187 @@ export default function SkillsClient() {
                       </div>
                     </dl>
 
-                    {/* Actions — admin only, non-platform only */}
+                    {/* Actions -- admin only, non-platform only */}
+                    {isAdmin && !skill.is_platform && (
+                      <div className="flex items-center gap-2">
+                        <button
+                          onClick={() => handleEdit(skill)}
+                          className="px-3 py-1.5 text-xs font-medium rounded-md border border-navy-600 text-mountain-400 hover:text-white hover:border-navy-500 transition-colors cursor-pointer"
+                        >
+                          Edit
+                        </button>
+                        <button
+                          onClick={() => handleDelete(skill)}
+                          disabled={actionLoading === skill.id}
+                          className="px-3 py-1.5 text-xs font-medium rounded-md border border-red-700 text-red-400 hover:bg-red-900/30 transition-colors disabled:opacity-50 cursor-pointer disabled:cursor-not-allowed"
+                        >
+                          Delete
+                        </button>
+                      </div>
+                    )}
+                  </div>
+                )}
+              </div>
+            )
+          })}
+        </div>
+      )}
+
+      {/* Skills section */}
+      <h2 className="text-lg font-semibold text-white mb-3">Skills (capabilities)</h2>
+      {skillItems.length === 0 ? (
+        <p className="text-sm text-mountain-500 mb-6">No skills yet</p>
+      ) : (
+        <div className="space-y-3">
+          {skillItems.map((skill) => {
+            const isExpanded = expandedId === skill.id
+            const tc = skill.tools_config
+
+            return (
+              <div
+                key={skill.id}
+                className="rounded-lg border border-navy-700 bg-navy-900 overflow-hidden"
+              >
+                {/* Summary row */}
+                <div
+                  className="flex items-center gap-4 px-4 py-3 cursor-pointer hover:bg-navy-800 transition-colors"
+                  onClick={() => setExpandedId(isExpanded ? null : skill.id)}
+                  role="button"
+                  tabIndex={0}
+                  aria-expanded={isExpanded}
+                  onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') setExpandedId(isExpanded ? null : skill.id) }}
+                >
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-3">
+                      <span className="font-medium text-white">{skill.name}</span>
+                      {skill.is_platform && (
+                        <span className="px-2 py-0.5 text-xs rounded-md bg-mountain-500/20 text-mountain-300 border border-mountain-500/30">
+                          Platform
+                        </span>
+                      )}
+                      {skill.scope && (
+                        <span className={`px-2 py-0.5 text-xs rounded-md ${scopeBadge(skill.scope).colorClasses}`}>
+                          {scopeBadge(skill.scope).label}
+                        </span>
+                      )}
+                      <div className="flex flex-wrap gap-1">
+                        {tc.shell.enabled && (
+                          <span className="inline-flex items-center gap-1 px-2 py-0.5 text-xs rounded-md bg-brand-900/50 text-brand-400 border border-brand-700">
+                            <Terminal className="w-3 h-3" /> Shell
+                          </span>
+                        )}
+                        {tc.filesystem.enabled && (
+                          <span className="inline-flex items-center gap-1 px-2 py-0.5 text-xs rounded-md bg-brand-900/50 text-brand-400 border border-brand-700">
+                            <FolderOpen className="w-3 h-3" /> Filesystem
+                            {tc.filesystem.read_only && <span className="text-mountain-400">(ro)</span>}
+                          </span>
+                        )}
+                        {tc.health.enabled && (
+                          <span className="inline-flex items-center gap-1 px-2 py-0.5 text-xs rounded-md bg-brand-900/50 text-brand-400 border border-brand-700">
+                            <Heart className="w-3 h-3" /> Health
+                          </span>
+                        )}
+                        {skill.tool_dependencies?.length > 0 && (
+                          <span className="inline-flex items-center gap-1 px-2 py-0.5 text-xs rounded-md bg-navy-800 text-mountain-300 border border-navy-600 font-mono">
+                            Requires: {skill.tool_dependencies.join(', ')}
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                    {skill.description && (
+                      <p className="text-xs text-mountain-400 mt-1 truncate">{skill.description}</p>
+                    )}
+                  </div>
+                  <div className="shrink-0">
+                    <svg
+                      className={`w-4 h-4 text-mountain-400 transition-transform ${isExpanded ? 'rotate-180' : ''}`}
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                    >
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                    </svg>
+                  </div>
+                </div>
+
+                {/* Expanded detail */}
+                {isExpanded && (
+                  <div className="border-t border-navy-700 px-4 py-4 bg-navy-800/50">
+                    {skill.description && (
+                      <p className="text-sm text-mountain-300 mb-4">{skill.description}</p>
+                    )}
+
+                    {/* Instructions preview */}
+                    {skill.instructions_md && (
+                      <div className="mb-4">
+                        <h3 className="text-xs font-medium text-mountain-400 uppercase tracking-wide mb-2">Instructions</h3>
+                        <div className="rounded-md border border-navy-700 bg-navy-900 p-3">
+                          <p className="text-sm text-mountain-300 whitespace-pre-wrap">{skill.instructions_md}</p>
+                        </div>
+                      </div>
+                    )}
+
+                    <dl className="grid grid-cols-1 sm:grid-cols-2 gap-4 text-sm mb-4">
+                      {/* Shell config */}
+                      <div>
+                        <dt className="text-mountain-400 mb-1">Shell</dt>
+                        <dd className="text-white">
+                          {tc.shell.enabled ? (
+                            <div className="space-y-1">
+                              <div className="flex flex-wrap gap-1">
+                                {tc.shell.allowed_binaries.map((b) => (
+                                  <span key={b} className="px-2 py-0.5 text-xs rounded-md bg-navy-900 text-brand-400 border border-navy-700">
+                                    {b}
+                                  </span>
+                                ))}
+                              </div>
+                              {tc.shell.denied_patterns.length > 0 && (
+                                <div className="text-xs text-mountain-400">
+                                  Denied: {tc.shell.denied_patterns.map((p) => (
+                                    <span key={p} className="px-1.5 py-0.5 rounded bg-red-900/30 text-red-400 border border-red-700/50 mr-1">
+                                      {p}
+                                    </span>
+                                  ))}
+                                </div>
+                              )}
+                              <div className="text-xs text-mountain-500">Timeout: {tc.shell.max_timeout}s</div>
+                            </div>
+                          ) : (
+                            <span className="text-mountain-500">Disabled</span>
+                          )}
+                        </dd>
+                      </div>
+
+                      {/* Filesystem config */}
+                      <div>
+                        <dt className="text-mountain-400 mb-1">Filesystem</dt>
+                        <dd className="text-white">
+                          {tc.filesystem.enabled ? (
+                            <div className="space-y-1">
+                              <div className="text-xs">
+                                {tc.filesystem.read_only ? 'Read-only' : 'Read-write'}
+                              </div>
+                              <div className="flex flex-wrap gap-1">
+                                {tc.filesystem.allowed_paths.map((p) => (
+                                  <span key={p} className="px-2 py-0.5 text-xs rounded-md bg-navy-900 text-brand-400 border border-navy-700">
+                                    {p}
+                                  </span>
+                                ))}
+                              </div>
+                            </div>
+                          ) : (
+                            <span className="text-mountain-500">Disabled</span>
+                          )}
+                        </dd>
+                      </div>
+
+                      <div>
+                        <dt className="text-mountain-400">Created</dt>
+                        <dd className="text-white mt-1">{new Date(skill.created_at).toLocaleString()}</dd>
+                      </div>
+                    </dl>
+
+                    {/* Actions -- admin only, non-platform only */}
                     {isAdmin && !skill.is_platform && (
                       <div className="flex items-center gap-2">
                         <button


### PR DESCRIPTION
## Summary
- Adds `kind` column (`'skill'` or `'profile'`) to the shared skills table as a transitional concept discriminator
- Adds `tool_dependencies` (JSONB array of binary names) for skills to declare tool requirements
- Reclassifies the 4 seeded platform entries (Minimal, Developer, Research, Operator) as `kind = 'profile'`
- UI visually separates profiles and skills into labeled sections across harness, agent form, and agent detail
- Backend validates kind values, enforces profiles cannot have tool_dependencies, supports `?kind=` filter

## Scope confirmation
- Transitional `kind` split within shared collection (single table, single route, `kind` as discriminator)
- `tool_dependencies` as skill-specific declarative field
- Seeded profiles reclassified — no longer presented as capability skills
- No runtime changes (no mergeToolsConfigs, no agentbox, no agent-files.ts modifications)
- No new API routes (shared `/skills` route with `?kind=` filter)
- No tools-product/marketplace drift

## Files changed (12)
**New (1):** Migration 020 — `kind` + `tool_dependencies` columns, seed reclassification
**Backend (3):** skills.ts CRUD + validation, agents.ts 4 skill-response queries, OpenAPI spec
**Docs (1):** OpenAPI mirror (byte-identical to source)
**UI (3):** SkillsClient (sections + create form), AgentFormClient (grouped checkboxes), AgentDetailClient (kind badge + deps)
**Tests (5):** 12 backend tests (T1-T12), 6 UI tests (U1-U6)

## Validation evidence

| # | Check | Result |
|---|-------|--------|
| V1 | Skills route tests | 41 passed, 0 failed |
| V2 | Full API tests | 306 passed, 0 failed (27 suites) |
| V3 | UI tests | 297 passed, 0 failed (33 suites) |
| V4 | TypeScript API | 0 errors (clean) |
| V5 | TypeScript UI | 9 pre-existing errors only (8x middleware.test.ts TS2554, 1x UsageClient.test.tsx TS2345). None introduced by this phase. |
| V6 | OpenAPI source/mirror equality | `diff` empty — byte-identical |
| V7 | OpenAPI drift check | 13 passed, 0 failed |
| V8 | Seeded profiles reclassified | Migration UPDATE targets 4 names + `is_platform = true` |

## Test plan
- [ ] V1: `cd services/api && npx jest routes-skills --verbose` — 41 pass
- [ ] V2: `cd services/api && npx jest --runInBand --verbose` — 306 pass, no regressions
- [ ] V3: `cd services/ui && npx vitest run` — 297 pass
- [ ] V4: `cd services/api && npx tsc --noEmit` — 0 errors
- [ ] V5: `cd services/ui && npx tsc --noEmit` — 9 pre-existing only
- [ ] V6: `diff services/api/src/openapi/openapi.yaml docs/site/openapi.yaml` — empty
- [ ] V7: `cd services/api && npx jest docs.test --verbose` — 13 pass
- [ ] V10: CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)