### PR TITLE
feat: expose tools management and editable seeded skills

### DIFF
--- a/services/api/src/__tests__/routes-skills.test.ts
+++ b/services/api/src/__tests__/routes-skills.test.ts
@@ -225,14 +225,18 @@ describe('Skill CRUD routes', () => {
     expect(res.status).toBe(403);
   });
 
-  it('PUT /skills/:id rejects update of platform skill', async () => {
-    mockQuery.mockResolvedValueOnce({ rows: [developerSkill] });
+  it('PUT /skills/:id admin updates platform skill', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [developerSkill] })
+      .mockResolvedValueOnce({ rows: [{ ...developerSkill, name: 'Renamed Developer' }] });
+    // fetchToolsForSkills query
+    mockQuery.mockResolvedValueOnce({ rows: [] });
     const res = await request(app)
       .put('/skills/skill-dev')
       .set('Authorization', `Bearer ${adminToken}`)
       .send({ name: 'Renamed Developer' });
-    expect(res.status).toBe(403);
-    expect(res.body.error).toContain('platform');
+    expect(res.status).toBe(200);
+    expect(res.body.name).toBe('Renamed Developer');
   });
 
   it('PUT /skills/:id admin updates non-platform skill', async () => {

--- a/services/api/src/__tests__/routes-tools.test.ts
+++ b/services/api/src/__tests__/routes-tools.test.ts
@@ -129,15 +129,19 @@ describe('Tools CRUD routes', () => {
     expect(res.body.name).toBe('renamed');
   });
 
-  // T7: PUT /tools/:id rejects platform tool mutation
-  it('PUT /tools/:id rejects platform tool mutation', async () => {
-    mockQuery.mockResolvedValueOnce({ rows: [{ id: 'tool-1', is_platform: true }] });
+  // T7: PUT /tools/:id updates platform tool (examples remain editable)
+  it('PUT /tools/:id updates platform tool', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ id: 'tool-1' }] })
+      .mockResolvedValueOnce({
+        rows: [{ id: 'tool-1', name: 'bash-updated', description: 'Updated shell', install_method: 'builtin', install_ref: '', is_platform: true, created_at: '2026-01-01T00:00:00Z' }],
+      });
     const res = await request(app)
       .put('/tools/tool-1')
       .set('Authorization', `Bearer ${adminToken}`)
-      .send({ name: 'renamed' });
-    expect(res.status).toBe(403);
-    expect(res.body.error).toContain('platform');
+      .send({ name: 'bash-updated', description: 'Updated shell' });
+    expect(res.status).toBe(200);
+    expect(res.body.name).toBe('bash-updated');
   });
 
   // T8: DELETE /tools/:id deletes non-platform tool

--- a/services/api/src/routes/skills.ts
+++ b/services/api/src/routes/skills.ts
@@ -159,19 +159,15 @@ router.post('/', requireRole('admin'), async (req: Request, res: Response) => {
   }
 });
 
