### PR TITLE
feat: remove profile compromise, introduce Tools with install lifecycle (Phase 6A)

### DIFF
--- a/docs/site/openapi.yaml
+++ b/docs/site/openapi.yaml
@@ -56,6 +56,11 @@ components:
           format: uuid
           nullable: true
           description: ID of the model policy controlling LLM access. Users can assign own or platform policies to own agents; admins can assign any.
+        sandbox_profile:
+          type: string
+          nullable: true
+          enum: [minimal, developer, research, operator]
+          description: Sandbox profile providing base tool configuration
         skills:
           type: array
           items:
@@ -69,7 +74,22 @@ components:
               scope:
                 type: string
                 enum: [container_local, host_docker, vps_system]
-          description: Skills assigned to this agent (max 1 in current phase).
+              tools:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                      format: uuid
+                    name:
+                      type: string
+                    description:
+                      type: string
+                    install_method:
+                      type: string
+                      enum: [builtin, apt, binary]
+          description: Skills assigned to this agent.
         error_message:
           type: string
           nullable: true
@@ -260,22 +280,21 @@ components:
           enum: [container_local, host_docker, vps_system]
           default: container_local
           description: Scope determines assignment authority. container_local — any user. host_docker/vps_system — admin only.
-        kind:
-          type: string
-          enum: [skill, profile]
-          default: skill
-          description: >-
-            Concept type. 'skill' = capability declaration with tool requirements
-            and behavioral guidance. 'profile' = sandbox environment preset.
-        tool_dependencies:
+        tools:
           type: array
           items:
-            type: string
-          default: []
-          description: >-
-            Binary names this skill requires (e.g., ["gh", "git"]).
-            Declarative — not enforced at runtime.
-            Must be empty for kind=profile.
+            type: object
+            properties:
+              id:
+                type: string
+                format: uuid
+              name:
+                type: string
+              description:
+                type: string
+              install_method:
+                type: string
+                enum: [builtin, apt, binary]
         is_platform:
           type: boolean
           description: Platform skills are immutable and undeletable.
@@ -289,6 +308,41 @@ components:
         updated_at:
           type: string
           format: date-time
+
+    Tool:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        description:
+          type: string
+        install_method:
+          type: string
+          enum: [builtin, apt, binary]
+        install_ref:
+          type: string
+        is_platform:
+          type: boolean
+        created_at:
+          type: string
+          format: date-time
+
+    ToolCreate:
+      type: object
+      required: [name]
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        install_method:
+          type: string
+          enum: [builtin, apt, binary]
+        install_ref:
+          type: string
 
     UsageSummary:
       type: object
@@ -654,6 +708,11 @@ paths:
                   format: uuid
                   nullable: true
                   description: ID of a model policy to assign at creation. Users can assign own or platform policies; admins can assign any.
+                sandbox_profile:
+                  type: string
+                  nullable: true
+                  enum: [minimal, developer, research, operator]
+                  description: Sandbox profile providing base tool configuration
                 skill_ids:
                   type: array
                   items:
@@ -737,6 +796,11 @@ paths:
                   format: uuid
                   nullable: true
                   description: Model policy ID. Users can assign own or platform policies; admins can assign any. Set to null to remove.
+                sandbox_profile:
+                  type: string
+                  nullable: true
+                  enum: [minimal, developer, research, operator]
+                  description: Sandbox profile providing base tool configuration
                 skill_ids:
                   type: array
                   items:
@@ -2190,6 +2254,12 @@ paths:
                   enum: [container_local, host_docker, vps_system]
                   default: container_local
                   description: Scope determines assignment authority.
+                tool_ids:
+                  type: array
+                  items:
+                    type: string
+                    format: uuid
+                  description: Tool IDs to associate with this skill
       responses:
         "201":
           description: Skill created
@@ -2257,6 +2327,12 @@ paths:
                 scope:
                   type: string
                   enum: [container_local, host_docker, vps_system]
+                tool_ids:
+                  type: array
+                  items:
+                    type: string
+                    format: uuid
+                  description: Tool IDs to associate with this skill
       responses:
         "200":
           description: Skill updated
@@ -2296,6 +2372,130 @@ paths:
           description: Skill not found
         "409":
           description: Skill is assigned to agents
+
+  /tools:
+    get:
+      summary: List tools
+      description: Returns all tools in the catalog.
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Tool list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Tool"
+        "401":
+          description: Not authenticated
+        "403":
+          description: Requires user role
+
+    post:
+      summary: Create tool
+      description: Creates a new tool. Admin only.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ToolCreate"
+      responses:
+        "201":
+          description: Tool created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Tool"
+        "400":
+          description: Invalid input
+        "401":
+          description: Not authenticated
+        "403":
+          description: Requires admin role
+        "409":
+          description: Duplicate tool name
+
+  /tools/{id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+
+    get:
+      summary: Get tool
+      description: Returns a single tool. All authenticated users can read.
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Tool detail
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Tool"
+        "401":
+          description: Not authenticated
+        "403":
+          description: Requires user role
+        "404":
+          description: Tool not found
+
+    put:
+      summary: Update tool
+      description: Updates a tool. Admin only. Platform tools are immutable (403).
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ToolCreate"
+      responses:
+        "200":
+          description: Tool updated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Tool"
+        "401":
+          description: Not authenticated
+        "403":
+          description: Requires admin role or platform tool is immutable
+        "404":
+          description: Tool not found
+
+    delete:
+      summary: Delete tool
+      description: Deletes a tool. Admin only. Platform tools cannot be deleted. Tools referenced by skills cannot be deleted.
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Tool deleted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  deleted:
+                    type: boolean
+        "401":
+          description: Not authenticated
+        "403":
+          description: Requires admin role or platform tool is undeletable
+        "404":
+          description: Tool not found
+        "409":
+          description: Tool is referenced by a skill
 
   /agents/{id}/skills:
     parameters:

--- a/services/api/src/__tests__/docs.test.ts
+++ b/services/api/src/__tests__/docs.test.ts
@@ -172,6 +172,8 @@ const EXPECTED_PATHS = [
   '/shared-knowledge/search',
   '/skills',
   '/skills/{id}',
+  '/tools',
+  '/tools/{id}',
   '/agents/{id}/skills',
   '/agents/{id}/skills/{skillId}',
 ];

--- a/services/api/src/__tests__/merge-tools-config.test.ts
+++ b/services/api/src/__tests__/merge-tools-config.test.ts
@@ -249,4 +249,46 @@ describe('mergeToolsConfigs', () => {
     expect(result.filesystem.allowed_paths.sort()).toEqual(['/data', '/workspace']);
     expect(result.filesystem.denied_paths.sort()).toEqual(['/etc/shadow', '/root']);
   });
+
+  // T24: Profile base + skill overlay merge
+  it('mergeToolsConfigs with profile base + skill overlay', () => {
+    // Import SANDBOX_PROFILES lazily to verify it works with mergeToolsConfigs
+    const { SANDBOX_PROFILES } = require('../services/sandbox-profiles');
+    const developerProfile: ToolsConfig = SANDBOX_PROFILES.developer;
+
+    const skillConfig: ToolsConfig = {
+      shell: { enabled: true, allowed_binaries: ['python3'], denied_patterns: ['eval'], max_timeout: 600 },
+      filesystem: { enabled: true, read_only: false, allowed_paths: ['/opt/data'], denied_paths: [] },
+      health: { enabled: true },
+    };
+
+    const result = mergeToolsConfigs([developerProfile, skillConfig]);
+
+    // shell.enabled: OR → true (both true)
+    expect(result.shell.enabled).toBe(true);
+    // shell.allowed_binaries: UNION of developer + skill
+    expect(result.shell.allowed_binaries).toContain('bash');
+    expect(result.shell.allowed_binaries).toContain('git');
+    expect(result.shell.allowed_binaries).toContain('make');
+    expect(result.shell.allowed_binaries).toContain('python3');
+    // shell.denied_patterns: UNION
+    expect(result.shell.denied_patterns).toContain('rm -rf /');
+    expect(result.shell.denied_patterns).toContain('eval');
+    // shell.max_timeout: MAX(300, 600) = 600
+    expect(result.shell.max_timeout).toBe(600);
+    // filesystem.enabled: OR → true
+    expect(result.filesystem.enabled).toBe(true);
+    // filesystem.read_only: AND → false (both false)
+    expect(result.filesystem.read_only).toBe(false);
+    // filesystem.allowed_paths: UNION
+    expect(result.filesystem.allowed_paths).toContain('/workspace');
+    expect(result.filesystem.allowed_paths).toContain('/data');
+    expect(result.filesystem.allowed_paths).toContain('/opt/data');
+    // filesystem.denied_paths: UNION
+    expect(result.filesystem.denied_paths).toContain('/etc/shadow');
+    expect(result.filesystem.denied_paths).toContain('/etc/passwd');
+    expect(result.filesystem.denied_paths).toContain('/root');
+    // health.enabled: OR → true
+    expect(result.health.enabled).toBe(true);
+  });
 });

--- a/services/api/src/__tests__/routes-agents-skill.test.ts
+++ b/services/api/src/__tests__/routes-agents-skill.test.ts
@@ -625,3 +625,141 @@ describe('Agent start reads from agent_skills', () => {
     expect(callArgs[1]).toBeUndefined();
   });
 });
+
+// sandbox_profile tests
+describe('Agent sandbox_profile behavior', () => {
+  beforeEach(() => {
+    mockQuery.mockReset();
+    process.env.DATABASE_URL = 'postgresql://test:test@localhost:5432/test';
+  });
+
+  afterEach(() => {
+    delete process.env.DATABASE_URL;
+  });
+
+  // T18: POST /agents with sandbox_profile sets base config
+  it('POST /agents with sandbox_profile sets base config', async () => {
+    // 1. INSERT agent (no skill lookup since no skill_ids)
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ ...agentRow, id: 'uuid-profile', sandbox_profile: 'developer' }],
+    });
+    // 2. SELECT skills for response (empty)
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    const res = await request(app)
+      .post('/agents')
+      .set('Authorization', `Bearer ${userToken}`)
+      .send({
+        agent_id: 'test-agent',
+        name: 'Test Agent',
+        sandbox_profile: 'developer',
+      });
+
+    expect(res.status).toBe(201);
+    // Verify the INSERT used the developer profile's tools_config
+    const insertCall = mockQuery.mock.calls[0];
+    const toolsConfigParam = insertCall[1][3]; // tools_config is 4th param
+    const parsed = JSON.parse(toolsConfigParam);
+    expect(parsed.shell.enabled).toBe(true);
+    expect(parsed.shell.allowed_binaries).toContain('bash');
+    expect(parsed.shell.allowed_binaries).toContain('git');
+    expect(parsed.filesystem.enabled).toBe(true);
+  });
+
+  // T19: POST /agents with sandbox_profile + skill_ids merges
+  it('POST /agents with sandbox_profile + skill_ids merges', async () => {
+    const skillConfig = {
+      shell: { enabled: true, allowed_binaries: ['python3'], denied_patterns: [], max_timeout: 600 },
+      filesystem: { enabled: false, read_only: false, allowed_paths: [], denied_paths: [] },
+      health: { enabled: true },
+    };
+    // 1. Skill batch lookup
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: 'skill-py', tools_config: skillConfig, scope: 'container_local' }],
+    });
+    // 2. INSERT agent
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ ...agentRow, id: 'uuid-merged', sandbox_profile: 'developer' }],
+    });
+    // 3. INSERT agent_skills
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    // 4. SELECT skills for response
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: 'skill-py', name: 'Python', scope: 'container_local' }],
+    });
+
+    const res = await request(app)
+      .post('/agents')
+      .set('Authorization', `Bearer ${userToken}`)
+      .send({
+        agent_id: 'test-agent',
+        name: 'Test Agent',
+        sandbox_profile: 'developer',
+        skill_ids: ['skill-py'],
+      });
+
+    expect(res.status).toBe(201);
+    // Verify merged: developer profile + skill config
+    const insertCall = mockQuery.mock.calls[1]; // INSERT is 2nd call
+    const parsed = JSON.parse(insertCall[1][3]);
+    expect(parsed.shell.enabled).toBe(true);
+    // UNION of developer binaries + skill's python3
+    expect(parsed.shell.allowed_binaries).toContain('bash');
+    expect(parsed.shell.allowed_binaries).toContain('python3');
+    // MAX timeout: developer=300, skill=600
+    expect(parsed.shell.max_timeout).toBe(600);
+  });
+
+  // T20: POST /agents rejects invalid sandbox_profile
+  it('POST /agents rejects invalid sandbox_profile', async () => {
+    const res = await request(app)
+      .post('/agents')
+      .set('Authorization', `Bearer ${userToken}`)
+      .send({
+        agent_id: 'test-agent',
+        name: 'Test Agent',
+        sandbox_profile: 'nonexistent',
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain('sandbox_profile');
+  });
+
+  // T22: GET /agents returns sandbox_profile
+  it('GET /agents returns sandbox_profile in query', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ ...agentRow, sandbox_profile: 'developer', skills: [] }],
+    });
+
+    const res = await request(app)
+      .get('/agents')
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(res.status).toBe(200);
+    const selectCall = mockQuery.mock.calls[0][0];
+    expect(selectCall).toContain('sandbox_profile');
+  });
+
+  // T23: Agent skill sub-objects have no kind or tool_dependencies
+  it('Agent skill response SQL does not contain kind or tool_dependencies', async () => {
+    // 1. INSERT agent (no skills)
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ ...agentRow, id: 'uuid-new' }],
+    });
+    // 2. SELECT skills for response
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    await request(app)
+      .post('/agents')
+      .set('Authorization', `Bearer ${userToken}`)
+      .send({
+        agent_id: 'test-agent',
+        name: 'Test Agent',
+      });
+
+    // The SELECT skills query should not reference kind or tool_dependencies
+    const skillSelectCall = mockQuery.mock.calls[1][0];
+    expect(skillSelectCall).not.toContain('kind');
+    expect(skillSelectCall).not.toContain('tool_dependencies');
+  });
+});

--- a/services/api/src/__tests__/routes-agents-skills.test.ts
+++ b/services/api/src/__tests__/routes-agents-skills.test.ts
@@ -98,6 +98,7 @@ describe('Agent skill assignment endpoints', () => {
       .mockResolvedValueOnce({ rows: [stoppedAgent] })  // agent lookup (user scope)
       .mockResolvedValueOnce({ rows: [containerSkill] }) // skill lookup
       .mockResolvedValueOnce({ rows: [assignmentRecord] }) // INSERT (additive)
+      .mockResolvedValueOnce({ rows: [{ sandbox_profile: null }] }) // SELECT sandbox_profile
       .mockResolvedValueOnce({ rows: [{ tools_config: devToolsConfig }] }) // SELECT all skills for merge
       .mockResolvedValueOnce({ rowCount: 1 });            // UPDATE agents.tools_config
 
@@ -141,6 +142,7 @@ describe('Agent skill assignment endpoints', () => {
       .mockResolvedValueOnce({ rows: [stoppedAgent] })  // agent lookup
       .mockResolvedValueOnce({ rows: [containerSkill] }) // skill lookup
       .mockResolvedValueOnce({ rows: [assignmentRecord] }) // INSERT
+      .mockResolvedValueOnce({ rows: [{ sandbox_profile: null }] }) // SELECT sandbox_profile
       .mockResolvedValueOnce({                            // SELECT all skills for merge (2 skills now)
         rows: [
           { tools_config: devToolsConfig },
@@ -157,7 +159,7 @@ describe('Agent skill assignment endpoints', () => {
     expect(res.status).toBe(201);
 
     // Verify the UPDATE used a merged config
-    const updateCall = mockQuery.mock.calls[4];
+    const updateCall = mockQuery.mock.calls[5];
     expect(updateCall[0]).toContain('UPDATE agents');
     const mergedConfig = JSON.parse(updateCall[1][0]);
     // OR: shell enabled because devToolsConfig has shell.enabled=true
@@ -172,6 +174,7 @@ describe('Agent skill assignment endpoints', () => {
       .mockResolvedValueOnce({ rows: [stoppedAgent] })
       .mockResolvedValueOnce({ rows: [containerSkill] })
       .mockResolvedValueOnce({ rows: [assignmentRecord] }) // INSERT
+      .mockResolvedValueOnce({ rows: [{ sandbox_profile: null }] }) // SELECT sandbox_profile
       .mockResolvedValueOnce({ rows: [{ tools_config: devToolsConfig }] }) // SELECT all skills
       .mockResolvedValueOnce({ rowCount: 1 });            // UPDATE agents.tools_config
 
@@ -220,6 +223,7 @@ describe('Agent skill assignment endpoints', () => {
       .mockResolvedValueOnce({ rows: [stoppedAgent] })   // agent lookup (admin scope = 1=1)
       .mockResolvedValueOnce({ rows: [hostDockerSkill] }) // skill lookup
       .mockResolvedValueOnce({ rows: [adminAssignment] }) // INSERT
+      .mockResolvedValueOnce({ rows: [{ sandbox_profile: null }] }) // SELECT sandbox_profile
       .mockResolvedValueOnce({ rows: [{ tools_config: devToolsConfig }] }) // SELECT all skills
       .mockResolvedValueOnce({ rowCount: 1 });            // UPDATE agents.tools_config
 
@@ -292,6 +296,7 @@ describe('Agent skill assignment endpoints', () => {
       .mockResolvedValueOnce({ rows: [stoppedAgent] })  // agent lookup
       .mockResolvedValueOnce({ rows: [containerSkill] }) // skill lookup
       .mockResolvedValueOnce({ rowCount: 1 })            // DELETE
+      .mockResolvedValueOnce({ rows: [{ sandbox_profile: null }] }) // SELECT sandbox_profile
       .mockResolvedValueOnce({ rows: [{ tools_config: minToolsConfig }] }) // remaining skills
       .mockResolvedValueOnce({ rowCount: 1 });           // UPDATE agents.tools_config
 
@@ -303,7 +308,7 @@ describe('Agent skill assignment endpoints', () => {
     expect(res.body.removed).toBe(true);
 
     // Verify UPDATE agents was called with remaining skill's config
-    const updateCall = mockQuery.mock.calls[4];
+    const updateCall = mockQuery.mock.calls[5];
     expect(updateCall[0]).toContain('UPDATE agents');
     const updatedConfig = JSON.parse(updateCall[1][0]);
     expect(updatedConfig.shell.enabled).toBe(false);
@@ -316,6 +321,7 @@ describe('Agent skill assignment endpoints', () => {
       .mockResolvedValueOnce({ rows: [stoppedAgent] })  // agent lookup
       .mockResolvedValueOnce({ rows: [containerSkill] }) // skill lookup
       .mockResolvedValueOnce({ rowCount: 1 })            // DELETE
+      .mockResolvedValueOnce({ rows: [{ sandbox_profile: null }] }) // SELECT sandbox_profile
       .mockResolvedValueOnce({ rows: [] })               // no remaining skills
       .mockResolvedValueOnce({ rowCount: 1 });           // UPDATE agents.tools_config
 
@@ -326,7 +332,7 @@ describe('Agent skill assignment endpoints', () => {
     expect(res.status).toBe(200);
 
     // Verify UPDATE used default config (shell/fs disabled, health enabled)
-    const updateCall = mockQuery.mock.calls[4];
+    const updateCall = mockQuery.mock.calls[5];
     expect(updateCall[0]).toContain('UPDATE agents');
     const defaultConfig = JSON.parse(updateCall[1][0]);
     expect(defaultConfig.shell.enabled).toBe(false);
@@ -354,6 +360,7 @@ describe('Agent skill assignment endpoints', () => {
       .mockResolvedValueOnce({ rows: [stoppedAgent] })
       .mockResolvedValueOnce({ rows: [containerSkill] })
       .mockResolvedValueOnce({ rowCount: 1 })             // DELETE
+      .mockResolvedValueOnce({ rows: [{ sandbox_profile: null }] }) // SELECT sandbox_profile
       .mockResolvedValueOnce({ rows: [] })                 // remaining skills (empty)
       .mockResolvedValueOnce({ rowCount: 1 });             // UPDATE agents.tools_config
 
@@ -398,6 +405,7 @@ describe('Agent skill assignment endpoints', () => {
       .mockResolvedValueOnce({ rows: [stoppedAgent] })
       .mockResolvedValueOnce({ rows: [vpsSystemSkill] })
       .mockResolvedValueOnce({ rowCount: 1 })             // DELETE
+      .mockResolvedValueOnce({ rows: [{ sandbox_profile: null }] }) // SELECT sandbox_profile
       .mockResolvedValueOnce({ rows: [] })                 // remaining skills (empty)
       .mockResolvedValueOnce({ rowCount: 1 });             // UPDATE agents.tools_config
 

--- a/services/api/src/__tests__/routes-skills.test.ts
+++ b/services/api/src/__tests__/routes-skills.test.ts
@@ -106,6 +106,8 @@ describe('Skill CRUD routes', () => {
     mockQuery.mockResolvedValueOnce({
       rows: [developerSkill, minimalSkill, adminCreatedSkill],
     });
+    // fetchToolsForSkills query
+    mockQuery.mockResolvedValueOnce({ rows: [] });
     const res = await request(app)
       .get('/skills')
       .set('Authorization', `Bearer ${adminToken}`);
@@ -117,6 +119,8 @@ describe('Skill CRUD routes', () => {
     mockQuery.mockResolvedValueOnce({
       rows: [developerSkill, minimalSkill],
     });
+    // fetchToolsForSkills query
+    mockQuery.mockResolvedValueOnce({ rows: [] });
     const res = await request(app)
       .get('/skills')
       .set('Authorization', `Bearer ${userToken}`);
@@ -169,6 +173,8 @@ describe('Skill CRUD routes', () => {
   it('POST /skills admin creates skill', async () => {
     const newSkill = { ...adminCreatedSkill, id: 'new-id' };
     mockQuery.mockResolvedValueOnce({ rows: [newSkill] });
+    // fetchToolsForSkills query
+    mockQuery.mockResolvedValueOnce({ rows: [] });
     const res = await request(app)
       .post('/skills')
       .set('Authorization', `Bearer ${adminToken}`)
@@ -194,6 +200,8 @@ describe('Skill CRUD routes', () => {
 
   it('GET /skills/:id returns skill', async () => {
     mockQuery.mockResolvedValueOnce({ rows: [developerSkill] });
+    // fetchToolsForSkills query
+    mockQuery.mockResolvedValueOnce({ rows: [] });
     const res = await request(app)
       .get('/skills/skill-dev')
       .set('Authorization', `Bearer ${adminToken}`);
@@ -231,6 +239,8 @@ describe('Skill CRUD routes', () => {
     mockQuery
       .mockResolvedValueOnce({ rows: [adminCreatedSkill] })
       .mockResolvedValueOnce({ rows: [{ ...adminCreatedSkill, name: 'Renamed' }] });
+    // fetchToolsForSkills query
+    mockQuery.mockResolvedValueOnce({ rows: [] });
     const res = await request(app)
       .put('/skills/skill-custom')
       .set('Authorization', `Bearer ${adminToken}`)
@@ -293,6 +303,8 @@ describe('Skill CRUD routes', () => {
       instructions_md: 'You have full developer access with bash, git, make, curl, and jq available.',
     };
     mockQuery.mockResolvedValueOnce({ rows: [skillWithInstructions] });
+    // fetchToolsForSkills query
+    mockQuery.mockResolvedValueOnce({ rows: [] });
     const res = await request(app)
       .get('/skills')
       .set('Authorization', `Bearer ${adminToken}`);
@@ -309,6 +321,8 @@ describe('Skill CRUD routes', () => {
       instructions_md: 'Custom instructions for this skill.',
     };
     mockQuery.mockResolvedValueOnce({ rows: [created] });
+    // fetchToolsForSkills query
+    mockQuery.mockResolvedValueOnce({ rows: [] });
     const res = await request(app)
       .post('/skills')
       .set('Authorization', `Bearer ${adminToken}`)
@@ -330,6 +344,8 @@ describe('Skill CRUD routes', () => {
       .mockResolvedValueOnce({
         rows: [{ ...adminCreatedSkill, instructions_md: 'Updated instructions.' }],
       });
+    // fetchToolsForSkills query
+    mockQuery.mockResolvedValueOnce({ rows: [] });
     const res = await request(app)
       .put('/skills/skill-custom')
       .set('Authorization', `Bearer ${adminToken}`)
@@ -343,6 +359,8 @@ describe('Skill CRUD routes', () => {
   it('GET /skills includes scope in response', async () => {
     const skillWithScope = { ...developerSkill, scope: 'container_local' };
     mockQuery.mockResolvedValueOnce({ rows: [skillWithScope] });
+    // fetchToolsForSkills query
+    mockQuery.mockResolvedValueOnce({ rows: [] });
     const res = await request(app)
       .get('/skills')
       .set('Authorization', `Bearer ${adminToken}`);
@@ -355,6 +373,8 @@ describe('Skill CRUD routes', () => {
   it('POST /skills admin creates skill with scope', async () => {
     const created = { ...adminCreatedSkill, id: 'new-id', scope: 'host_docker' };
     mockQuery.mockResolvedValueOnce({ rows: [created] });
+    // fetchToolsForSkills query
+    mockQuery.mockResolvedValueOnce({ rows: [] });
     const res = await request(app)
       .post('/skills')
       .set('Authorization', `Bearer ${adminToken}`)
@@ -400,6 +420,8 @@ describe('Skill CRUD routes', () => {
       instructions_md: '',
     };
     mockQuery.mockResolvedValueOnce({ rows: [created] });
+    // fetchToolsForSkills query
+    mockQuery.mockResolvedValueOnce({ rows: [] });
     const res = await request(app)
       .post('/skills')
       .set('Authorization', `Bearer ${adminToken}`)
@@ -417,6 +439,8 @@ describe('Skill CRUD routes', () => {
     mockQuery.mockResolvedValueOnce({
       rows: [developerSkill, minimalSkill],
     });
+    // fetchToolsForSkills query
+    mockQuery.mockResolvedValueOnce({ rows: [] });
     const res = await request(app)
       .get('/tool-presets')
       .set('Authorization', `Bearer ${adminToken}`);
@@ -428,6 +452,8 @@ describe('Skill CRUD routes', () => {
   it('POST /tool-presets compat alias creates skill', async () => {
     const newSkill = { ...adminCreatedSkill, id: 'new-id' };
     mockQuery.mockResolvedValueOnce({ rows: [newSkill] });
+    // fetchToolsForSkills query
+    mockQuery.mockResolvedValueOnce({ rows: [] });
     const res = await request(app)
       .post('/tool-presets')
       .set('Authorization', `Bearer ${adminToken}`)
@@ -442,193 +468,126 @@ describe('Skill CRUD routes', () => {
     expect(insertCall[0]).toContain('INSERT INTO skills');
   });
 
-  // kind and tool_dependencies
-  describe('kind and tool_dependencies', () => {
-    // T1: GET /skills returns kind and tool_dependencies
-    it('GET /skills returns kind and tool_dependencies', async () => {
-      const skillWithKind = { ...developerSkill, kind: 'profile', tool_dependencies: [] };
-      const skillWithDeps = { ...adminCreatedSkill, kind: 'skill', tool_dependencies: ['gh', 'git'] };
-      mockQuery.mockResolvedValueOnce({ rows: [skillWithKind, skillWithDeps] });
+  // tools array on skills
+  describe('tools array on skills', () => {
+    // T11: GET /skills does NOT return kind or tool_dependencies
+    it('GET /skills does NOT return kind or tool_dependencies', async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [developerSkill] });
+      // fetchToolsForSkills query
+      mockQuery.mockResolvedValueOnce({ rows: [] });
+      await request(app)
+        .get('/skills')
+        .set('Authorization', `Bearer ${adminToken}`);
+      const selectCall = mockQuery.mock.calls[0][0];
+      expect(selectCall).not.toContain('kind');
+      expect(selectCall).not.toContain('tool_dependencies');
+    });
+
+    // T12: GET /skills returns tools array per skill
+    it('GET /skills returns tools array per skill', async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [developerSkill] });
+      // fetchToolsForSkills returns tools for skill-dev
+      mockQuery.mockResolvedValueOnce({
+        rows: [{ skill_id: 'skill-dev', id: 'tool-1', name: 'bash', description: 'shell', install_method: 'builtin' }],
+      });
       const res = await request(app)
         .get('/skills')
         .set('Authorization', `Bearer ${adminToken}`);
       expect(res.status).toBe(200);
-      expect(res.body[0].kind).toBe('profile');
-      expect(res.body[0].tool_dependencies).toEqual([]);
-      expect(res.body[1].kind).toBe('skill');
-      expect(res.body[1].tool_dependencies).toEqual(['gh', 'git']);
+      expect(res.body[0].tools).toHaveLength(1);
+      expect(res.body[0].tools[0].name).toBe('bash');
     });
 
-    // T2: GET /skills?kind=profile returns only profiles
-    it('GET /skills?kind=profile returns only profiles', async () => {
-      const profileSkill = { ...developerSkill, kind: 'profile', tool_dependencies: [] };
-      mockQuery.mockResolvedValueOnce({ rows: [profileSkill] });
-      const res = await request(app)
-        .get('/skills?kind=profile')
-        .set('Authorization', `Bearer ${adminToken}`);
-      expect(res.status).toBe(200);
-      expect(res.body).toHaveLength(1);
-      expect(res.body[0].kind).toBe('profile');
-      const selectCall = mockQuery.mock.calls[0];
-      expect(selectCall[0]).toContain('WHERE kind = $1');
-      expect(selectCall[1]).toContain('profile');
-    });
-
-    // T3: GET /skills?kind=skill returns only skills
-    it('GET /skills?kind=skill returns only skills', async () => {
-      const skillOnly = { ...adminCreatedSkill, kind: 'skill', tool_dependencies: [] };
-      mockQuery.mockResolvedValueOnce({ rows: [skillOnly] });
-      const res = await request(app)
-        .get('/skills?kind=skill')
-        .set('Authorization', `Bearer ${adminToken}`);
-      expect(res.status).toBe(200);
-      expect(res.body).toHaveLength(1);
-      expect(res.body[0].kind).toBe('skill');
-      const selectCall = mockQuery.mock.calls[0];
-      expect(selectCall[0]).toContain('WHERE kind = $1');
-      expect(selectCall[1]).toContain('skill');
-    });
-
-    // T4: POST /skills defaults kind to 'skill'
-    it('POST /skills defaults kind to skill', async () => {
-      const created = { ...adminCreatedSkill, id: 'new-id', kind: 'skill', tool_dependencies: [] };
+    // T13: POST /skills with tool_ids creates skill_tools rows
+    it('POST /skills with tool_ids creates skill_tools rows', async () => {
+      const created = { ...adminCreatedSkill, id: 'skill-new' };
+      // 1. INSERT skill
       mockQuery.mockResolvedValueOnce({ rows: [created] });
+      // 2. setSkillTools: validate tool_ids exist
+      mockQuery.mockResolvedValueOnce({ rows: [{ id: 'tool-1' }] });
+      // 3. setSkillTools: DELETE existing skill_tools
+      mockQuery.mockResolvedValueOnce({ rowCount: 0 });
+      // 4. setSkillTools: INSERT skill_tools
+      mockQuery.mockResolvedValueOnce({ rowCount: 1 });
+      // 5. fetchToolsForSkills
+      mockQuery.mockResolvedValueOnce({
+        rows: [{ skill_id: 'skill-new', id: 'tool-1', name: 'bash', description: 'shell', install_method: 'builtin' }],
+      });
+
       const res = await request(app)
         .post('/skills')
         .set('Authorization', `Bearer ${adminToken}`)
         .send({
-          name: 'Default Kind Skill',
+          name: 'New Skill',
           tools_config: adminCreatedSkill.tools_config,
+          tool_ids: ['tool-1'],
         });
       expect(res.status).toBe(201);
-      const insertCall = mockQuery.mock.calls[0];
-      expect(insertCall[0]).toContain('INSERT INTO skills');
-      expect(insertCall[1]).toContain('skill');
+      expect(res.body.tools).toHaveLength(1);
+      expect(res.body.tools[0].id).toBe('tool-1');
     });
 
-    // T5: POST /skills creates profile with kind=profile
-    it('POST /skills creates profile with kind=profile', async () => {
-      const created = { ...adminCreatedSkill, id: 'new-id', kind: 'profile', tool_dependencies: [] };
+    // T14: POST /skills with invalid tool_ids returns 400
+    it('POST /skills with invalid tool_ids returns 400', async () => {
+      const created = { ...adminCreatedSkill, id: 'skill-new' };
+      // 1. INSERT skill
       mockQuery.mockResolvedValueOnce({ rows: [created] });
-      const res = await request(app)
-        .post('/skills')
-        .set('Authorization', `Bearer ${adminToken}`)
-        .send({
-          name: 'My Profile',
-          tools_config: adminCreatedSkill.tools_config,
-          kind: 'profile',
-        });
-      expect(res.status).toBe(201);
-      const insertCall = mockQuery.mock.calls[0];
-      expect(insertCall[1]).toContain('profile');
-    });
+      // 2. setSkillTools: validate tool_ids — returns empty (not found)
+      mockQuery.mockResolvedValueOnce({ rows: [] });
 
-    // T6: POST /skills creates skill with tool_dependencies
-    it('POST /skills creates skill with tool_dependencies', async () => {
-      const created = { ...adminCreatedSkill, id: 'new-id', kind: 'skill', tool_dependencies: ['gh', 'git'] };
-      mockQuery.mockResolvedValueOnce({ rows: [created] });
       const res = await request(app)
         .post('/skills')
         .set('Authorization', `Bearer ${adminToken}`)
         .send({
-          name: 'Deps Skill',
+          name: 'Bad Tools',
           tools_config: adminCreatedSkill.tools_config,
-          tool_dependencies: ['gh', 'git'],
-        });
-      expect(res.status).toBe(201);
-      const insertCall = mockQuery.mock.calls[0];
-      expect(insertCall[0]).toContain('tool_dependencies');
-      expect(insertCall[1]).toContain(JSON.stringify(['gh', 'git']));
-    });
-
-    // T7: POST /skills defaults tool_dependencies to []
-    it('POST /skills defaults tool_dependencies to empty array', async () => {
-      const created = { ...adminCreatedSkill, id: 'new-id', kind: 'skill', tool_dependencies: [] };
-      mockQuery.mockResolvedValueOnce({ rows: [created] });
-      const res = await request(app)
-        .post('/skills')
-        .set('Authorization', `Bearer ${adminToken}`)
-        .send({
-          name: 'No Deps Skill',
-          tools_config: adminCreatedSkill.tools_config,
-        });
-      expect(res.status).toBe(201);
-      const insertCall = mockQuery.mock.calls[0];
-      expect(insertCall[1]).toContain('[]');
-    });
-
-    // T8: POST /skills rejects profile with non-empty tool_dependencies
-    it('POST /skills rejects profile with non-empty tool_dependencies', async () => {
-      const res = await request(app)
-        .post('/skills')
-        .set('Authorization', `Bearer ${adminToken}`)
-        .send({
-          name: 'Bad Profile',
-          tools_config: adminCreatedSkill.tools_config,
-          kind: 'profile',
-          tool_dependencies: ['gh'],
+          tool_ids: ['nonexistent'],
         });
       expect(res.status).toBe(400);
-      expect(res.body.error).toContain('Profiles cannot have tool_dependencies');
+      expect(res.body.error).toContain('Tool(s) not found');
     });
 
-    // T9: POST /skills rejects invalid kind
-    it('POST /skills rejects invalid kind', async () => {
-      const res = await request(app)
-        .post('/skills')
-        .set('Authorization', `Bearer ${adminToken}`)
-        .send({
-          name: 'Bad Kind',
-          tools_config: adminCreatedSkill.tools_config,
-          kind: 'banana',
-        });
-      expect(res.status).toBe(400);
-      expect(res.body.error).toContain('kind');
-    });
+    // T15: PUT /skills/:id with tool_ids replaces skill_tools
+    it('PUT /skills/:id with tool_ids replaces skill_tools', async () => {
+      // 1. SELECT existing (non-platform)
+      mockQuery.mockResolvedValueOnce({ rows: [adminCreatedSkill] });
+      // 2. UPDATE skill
+      mockQuery.mockResolvedValueOnce({ rows: [{ ...adminCreatedSkill, name: 'Updated' }] });
+      // 3. setSkillTools: validate tool_ids
+      mockQuery.mockResolvedValueOnce({ rows: [{ id: 'tool-1' }] });
+      // 4. setSkillTools: DELETE existing
+      mockQuery.mockResolvedValueOnce({ rowCount: 0 });
+      // 5. setSkillTools: INSERT
+      mockQuery.mockResolvedValueOnce({ rowCount: 1 });
+      // 6. fetchToolsForSkills
+      mockQuery.mockResolvedValueOnce({
+        rows: [{ skill_id: 'skill-custom', id: 'tool-1', name: 'bash', description: 'shell', install_method: 'builtin' }],
+      });
 
-    // T10: POST /skills rejects non-array tool_dependencies
-    it('POST /skills rejects non-array tool_dependencies', async () => {
-      const res = await request(app)
-        .post('/skills')
-        .set('Authorization', `Bearer ${adminToken}`)
-        .send({
-          name: 'Bad Deps',
-          tools_config: adminCreatedSkill.tools_config,
-          tool_dependencies: 'not-an-array',
-        });
-      expect(res.status).toBe(400);
-      expect(res.body.error).toContain('tool_dependencies');
-    });
-
-    // T11: POST /skills rejects non-string array entries
-    it('POST /skills rejects non-string array entries in tool_dependencies', async () => {
-      const res = await request(app)
-        .post('/skills')
-        .set('Authorization', `Bearer ${adminToken}`)
-        .send({
-          name: 'Bad Entries',
-          tools_config: adminCreatedSkill.tools_config,
-          tool_dependencies: [123],
-        });
-      expect(res.status).toBe(400);
-      expect(res.body.error).toContain('tool_dependencies');
-    });
-
-    // T12: PUT /skills/:id updates kind and tool_dependencies
-    it('PUT /skills/:id updates kind and tool_dependencies', async () => {
-      const existingSkill = { ...adminCreatedSkill, kind: 'skill', tool_dependencies: [] };
-      const updatedSkill = { ...adminCreatedSkill, kind: 'skill', tool_dependencies: ['gh', 'git'] };
-      mockQuery
-        .mockResolvedValueOnce({ rows: [existingSkill] })
-        .mockResolvedValueOnce({ rows: [updatedSkill] });
       const res = await request(app)
         .put('/skills/skill-custom')
         .set('Authorization', `Bearer ${adminToken}`)
-        .send({ kind: 'skill', tool_dependencies: ['gh', 'git'] });
+        .send({ name: 'Updated', tool_ids: ['tool-1'] });
       expect(res.status).toBe(200);
-      const updateCall = mockQuery.mock.calls[1];
-      expect(updateCall[0]).toContain('kind');
-      expect(updateCall[0]).toContain('tool_dependencies');
+      expect(res.body.tools).toHaveLength(1);
+    });
+
+    // T17: POST /skills no longer accepts kind parameter
+    it('POST /skills no longer accepts kind parameter', async () => {
+      const created = { ...adminCreatedSkill, id: 'new-id' };
+      mockQuery.mockResolvedValueOnce({ rows: [created] });
+      // fetchToolsForSkills query
+      mockQuery.mockResolvedValueOnce({ rows: [] });
+      await request(app)
+        .post('/skills')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({
+          name: 'Test',
+          tools_config: adminCreatedSkill.tools_config,
+          kind: 'profile',
+        });
+      const insertSql = mockQuery.mock.calls[0][0];
+      expect(insertSql).not.toContain('kind');
     });
   });
 });

--- a/services/api/src/__tests__/routes-tools.test.ts
+++ b/services/api/src/__tests__/routes-tools.test.ts
@@ -1,0 +1,176 @@
+import request from 'supertest';
+import * as crypto from 'crypto';
+import * as jwt from 'jsonwebtoken';
+import { createApp } from '../app';
+
+const { privateKey, publicKey } = crypto.generateKeyPairSync('rsa', {
+  modulusLength: 2048,
+  publicKeyEncoding: { type: 'spki', format: 'pem' },
+  privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+});
+
+const TEST_ISSUER = 'https://auth.hill90.com/realms/hill90';
+
+const mockQuery = jest.fn();
+jest.mock('../db/pool', () => ({
+  getPool: () => ({ query: mockQuery }),
+}));
+
+jest.mock('../services/docker', () => ({
+  createAndStartContainer: jest.fn(),
+  stopAndRemoveContainer: jest.fn(),
+  inspectContainer: jest.fn(),
+  getContainerLogs: jest.fn(),
+  removeAgentVolumes: jest.fn(),
+  reconcileAgentStatuses: jest.fn(),
+}));
+jest.mock('../services/agent-files', () => ({
+  writeAgentFiles: jest.fn(),
+  removeAgentFiles: jest.fn(),
+}));
+
+const app = createApp({
+  issuer: TEST_ISSUER,
+  getSigningKey: async () => publicKey,
+});
+
+function makeToken(sub: string, roles: string[]) {
+  return jwt.sign(
+    { sub, realm_roles: roles },
+    privateKey,
+    { algorithm: 'RS256', issuer: TEST_ISSUER, expiresIn: '5m' }
+  );
+}
+
+const adminToken = makeToken('admin-user', ['admin', 'user']);
+const userToken = makeToken('regular-user', ['user']);
+
+describe('Tools CRUD routes', () => {
+  beforeEach(() => {
+    mockQuery.mockReset();
+    process.env.DATABASE_URL = 'postgresql://test:test@localhost:5432/test';
+  });
+
+  afterEach(() => {
+    delete process.env.DATABASE_URL;
+  });
+
+  // T1: GET /tools returns tools
+  it('GET /tools returns tools', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        { id: 'tool-1', name: 'bash', description: 'Bourne Again Shell', install_method: 'builtin', install_ref: '', is_platform: true, created_at: '2026-01-01T00:00:00Z' },
+        { id: 'tool-2', name: 'gh', description: 'GitHub CLI', install_method: 'binary', install_ref: 'https://github.com/cli/cli', is_platform: false, created_at: '2026-01-01T00:00:00Z' },
+      ],
+    });
+    const res = await request(app)
+      .get('/tools')
+      .set('Authorization', `Bearer ${userToken}`);
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(2);
+    expect(res.body[0].name).toBe('bash');
+    expect(res.body[1].install_method).toBe('binary');
+  });
+
+  // T2: POST /tools creates tool with install_method (admin)
+  it('POST /tools creates tool with install_method (admin)', async () => {
+    const created = { id: 'tool-new', name: 'ripgrep', description: 'Fast grep', install_method: 'binary', install_ref: 'https://github.com/BurntSushi/ripgrep', is_platform: false, created_at: '2026-01-01T00:00:00Z' };
+    mockQuery.mockResolvedValueOnce({ rows: [created] });
+    const res = await request(app)
+      .post('/tools')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ name: 'ripgrep', description: 'Fast grep', install_method: 'binary', install_ref: 'https://github.com/BurntSushi/ripgrep' });
+    expect(res.status).toBe(201);
+    expect(res.body.name).toBe('ripgrep');
+    expect(res.body.install_method).toBe('binary');
+  });
+
+  // T3: POST /tools rejects non-admin
+  it('POST /tools rejects non-admin', async () => {
+    const res = await request(app)
+      .post('/tools')
+      .set('Authorization', `Bearer ${userToken}`)
+      .send({ name: 'test-tool' });
+    expect(res.status).toBe(403);
+  });
+
+  // T4: POST /tools rejects duplicate name
+  it('POST /tools rejects duplicate name', async () => {
+    mockQuery.mockRejectedValueOnce({ code: '23505' });
+    const res = await request(app)
+      .post('/tools')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ name: 'bash', description: 'duplicate' });
+    expect(res.status).toBe(409);
+  });
+
+  // T5: POST /tools rejects invalid install_method
+  it('POST /tools rejects invalid install_method', async () => {
+    const res = await request(app)
+      .post('/tools')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ name: 'something', install_method: 'pip' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain('install_method');
+  });
+
+  // T6: PUT /tools/:id updates tool (admin)
+  it('PUT /tools/:id updates tool (admin)', async () => {
+    const existing = { id: 'tool-1', is_platform: false };
+    const updated = { id: 'tool-1', name: 'renamed', description: 'Updated', install_method: 'apt', install_ref: 'ripgrep', is_platform: false, created_at: '2026-01-01T00:00:00Z' };
+    mockQuery
+      .mockResolvedValueOnce({ rows: [existing] })
+      .mockResolvedValueOnce({ rows: [updated] });
+    const res = await request(app)
+      .put('/tools/tool-1')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ name: 'renamed', description: 'Updated' });
+    expect(res.status).toBe(200);
+    expect(res.body.name).toBe('renamed');
+  });
+
+  // T7: PUT /tools/:id rejects platform tool mutation
+  it('PUT /tools/:id rejects platform tool mutation', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: 'tool-1', is_platform: true }] });
+    const res = await request(app)
+      .put('/tools/tool-1')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ name: 'renamed' });
+    expect(res.status).toBe(403);
+    expect(res.body.error).toContain('platform');
+  });
+
+  // T8: DELETE /tools/:id deletes non-platform tool
+  it('DELETE /tools/:id deletes non-platform tool', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ id: 'tool-1', is_platform: false }] })
+      .mockResolvedValueOnce({ rowCount: 1 });
+    const res = await request(app)
+      .delete('/tools/tool-1')
+      .set('Authorization', `Bearer ${adminToken}`);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ deleted: true });
+  });
+
+  // T9: DELETE /tools/:id rejects platform tool
+  it('DELETE /tools/:id rejects platform tool', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: 'tool-1', is_platform: true }] });
+    const res = await request(app)
+      .delete('/tools/tool-1')
+      .set('Authorization', `Bearer ${adminToken}`);
+    expect(res.status).toBe(403);
+    expect(res.body.error).toContain('platform');
+  });
+
+  // T10: DELETE /tools/:id rejects tool referenced by skill
+  it('DELETE /tools/:id rejects tool referenced by skill', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ id: 'tool-1', is_platform: false }] })
+      .mockRejectedValueOnce({ code: '23503' });
+    const res = await request(app)
+      .delete('/tools/tool-1')
+      .set('Authorization', `Bearer ${adminToken}`);
+    expect(res.status).toBe(409);
+    expect(res.body.error).toContain('skills');
+  });
+});

--- a/services/api/src/app.ts
+++ b/services/api/src/app.ts
@@ -6,6 +6,7 @@ import knowledgeRouter from './routes/knowledge';
 import sharedKnowledgeRouter from './routes/shared-knowledge';
 import modelPoliciesRouter from './routes/model-policies';
 import skillsRouter from './routes/skills';
+import toolsRouter from './routes/tools';
 import providerConnectionsRouter from './routes/provider-connections';
 import userModelsRouter from './routes/user-models';
 import profileRouter from './routes/profile';
@@ -54,6 +55,9 @@ export function createApp(opts: AppOptions = {}): Application {
   // Skill management routes (admin-only mutations, enforced in router)
   app.use('/skills', requireAuth, skillsRouter);
   app.use('/tool-presets', requireAuth, skillsRouter); // compat alias
+
+  // Tools catalog routes (admin-only mutations, enforced in router)
+  app.use('/tools', requireAuth, toolsRouter);
 
   // Provider connections (user-scoped BYOK credentials)
   app.use('/provider-connections', requireAuth, providerConnectionsRouter);

--- a/services/api/src/db/migrations/021_tools_and_profile_reset.sql
+++ b/services/api/src/db/migrations/021_tools_and_profile_reset.sql
@@ -1,0 +1,131 @@
+-- Phase 6A: Remove profile compromise, introduce Tools with install metadata.
+
+-- 1. Create tools table
+CREATE TABLE IF NOT EXISTS tools (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name VARCHAR(64) NOT NULL UNIQUE,
+    description TEXT DEFAULT '',
+    install_method VARCHAR(16) NOT NULL DEFAULT 'builtin',
+    install_ref TEXT DEFAULT '',
+    is_platform BOOLEAN DEFAULT false,
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- 2. Seed platform tools (install_method reflects actual image state)
+INSERT INTO tools (name, description, install_method, install_ref, is_platform) VALUES
+('bash', 'Bourne-Again Shell', 'builtin', '', true),
+('git', 'Distributed version control', 'builtin', '', true),
+('make', 'Build automation tool', 'builtin', '', true),
+('curl', 'HTTP client', 'builtin', '', true),
+('wget', 'HTTP/FTP downloader', 'builtin', '', true),
+('jq', 'JSON processor', 'builtin', '', true),
+('rsync', 'Remote sync', 'builtin', '', true),
+('ssh', 'Secure shell client', 'builtin', '', true),
+('vim', 'Text editor', 'builtin', '', true),
+('python3', 'Python interpreter', 'builtin', '', true),
+('gh', 'GitHub CLI', 'binary', 'https://github.com/cli/cli/releases/download/v{version}/gh_{version}_linux_amd64.tar.gz', true),
+('docker', 'Docker CLI', 'binary', 'https://download.docker.com/linux/static/stable/x86_64/docker-{version}.tgz', true)
+ON CONFLICT (name) DO NOTHING;
+
+-- 3. Create skill_tools join table
+CREATE TABLE IF NOT EXISTS skill_tools (
+    skill_id UUID NOT NULL REFERENCES skills(id) ON DELETE CASCADE,
+    tool_id UUID NOT NULL REFERENCES tools(id) ON DELETE RESTRICT,
+    PRIMARY KEY (skill_id, tool_id)
+);
+
+-- 4. Migrate tool_dependencies string arrays to skill_tools references
+INSERT INTO skill_tools (skill_id, tool_id)
+SELECT s.id, t.id
+FROM skills s,
+     jsonb_array_elements_text(s.tool_dependencies) AS dep_name
+     JOIN tools t ON t.name = dep_name
+WHERE s.tool_dependencies IS NOT NULL
+  AND s.tool_dependencies != '[]'::jsonb
+  AND s.kind = 'skill'
+ON CONFLICT DO NOTHING;
+
+-- 5. Add sandbox_profile to agents
+ALTER TABLE agents ADD COLUMN IF NOT EXISTS sandbox_profile VARCHAR(32);
+
+-- 6. Migrate profile assignments: set sandbox_profile on agents that reference profiles
+UPDATE agents a SET sandbox_profile = LOWER(s.name)
+FROM agent_skills asks
+JOIN skills s ON s.id = asks.skill_id
+WHERE asks.agent_id = a.id
+  AND s.kind = 'profile'
+  AND s.is_platform = true;
+
+-- 7. Remove profile assignments from agent_skills
+DELETE FROM agent_skills asks
+USING skills s
+WHERE asks.skill_id = s.id
+  AND s.kind = 'profile';
+
+-- 8. Delete profile rows from skills
+DELETE FROM skills WHERE kind = 'profile';
+
+-- 9. Drop kind column and constraint
+ALTER TABLE skills DROP CONSTRAINT IF EXISTS chk_skill_kind;
+ALTER TABLE skills DROP COLUMN IF EXISTS kind;
+
+-- 10. Drop tool_dependencies column (data migrated to skill_tools)
+ALTER TABLE skills DROP COLUMN IF EXISTS tool_dependencies;
+
+-- 11. Seed example capability skills (only skills whose every tool is builtin)
+-- GitHub and Docker are deferred to Phase 6B (depend on non-builtin tools: gh, docker)
+WITH new_skills AS (
+    INSERT INTO skills (name, description, tools_config, instructions_md, scope, is_platform)
+    VALUES
+    (
+      'Claude Code',
+      'AI-assisted software development workflow using Claude.',
+      '{"shell":{"enabled":true,"allowed_binaries":["bash","git","curl","jq","python3","make"],"denied_patterns":["rm -rf /"],"max_timeout":300},"filesystem":{"enabled":true,"read_only":false,"allowed_paths":["/workspace","/data"],"denied_paths":["/etc/shadow","/etc/passwd","/root"]},"health":{"enabled":true}}',
+      E'AI-assisted software development workflow.\n- Write, review, and refactor code in /workspace\n- Use git for version control\n- Run tests and validate changes\n- Model access provided via model router JWT',
+      'container_local',
+      true
+    ),
+    (
+      'Codex',
+      'AI-assisted software development using OpenAI Codex.',
+      '{"shell":{"enabled":true,"allowed_binaries":["bash","git","curl","jq","python3","make"],"denied_patterns":["rm -rf /"],"max_timeout":300},"filesystem":{"enabled":true,"read_only":false,"allowed_paths":["/workspace","/data"],"denied_paths":["/etc/shadow","/etc/passwd","/root"]},"health":{"enabled":true}}',
+      E'AI-assisted software development using OpenAI tools.\n- Write, review, and refactor code in /workspace\n- Use git for version control\n- Run tests and validate changes\n- Model access provided via model router JWT',
+      'container_local',
+      true
+    ),
+    (
+      'Hostinger',
+      'Hostinger VPS and DNS management via API and SSH.',
+      '{"shell":{"enabled":true,"allowed_binaries":["bash","curl","ssh","python3","jq"],"denied_patterns":["rm -rf /"],"max_timeout":600},"filesystem":{"enabled":true,"read_only":false,"allowed_paths":["/workspace","/data"],"denied_paths":["/etc/shadow","/etc/passwd","/root"]},"health":{"enabled":true}}',
+      E'Manage Hostinger VPS and DNS infrastructure.\n- API-based VPS operations (start, stop, rebuild)\n- DNS record management for hill90.com\n- SSH-based remote administration\n- Authenticate using Hostinger API token',
+      'vps_system',
+      true
+    ),
+    (
+      'VPS Administration',
+      'System-level VPS administration and operations.',
+      '{"shell":{"enabled":true,"allowed_binaries":["bash","ssh","rsync","curl","wget","jq","vim","make"],"denied_patterns":["rm -rf /"],"max_timeout":600},"filesystem":{"enabled":true,"read_only":false,"allowed_paths":["/workspace","/data","/var/log/agentbox"],"denied_paths":["/etc/shadow","/etc/passwd","/root"]},"health":{"enabled":true}}',
+      E'System-level VPS administration and operations.\n- SSH to remote hosts for management\n- File synchronization with rsync\n- Service management and monitoring\n- Log analysis and troubleshooting',
+      'vps_system',
+      true
+    )
+    ON CONFLICT (name) DO NOTHING
+    RETURNING id, name
+)
+INSERT INTO skill_tools (skill_id, tool_id)
+SELECT ns.id, t.id
+FROM (VALUES
+    ('Claude Code', 'git'), ('Claude Code', 'bash'), ('Claude Code', 'curl'),
+    ('Claude Code', 'jq'), ('Claude Code', 'python3'), ('Claude Code', 'make'),
+    ('Codex', 'git'), ('Codex', 'bash'), ('Codex', 'curl'),
+    ('Codex', 'jq'), ('Codex', 'python3'), ('Codex', 'make'),
+    ('Hostinger', 'curl'), ('Hostinger', 'ssh'), ('Hostinger', 'python3'),
+    ('Hostinger', 'jq'), ('Hostinger', 'bash'),
+    ('VPS Administration', 'ssh'), ('VPS Administration', 'rsync'),
+    ('VPS Administration', 'bash'), ('VPS Administration', 'curl'),
+    ('VPS Administration', 'wget'), ('VPS Administration', 'jq'),
+    ('VPS Administration', 'vim'), ('VPS Administration', 'make')
+) AS mappings(skill_name, tool_name)
+JOIN new_skills ns ON ns.name = mappings.skill_name
+JOIN tools t ON t.name = mappings.tool_name
+ON CONFLICT DO NOTHING;

--- a/services/api/src/openapi/openapi.yaml
+++ b/services/api/src/openapi/openapi.yaml
@@ -56,6 +56,11 @@ components:
           format: uuid
           nullable: true
           description: ID of the model policy controlling LLM access. Users can assign own or platform policies to own agents; admins can assign any.
+        sandbox_profile:
+          type: string
+          nullable: true
+          enum: [minimal, developer, research, operator]
+          description: Sandbox profile providing base tool configuration
         skills:
           type: array
           items:
@@ -69,7 +74,22 @@ components:
               scope:
                 type: string
                 enum: [container_local, host_docker, vps_system]
-          description: Skills assigned to this agent (max 1 in current phase).
+              tools:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                      format: uuid
+                    name:
+                      type: string
+                    description:
+                      type: string
+                    install_method:
+                      type: string
+                      enum: [builtin, apt, binary]
+          description: Skills assigned to this agent.
         error_message:
           type: string
           nullable: true
@@ -260,22 +280,21 @@ components:
           enum: [container_local, host_docker, vps_system]
           default: container_local
           description: Scope determines assignment authority. container_local — any user. host_docker/vps_system — admin only.
-        kind:
-          type: string
-          enum: [skill, profile]
-          default: skill
-          description: >-
-            Concept type. 'skill' = capability declaration with tool requirements
-            and behavioral guidance. 'profile' = sandbox environment preset.
-        tool_dependencies:
+        tools:
           type: array
           items:
-            type: string
-          default: []
-          description: >-
-            Binary names this skill requires (e.g., ["gh", "git"]).
-            Declarative — not enforced at runtime.
-            Must be empty for kind=profile.
+            type: object
+            properties:
+              id:
+                type: string
+                format: uuid
+              name:
+                type: string
+              description:
+                type: string
+              install_method:
+                type: string
+                enum: [builtin, apt, binary]
         is_platform:
           type: boolean
           description: Platform skills are immutable and undeletable.
@@ -289,6 +308,41 @@ components:
         updated_at:
           type: string
           format: date-time
+
+    Tool:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        description:
+          type: string
+        install_method:
+          type: string
+          enum: [builtin, apt, binary]
+        install_ref:
+          type: string
+        is_platform:
+          type: boolean
+        created_at:
+          type: string
+          format: date-time
+
+    ToolCreate:
+      type: object
+      required: [name]
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        install_method:
+          type: string
+          enum: [builtin, apt, binary]
+        install_ref:
+          type: string
 
     UsageSummary:
       type: object
@@ -654,6 +708,11 @@ paths:
                   format: uuid
                   nullable: true
                   description: ID of a model policy to assign at creation. Users can assign own or platform policies; admins can assign any.
+                sandbox_profile:
+                  type: string
+                  nullable: true
+                  enum: [minimal, developer, research, operator]
+                  description: Sandbox profile providing base tool configuration
                 skill_ids:
                   type: array
                   items:
@@ -737,6 +796,11 @@ paths:
                   format: uuid
                   nullable: true
                   description: Model policy ID. Users can assign own or platform policies; admins can assign any. Set to null to remove.
+                sandbox_profile:
+                  type: string
+                  nullable: true
+                  enum: [minimal, developer, research, operator]
+                  description: Sandbox profile providing base tool configuration
                 skill_ids:
                   type: array
                   items:
@@ -2190,6 +2254,12 @@ paths:
                   enum: [container_local, host_docker, vps_system]
                   default: container_local
                   description: Scope determines assignment authority.
+                tool_ids:
+                  type: array
+                  items:
+                    type: string
+                    format: uuid
+                  description: Tool IDs to associate with this skill
       responses:
         "201":
           description: Skill created
@@ -2257,6 +2327,12 @@ paths:
                 scope:
                   type: string
                   enum: [container_local, host_docker, vps_system]
+                tool_ids:
+                  type: array
+                  items:
+                    type: string
+                    format: uuid
+                  description: Tool IDs to associate with this skill
       responses:
         "200":
           description: Skill updated
@@ -2296,6 +2372,130 @@ paths:
           description: Skill not found
         "409":
           description: Skill is assigned to agents
+
+  /tools:
+    get:
+      summary: List tools
+      description: Returns all tools in the catalog.
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Tool list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Tool"
+        "401":
+          description: Not authenticated
+        "403":
+          description: Requires user role
+
+    post:
+      summary: Create tool
+      description: Creates a new tool. Admin only.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ToolCreate"
+      responses:
+        "201":
+          description: Tool created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Tool"
+        "400":
+          description: Invalid input
+        "401":
+          description: Not authenticated
+        "403":
+          description: Requires admin role
+        "409":
+          description: Duplicate tool name
+
+  /tools/{id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+
+    get:
+      summary: Get tool
+      description: Returns a single tool. All authenticated users can read.
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Tool detail
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Tool"
+        "401":
+          description: Not authenticated
+        "403":
+          description: Requires user role
+        "404":
+          description: Tool not found
+
+    put:
+      summary: Update tool
+      description: Updates a tool. Admin only. Platform tools are immutable (403).
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ToolCreate"
+      responses:
+        "200":
+          description: Tool updated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Tool"
+        "401":
+          description: Not authenticated
+        "403":
+          description: Requires admin role or platform tool is immutable
+        "404":
+          description: Tool not found
+
+    delete:
+      summary: Delete tool
+      description: Deletes a tool. Admin only. Platform tools cannot be deleted. Tools referenced by skills cannot be deleted.
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Tool deleted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  deleted:
+                    type: boolean
+        "401":
+          description: Not authenticated
+        "403":
+          description: Requires admin role or platform tool is undeletable
+        "404":
+          description: Tool not found
+        "409":
+          description: Tool is referenced by a skill
 
   /agents/{id}/skills:
     parameters:

--- a/services/api/src/routes/agents.ts
+++ b/services/api/src/routes/agents.ts
@@ -4,6 +4,7 @@ import { requireRole } from '../middleware/role';
 import { scopeToOwner } from '../helpers/scope';
 import { writeAgentFiles, removeAgentFiles } from '../services/agent-files';
 import { mergeToolsConfigs, DEFAULT_TOOLS_CONFIG } from '../services/merge-tools-config';
+import { getSandboxProfileConfig, VALID_SANDBOX_PROFILES } from '../services/sandbox-profiles';
 import {
   createAndStartContainer,
   stopAndRemoveContainer,
@@ -58,10 +59,10 @@ router.get('/', requireRole('user'), async (req: Request, res: Response) => {
     const scope = scopeToOwner(req);
     const { rows } = await getPool().query(
       `SELECT a.id, a.agent_id, a.name, a.description, a.status, a.tools_config,
-              a.cpus, a.mem_limit, a.pids_limit, a.model_policy_id,
+              a.cpus, a.mem_limit, a.pids_limit, a.model_policy_id, a.sandbox_profile,
               a.created_at, a.updated_at, a.created_by,
               COALESCE(
-                json_agg(json_build_object('id', s.id, 'name', s.name, 'scope', s.scope, 'kind', s.kind, 'tool_dependencies', s.tool_dependencies))
+                json_agg(json_build_object('id', s.id, 'name', s.name, 'scope', s.scope))
                 FILTER (WHERE s.id IS NOT NULL), '[]'
               ) AS skills
        FROM agents a
@@ -83,7 +84,7 @@ router.get('/', requireRole('user'), async (req: Request, res: Response) => {
 router.post('/', requireRole('user'), async (req: Request, res: Response) => {
   try {
     const user = (req as any).user;
-    const { agent_id, name, description, tools_config, cpus, mem_limit, pids_limit, soul_md, rules_md, model_policy_id, skill_ids } = req.body;
+    const { agent_id, name, description, tools_config, cpus, mem_limit, pids_limit, soul_md, rules_md, model_policy_id, skill_ids, sandbox_profile } = req.body;
 
     // Reject legacy field
     if (req.body.tool_preset_id !== undefined) {
@@ -93,6 +94,12 @@ router.post('/', requireRole('user'), async (req: Request, res: Response) => {
 
     if (!agent_id || !name) {
       res.status(400).json({ error: 'agent_id and name are required' });
+      return;
+    }
+
+    // Validate sandbox_profile
+    if (sandbox_profile !== undefined && sandbox_profile !== null && !VALID_SANDBOX_PROFILES.includes(sandbox_profile)) {
+      res.status(400).json({ error: `Invalid sandbox_profile. Must be one of: ${VALID_SANDBOX_PROFILES.join(', ')}` });
       return;
     }
 
@@ -133,8 +140,9 @@ router.post('/', requireRole('user'), async (req: Request, res: Response) => {
       validatedPolicyId = model_policy_id;
     }
 
-    // Resolve skills: if skill_ids provided, batch-lookup and merge tools_configs
-    let resolvedToolsConfig = tools_config || DEFAULT_TOOLS_CONFIG;
+    // Resolve tools_config: profile base + skill overlay
+    const profileConfig = sandbox_profile ? getSandboxProfileConfig(sandbox_profile) : undefined;
+    let resolvedToolsConfig = tools_config || profileConfig || DEFAULT_TOOLS_CONFIG;
     let validatedSkillIds: string[] = [];
     if (skill_ids && skill_ids.length > 0) {
       const { rows: skillRows } = await getPool().query(
@@ -150,13 +158,15 @@ router.post('/', requireRole('user'), async (req: Request, res: Response) => {
         res.status(403).json({ error: `Assigning ${elevatedScope} skills requires admin role` });
         return;
       }
-      resolvedToolsConfig = mergeToolsConfigs(skillRows.map((r: any) => r.tools_config));
+      const configs = skillRows.map((r: any) => r.tools_config);
+      if (profileConfig) configs.unshift(profileConfig);
+      resolvedToolsConfig = mergeToolsConfigs(configs);
       validatedSkillIds = skill_ids;
     }
 
     const { rows } = await getPool().query(
-      `INSERT INTO agents (agent_id, name, description, tools_config, cpus, mem_limit, pids_limit, soul_md, rules_md, model_policy_id, created_by)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+      `INSERT INTO agents (agent_id, name, description, tools_config, cpus, mem_limit, pids_limit, soul_md, rules_md, model_policy_id, sandbox_profile, created_by)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
        RETURNING *`,
       [
         agent_id,
@@ -169,6 +179,7 @@ router.post('/', requireRole('user'), async (req: Request, res: Response) => {
         soul_md || '',
         rules_md || '',
         validatedPolicyId,
+        sandbox_profile || null,
         user.sub,
       ]
     );
@@ -184,13 +195,13 @@ router.post('/', requireRole('user'), async (req: Request, res: Response) => {
     }
 
     // Fetch the skills array for response
-    const { rows: skillRows } = await getPool().query(
-      `SELECT s.id, s.name, s.scope, s.kind, s.tool_dependencies FROM agent_skills asks
+    const { rows: skillRows2 } = await getPool().query(
+      `SELECT s.id, s.name, s.scope FROM agent_skills asks
        JOIN skills s ON s.id = asks.skill_id
        WHERE asks.agent_id = $1`,
       [createdAgent.id]
     );
-    createdAgent.skills = skillRows;
+    createdAgent.skills = skillRows2;
 
     res.status(201).json(createdAgent);
   } catch (err: any) {
@@ -221,7 +232,7 @@ router.get('/:id', requireRole('user'), async (req: Request, res: Response) => {
 
     // Fetch skills for this agent
     const { rows: skillRows } = await getPool().query(
-      `SELECT s.id, s.name, s.scope, s.kind, s.tool_dependencies FROM agent_skills asks
+      `SELECT s.id, s.name, s.scope FROM agent_skills asks
        JOIN skills s ON s.id = asks.skill_id
        WHERE asks.agent_id = $1`,
       [agent.id]
@@ -262,7 +273,13 @@ router.put('/:id', requireRole('user'), async (req: Request, res: Response) => {
     }
 
     const user = (req as any).user;
-    const { name, description, tools_config, cpus, mem_limit, pids_limit, soul_md, rules_md, model_policy_id, skill_ids } = req.body;
+    const { name, description, tools_config, cpus, mem_limit, pids_limit, soul_md, rules_md, model_policy_id, skill_ids, sandbox_profile } = req.body;
+
+    // Validate sandbox_profile
+    if (sandbox_profile !== undefined && sandbox_profile !== null && !VALID_SANDBOX_PROFILES.includes(sandbox_profile)) {
+      res.status(400).json({ error: `Invalid sandbox_profile. Must be one of: ${VALID_SANDBOX_PROFILES.join(', ')}` });
+      return;
+    }
 
     // Validate skill_ids
     if (skill_ids !== undefined) {
@@ -299,7 +316,10 @@ router.put('/:id', requireRole('user'), async (req: Request, res: Response) => {
       }
     }
 
-    // Resolve skills: if skill_ids provided, batch-lookup and merge tools_configs
+    // Resolve tools_config: profile base + skill overlay
+    // Determine profile: explicit in body > existing on agent
+    const effectiveProfile = sandbox_profile !== undefined ? sandbox_profile : existing[0].sandbox_profile;
+    const updateProfileConfig = effectiveProfile ? getSandboxProfileConfig(effectiveProfile) : undefined;
     let resolvedToolsConfig = tools_config ? JSON.stringify(tools_config) : null;
     if (skill_ids !== undefined) {
       if (skill_ids.length > 0) {
@@ -316,7 +336,12 @@ router.put('/:id', requireRole('user'), async (req: Request, res: Response) => {
           res.status(403).json({ error: `Assigning ${elevatedScope} skills requires admin role` });
           return;
         }
-        resolvedToolsConfig = JSON.stringify(mergeToolsConfigs(skillRows.map((r: any) => r.tools_config)));
+        const configs = skillRows.map((r: any) => r.tools_config);
+        if (updateProfileConfig) configs.unshift(updateProfileConfig);
+        resolvedToolsConfig = JSON.stringify(mergeToolsConfigs(configs));
+      } else if (updateProfileConfig) {
+        // skill_ids is empty array but profile exists — use profile config
+        resolvedToolsConfig = JSON.stringify(updateProfileConfig);
       }
 
       // Check for implicit elevated-skill removal (non-admin removing elevated skills via PUT)
@@ -337,8 +362,9 @@ router.put('/:id', requireRole('user'), async (req: Request, res: Response) => {
       }
     }
 
-    // Build SET clause: model_policy_id uses explicit flag to allow clearing to NULL
+    // Build SET clause: model_policy_id and sandbox_profile use explicit flag to allow clearing to NULL
     const modelPolicyProvided = model_policy_id !== undefined;
+    const sandboxProfileProvided = sandbox_profile !== undefined;
     const { rows } = await getPool().query(
       `UPDATE agents SET
         name = COALESCE($1, name),
@@ -350,8 +376,9 @@ router.put('/:id', requireRole('user'), async (req: Request, res: Response) => {
         soul_md = COALESCE($7, soul_md),
         rules_md = COALESCE($8, rules_md),
         model_policy_id = CASE WHEN $9::boolean THEN $10::uuid ELSE model_policy_id END,
+        sandbox_profile = CASE WHEN $11::boolean THEN $12 ELSE sandbox_profile END,
         updated_at = NOW()
-       WHERE id = $11
+       WHERE id = $13
        RETURNING *`,
       [
         name || null,
@@ -364,6 +391,8 @@ router.put('/:id', requireRole('user'), async (req: Request, res: Response) => {
         rules_md ?? null,
         modelPolicyProvided,
         modelPolicyProvided ? (model_policy_id ?? null) : null,
+        sandboxProfileProvided,
+        sandboxProfileProvided ? (sandbox_profile ?? null) : null,
         req.params.id,
       ]
     );
@@ -385,7 +414,7 @@ router.put('/:id', requireRole('user'), async (req: Request, res: Response) => {
 
     // Fetch skills for response
     const { rows: agentSkills } = await getPool().query(
-      `SELECT s.id, s.name, s.scope, s.kind, s.tool_dependencies FROM agent_skills asks
+      `SELECT s.id, s.name, s.scope FROM agent_skills asks
        JOIN skills s ON s.id = asks.skill_id
        WHERE asks.agent_id = $1`,
       [req.params.id]
@@ -888,14 +917,21 @@ router.post('/:id/skills', requireRole('user'), async (req: Request, res: Respon
       throw insertErr;
     }
 
-    // Resolve-on-save: merge tools_config from ALL skills for this agent
+    // Resolve-on-save: merge tools_config from profile base + ALL skills for this agent
+    const { rows: agentForProfile } = await getPool().query(
+      'SELECT sandbox_profile FROM agents WHERE id = $1', [req.params.id]
+    );
+    const assignProfileConfig = agentForProfile[0]?.sandbox_profile
+      ? getSandboxProfileConfig(agentForProfile[0].sandbox_profile) : undefined;
     const { rows: allSkillConfigs } = await getPool().query(
       `SELECT s.tools_config FROM agent_skills asks
        JOIN skills s ON s.id = asks.skill_id
        WHERE asks.agent_id = $1`,
       [req.params.id]
     );
-    const mergedConfig = mergeToolsConfigs(allSkillConfigs.map((r: any) => r.tools_config));
+    const allConfigs = allSkillConfigs.map((r: any) => r.tools_config);
+    if (assignProfileConfig) allConfigs.unshift(assignProfileConfig);
+    const mergedConfig = mergeToolsConfigs(allConfigs);
     await getPool().query(
       'UPDATE agents SET tools_config = $1 WHERE id = $2',
       [JSON.stringify(mergedConfig), req.params.id]
@@ -953,19 +989,26 @@ router.delete('/:id/skills/:skillId', requireRole('user'), async (req: Request, 
       return;
     }
 
-    // Recompute tools_config from remaining skills
+    // Recompute tools_config from profile base + remaining skills
+    const { rows: agentForRemove } = await getPool().query(
+      'SELECT sandbox_profile FROM agents WHERE id = $1', [req.params.id]
+    );
+    const removeProfileConfig = agentForRemove[0]?.sandbox_profile
+      ? getSandboxProfileConfig(agentForRemove[0].sandbox_profile) : undefined;
     const { rows: remainingConfigs } = await getPool().query(
       `SELECT s.tools_config FROM agent_skills asks
        JOIN skills s ON s.id = asks.skill_id
        WHERE asks.agent_id = $1`,
       [req.params.id]
     );
-    const mergedConfig = remainingConfigs.length > 0
-      ? mergeToolsConfigs(remainingConfigs.map((r: any) => r.tools_config))
+    const removeConfigs = remainingConfigs.map((r: any) => r.tools_config);
+    if (removeProfileConfig) removeConfigs.unshift(removeProfileConfig);
+    const removeMerged = removeConfigs.length > 0
+      ? mergeToolsConfigs(removeConfigs)
       : DEFAULT_TOOLS_CONFIG;
     await getPool().query(
       'UPDATE agents SET tools_config = $1 WHERE id = $2',
-      [JSON.stringify(mergedConfig), req.params.id]
+      [JSON.stringify(removeMerged), req.params.id]
     );
 
     res.json({ removed: true });

--- a/services/api/src/routes/skills.ts
+++ b/services/api/src/routes/skills.ts
@@ -5,11 +5,6 @@ import { requireRole } from '../middleware/role';
 const router = Router();
 
 const VALID_SCOPES = ['container_local', 'host_docker', 'vps_system'] as const;
-const VALID_KINDS = ['skill', 'profile'] as const;
-
-function validateToolDependencies(deps: unknown): deps is string[] {
-  return Array.isArray(deps) && deps.every(d => typeof d === 'string');
-}
 
 function dbHealthCheck(_req: Request, res: Response, next: () => void) {
   if (!process.env.DATABASE_URL) {
@@ -27,26 +22,63 @@ function isAdmin(req: Request): boolean {
   return roles.includes('admin');
 }
 
+// Helper: fetch tools for a set of skill IDs via skill_tools join
+async function fetchToolsForSkills(skillIds: string[]): Promise<Record<string, any[]>> {
+  if (skillIds.length === 0) return {};
+  const { rows } = await getPool().query(
+    `SELECT st.skill_id, t.id, t.name, t.description, t.install_method
+     FROM skill_tools st
+     JOIN tools t ON t.id = st.tool_id
+     WHERE st.skill_id = ANY($1::uuid[])
+     ORDER BY t.name ASC`,
+    [skillIds]
+  );
+  const map: Record<string, any[]> = {};
+  for (const row of rows) {
+    if (!map[row.skill_id]) map[row.skill_id] = [];
+    map[row.skill_id].push({ id: row.id, name: row.name, description: row.description, install_method: row.install_method });
+  }
+  return map;
+}
+
+// Helper: validate and insert skill_tools rows
+async function setSkillTools(skillId: string, toolIds: string[]): Promise<void> {
+  if (!toolIds || toolIds.length === 0) return;
+
+  // Validate all tool_ids exist
+  const { rows: existingTools } = await getPool().query(
+    'SELECT id FROM tools WHERE id = ANY($1::uuid[])',
+    [toolIds]
+  );
+  if (existingTools.length !== toolIds.length) {
+    const found = new Set(existingTools.map((t: any) => t.id));
+    const missing = toolIds.filter(id => !found.has(id));
+    throw { validationError: true, message: `Tool(s) not found: ${missing.join(', ')}` };
+  }
+
+  // Delete existing and insert new
+  await getPool().query('DELETE FROM skill_tools WHERE skill_id = $1', [skillId]);
+  for (const toolId of toolIds) {
+    await getPool().query(
+      'INSERT INTO skill_tools (skill_id, tool_id) VALUES ($1, $2) ON CONFLICT DO NOTHING',
+      [skillId, toolId]
+    );
+  }
+}
+
 // List all skills — all authenticated users see all skills
-router.get('/', requireRole('user'), async (req: Request, res: Response) => {
+router.get('/', requireRole('user'), async (_req: Request, res: Response) => {
   try {
-    const kindFilter = req.query.kind as string | undefined;
-    if (kindFilter && !(VALID_KINDS as readonly string[]).includes(kindFilter)) {
-      res.status(400).json({ error: `Invalid kind filter. Must be one of: ${VALID_KINDS.join(', ')}` });
-      return;
-    }
+    const { rows } = await getPool().query(
+      `SELECT id, name, description, tools_config, instructions_md, scope, is_platform, created_by, created_at, updated_at
+       FROM skills ORDER BY is_platform DESC, name ASC`
+    );
 
-    let query = `SELECT id, name, description, tools_config, instructions_md, scope, kind, tool_dependencies, is_platform, created_by, created_at, updated_at
-       FROM skills`;
-    const params: string[] = [];
-    if (kindFilter) {
-      query += ` WHERE kind = $1`;
-      params.push(kindFilter);
-    }
-    query += ` ORDER BY is_platform DESC, name ASC`;
+    // Fetch tools for all skills
+    const toolsMap = await fetchToolsForSkills(rows.map((r: any) => r.id));
+    const result = rows.map((r: any) => ({ ...r, tools: toolsMap[r.id] || [] }));
 
-    const { rows } = await getPool().query(query, params);
-    res.json(rows);
+    res.json(result);
   } catch (err) {
     console.error('[skills] List error:', err);
     res.status(500).json({ error: 'Failed to list skills' });
@@ -57,7 +89,7 @@ router.get('/', requireRole('user'), async (req: Request, res: Response) => {
 router.get('/:id', requireRole('user'), async (req: Request, res: Response) => {
   try {
     const { rows } = await getPool().query(
-      `SELECT id, name, description, tools_config, instructions_md, scope, kind, tool_dependencies, is_platform, created_by, created_at, updated_at
+      `SELECT id, name, description, tools_config, instructions_md, scope, is_platform, created_by, created_at, updated_at
        FROM skills WHERE id = $1`,
       [req.params.id]
     );
@@ -65,7 +97,9 @@ router.get('/:id', requireRole('user'), async (req: Request, res: Response) => {
       res.status(404).json({ error: 'Skill not found' });
       return;
     }
-    res.json(rows[0]);
+
+    const toolsMap = await fetchToolsForSkills([rows[0].id]);
+    res.json({ ...rows[0], tools: toolsMap[rows[0].id] || [] });
   } catch (err) {
     console.error('[skills] Get error:', err);
     res.status(500).json({ error: 'Failed to get skill' });
@@ -75,7 +109,7 @@ router.get('/:id', requireRole('user'), async (req: Request, res: Response) => {
 // Create skill — admin only
 router.post('/', requireRole('admin'), async (req: Request, res: Response) => {
   try {
-    const { name, description, tools_config, instructions_md, scope, kind, tool_dependencies } = req.body;
+    const { name, description, tools_config, instructions_md, scope, tool_ids } = req.body;
 
     if (!name) {
       res.status(400).json({ error: 'name is required' });
@@ -90,31 +124,32 @@ router.post('/', requireRole('admin'), async (req: Request, res: Response) => {
       return;
     }
 
-    const resolvedKind = kind || 'skill';
-    if (!(VALID_KINDS as readonly string[]).includes(resolvedKind)) {
-      res.status(400).json({ error: `Invalid kind. Must be one of: ${VALID_KINDS.join(', ')}` });
-      return;
-    }
-
-    const resolvedDeps = tool_dependencies ?? [];
-    if (!validateToolDependencies(resolvedDeps)) {
-      res.status(400).json({ error: 'tool_dependencies must be an array of strings' });
-      return;
-    }
-    if (resolvedKind === 'profile' && resolvedDeps.length > 0) {
-      res.status(400).json({ error: 'Profiles cannot have tool_dependencies' });
+    if (tool_ids !== undefined && (!Array.isArray(tool_ids) || !tool_ids.every((id: unknown) => typeof id === 'string'))) {
+      res.status(400).json({ error: 'tool_ids must be an array of UUIDs' });
       return;
     }
 
     const { rows } = await getPool().query(
-      `INSERT INTO skills (name, description, tools_config, instructions_md, scope, kind, tool_dependencies, is_platform, created_by)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, false, NULL)
+      `INSERT INTO skills (name, description, tools_config, instructions_md, scope, is_platform, created_by)
+       VALUES ($1, $2, $3, $4, $5, false, NULL)
        RETURNING *`,
-      [name, description || '', JSON.stringify(tools_config), instructions_md || '', scope || 'container_local', resolvedKind, JSON.stringify(resolvedDeps)]
+      [name, description || '', JSON.stringify(tools_config), instructions_md || '', scope || 'container_local']
     );
 
-    res.status(201).json(rows[0]);
+    const skill = rows[0];
+
+    // Insert skill_tools if provided
+    if (tool_ids && tool_ids.length > 0) {
+      await setSkillTools(skill.id, tool_ids);
+    }
+
+    const toolsMap = await fetchToolsForSkills([skill.id]);
+    res.status(201).json({ ...skill, tools: toolsMap[skill.id] || [] });
   } catch (err: any) {
+    if (err.validationError) {
+      res.status(400).json({ error: err.message });
+      return;
+    }
     if (err.code === '23505') {
       res.status(409).json({ error: 'A skill with this name already exists' });
       return;
@@ -128,7 +163,7 @@ router.post('/', requireRole('admin'), async (req: Request, res: Response) => {
 router.put('/:id', requireRole('admin'), async (req: Request, res: Response) => {
   try {
     const { rows: existing } = await getPool().query(
-      'SELECT id, is_platform, tool_dependencies FROM skills WHERE id = $1',
+      'SELECT id, is_platform FROM skills WHERE id = $1',
       [req.params.id]
     );
     if (existing.length === 0) {
@@ -140,31 +175,16 @@ router.put('/:id', requireRole('admin'), async (req: Request, res: Response) => 
       return;
     }
 
-    const { name, description, tools_config, instructions_md, scope, kind, tool_dependencies } = req.body;
+    const { name, description, tools_config, instructions_md, scope, tool_ids } = req.body;
 
     if (scope !== undefined && !VALID_SCOPES.includes(scope)) {
       res.status(400).json({ error: `Invalid scope. Must be one of: ${VALID_SCOPES.join(', ')}` });
       return;
     }
 
-    if (kind !== undefined && !(VALID_KINDS as readonly string[]).includes(kind)) {
-      res.status(400).json({ error: `Invalid kind. Must be one of: ${VALID_KINDS.join(', ')}` });
+    if (tool_ids !== undefined && (!Array.isArray(tool_ids) || !tool_ids.every((id: unknown) => typeof id === 'string'))) {
+      res.status(400).json({ error: 'tool_ids must be an array of UUIDs' });
       return;
-    }
-
-    if (tool_dependencies !== undefined && !validateToolDependencies(tool_dependencies)) {
-      res.status(400).json({ error: 'tool_dependencies must be an array of strings' });
-      return;
-    }
-
-    // Cross-validation: if updating kind to 'profile', tool_dependencies must be empty
-    if (kind === 'profile') {
-      const effectiveDeps = tool_dependencies ?? existing[0].tool_dependencies ?? [];
-      const depsArray = Array.isArray(effectiveDeps) ? effectiveDeps : [];
-      if (depsArray.length > 0) {
-        res.status(400).json({ error: 'Profiles cannot have tool_dependencies' });
-        return;
-      }
     }
 
     const { rows } = await getPool().query(
@@ -174,10 +194,8 @@ router.put('/:id', requireRole('admin'), async (req: Request, res: Response) => 
         tools_config = COALESCE($3, tools_config),
         instructions_md = COALESCE($4, instructions_md),
         scope = COALESCE($5, scope),
-        kind = COALESCE($6, kind),
-        tool_dependencies = COALESCE($7, tool_dependencies),
         updated_at = NOW()
-       WHERE id = $8
+       WHERE id = $6
        RETURNING *`,
       [
         name || null,
@@ -185,14 +203,22 @@ router.put('/:id', requireRole('admin'), async (req: Request, res: Response) => 
         tools_config ? JSON.stringify(tools_config) : null,
         instructions_md ?? null,
         scope || null,
-        kind || null,
-        tool_dependencies ? JSON.stringify(tool_dependencies) : null,
         req.params.id,
       ]
     );
 
-    res.json(rows[0]);
+    // Update skill_tools if provided
+    if (tool_ids !== undefined) {
+      await setSkillTools(rows[0].id, tool_ids);
+    }
+
+    const toolsMap = await fetchToolsForSkills([rows[0].id]);
+    res.json({ ...rows[0], tools: toolsMap[rows[0].id] || [] });
   } catch (err: any) {
+    if (err.validationError) {
+      res.status(400).json({ error: err.message });
+      return;
+    }
     if (err.code === '23505') {
       res.status(409).json({ error: 'A skill with this name already exists' });
       return;
@@ -234,6 +260,7 @@ router.delete('/:id', requireRole('admin'), async (req: Request, res: Response) 
       return;
     }
 
+    // skill_tools rows cascade-delete via FK
     await getPool().query('DELETE FROM skills WHERE id = $1', [req.params.id]);
     res.json({ deleted: true });
   } catch (err) {

--- a/services/api/src/routes/tools.ts
+++ b/services/api/src/routes/tools.ts
@@ -1,0 +1,171 @@
+import { Router, Request, Response } from 'express';
+import { getPool } from '../db/pool';
+import { requireRole } from '../middleware/role';
+
+const router = Router();
+
+const VALID_INSTALL_METHODS = ['builtin', 'apt', 'binary'] as const;
+
+function dbHealthCheck(_req: Request, res: Response, next: () => void) {
+  if (!process.env.DATABASE_URL) {
+    res.status(503).json({ error: 'Database not configured' });
+    return;
+  }
+  next();
+}
+
+router.use(dbHealthCheck);
+
+function isAdmin(req: Request): boolean {
+  const user = (req as any).user;
+  const roles: string[] = user?.realm_roles || [];
+  return roles.includes('admin');
+}
+
+// List all tools
+router.get('/', requireRole('user'), async (_req: Request, res: Response) => {
+  try {
+    const { rows } = await getPool().query(
+      `SELECT id, name, description, install_method, install_ref, is_platform, created_at
+       FROM tools ORDER BY is_platform DESC, name ASC`
+    );
+    res.json(rows);
+  } catch (err) {
+    console.error('[tools] List error:', err);
+    res.status(500).json({ error: 'Failed to list tools' });
+  }
+});
+
+// Get single tool
+router.get('/:id', requireRole('user'), async (req: Request, res: Response) => {
+  try {
+    const { rows } = await getPool().query(
+      `SELECT id, name, description, install_method, install_ref, is_platform, created_at
+       FROM tools WHERE id = $1`,
+      [req.params.id]
+    );
+    if (rows.length === 0) {
+      res.status(404).json({ error: 'Tool not found' });
+      return;
+    }
+    res.json(rows[0]);
+  } catch (err) {
+    console.error('[tools] Get error:', err);
+    res.status(500).json({ error: 'Failed to get tool' });
+  }
+});
+
+// Create tool — admin only
+router.post('/', requireRole('admin'), async (req: Request, res: Response) => {
+  try {
+    const { name, description, install_method, install_ref } = req.body;
+
+    if (!name) {
+      res.status(400).json({ error: 'name is required' });
+      return;
+    }
+    const resolvedMethod = install_method || 'builtin';
+    if (!(VALID_INSTALL_METHODS as readonly string[]).includes(resolvedMethod)) {
+      res.status(400).json({ error: `Invalid install_method. Must be one of: ${VALID_INSTALL_METHODS.join(', ')}` });
+      return;
+    }
+
+    const { rows } = await getPool().query(
+      `INSERT INTO tools (name, description, install_method, install_ref, is_platform)
+       VALUES ($1, $2, $3, $4, false)
+       RETURNING *`,
+      [name, description || '', resolvedMethod, install_ref || '']
+    );
+
+    res.status(201).json(rows[0]);
+  } catch (err: any) {
+    if (err.code === '23505') {
+      res.status(409).json({ error: 'A tool with this name already exists' });
+      return;
+    }
+    console.error('[tools] Create error:', err);
+    res.status(500).json({ error: 'Failed to create tool' });
+  }
+});
+
+// Update tool — admin only, platform tools immutable
+router.put('/:id', requireRole('admin'), async (req: Request, res: Response) => {
+  try {
+    const { rows: existing } = await getPool().query(
+      'SELECT id, is_platform FROM tools WHERE id = $1',
+      [req.params.id]
+    );
+    if (existing.length === 0) {
+      res.status(404).json({ error: 'Tool not found' });
+      return;
+    }
+    if (existing[0].is_platform) {
+      res.status(403).json({ error: 'Cannot modify a platform tool' });
+      return;
+    }
+
+    const { name, description, install_method, install_ref } = req.body;
+
+    if (install_method !== undefined && !(VALID_INSTALL_METHODS as readonly string[]).includes(install_method)) {
+      res.status(400).json({ error: `Invalid install_method. Must be one of: ${VALID_INSTALL_METHODS.join(', ')}` });
+      return;
+    }
+
+    const { rows } = await getPool().query(
+      `UPDATE tools SET
+        name = COALESCE($1, name),
+        description = COALESCE($2, description),
+        install_method = COALESCE($3, install_method),
+        install_ref = COALESCE($4, install_ref)
+       WHERE id = $5
+       RETURNING *`,
+      [
+        name || null,
+        description ?? null,
+        install_method || null,
+        install_ref ?? null,
+        req.params.id,
+      ]
+    );
+
+    res.json(rows[0]);
+  } catch (err: any) {
+    if (err.code === '23505') {
+      res.status(409).json({ error: 'A tool with this name already exists' });
+      return;
+    }
+    console.error('[tools] Update error:', err);
+    res.status(500).json({ error: 'Failed to update tool' });
+  }
+});
+
+// Delete tool — admin only, platform tools undeletable
+router.delete('/:id', requireRole('admin'), async (req: Request, res: Response) => {
+  try {
+    const { rows: existing } = await getPool().query(
+      'SELECT id, is_platform FROM tools WHERE id = $1',
+      [req.params.id]
+    );
+    if (existing.length === 0) {
+      res.status(404).json({ error: 'Tool not found' });
+      return;
+    }
+    if (existing[0].is_platform) {
+      res.status(403).json({ error: 'Cannot delete a platform tool' });
+      return;
+    }
+
+    await getPool().query('DELETE FROM tools WHERE id = $1', [req.params.id]);
+    res.json({ deleted: true });
+  } catch (err: any) {
+    // FK RESTRICT from skill_tools
+    if (err.code === '23503') {
+      res.status(409).json({ error: 'Cannot delete tool while skills reference it' });
+      return;
+    }
+    console.error('[tools] Delete error:', err);
+    res.status(500).json({ error: 'Failed to delete tool' });
+  }
+});
+
+export default router;

--- a/services/api/src/services/sandbox-profiles.ts
+++ b/services/api/src/services/sandbox-profiles.ts
@@ -1,0 +1,30 @@
+import { ToolsConfig } from './merge-tools-config';
+
+export const SANDBOX_PROFILES: Record<string, ToolsConfig> = {
+  minimal: {
+    shell: { enabled: false, allowed_binaries: [], denied_patterns: [], max_timeout: 300 },
+    filesystem: { enabled: false, read_only: false, allowed_paths: ['/workspace'], denied_paths: ['/etc/shadow', '/etc/passwd', '/root'] },
+    health: { enabled: true },
+  },
+  developer: {
+    shell: { enabled: true, allowed_binaries: ['bash', 'git', 'make', 'curl', 'jq'], denied_patterns: ['rm -rf /', ':(){ :|:& };:'], max_timeout: 300 },
+    filesystem: { enabled: true, read_only: false, allowed_paths: ['/workspace', '/data'], denied_paths: ['/etc/shadow', '/etc/passwd', '/root'] },
+    health: { enabled: true },
+  },
+  research: {
+    shell: { enabled: true, allowed_binaries: ['bash', 'curl', 'wget', 'jq'], denied_patterns: ['rm ', 'mv ', 'dd ', 'mkfs', '> /', '>> /'], max_timeout: 120 },
+    filesystem: { enabled: true, read_only: true, allowed_paths: ['/workspace', '/data'], denied_paths: ['/etc/shadow', '/etc/passwd', '/root'] },
+    health: { enabled: true },
+  },
+  operator: {
+    shell: { enabled: true, allowed_binaries: ['bash', 'git', 'curl', 'wget', 'jq', 'rsync', 'ssh', 'make', 'vim'], denied_patterns: ['rm -rf /', ':(){ :|:& };:'], max_timeout: 600 },
+    filesystem: { enabled: true, read_only: false, allowed_paths: ['/workspace', '/data', '/var/log/agentbox'], denied_paths: ['/etc/shadow', '/etc/passwd', '/root'] },
+    health: { enabled: true },
+  },
+};
+
+export const VALID_SANDBOX_PROFILES = Object.keys(SANDBOX_PROFILES);
+
+export function getSandboxProfileConfig(name: string): ToolsConfig | undefined {
+  return SANDBOX_PROFILES[name.toLowerCase()];
+}

--- a/services/ui/src/__tests__/AgentDetailClient.test.tsx
+++ b/services/ui/src/__tests__/AgentDetailClient.test.tsx
@@ -60,13 +60,13 @@ const MOCK_AGENT = {
 
 const MOCK_AGENT_WITH_SKILL = {
   ...MOCK_AGENT,
+  sandbox_profile: 'developer',
   skills: [
     {
       id: 'preset-dev',
       name: 'Developer',
       scope: 'container_local',
-      kind: 'skill',
-      tool_dependencies: ['gh', 'git'],
+      tools: [{ id: 'tool-gh', name: 'gh' }, { id: 'tool-git', name: 'git' }],
       instructions_md: 'Always write tests before implementation.\nFollow TDD red-green-refactor.',
     },
   ],
@@ -105,9 +105,9 @@ const USER_SESSION = {
 }
 
 const MOCK_ALL_SKILLS = [
-  { id: 'preset-dev', name: 'Developer', scope: 'container_local', kind: 'skill', tool_dependencies: ['gh', 'git'], instructions_md: 'Dev instructions' },
-  { id: 'skill-docker', name: 'Docker Access', scope: 'host_docker', kind: 'profile', tool_dependencies: [], instructions_md: 'Docker instructions' },
-  { id: 'skill-vps', name: 'VPS Admin', scope: 'vps_system', kind: 'skill', tool_dependencies: [], instructions_md: 'VPS instructions' },
+  { id: 'preset-dev', name: 'Developer', scope: 'container_local', tools: [{ id: 'tool-gh', name: 'gh' }, { id: 'tool-git', name: 'git' }], instructions_md: 'Dev instructions' },
+  { id: 'skill-docker', name: 'Docker Access', scope: 'host_docker', tools: [], instructions_md: 'Docker instructions' },
+  { id: 'skill-vps', name: 'VPS Admin', scope: 'vps_system', tools: [], instructions_md: 'VPS instructions' },
 ]
 
 const MOCK_AGENT_WITH_MULTI_SKILLS = {
@@ -117,16 +117,14 @@ const MOCK_AGENT_WITH_MULTI_SKILLS = {
       id: 'preset-dev',
       name: 'Developer',
       scope: 'container_local',
-      kind: 'skill',
-      tool_dependencies: ['gh', 'git'],
+      tools: [{ id: 'tool-gh', name: 'gh' }, { id: 'tool-git', name: 'git' }],
       instructions_md: 'Dev instructions.',
     },
     {
       id: 'skill-docker',
       name: 'Docker Access',
       scope: 'host_docker',
-      kind: 'profile',
-      tool_dependencies: [],
+      tools: [],
       instructions_md: 'Docker instructions here.',
     },
   ],
@@ -139,8 +137,7 @@ const MOCK_AGENT_WITH_ELEVATED_SKILL = {
       id: 'skill-docker',
       name: 'Docker Access',
       scope: 'host_docker',
-      kind: 'profile',
-      tool_dependencies: [],
+      tools: [],
       instructions_md: 'Docker instructions here.',
     },
   ],
@@ -486,7 +483,7 @@ describe('AgentDetailClient', () => {
     // Click "Assign Skill" to open picker
     fireEvent.click(screen.getByText('Assign Skill'))
 
-    // Developer is already assigned — should NOT appear in picker
+    // Developer is already assigned -- should NOT appear in picker
     // But Docker Access and VPS Admin should appear (admin sees all)
     await waitFor(() => {
       expect(screen.getByText('Docker Access')).toBeInTheDocument()
@@ -499,7 +496,7 @@ describe('AgentDetailClient', () => {
     const pickerButtons = screen.getAllByRole('button').filter(
       btn => btn.textContent?.includes('Developer') && btn.closest('[class*="navy-900"]')
     )
-    // The picker is inside a navy-900 div — should not have Developer there
+    // The picker is inside a navy-900 div -- should not have Developer there
     expect(pickerButtons).toHaveLength(0)
   })
 
@@ -539,8 +536,8 @@ describe('AgentDetailClient', () => {
     })
   })
 
-  // U5: Detail shows kind badge on cards
-  it('shows kind badge on skill cards', async () => {
+  // U5: Detail shows NO kind badge — shows tools instead
+  it('shows no kind badge on skill cards, shows tools instead', async () => {
     mockFetchDefaults(MOCK_AGENT_WITH_SKILL as any)
 
     render(<AgentDetailClient agentId="uuid-1" session={ADMIN_SESSION as any} />)
@@ -549,12 +546,17 @@ describe('AgentDetailClient', () => {
       expect(screen.getByText('Developer')).toBeInTheDocument()
     })
 
-    // Should show "Skill" kind badge
-    expect(screen.getByText('Skill')).toBeInTheDocument()
+    // Should NOT show "Skill" or "Profile" kind badges
+    const skillCard = screen.getByText('Developer').closest('[class*="rounded-md"]')!
+    expect(skillCard.textContent).not.toMatch(/\bSkill\b/)
+    expect(skillCard.textContent).not.toContain('Profile')
+
+    // Should show tools
+    expect(screen.getByText('Tools: gh, git')).toBeInTheDocument()
   })
 
-  // U6: Detail shows tool_dependencies on skill cards
-  it('shows tool_dependencies as Requires badges on skill cards', async () => {
+  // U6: Detail shows tools on skill cards
+  it('shows tools as badges on skill cards', async () => {
     mockFetchDefaults(MOCK_AGENT_WITH_SKILL as any)
 
     render(<AgentDetailClient agentId="uuid-1" session={ADMIN_SESSION as any} />)
@@ -563,7 +565,22 @@ describe('AgentDetailClient', () => {
       expect(screen.getByText('Developer')).toBeInTheDocument()
     })
 
-    // Should show tool dependencies
-    expect(screen.getByText('Requires: gh, git')).toBeInTheDocument()
+    // Should show tool names
+    expect(screen.getByText('Tools: gh, git')).toBeInTheDocument()
+  })
+
+  // U6 new: Shows sandbox_profile badge in overview
+  it('shows sandbox_profile badge in overview', async () => {
+    mockFetchDefaults(MOCK_AGENT_WITH_SKILL as any)
+
+    render(<AgentDetailClient agentId="uuid-1" session={ADMIN_SESSION as any} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('ResearchBot')).toBeInTheDocument()
+    })
+
+    // Should show sandbox profile label and value
+    expect(screen.getByText('Sandbox Profile')).toBeInTheDocument()
+    expect(screen.getByText('developer')).toBeInTheDocument()
   })
 })

--- a/services/ui/src/__tests__/AgentFormClient.test.tsx
+++ b/services/ui/src/__tests__/AgentFormClient.test.tsx
@@ -38,8 +38,7 @@ const MOCK_PRESETS = [
     },
     instructions_md: 'You have no shell or filesystem access.',
     is_platform: true,
-    kind: 'profile',
-    tool_dependencies: [],
+    tools: [],
   },
   {
     id: 'preset-dev',
@@ -53,8 +52,7 @@ const MOCK_PRESETS = [
     },
     instructions_md: 'You have full developer access with bash, git, make, curl, and jq available.',
     is_platform: true,
-    kind: 'profile',
-    tool_dependencies: [],
+    tools: [],
   },
   {
     id: 'preset-docker',
@@ -68,8 +66,7 @@ const MOCK_PRESETS = [
     },
     instructions_md: 'You have Docker socket access.',
     is_platform: false,
-    kind: 'skill',
-    tool_dependencies: ['docker'],
+    tools: [{ id: 'tool-docker', name: 'docker' }],
   },
 ]
 
@@ -287,7 +284,7 @@ describe('AgentFormClient', () => {
       expect(screen.getByText('Tools')).toBeInTheDocument()
     })
 
-    // Edit mode with no skills → Custom mode, tool toggles visible
+    // Edit mode with no skills -> Custom mode, tool toggles visible
     const shellCheckbox = screen.getByLabelText('Shell access') as HTMLInputElement
     expect(shellCheckbox.checked).toBe(true)
 
@@ -361,12 +358,12 @@ describe('AgentFormClient', () => {
       expect(screen.getByLabelText('Skills')).toBeInTheDocument()
     })
 
-    // Default: Skills mode — skill checkboxes visible
+    // Default: Skills mode -- skill checkboxes visible
     await waitFor(() => {
-      expect(screen.getByText(/Minimal/)).toBeInTheDocument()
+      expect(screen.getAllByText(/Minimal/).length).toBeGreaterThan(0)
     })
 
-    // Switch to Custom — manual tool editors visible
+    // Switch to Custom -- manual tool editors visible
     fireEvent.click(screen.getByLabelText('Custom'))
 
     await waitFor(() => {
@@ -400,7 +397,63 @@ describe('AgentFormClient', () => {
     expect(body.tools_config).toBeDefined()
   })
 
-  // U4: Form Skills mode: checkboxes shown, skill_ids submitted
+  // U4: Shows sandbox profile dropdown
+  it('Shows sandbox profile dropdown', async () => {
+    render(<AgentFormClient />)
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Skills')).toBeInTheDocument()
+    })
+
+    // Should have sandbox profile select
+    const profileSelect = screen.getByLabelText('Sandbox Profile')
+    expect(profileSelect).toBeInTheDocument()
+
+    // Verify options
+    const options = profileSelect.querySelectorAll('option')
+    const optionTexts = Array.from(options).map(o => o.textContent)
+    expect(optionTexts).toContain('None (custom / skill-only)')
+    expect(optionTexts).toContain('Minimal')
+    expect(optionTexts).toContain('Developer')
+    expect(optionTexts).toContain('Research')
+    expect(optionTexts).toContain('Operator')
+  })
+
+  // Submit body includes sandbox_profile when selected
+  it('submit body includes sandbox_profile when selected', async () => {
+    render(<AgentFormClient isAdmin />)
+
+    await waitFor(() => {
+      expect(screen.getByText(/Minimal/)).toBeInTheDocument()
+    })
+
+    fireEvent.change(screen.getByLabelText('Agent ID (slug)'), { target: { value: 'test-agent' } })
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Test Agent' } })
+
+    // Select sandbox profile
+    fireEvent.change(screen.getByLabelText('Sandbox Profile'), { target: { value: 'developer' } })
+
+    // Check a skill
+    const checkboxes = screen.getAllByRole('checkbox')
+    const minCheckbox = checkboxes.find(cb => cb.closest('label')?.textContent?.includes('Minimal'))!
+    fireEvent.click(minCheckbox)
+
+    fireEvent.click(screen.getByRole('button', { name: /create agent/i }))
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith('/api/agents', expect.objectContaining({
+        method: 'POST',
+      }))
+    })
+
+    const postCall = mockFetch.mock.calls.find(
+      (c: any[]) => c[0] === '/api/agents' && c[1]?.method === 'POST'
+    )!
+    const body = JSON.parse(postCall[1].body)
+    expect(body.sandbox_profile).toBe('developer')
+  })
+
+  // U4 (old): Form Skills mode: checkboxes shown, skill_ids submitted
   it('Skills mode submits checked skill_ids', async () => {
     render(<AgentFormClient isAdmin />)
 
@@ -477,10 +530,10 @@ describe('AgentFormClient', () => {
     // Make a manual change (enable shell)
     fireEvent.click(screen.getByLabelText('Shell access'))
 
-    // Try to switch to Skills — user cancels
+    // Try to switch to Skills -- user cancels
     fireEvent.click(screen.getByLabelText('Skills'))
 
-    // Should still be in Custom mode — tool toggles visible
+    // Should still be in Custom mode -- tool toggles visible
     expect(screen.getByLabelText('Shell access')).toBeInTheDocument()
     const shellCheckbox = screen.getByLabelText('Shell access') as HTMLInputElement
     expect(shellCheckbox.checked).toBe(true)
@@ -490,7 +543,7 @@ describe('AgentFormClient', () => {
     render(<AgentFormClient />)
     await selectCustomMode()
 
-    // Don't make any changes — just switch back to Skills
+    // Don't make any changes -- just switch back to Skills
     fireEvent.click(screen.getByLabelText('Skills'))
 
     // confirm() should NOT have been called
@@ -573,16 +626,15 @@ describe('AgentFormClient', () => {
     expect(screen.getAllByText('Container').length).toBeGreaterThan(0)
   })
 
-  // U4: Form Skills mode shows profiles and skills groups
-  it('Skills mode shows separate profiles and skills group headings', async () => {
+  // U4 (original): Form Skills mode shows no separate profiles/skills groups
+  it('Skills mode shows no separate profiles and skills group headings', async () => {
     render(<AgentFormClient isAdmin />)
 
     await waitFor(() => {
       expect(screen.getByText(/Minimal/)).toBeInTheDocument()
     })
 
-    // Both group headings should be present
-    expect(screen.getByText('Profiles (sandbox presets)')).toBeInTheDocument()
-    expect(screen.getByText('Skills (capabilities)')).toBeInTheDocument()
+    // Should NOT have separate group headings
+    expect(screen.queryByText('Profiles (sandbox presets)')).not.toBeInTheDocument()
   })
 })

--- a/services/ui/src/__tests__/SkillsClient.test.tsx
+++ b/services/ui/src/__tests__/SkillsClient.test.tsx
@@ -36,8 +36,7 @@ const MOCK_SKILLS = [
     },
     instructions_md: 'You have no shell or filesystem access. You can only monitor your own resource usage via the health endpoint.',
     is_platform: true,
-    kind: 'profile' as const,
-    tool_dependencies: [],
+    tools: [],
     created_at: '2026-01-01T00:00:00Z',
     updated_at: '2026-01-01T00:00:00Z',
   },
@@ -53,8 +52,7 @@ const MOCK_SKILLS = [
     },
     instructions_md: 'You have full developer access with bash, git, make, curl, and jq available. Use /workspace as your primary working directory.',
     is_platform: true,
-    kind: 'profile' as const,
-    tool_dependencies: [],
+    tools: [],
     created_at: '2026-01-01T00:00:00Z',
     updated_at: '2026-01-01T00:00:00Z',
   },
@@ -70,17 +68,28 @@ const MOCK_SKILLS = [
     },
     instructions_md: 'Run CI pipelines in isolated containers.',
     is_platform: false,
-    kind: 'skill' as const,
-    tool_dependencies: ['gh', 'git'],
+    tools: [
+      { id: 'tool-gh', name: 'gh', description: 'GitHub CLI', install_method: 'binary' },
+      { id: 'tool-git', name: 'git', description: 'VCS', install_method: 'builtin' },
+    ],
     created_at: '2026-02-15T00:00:00Z',
     updated_at: '2026-02-15T00:00:00Z',
   },
+]
+
+const MOCK_TOOLS = [
+  { id: 'tool-bash', name: 'bash', description: 'Shell', install_method: 'builtin', install_ref: '', is_platform: true },
+  { id: 'tool-git', name: 'git', description: 'VCS', install_method: 'builtin', install_ref: '', is_platform: true },
+  { id: 'tool-gh', name: 'gh', description: 'GitHub CLI', install_method: 'binary', install_ref: '', is_platform: true },
 ]
 
 function mockFetchDefaults(skills = MOCK_SKILLS) {
   mockFetch.mockImplementation((url: string, opts?: any) => {
     if (url === '/api/skills' && (!opts || !opts.method || opts.method === 'GET')) {
       return Promise.resolve({ ok: true, json: () => Promise.resolve(skills) })
+    }
+    if (url === '/api/tools' && (!opts || !opts.method || opts.method === 'GET')) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_TOOLS) })
     }
     if (url === '/api/skills' && opts?.method === 'POST') {
       return Promise.resolve({ ok: true, json: () => Promise.resolve({ id: 'new-preset', ...JSON.parse(opts.body) }) })
@@ -116,8 +125,8 @@ describe('SkillsClient', () => {
     await waitFor(() => {
       expect(screen.getByText('Skills')).toBeInTheDocument()
     })
-    // Should show separate profiles/skills counts
-    expect(screen.getByText('2 profiles, 1 skill')).toBeInTheDocument()
+    // Should show single count for all skills
+    expect(screen.getByText('3 skills')).toBeInTheDocument()
   })
 
   // T8: Skills page shows instructions preview in expanded view
@@ -188,46 +197,63 @@ describe('SkillsClient', () => {
       expect(screen.getByText('Minimal')).toBeInTheDocument()
     })
 
-    // container_local → "Container"
+    // container_local -> "Container"
     expect(screen.getByText('Container')).toBeInTheDocument()
-    // host_docker → "Host · Docker"
+    // host_docker -> "Host . Docker"
     expect(screen.getByText('Host · Docker')).toBeInTheDocument()
-    // vps_system → "VPS · System"
+    // vps_system -> "VPS . System"
     expect(screen.getByText('VPS · System')).toBeInTheDocument()
   })
 
-  // U1: Harness shows separate Profiles and Skills sections
-  it('Harness shows separate Profiles and Skills sections', async () => {
-    render(<SkillsClient />)
-
-    await waitFor(() => {
-      expect(screen.getByText('Profiles (sandbox presets)')).toBeInTheDocument()
-      expect(screen.getByText('Skills (capabilities)')).toBeInTheDocument()
-    })
-  })
-
-  // U2: Skill with tool_dependencies shows Requires badges
-  it('Skill with tool_dependencies shows Requires badges', async () => {
-    render(<SkillsClient />)
-
-    await waitFor(() => {
-      expect(screen.getByText('CI Runner')).toBeInTheDocument()
-    })
-
-    expect(screen.getByText('Requires: gh, git')).toBeInTheDocument()
-  })
-
-  // U3: Profile shows no Requires badges for empty tool_dependencies
-  it('Profile shows no Requires badges for empty tool_dependencies', async () => {
+  // U1: No separate Profiles/Skills sections — single flat list
+  it('shows all skills in a single list without Profiles/Skills headings', async () => {
     render(<SkillsClient />)
 
     await waitFor(() => {
       expect(screen.getByText('Minimal')).toBeInTheDocument()
     })
 
-    // Minimal is a profile with empty tool_dependencies — should not show "Requires"
-    const minimalCard = screen.getByText('Minimal').closest('[class*="rounded-lg"]')!
-    expect(minimalCard.textContent).not.toContain('Requires')
+    // Should NOT have separate section headings
+    expect(screen.queryByText('Profiles (sandbox presets)')).not.toBeInTheDocument()
+    expect(screen.queryByText('Skills (capabilities)')).not.toBeInTheDocument()
+
+    // All three skills should be visible in a single list
+    expect(screen.getByText('Developer')).toBeInTheDocument()
+    expect(screen.getByText('CI Runner')).toBeInTheDocument()
+  })
+
+  // U2: Skill with tools shows Tools badges
+  it('Skill with tools shows Tools badges', async () => {
+    render(<SkillsClient />)
+
+    await waitFor(() => {
+      expect(screen.getByText('CI Runner')).toBeInTheDocument()
+    })
+
+    expect(screen.getByText('Tools: gh, git')).toBeInTheDocument()
+  })
+
+  // U3: Create form has tool checkboxes
+  it('SkillsClient create form has tool checkboxes', async () => {
+    render(<SkillsClient />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Minimal')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByText('Add Skill'))
+
+    await waitFor(() => {
+      expect(screen.getByText('New Skill')).toBeInTheDocument()
+    })
+
+    // Tool checkboxes should appear
+    await waitFor(() => {
+      expect(screen.getByText('Required Tools')).toBeInTheDocument()
+    })
+    expect(screen.getByLabelText('bash')).toBeInTheDocument()
+    expect(screen.getByLabelText('git')).toBeInTheDocument()
+    expect(screen.getByLabelText('gh')).toBeInTheDocument()
   })
 
   // T11: Nav says "Skills" with /harness/skills href

--- a/services/ui/src/app/agents/[id]/AgentDetailClient.tsx
+++ b/services/ui/src/app/agents/[id]/AgentDetailClient.tsx
@@ -20,7 +20,8 @@ interface Agent {
   rules_md: string
   container_id: string | null
   model_policy_id: string | null
-  skills: Array<{ id: string; name: string; scope: string; kind?: string; tool_dependencies?: string[]; instructions_md?: string }>
+  sandbox_profile?: string | null
+  skills: Array<{ id: string; name: string; scope: string; tools?: Array<{ id: string; name: string }>; instructions_md?: string }>
   error_message: string | null
   created_at: string
   updated_at: string
@@ -40,8 +41,7 @@ interface SkillRecord {
   id: string
   name: string
   scope: string
-  kind?: string
-  tool_dependencies?: string[]
+  tools?: Array<{ id: string; name: string }>
   instructions_md?: string
 }
 
@@ -406,6 +406,18 @@ export default function AgentDetailClient({
                 <dd className="text-white mt-1">{new Date(agent.updated_at).toLocaleString()}</dd>
               </div>
             </dl>
+            {agent.sandbox_profile && (
+              <dl className="grid grid-cols-1 sm:grid-cols-3 gap-4 text-sm mt-4">
+                <div>
+                  <dt className="text-mountain-400">Sandbox Profile</dt>
+                  <dd className="text-white mt-1">
+                    <span className="px-2 py-0.5 text-xs rounded-md bg-navy-800 text-mountain-300 border border-navy-600">
+                      {agent.sandbox_profile}
+                    </span>
+                  </dd>
+                </div>
+              </dl>
+            )}
             {agent.error_message && (
               <div className="mt-3 rounded-md border border-red-700 bg-red-900/30 p-3 text-sm text-red-400">
                 {agent.error_message}
@@ -473,16 +485,9 @@ export default function AgentDetailClient({
                           <span className={`px-1.5 py-0.5 text-xs rounded-md ${badge.colorClasses}`}>
                             {badge.label}
                           </span>
-                          <span className={`px-1.5 py-0.5 text-xs rounded-md ${
-                            skill.kind === 'profile'
-                              ? 'bg-navy-800 text-blue-400 border border-navy-600'
-                              : 'bg-brand-900/50 text-brand-400 border border-brand-700'
-                          }`}>
-                            {skill.kind === 'profile' ? 'Profile' : 'Skill'}
-                          </span>
-                          {skill.tool_dependencies && skill.tool_dependencies.length > 0 && (
+                          {skill.tools && skill.tools.length > 0 && (
                             <span className="px-1.5 py-0.5 text-xs rounded-md bg-navy-800 text-mountain-300 border border-navy-600 font-mono">
-                              Requires: {skill.tool_dependencies.join(', ')}
+                              Tools: {skill.tools.map(t => t.name).join(', ')}
                             </span>
                           )}
                         </div>

--- a/services/ui/src/app/agents/new/AgentFormClient.tsx
+++ b/services/ui/src/app/agents/new/AgentFormClient.tsx
@@ -25,8 +25,7 @@ interface SkillOption {
   tools_config: ToolsConfig
   instructions_md?: string
   is_platform: boolean
-  kind?: 'skill' | 'profile'
-  tool_dependencies?: string[]
+  tools?: Array<{ id: string; name: string }>
 }
 
 const ELEVATED_SCOPES = ['host_docker', 'vps_system']
@@ -67,6 +66,7 @@ export default function AgentFormClient({
     rules_md: string
     model_policy_id?: string | null
     skills?: Array<{ id: string; name: string; scope: string }>
+    sandbox_profile?: string | null
   }
   agentUuid?: string
   disabled?: boolean
@@ -90,6 +90,7 @@ export default function AgentFormClient({
   const [modelPolicyId, setModelPolicyId] = useState(initial?.model_policy_id || '')
   const [policies, setPolicies] = useState<PolicyOption[]>([])
   const [skills, setSkills] = useState<SkillOption[]>([])
+  const [sandboxProfile, setSandboxProfile] = useState(initial?.sandbox_profile || '')
   // Mode: 'custom' = manual tools_config; 'skills' = checkbox multi-select
   const hasInitialSkills = (initial?.skills?.length ?? 0) > 0
   const [mode, setMode] = useState<'custom' | 'skills'>(
@@ -182,6 +183,7 @@ export default function AgentFormClient({
       rules_md: rulesMd,
       model_policy_id: modelPolicyId || null,
       skill_ids: mode === 'skills' ? [...selectedSkillIds] : [],
+      sandbox_profile: sandboxProfile || null,
     }
 
     try {
@@ -287,6 +289,23 @@ export default function AgentFormClient({
       <fieldset disabled={disabled} className="space-y-4">
         <legend className="text-lg font-semibold text-white mb-4">Tools</legend>
 
+        {/* Sandbox Profile */}
+        <div className="mb-4">
+          <label htmlFor="sandbox_profile" className="block text-xs font-medium text-mountain-500 uppercase tracking-wide mb-1">Sandbox Profile</label>
+          <select
+            id="sandbox_profile"
+            value={sandboxProfile}
+            onChange={(e) => setSandboxProfile(e.target.value)}
+            className="rounded-lg border border-navy-600 bg-navy-900 px-3 py-2 text-sm text-white focus:border-brand-500 focus:outline-none"
+          >
+            <option value="">None (custom / skill-only)</option>
+            <option value="minimal">Minimal</option>
+            <option value="developer">Developer</option>
+            <option value="research">Research</option>
+            <option value="operator">Operator</option>
+          </select>
+        </div>
+
         {/* Mode radio toggle */}
         <div className="flex items-center gap-4" role="radiogroup" aria-label="Tools mode">
           <label className="flex items-center gap-2 cursor-pointer">
@@ -321,63 +340,30 @@ export default function AgentFormClient({
             </p>
             {(() => {
               const visibleSkills = isAdmin ? skills : skills.filter(s => !ELEVATED_SCOPES.includes(s.scope))
-              const profiles = visibleSkills.filter(s => s.kind === 'profile')
-              const skillItems = visibleSkills.filter(s => s.kind !== 'profile')
               return (
-                <div className="space-y-4">
-                  {profiles.length > 0 && (
-                    <div>
-                      <p className="text-xs font-medium text-mountain-400 uppercase tracking-wide mb-2">Profiles (sandbox presets)</p>
-                      <div className="space-y-2">
-                        {profiles.map((skill) => {
-                          const badge = scopeBadge(skill.scope)
-                          return (
-                            <label key={skill.id} className="flex items-center gap-3 cursor-pointer py-1">
-                              <input
-                                type="checkbox"
-                                checked={selectedSkillIds.has(skill.id)}
-                                onChange={() => handleSkillToggle(skill.id)}
-                                className="rounded border-navy-600"
-                              />
-                              <span className="text-sm text-white">{skill.name}</span>
-                              <span className={`px-1.5 py-0.5 text-xs rounded-md ${badge.colorClasses}`}>
-                                {badge.label}
-                              </span>
-                            </label>
-                          )
-                        })}
-                      </div>
-                    </div>
-                  )}
-                  {skillItems.length > 0 && (
-                    <div>
-                      <p className="text-xs font-medium text-mountain-400 uppercase tracking-wide mb-2">Skills (capabilities)</p>
-                      <div className="space-y-2">
-                        {skillItems.map((skill) => {
-                          const badge = scopeBadge(skill.scope)
-                          return (
-                            <label key={skill.id} className="flex items-center gap-3 cursor-pointer py-1">
-                              <input
-                                type="checkbox"
-                                checked={selectedSkillIds.has(skill.id)}
-                                onChange={() => handleSkillToggle(skill.id)}
-                                className="rounded border-navy-600"
-                              />
-                              <span className="text-sm text-white">{skill.name}</span>
-                              <span className={`px-1.5 py-0.5 text-xs rounded-md ${badge.colorClasses}`}>
-                                {badge.label}
-                              </span>
-                              {skill.tool_dependencies && skill.tool_dependencies.length > 0 && (
-                                <span className="px-1.5 py-0.5 text-xs rounded-md bg-navy-800 text-mountain-300 border border-navy-600 font-mono">
-                                  {skill.tool_dependencies.join(', ')}
-                                </span>
-                              )}
-                            </label>
-                          )
-                        })}
-                      </div>
-                    </div>
-                  )}
+                <div className="space-y-2">
+                  {visibleSkills.map((skill) => {
+                    const badge = scopeBadge(skill.scope)
+                    return (
+                      <label key={skill.id} className="flex items-center gap-3 cursor-pointer py-1">
+                        <input
+                          type="checkbox"
+                          checked={selectedSkillIds.has(skill.id)}
+                          onChange={() => handleSkillToggle(skill.id)}
+                          className="rounded border-navy-600"
+                        />
+                        <span className="text-sm text-white">{skill.name}</span>
+                        <span className={`px-1.5 py-0.5 text-xs rounded-md ${badge.colorClasses}`}>
+                          {badge.label}
+                        </span>
+                        {skill.tools && skill.tools.length > 0 && (
+                          <span className="px-1.5 py-0.5 text-xs rounded-md bg-navy-800 text-mountain-300 border border-navy-600 font-mono">
+                            {skill.tools.map(t => t.name).join(', ')}
+                          </span>
+                        )}
+                      </label>
+                    )
+                  })}
                   {visibleSkills.length === 0 && (
                     <p className="text-xs text-mountain-500">No skills available</p>
                   )}

--- a/services/ui/src/app/api/tools/[...path]/route.ts
+++ b/services/ui/src/app/api/tools/[...path]/route.ts
@@ -1,0 +1,13 @@
+import { NextRequest } from 'next/server'
+import { proxyToApi } from '@/utils/api-proxy'
+
+async function proxyRequest(req: NextRequest, { params }: { params: Promise<{ path: string[] }> }) {
+  const { path } = await params
+  const pathStr = path.join('/')
+  return proxyToApi(req, `/tools/${pathStr}`, { label: 'tools-proxy' })
+}
+
+export const GET = proxyRequest
+export const POST = proxyRequest
+export const PUT = proxyRequest
+export const DELETE = proxyRequest

--- a/services/ui/src/app/api/tools/route.ts
+++ b/services/ui/src/app/api/tools/route.ts
@@ -1,0 +1,9 @@
+import { NextRequest } from 'next/server'
+import { proxyToApi } from '@/utils/api-proxy'
+
+async function proxyRequest(req: NextRequest) {
+  return proxyToApi(req, '/tools', { label: 'tools-proxy' })
+}
+
+export const GET = proxyRequest
+export const POST = proxyRequest

--- a/services/ui/src/app/harness/skills/SkillsClient.tsx
+++ b/services/ui/src/app/harness/skills/SkillsClient.tsx
@@ -10,6 +10,15 @@ interface ToolsConfig {
   health: { enabled: boolean }
 }
 
+interface Tool {
+  id: string
+  name: string
+  description: string
+  install_method: string
+  install_ref: string
+  is_platform: boolean
+}
+
 interface Skill {
   id: string
   name: string
@@ -18,8 +27,7 @@ interface Skill {
   tools_config: ToolsConfig
   instructions_md: string
   is_platform: boolean
-  kind: 'skill' | 'profile'
-  tool_dependencies: string[]
+  tools: Array<{ id: string; name: string; description: string; install_method: string }>
   created_at: string
   updated_at: string
 }
@@ -42,17 +50,17 @@ export default function SkillsClient() {
   const isAdmin = (session?.user as any)?.roles?.includes('admin')
 
   const [skills, setSkills] = useState<Skill[]>([])
+  const [allTools, setAllTools] = useState<Tool[]>([])
   const [loading, setLoading] = useState(true)
   const [expandedId, setExpandedId] = useState<string | null>(null)
   const [showForm, setShowForm] = useState(false)
   const [editingId, setEditingId] = useState<string | null>(null)
   const [actionLoading, setActionLoading] = useState<string | null>(null)
+  const [selectedToolIds, setSelectedToolIds] = useState<string[]>([])
   const [formData, setFormData] = useState({
     name: '',
     description: '',
     instructions_md: '',
-    kind: 'skill' as 'skill' | 'profile',
-    tool_dependencies: '',
     shellEnabled: false,
     filesystemEnabled: false,
     readOnly: false,
@@ -78,6 +86,10 @@ export default function SkillsClient() {
 
   useEffect(() => {
     fetchSkills()
+    fetch('/api/tools')
+      .then(res => res.ok ? res.json() : [])
+      .then(data => setAllTools(data))
+      .catch(() => {})
   }, [fetchSkills])
 
   const resetForm = () => {
@@ -85,8 +97,6 @@ export default function SkillsClient() {
       name: '',
       description: '',
       instructions_md: '',
-      kind: 'skill',
-      tool_dependencies: '',
       shellEnabled: false,
       filesystemEnabled: false,
       readOnly: false,
@@ -97,6 +107,7 @@ export default function SkillsClient() {
       denied_paths: '/etc/shadow, /etc/passwd, /root',
       max_timeout: '300',
     })
+    setSelectedToolIds([])
     setFormError('')
     setShowForm(false)
     setEditingId(null)
@@ -132,12 +143,7 @@ export default function SkillsClient() {
       tools_config,
       instructions_md: formData.instructions_md,
     }
-    body.kind = formData.kind
-    if (formData.kind === 'skill' && formData.tool_dependencies.trim()) {
-      body.tool_dependencies = formData.tool_dependencies.split(',').map(s => s.trim()).filter(Boolean)
-    } else {
-      body.tool_dependencies = []
-    }
+    body.tool_ids = selectedToolIds
     if (formData.description.trim()) {
       body.description = formData.description.trim()
     }
@@ -188,8 +194,6 @@ export default function SkillsClient() {
       name: skill.name,
       description: skill.description || '',
       instructions_md: skill.instructions_md || '',
-      kind: skill.kind || 'skill',
-      tool_dependencies: skill.tool_dependencies?.join(', ') || '',
       shellEnabled: tc.shell.enabled,
       filesystemEnabled: tc.filesystem.enabled,
       readOnly: tc.filesystem.read_only,
@@ -200,6 +204,7 @@ export default function SkillsClient() {
       denied_paths: tc.filesystem.denied_paths.join(', '),
       max_timeout: tc.shell.max_timeout.toString(),
     })
+    setSelectedToolIds(skill.tools?.map(t => t.id) || [])
     setEditingId(skill.id)
     setShowForm(true)
     setFormError('')
@@ -213,16 +218,13 @@ export default function SkillsClient() {
     )
   }
 
-  const profiles = skills.filter(s => s.kind === 'profile')
-  const skillItems = skills.filter(s => s.kind === 'skill')
-
   return (
     <>
       <div className="flex items-center justify-between mb-8">
         <div>
           <h1 className="text-2xl font-bold">Skills</h1>
           <p className="text-sm text-mountain-400 mt-1">
-            {profiles.length} profile{profiles.length !== 1 ? 's' : ''}, {skillItems.length} skill{skillItems.length !== 1 ? 's' : ''}
+            {skills.length} skill{skills.length !== 1 ? 's' : ''}
           </p>
         </div>
         {isAdmin && (
@@ -267,39 +269,6 @@ export default function SkillsClient() {
               </div>
             </div>
 
-            {/* Kind selector */}
-            <div>
-              <label className="block text-sm text-mountain-400 mb-1">Kind</label>
-              <div className="flex items-center gap-4">
-                <label className="flex items-center gap-2 text-sm text-white cursor-pointer">
-                  <input type="radio" name="kind" value="skill" checked={formData.kind === 'skill'}
-                    onChange={() => setFormData({ ...formData, kind: 'skill' })} />
-                  Skill
-                </label>
-                <label className="flex items-center gap-2 text-sm text-white cursor-pointer">
-                  <input type="radio" name="kind" value="profile" checked={formData.kind === 'profile'}
-                    onChange={() => setFormData({ ...formData, kind: 'profile' })} />
-                  Profile
-                </label>
-              </div>
-            </div>
-
-            {/* Tool dependencies (skill only) */}
-            {formData.kind === 'skill' && (
-              <div>
-                <label className="block text-sm text-mountain-400 mb-1">
-                  Tool Dependencies <span className="text-mountain-500">(optional, comma-separated)</span>
-                </label>
-                <input
-                  type="text"
-                  value={formData.tool_dependencies}
-                  onChange={(e) => setFormData({ ...formData, tool_dependencies: e.target.value })}
-                  className="w-full rounded-md border border-navy-600 bg-navy-900 px-3 py-2 text-sm text-white font-mono placeholder-mountain-500 focus:border-brand-500 focus:outline-none"
-                  placeholder="gh, git, curl"
-                />
-              </div>
-            )}
-
             {/* Instructions */}
             <div>
               <label className="block text-sm text-mountain-400 mb-1">
@@ -316,6 +285,34 @@ export default function SkillsClient() {
                 Tool access is applied when a skill is assigned to an agent. Instructions take effect on the agent&apos;s next start.
               </p>
             </div>
+
+            {/* Required Tools */}
+            {allTools.length > 0 && (
+              <div>
+                <label className="block text-sm text-mountain-400 mb-2">Required Tools</label>
+                <div className="space-y-2">
+                  {allTools.map((tool) => (
+                    <label key={tool.id} className="flex items-center gap-2 text-sm text-white cursor-pointer">
+                      <input
+                        type="checkbox"
+                        checked={selectedToolIds.includes(tool.id)}
+                        onChange={() => {
+                          setSelectedToolIds(prev =>
+                            prev.includes(tool.id)
+                              ? prev.filter(id => id !== tool.id)
+                              : [...prev, tool.id]
+                          )
+                        }}
+                        className="rounded border-navy-600"
+                        aria-label={tool.name}
+                      />
+                      {tool.name}
+                      <span className="text-xs text-mountain-500">({tool.description})</span>
+                    </label>
+                  ))}
+                </div>
+              </div>
+            )}
 
             {/* Tool toggles */}
             <div className="space-y-3">
@@ -399,188 +396,12 @@ export default function SkillsClient() {
         </div>
       )}
 
-      {/* Profiles section */}
-      <h2 className="text-lg font-semibold text-white mb-3">Profiles (sandbox presets)</h2>
-      {profiles.length === 0 ? (
-        <p className="text-sm text-mountain-500 mb-6">No profiles yet</p>
-      ) : (
-        <div className="space-y-3 mb-6">
-          {profiles.map((skill) => {
-            const isExpanded = expandedId === skill.id
-            const tc = skill.tools_config
-
-            return (
-              <div
-                key={skill.id}
-                className="rounded-lg border border-navy-700 bg-navy-900 overflow-hidden"
-              >
-                {/* Summary row */}
-                <div
-                  className="flex items-center gap-4 px-4 py-3 cursor-pointer hover:bg-navy-800 transition-colors"
-                  onClick={() => setExpandedId(isExpanded ? null : skill.id)}
-                  role="button"
-                  tabIndex={0}
-                  aria-expanded={isExpanded}
-                  onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') setExpandedId(isExpanded ? null : skill.id) }}
-                >
-                  <div className="flex-1 min-w-0">
-                    <div className="flex items-center gap-3">
-                      <span className="font-medium text-white">{skill.name}</span>
-                      {skill.is_platform && (
-                        <span className="px-2 py-0.5 text-xs rounded-md bg-mountain-500/20 text-mountain-300 border border-mountain-500/30">
-                          Platform
-                        </span>
-                      )}
-                      {skill.scope && (
-                        <span className={`px-2 py-0.5 text-xs rounded-md ${scopeBadge(skill.scope).colorClasses}`}>
-                          {scopeBadge(skill.scope).label}
-                        </span>
-                      )}
-                      <div className="flex flex-wrap gap-1">
-                        {tc.shell.enabled && (
-                          <span className="inline-flex items-center gap-1 px-2 py-0.5 text-xs rounded-md bg-brand-900/50 text-brand-400 border border-brand-700">
-                            <Terminal className="w-3 h-3" /> Shell
-                          </span>
-                        )}
-                        {tc.filesystem.enabled && (
-                          <span className="inline-flex items-center gap-1 px-2 py-0.5 text-xs rounded-md bg-brand-900/50 text-brand-400 border border-brand-700">
-                            <FolderOpen className="w-3 h-3" /> Filesystem
-                            {tc.filesystem.read_only && <span className="text-mountain-400">(ro)</span>}
-                          </span>
-                        )}
-                        {tc.health.enabled && (
-                          <span className="inline-flex items-center gap-1 px-2 py-0.5 text-xs rounded-md bg-brand-900/50 text-brand-400 border border-brand-700">
-                            <Heart className="w-3 h-3" /> Health
-                          </span>
-                        )}
-                      </div>
-                    </div>
-                    {skill.description && (
-                      <p className="text-xs text-mountain-400 mt-1 truncate">{skill.description}</p>
-                    )}
-                  </div>
-                  <div className="shrink-0">
-                    <svg
-                      className={`w-4 h-4 text-mountain-400 transition-transform ${isExpanded ? 'rotate-180' : ''}`}
-                      fill="none"
-                      stroke="currentColor"
-                      viewBox="0 0 24 24"
-                    >
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-                    </svg>
-                  </div>
-                </div>
-
-                {/* Expanded detail */}
-                {isExpanded && (
-                  <div className="border-t border-navy-700 px-4 py-4 bg-navy-800/50">
-                    {skill.description && (
-                      <p className="text-sm text-mountain-300 mb-4">{skill.description}</p>
-                    )}
-
-                    {/* Instructions preview */}
-                    {skill.instructions_md && (
-                      <div className="mb-4">
-                        <h3 className="text-xs font-medium text-mountain-400 uppercase tracking-wide mb-2">Instructions</h3>
-                        <div className="rounded-md border border-navy-700 bg-navy-900 p-3">
-                          <p className="text-sm text-mountain-300 whitespace-pre-wrap">{skill.instructions_md}</p>
-                        </div>
-                      </div>
-                    )}
-
-                    <dl className="grid grid-cols-1 sm:grid-cols-2 gap-4 text-sm mb-4">
-                      {/* Shell config */}
-                      <div>
-                        <dt className="text-mountain-400 mb-1">Shell</dt>
-                        <dd className="text-white">
-                          {tc.shell.enabled ? (
-                            <div className="space-y-1">
-                              <div className="flex flex-wrap gap-1">
-                                {tc.shell.allowed_binaries.map((b) => (
-                                  <span key={b} className="px-2 py-0.5 text-xs rounded-md bg-navy-900 text-brand-400 border border-navy-700">
-                                    {b}
-                                  </span>
-                                ))}
-                              </div>
-                              {tc.shell.denied_patterns.length > 0 && (
-                                <div className="text-xs text-mountain-400">
-                                  Denied: {tc.shell.denied_patterns.map((p) => (
-                                    <span key={p} className="px-1.5 py-0.5 rounded bg-red-900/30 text-red-400 border border-red-700/50 mr-1">
-                                      {p}
-                                    </span>
-                                  ))}
-                                </div>
-                              )}
-                              <div className="text-xs text-mountain-500">Timeout: {tc.shell.max_timeout}s</div>
-                            </div>
-                          ) : (
-                            <span className="text-mountain-500">Disabled</span>
-                          )}
-                        </dd>
-                      </div>
-
-                      {/* Filesystem config */}
-                      <div>
-                        <dt className="text-mountain-400 mb-1">Filesystem</dt>
-                        <dd className="text-white">
-                          {tc.filesystem.enabled ? (
-                            <div className="space-y-1">
-                              <div className="text-xs">
-                                {tc.filesystem.read_only ? 'Read-only' : 'Read-write'}
-                              </div>
-                              <div className="flex flex-wrap gap-1">
-                                {tc.filesystem.allowed_paths.map((p) => (
-                                  <span key={p} className="px-2 py-0.5 text-xs rounded-md bg-navy-900 text-brand-400 border border-navy-700">
-                                    {p}
-                                  </span>
-                                ))}
-                              </div>
-                            </div>
-                          ) : (
-                            <span className="text-mountain-500">Disabled</span>
-                          )}
-                        </dd>
-                      </div>
-
-                      <div>
-                        <dt className="text-mountain-400">Created</dt>
-                        <dd className="text-white mt-1">{new Date(skill.created_at).toLocaleString()}</dd>
-                      </div>
-                    </dl>
-
-                    {/* Actions -- admin only, non-platform only */}
-                    {isAdmin && !skill.is_platform && (
-                      <div className="flex items-center gap-2">
-                        <button
-                          onClick={() => handleEdit(skill)}
-                          className="px-3 py-1.5 text-xs font-medium rounded-md border border-navy-600 text-mountain-400 hover:text-white hover:border-navy-500 transition-colors cursor-pointer"
-                        >
-                          Edit
-                        </button>
-                        <button
-                          onClick={() => handleDelete(skill)}
-                          disabled={actionLoading === skill.id}
-                          className="px-3 py-1.5 text-xs font-medium rounded-md border border-red-700 text-red-400 hover:bg-red-900/30 transition-colors disabled:opacity-50 cursor-pointer disabled:cursor-not-allowed"
-                        >
-                          Delete
-                        </button>
-                      </div>
-                    )}
-                  </div>
-                )}
-              </div>
-            )
-          })}
-        </div>
-      )}
-
-      {/* Skills section */}
-      <h2 className="text-lg font-semibold text-white mb-3">Skills (capabilities)</h2>
-      {skillItems.length === 0 ? (
+      {/* Skills list */}
+      {skills.length === 0 ? (
         <p className="text-sm text-mountain-500 mb-6">No skills yet</p>
       ) : (
         <div className="space-y-3">
-          {skillItems.map((skill) => {
+          {skills.map((skill) => {
             const isExpanded = expandedId === skill.id
             const tc = skill.tools_config
 
@@ -628,9 +449,9 @@ export default function SkillsClient() {
                             <Heart className="w-3 h-3" /> Health
                           </span>
                         )}
-                        {skill.tool_dependencies?.length > 0 && (
+                        {skill.tools?.length > 0 && (
                           <span className="inline-flex items-center gap-1 px-2 py-0.5 text-xs rounded-md bg-navy-800 text-mountain-300 border border-navy-600 font-mono">
-                            Requires: {skill.tool_dependencies.join(', ')}
+                            Tools: {skill.tools.map(t => t.name).join(', ')}
                           </span>
                         )}
                       </div>


### PR DESCRIPTION
## Summary

- Profiles removed from the skills concept entirely — demoted to `sandbox_profile` column on agents backed by hardcoded constants
- Tools introduced as first-class entities (`tools` table, 12 seeded platform tools with honest `install_method` classification: 10 builtin, 2 binary)
- `skill_tools` M:N join table replaces `tool_dependencies` string arrays
- 4 example capability skills seeded (Claude Code, Codex, Hostinger, VPS Administration) — all tools builtin, all fully functional
- `kind` and `tool_dependencies` columns dropped from skills
- New `/tools` CRUD routes (admin write, user read)
- Skills routes accept `tool_ids` and return `tools` array
- Agents accept `sandbox_profile` on create/update with merge logic (profile base + skill overlay)
- OpenAPI spec updated for all schema changes
- UI: SkillsClient shows tool badges + picker, AgentFormClient has sandbox profile dropdown, AgentDetailClient shows profile badge + tool names

## Test plan

- [x] V1: Tools route tests — 10/10 pass (T1-T10)
- [x] V2: Skills route tests — 35/35 pass (T11-T17, T25-T28 + existing updated)
- [x] V3: Agent skill tests — 24/24 pass (T18-T23 + existing)
- [x] V4: Merge config tests — 15/15 pass (T24 + existing)
- [x] V5: Full API suite — 316/316 pass, 28 suites, 0 regressions
- [x] V6: Full UI suite — 300/300 pass, 33 suites, 0 regressions
- [x] V7: TypeScript API `--noEmit` — 0 errors
- [x] V8: TypeScript UI `--noEmit` — 9 pre-existing only
- [x] V9: OpenAPI source/mirror identical
- [x] V10: OpenAPI drift check pass (docs.test 13/13)
- [x] V11: No `kind` references in skills.ts — 0 matches
- [ ] V12: CI green

### Files changed (22)

**New (6):** migration 021, sandbox-profiles.ts, tools.ts routes, routes-tools.test.ts, 2 UI proxy routes
**Modified (16):** app.ts, skills.ts, agents.ts, openapi.yaml (2), docs.test.ts, 3 backend test files, 3 UI components, 3 UI test files

### Phase 6B dependency

This phase creates the `install_method` and `install_ref` columns on the tools table with honest classifications (verified from agentbox Dockerfile). Phase 6B (separate plan required) will implement the runtime tool installation lifecycle that reads these fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)