-// Update skill — admin only, platform skills immutable
+// Update skill — admin only
 router.put('/:id', requireRole('admin'), async (req: Request, res: Response) => {
   try {
     const { rows: existing } = await getPool().query(
-      'SELECT id, is_platform FROM skills WHERE id = $1',
+      'SELECT id FROM skills WHERE id = $1',
       [req.params.id]
     );
     if (existing.length === 0) {
       res.status(404).json({ error: 'Skill not found' });
-      return;
-    }
-    if (existing[0].is_platform) {
-      res.status(403).json({ error: 'Cannot modify a platform skill' });
       return;
     }
 

--- a/services/api/src/routes/tools.ts
+++ b/services/api/src/routes/tools.ts
@@ -88,19 +88,15 @@ router.post('/', requireRole('admin'), async (req: Request, res: Response) => {
   }
 });
 
-// Update tool — admin only, platform tools immutable
+// Update tool — admin only
 router.put('/:id', requireRole('admin'), async (req: Request, res: Response) => {
   try {
     const { rows: existing } = await getPool().query(
-      'SELECT id, is_platform FROM tools WHERE id = $1',
+      'SELECT id FROM tools WHERE id = $1',
       [req.params.id]
     );
     if (existing.length === 0) {
       res.status(404).json({ error: 'Tool not found' });
-      return;
-    }
-    if (existing[0].is_platform) {
-      res.status(403).json({ error: 'Cannot modify a platform tool' });
       return;
     }
 

--- a/services/ui/src/__tests__/SkillsClient.test.tsx
+++ b/services/ui/src/__tests__/SkillsClient.test.tsx
@@ -163,16 +163,15 @@ describe('SkillsClient', () => {
     expect(screen.getByPlaceholderText(/behavioral instructions/i)).toBeInTheDocument()
   })
 
-  // T10: Edit form pre-fills instructions_md
-  it('edit form pre-fills instructions_md', async () => {
+  // T10: Edit form pre-fills instructions_md for seeded examples too
+  it('edit form pre-fills instructions_md for seeded skills', async () => {
     render(<SkillsClient />)
 
     await waitFor(() => {
-      expect(screen.getByText('CI Runner')).toBeInTheDocument()
+      expect(screen.getByText('Developer')).toBeInTheDocument()
     })
 
-    // Expand CI Runner (non-platform, has Edit button)
-    fireEvent.click(screen.getByText('CI Runner'))
+    fireEvent.click(screen.getByText('Developer'))
 
     await waitFor(() => {
       expect(screen.getByText('Edit')).toBeInTheDocument()
@@ -186,7 +185,7 @@ describe('SkillsClient', () => {
 
     // Instructions textarea should be pre-filled
     const instructionsTextarea = screen.getByPlaceholderText(/behavioral instructions/i) as HTMLTextAreaElement
-    expect(instructionsTextarea.value).toBe('Run CI pipelines in isolated containers.')
+    expect(instructionsTextarea.value).toBe('You have full developer access with bash, git, make, curl, and jq available. Use /workspace as your primary working directory.')
   })
 
   // T14: Skills admin shows scope badge with correct labels

--- a/services/ui/src/__tests__/ToolsClient.test.tsx
+++ b/services/ui/src/__tests__/ToolsClient.test.tsx
@@ -1,0 +1,136 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+
+let mockSession: any = {
+  data: { user: { name: 'Admin', email: 'admin@hill90.com', roles: ['admin'] }, expires: '2026-12-31' },
+  status: 'authenticated',
+}
+
+vi.mock('next-auth/react', () => ({
+  useSession: () => mockSession,
+}))
+
+const mockFetch = vi.fn()
+vi.stubGlobal('fetch', mockFetch)
+vi.stubGlobal('confirm', vi.fn(() => true))
+vi.stubGlobal('alert', vi.fn())
+
+import ToolsClient from '@/app/harness/tools/ToolsClient'
+import { NAV_ITEMS, type NavGroup } from '@/components/nav-items'
+
+const MOCK_TOOLS = [
+  {
+    id: 'tool-bash',
+    name: 'bash',
+    description: 'Shell',
+    install_method: 'builtin',
+    install_ref: '',
+    is_platform: true,
+    created_at: '2026-01-01T00:00:00Z',
+  },
+  {
+    id: 'tool-gh',
+    name: 'gh',
+    description: 'GitHub CLI',
+    install_method: 'binary',
+    install_ref: 'https://github.com/cli/cli',
+    is_platform: false,
+    created_at: '2026-01-01T00:00:00Z',
+  },
+]
+
+function mockFetchDefaults() {
+  mockFetch.mockImplementation((url: string, opts?: any) => {
+    if (url === '/api/tools' && (!opts || !opts.method || opts.method === 'GET')) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_TOOLS) })
+    }
+    if (url === '/api/tools' && opts?.method === 'POST') {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ id: 'tool-new', ...JSON.parse(opts.body) }) })
+    }
+    if (typeof url === 'string' && url.startsWith('/api/tools/') && opts?.method === 'PUT') {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ id: url.split('/').pop(), ...JSON.parse(opts.body) }) })
+    }
+    if (typeof url === 'string' && url.startsWith('/api/tools/') && opts?.method === 'DELETE') {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+    }
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+  })
+}
+
+describe('ToolsClient', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSession = {
+      data: { user: { name: 'Admin', email: 'admin@hill90.com', roles: ['admin'] }, expires: '2026-12-31' },
+      status: 'authenticated',
+    }
+    mockFetchDefaults()
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('shows Tools page title and fetched tools', async () => {
+    render(<ToolsClient />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Tools')).toBeInTheDocument()
+    })
+
+    expect(screen.getByText('bash')).toBeInTheDocument()
+    expect(screen.getByText('gh')).toBeInTheDocument()
+    expect(screen.getByText('Builtin')).toBeInTheDocument()
+    expect(screen.getByText('Binary')).toBeInTheDocument()
+  })
+
+  it('allows editing seeded tools', async () => {
+    render(<ToolsClient />)
+
+    await waitFor(() => {
+      expect(screen.getByText('bash')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getAllByText('Edit')[0])
+
+    await waitFor(() => {
+      expect(screen.getByText('Edit Tool')).toBeInTheDocument()
+    })
+
+    const nameInput = screen.getByPlaceholderText('gh') as HTMLInputElement
+    expect(nameInput.value).toBe('bash')
+  })
+
+  it('create form can add a tool', async () => {
+    render(<ToolsClient />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Add Tool')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByText('Add Tool'))
+    fireEvent.change(screen.getByPlaceholderText('gh'), { target: { value: 'docker' } })
+    fireEvent.change(screen.getByPlaceholderText('GitHub CLI'), { target: { value: 'Docker CLI' } })
+    fireEvent.change(screen.getByDisplayValue('Builtin'), { target: { value: 'binary' } })
+    fireEvent.change(screen.getByPlaceholderText('Package name or download URL'), { target: { value: 'https://download.docker.com/' } })
+    fireEvent.click(screen.getByText('Create'))
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith('/api/tools', expect.objectContaining({
+        method: 'POST',
+      }))
+    })
+  })
+
+  it('nav items include Tools entry', () => {
+    const harness = NAV_ITEMS.find((item) => item.type === 'group' && item.id === 'harness') as NavGroup
+    expect(harness).toBeDefined()
+    const tools = harness.children.find((c) => c.id === 'tools')
+    expect(tools).toBeDefined()
+    expect(tools!.label).toBe('Tools')
+    expect(tools!.href).toBe('/harness/tools')
+    expect(tools!.adminOnly).toBe(true)
+  })
+})

--- a/services/ui/src/app/harness/skills/SkillsClient.tsx
+++ b/services/ui/src/app/harness/skills/SkillsClient.tsx
@@ -252,7 +252,7 @@ export default function SkillsClient() {
                   value={formData.name}
                   onChange={(e) => setFormData({ ...formData, name: e.target.value })}
                   className="w-full rounded-md border border-navy-600 bg-navy-900 px-3 py-2 text-sm text-white placeholder-mountain-500 focus:border-brand-500 focus:outline-none"
-                  placeholder="Profile name"
+                  placeholder="Skill name"
                 />
               </div>
               <div>
@@ -549,8 +549,8 @@ export default function SkillsClient() {
                       </div>
                     </dl>
 
-                    {/* Actions -- admin only, non-platform only */}
-                    {isAdmin && !skill.is_platform && (
+                    {/* Actions -- admin only; seeded examples remain editable */}
+                    {isAdmin && (
                       <div className="flex items-center gap-2">
                         <button
                           onClick={() => handleEdit(skill)}
@@ -558,13 +558,15 @@ export default function SkillsClient() {
                         >
                           Edit
                         </button>
-                        <button
-                          onClick={() => handleDelete(skill)}
-                          disabled={actionLoading === skill.id}
-                          className="px-3 py-1.5 text-xs font-medium rounded-md border border-red-700 text-red-400 hover:bg-red-900/30 transition-colors disabled:opacity-50 cursor-pointer disabled:cursor-not-allowed"
-                        >
-                          Delete
-                        </button>
+                        {!skill.is_platform && (
+                          <button
+                            onClick={() => handleDelete(skill)}
+                            disabled={actionLoading === skill.id}
+                            className="px-3 py-1.5 text-xs font-medium rounded-md border border-red-700 text-red-400 hover:bg-red-900/30 transition-colors disabled:opacity-50 cursor-pointer disabled:cursor-not-allowed"
+                          >
+                            Delete
+                          </button>
+                        )}
                       </div>
                     )}
                   </div>

--- a/services/ui/src/app/harness/tools/ToolsClient.tsx
+++ b/services/ui/src/app/harness/tools/ToolsClient.tsx
@@ -1,0 +1,299 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+import { useSession } from 'next-auth/react'
+
+interface Tool {
+  id: string
+  name: string
+  description: string
+  install_method: 'builtin' | 'apt' | 'binary'
+  install_ref: string
+  is_platform: boolean
+  created_at: string
+}
+
+function installMethodBadge(method: Tool['install_method']): { label: string; classes: string } {
+  switch (method) {
+    case 'builtin':
+      return { label: 'Builtin', classes: 'bg-brand-900/50 text-brand-400 border border-brand-700' }
+    case 'apt':
+      return { label: 'APT', classes: 'bg-amber-900/50 text-amber-400 border border-amber-700' }
+    case 'binary':
+      return { label: 'Binary', classes: 'bg-red-900/50 text-red-400 border border-red-700' }
+  }
+}
+
+export default function ToolsClient() {
+  const { data: session } = useSession()
+  const isAdmin = (session?.user as any)?.roles?.includes('admin')
+
+  const [tools, setTools] = useState<Tool[]>([])
+  const [loading, setLoading] = useState(true)
+  const [showForm, setShowForm] = useState(false)
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [actionLoading, setActionLoading] = useState<string | null>(null)
+  const [formError, setFormError] = useState('')
+  const [formData, setFormData] = useState({
+    name: '',
+    description: '',
+    install_method: 'builtin' as Tool['install_method'],
+    install_ref: '',
+  })
+
+  const fetchTools = useCallback(async () => {
+    try {
+      const res = await fetch('/api/tools')
+      if (res.ok) setTools(await res.json())
+    } catch (err) {
+      console.error('Failed to fetch tools:', err)
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    fetchTools()
+  }, [fetchTools])
+
+  const resetForm = () => {
+    setFormData({ name: '', description: '', install_method: 'builtin', install_ref: '' })
+    setFormError('')
+    setEditingId(null)
+    setShowForm(false)
+  }
+
+  const handleEdit = (tool: Tool) => {
+    setFormData({
+      name: tool.name,
+      description: tool.description || '',
+      install_method: tool.install_method,
+      install_ref: tool.install_ref || '',
+    })
+    setEditingId(tool.id)
+    setFormError('')
+    setShowForm(true)
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setFormError('')
+
+    if (!formData.name.trim()) {
+      setFormError('Name is required')
+      return
+    }
+
+    const body: Record<string, string> = {
+      name: formData.name.trim(),
+      install_method: formData.install_method,
+    }
+    if (formData.description.trim()) body.description = formData.description.trim()
+    if (formData.install_ref.trim()) body.install_ref = formData.install_ref.trim()
+
+    try {
+      const url = editingId ? `/api/tools/${editingId}` : '/api/tools'
+      const res = await fetch(url, {
+        method: editingId ? 'PUT' : 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      })
+
+      if (res.ok) {
+        resetForm()
+        await fetchTools()
+      } else {
+        const data = await res.json()
+        setFormError(data.error || (editingId ? 'Failed to update tool' : 'Failed to create tool'))
+      }
+    } catch {
+      setFormError('Request failed')
+    }
+  }
+
+  const handleDelete = async (tool: Tool) => {
+    if (!confirm(`Delete tool "${tool.name}"? Skills referencing it must be updated first.`)) return
+    setActionLoading(tool.id)
+    try {
+      const res = await fetch(`/api/tools/${tool.id}`, { method: 'DELETE' })
+      if (res.ok) {
+        await fetchTools()
+      } else {
+        const data = await res.json()
+        alert(data.error || 'Failed to delete tool')
+      }
+    } catch {
+      alert('Failed to delete tool')
+    } finally {
+      setActionLoading(null)
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-24">
+        <div className="h-8 w-8 rounded-full border-2 border-brand-500 border-t-transparent animate-spin" />
+      </div>
+    )
+  }
+
+  return (
+    <>
+      <div className="flex items-center justify-between mb-8">
+        <div>
+          <h1 className="text-2xl font-bold">Tools</h1>
+          <p className="text-sm text-mountain-400 mt-1">
+            Tools are dependencies that skills can reference.
+          </p>
+        </div>
+        {isAdmin && (
+          <button
+            onClick={() => { resetForm(); setShowForm(true) }}
+            className="px-4 py-2 text-sm font-medium rounded-lg bg-brand-600 hover:bg-brand-500 text-white transition-colors cursor-pointer"
+          >
+            Add Tool
+          </button>
+        )}
+      </div>
+
+      {showForm && (
+        <div className="rounded-lg border border-navy-700 bg-navy-800 p-5 mb-6">
+          <h2 className="text-lg font-semibold text-white mb-4">
+            {editingId ? 'Edit Tool' : 'New Tool'}
+          </h2>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <div>
+                <label className="block text-sm text-mountain-400 mb-1">Name</label>
+                <input
+                  type="text"
+                  value={formData.name}
+                  onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+                  className="w-full rounded-md border border-navy-600 bg-navy-900 px-3 py-2 text-sm text-white placeholder-mountain-500 focus:border-brand-500 focus:outline-none"
+                  placeholder="gh"
+                />
+              </div>
+              <div>
+                <label className="block text-sm text-mountain-400 mb-1">Install Method</label>
+                <select
+                  value={formData.install_method}
+                  onChange={(e) => setFormData({ ...formData, install_method: e.target.value as Tool['install_method'] })}
+                  className="w-full rounded-md border border-navy-600 bg-navy-900 px-3 py-2 text-sm text-white focus:border-brand-500 focus:outline-none"
+                >
+                  <option value="builtin">Builtin</option>
+                  <option value="apt">APT</option>
+                  <option value="binary">Binary</option>
+                </select>
+              </div>
+            </div>
+
+            <div>
+              <label className="block text-sm text-mountain-400 mb-1">
+                Description <span className="text-mountain-500">(optional)</span>
+              </label>
+              <input
+                type="text"
+                value={formData.description}
+                onChange={(e) => setFormData({ ...formData, description: e.target.value })}
+                className="w-full rounded-md border border-navy-600 bg-navy-900 px-3 py-2 text-sm text-white placeholder-mountain-500 focus:border-brand-500 focus:outline-none"
+                placeholder="GitHub CLI"
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm text-mountain-400 mb-1">
+                Install Reference <span className="text-mountain-500">(optional)</span>
+              </label>
+              <input
+                type="text"
+                value={formData.install_ref}
+                onChange={(e) => setFormData({ ...formData, install_ref: e.target.value })}
+                className="w-full rounded-md border border-navy-600 bg-navy-900 px-3 py-2 text-sm text-white placeholder-mountain-500 focus:border-brand-500 focus:outline-none"
+                placeholder="Package name or download URL"
+              />
+            </div>
+
+            {formError && (
+              <p className="text-sm text-red-400">{formError}</p>
+            )}
+
+            <div className="flex items-center gap-2">
+              <button
+                type="submit"
+                className="px-4 py-2 text-sm font-medium rounded-lg bg-brand-600 hover:bg-brand-500 text-white transition-colors cursor-pointer"
+              >
+                {editingId ? 'Update' : 'Create'}
+              </button>
+              <button
+                type="button"
+                onClick={resetForm}
+                className="px-4 py-2 text-sm font-medium rounded-lg border border-navy-600 text-mountain-400 hover:text-white hover:border-navy-500 transition-colors cursor-pointer"
+              >
+                Cancel
+              </button>
+            </div>
+          </form>
+        </div>
+      )}
+
+      {tools.length === 0 ? (
+        <p className="text-sm text-mountain-500 mb-6">No tools yet</p>
+      ) : (
+        <div className="space-y-3">
+          {tools.map((tool) => {
+            const badge = installMethodBadge(tool.install_method)
+            return (
+              <div
+                key={tool.id}
+                className="rounded-lg border border-navy-700 bg-navy-900 px-4 py-4"
+              >
+                <div className="flex items-start justify-between gap-4">
+                  <div className="min-w-0">
+                    <div className="flex items-center gap-3 flex-wrap">
+                      <span className="font-medium text-white">{tool.name}</span>
+                      {tool.is_platform && (
+                        <span className="px-2 py-0.5 text-xs rounded-md bg-mountain-500/20 text-mountain-300 border border-mountain-500/30">
+                          Seeded
+                        </span>
+                      )}
+                      <span className={`px-2 py-0.5 text-xs rounded-md ${badge.classes}`}>
+                        {badge.label}
+                      </span>
+                    </div>
+                    {tool.description && (
+                      <p className="text-sm text-mountain-300 mt-1">{tool.description}</p>
+                    )}
+                    {tool.install_ref && (
+                      <p className="text-xs text-mountain-500 mt-2 font-mono break-all">
+                        {tool.install_ref}
+                      </p>
+                    )}
+                  </div>
+                  {isAdmin && (
+                    <div className="flex items-center gap-2 shrink-0">
+                      <button
+                        onClick={() => handleEdit(tool)}
+                        className="px-3 py-1.5 text-xs font-medium rounded-md border border-navy-600 text-mountain-400 hover:text-white hover:border-navy-500 transition-colors cursor-pointer"
+                      >
+                        Edit
+                      </button>
+                      {!tool.is_platform && (
+                        <button
+                          onClick={() => handleDelete(tool)}
+                          disabled={actionLoading === tool.id}
+                          className="px-3 py-1.5 text-xs font-medium rounded-md border border-red-700 text-red-400 hover:bg-red-900/30 transition-colors disabled:opacity-50 cursor-pointer disabled:cursor-not-allowed"
+                        >
+                          Delete
+                        </button>
+                      )}
+                    </div>
+                  )}
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      )}
+    </>
+  )
+}

--- a/services/ui/src/app/harness/tools/page.tsx
+++ b/services/ui/src/app/harness/tools/page.tsx
@@ -1,0 +1,20 @@
+import { redirect } from 'next/navigation'
+import { auth } from '@/auth'
+import AppShell from '@/components/AppShell'
+import ToolsClient from './ToolsClient'
+
+export default async function ToolsPage() {
+  const session = await auth()
+
+  if (!session) {
+    redirect('/api/auth/signin')
+  }
+
+  return (
+    <AppShell>
+      <main className="flex-1 px-6 py-12 max-w-6xl mx-auto w-full">
+        <ToolsClient />
+      </main>
+    </AppShell>
+  )
+}

--- a/services/ui/src/components/nav-items.ts
+++ b/services/ui/src/components/nav-items.ts
@@ -36,6 +36,7 @@ export const NAV_ITEMS: NavItem[] = [
       { type: 'link', id: 'models', label: 'Models', href: '/harness/models', icon: Cpu },
       { type: 'link', id: 'policies', label: 'Policies', href: '/harness/policies', icon: Shield },
       { type: 'link', id: 'skills', label: 'Skills', href: '/harness/skills', icon: Wrench },
+      { type: 'link', id: 'tools', label: 'Tools', href: '/harness/tools', icon: Settings, adminOnly: true },
       { type: 'link', id: 'usage', label: 'Usage', href: '/harness/usage', icon: BarChart3 },
       { type: 'link', id: 'knowledge', label: 'Knowledge', href: '/harness/knowledge', icon: BookOpen },
       { type: 'link', id: 'shared-knowledge', label: 'Shared Knowledge', href: '/harness/shared-knowledge', icon: Library },


### PR DESCRIPTION
## Summary\n- make seeded example skills editable by admins instead of treating them as immutable platform records\n- add a Tools harness screen so the existing tools API is reachable from the UI\n- keep seeded delete protection in place while exposing create/edit for tools and skills\n\n## Validation\n- [x] \n- [x] 
 RUN  v3.2.4 /Users/jon/source/repos/Personal/Hill90/services/ui

 ✓ src/__tests__/ToolsClient.test.tsx (4 tests) 50ms
 ✓ src/__tests__/SkillsClient.test.tsx (9 tests) 108ms

 Test Files  2 passed (2)
      Tests  13 passed (13)
   Start at  01:31:27
   Duration  990ms (transform 117ms, setup 0ms, collect 464ms, tests 158ms, environment 610ms, prepare 75ms)\n- [x] \n- [x] src/__tests__/middleware.test.ts(39,20): error TS2554: Expected 2 arguments, but got 1.
src/__tests__/middleware.test.ts(51,20): error TS2554: Expected 2 arguments, but got 1.
src/__tests__/middleware.test.ts(61,20): error TS2554: Expected 2 arguments, but got 1.
src/__tests__/middleware.test.ts(73,20): error TS2554: Expected 2 arguments, but got 1.
src/__tests__/middleware.test.ts(85,20): error TS2554: Expected 2 arguments, but got 1.
src/__tests__/middleware.test.ts(94,20): error TS2554: Expected 2 arguments, but got 1.
src/__tests__/middleware.test.ts(103,20): error TS2554: Expected 2 arguments, but got 1.
src/__tests__/middleware.test.ts(115,20): error TS2554: Expected 2 arguments, but got 1.
src/__tests__/UsageClient.test.tsx(134,24): error TS2345: Argument of type '{ data: { model_name: string; total_requests: number; total_tokens: number; total_cost_usd: number; }[]; group_by: string; }' is not assignable to parameter of type '{ data: { agent_id: string; total_requests: number; total_tokens: number; total_cost_usd: number; }[]; group_by: string; }'.
  Types of property 'data' are incompatible.
    Type '{ model_name: string; total_requests: number; total_tokens: number; total_cost_usd: number; }[]' is not assignable to type '{ agent_id: string; total_requests: number; total_tokens: number; total_cost_usd: number; }[]'.
      Property 'agent_id' is missing in type '{ model_name: string; total_requests: number; total_tokens: number; total_cost_usd: number; }' but required in type '{ agent_id: string; total_requests: number; total_tokens: number; total_cost_usd: number; }'. (9 pre-existing errors only; none introduced by this change)\n