### PR TITLE
feat: install skill tool dependencies at agent start

### DIFF
--- a/services/api/src/__tests__/routes-agents-skill.test.ts
+++ b/services/api/src/__tests__/routes-agents-skill.test.ts
@@ -28,6 +28,9 @@ jest.mock('../services/agent-files', () => ({
   writeAgentFiles: jest.fn(),
   removeAgentFiles: jest.fn(),
 }));
+jest.mock('../services/tool-installer', () => ({
+  ensureRequiredToolsInstalled: jest.fn().mockResolvedValue(undefined),
+}));
 
 const app = createApp({
   issuer: TEST_ISSUER,

--- a/services/api/src/__tests__/routes-agents.test.ts
+++ b/services/api/src/__tests__/routes-agents.test.ts
@@ -14,14 +14,17 @@ const TEST_ISSUER = 'https://auth.hill90.com/realms/hill90';
 
 // Mock pg pool
 const mockQuery = jest.fn();
+const mockCreateAndStartContainer = jest.fn().mockResolvedValue('container-id-123');
+const mockStopAndRemoveContainer = jest.fn().mockResolvedValue(undefined);
+const mockEnsureRequiredToolsInstalled = jest.fn().mockResolvedValue(undefined);
 jest.mock('../db/pool', () => ({
   getPool: () => ({ query: mockQuery }),
 }));
 
 // Mock docker service
 jest.mock('../services/docker', () => ({
-  createAndStartContainer: jest.fn().mockResolvedValue('container-id-123'),
-  stopAndRemoveContainer: jest.fn().mockResolvedValue(undefined),
+  createAndStartContainer: (...args: any[]) => mockCreateAndStartContainer(...args),
+  stopAndRemoveContainer: (...args: any[]) => mockStopAndRemoveContainer(...args),
   inspectContainer: jest.fn().mockResolvedValue({ status: 'running', containerId: 'abc', health: 'healthy' }),
   getContainerLogs: jest.fn(),
   removeAgentVolumes: jest.fn().mockResolvedValue(undefined),
@@ -32,6 +35,9 @@ jest.mock('../services/docker', () => ({
 jest.mock('../services/agent-files', () => ({
   writeAgentFiles: jest.fn().mockReturnValue('/data/agentbox/test-agent'),
   removeAgentFiles: jest.fn(),
+}));
+jest.mock('../services/tool-installer', () => ({
+  ensureRequiredToolsInstalled: (...args: any[]) => mockEnsureRequiredToolsInstalled(...args),
 }));
 
 const app = createApp({
@@ -171,6 +177,12 @@ describe('Agent CRUD routes', () => {
 describe('Agent lifecycle routes', () => {
   beforeEach(() => {
     mockQuery.mockReset();
+    mockCreateAndStartContainer.mockReset();
+    mockCreateAndStartContainer.mockResolvedValue('container-id-123');
+    mockStopAndRemoveContainer.mockReset();
+    mockStopAndRemoveContainer.mockResolvedValue(undefined);
+    mockEnsureRequiredToolsInstalled.mockReset();
+    mockEnsureRequiredToolsInstalled.mockResolvedValue(undefined);
     process.env.DATABASE_URL = 'postgresql://test:test@localhost:5432/test';
     process.env.AGENTBOX_CONFIG_HOST_PATH = '/opt/hill90/agentbox-configs';
   });
@@ -213,6 +225,30 @@ describe('Agent lifecycle routes', () => {
     expect(res.status).toBe(200);
     expect(res.body.status).toBe('running');
     expect(res.body.container_id).toBe('container-id-123');
+  });
+
+  it('POST /agents/:id/start cleans up and marks error when tool install fails', async () => {
+    mockQuery
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'uuid-1', agent_id: 'test-agent', name: 'Test',
+          tools_config: {}, cpus: '1.0', mem_limit: '1g', pids_limit: 200,
+          soul_md: '', rules_md: '', description: '',
+        }],
+      })
+      .mockResolvedValueOnce({ rows: [] }) // SELECT agent_skills (no skill instructions)
+      .mockResolvedValueOnce({ rows: [] }); // UPDATE status=error in catch block
+    mockEnsureRequiredToolsInstalled.mockRejectedValueOnce(new Error('gh install failed'));
+
+    const res = await request(app)
+      .post('/agents/uuid-1/start')
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe('Failed to start agent');
+    expect(res.body.detail).toContain('Tool installation failed');
+    expect(mockStopAndRemoveContainer).toHaveBeenCalledWith('test-agent');
+    expect(mockEnsureRequiredToolsInstalled).toHaveBeenCalledWith('uuid-1', 'test-agent');
   });
 
   it('POST /agents/:id/stop requires admin role', async () => {

--- a/services/api/src/__tests__/tool-installer.test.ts
+++ b/services/api/src/__tests__/tool-installer.test.ts
@@ -1,0 +1,74 @@
+import { ensureRequiredToolsInstalled } from '../services/tool-installer';
+
+const mockQuery = jest.fn();
+const mockExec = jest.fn();
+
+jest.mock('../db/pool', () => ({
+  getPool: () => ({ query: mockQuery }),
+}));
+
+jest.mock('../services/docker', () => ({
+  execInContainerWithExit: (...args: any[]) => mockExec(...args),
+}));
+
+describe('tool-installer service', () => {
+  beforeEach(() => {
+    mockQuery.mockReset();
+    mockExec.mockReset();
+  });
+
+  it('no-ops when agent has no required tools', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] }); // required tools
+
+    await ensureRequiredToolsInstalled('agent-db-id', 'agent-slug');
+
+    expect(mockExec).not.toHaveBeenCalled();
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+  });
+
+  it('marks builtin tool installed when command exists', async () => {
+    mockQuery
+      .mockResolvedValueOnce({
+        rows: [{ id: 'tool-bash', name: 'bash', install_method: 'builtin', install_ref: '' }],
+      }) // required tools
+      .mockResolvedValue({ rowCount: 1 }); // status upserts
+    mockExec.mockResolvedValue({ exitCode: 0, stdout: '/usr/bin/bash\n', stderr: '' });
+
+    await ensureRequiredToolsInstalled('agent-db-id', 'agent-slug');
+
+    expect(mockExec).toHaveBeenCalledWith('agent-slug', ['bash', '-lc', 'command -v bash']);
+    expect(mockQuery).toHaveBeenCalled();
+  });
+
+  it('installs binary gh into persistent tools path', async () => {
+    mockQuery
+      .mockResolvedValueOnce({
+        rows: [{ id: 'tool-gh', name: 'gh', install_method: 'binary', install_ref: 'https://github.com/cli/cli/releases/download/v{version}/gh_{version}_linux_amd64.tar.gz' }],
+      }) // required tools
+      .mockResolvedValue({ rowCount: 1 }); // status upserts
+    mockExec.mockResolvedValue({ exitCode: 0, stdout: '', stderr: '' });
+
+    await ensureRequiredToolsInstalled('agent-db-id', 'agent-slug');
+
+    expect(mockExec).toHaveBeenCalledTimes(1);
+    const call = mockExec.mock.calls[0];
+    expect(call[0]).toBe('agent-slug');
+    expect(call[1][0]).toBe('bash');
+    expect(call[1][1]).toBe('-lc');
+    expect(call[1][2]).toContain('/data/tools/bin/gh');
+  });
+
+  it('marks tool failed and throws on install error', async () => {
+    mockQuery
+      .mockResolvedValueOnce({
+        rows: [{ id: 'tool-bash', name: 'bash', install_method: 'builtin', install_ref: '' }],
+      }) // required tools
+      .mockResolvedValue({ rowCount: 1 }); // pending + failed upserts
+    mockExec.mockResolvedValue({ exitCode: 1, stdout: '', stderr: 'not found' });
+
+    await expect(ensureRequiredToolsInstalled('agent-db-id', 'agent-slug')).rejects.toThrow(
+      /Failed installing required tool "bash"/
+    );
+  });
+});
+

--- a/services/api/src/db/migrations/022_agent_tool_install_state.sql
+++ b/services/api/src/db/migrations/022_agent_tool_install_state.sql
@@ -1,0 +1,14 @@
+-- Phase 6B foundation: persistent per-agent tool installation status
+
+CREATE TABLE IF NOT EXISTS agent_tool_installs (
+    agent_id UUID NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+    tool_id UUID NOT NULL REFERENCES tools(id) ON DELETE CASCADE,
+    status VARCHAR(16) NOT NULL CHECK (status IN ('pending', 'installed', 'failed')),
+    install_message TEXT DEFAULT '',
+    installed_at TIMESTAMPTZ,
+    updated_at TIMESTAMPTZ DEFAULT NOW(),
+    PRIMARY KEY (agent_id, tool_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_tool_installs_status ON agent_tool_installs(status);
+

--- a/services/api/src/routes/agents.ts
+++ b/services/api/src/routes/agents.ts
@@ -5,6 +5,7 @@ import { scopeToOwner } from '../helpers/scope';
 import { writeAgentFiles, removeAgentFiles } from '../services/agent-files';
 import { mergeToolsConfigs, DEFAULT_TOOLS_CONFIG } from '../services/merge-tools-config';
 import { getSandboxProfileConfig, VALID_SANDBOX_PROFILES } from '../services/sandbox-profiles';
+import { ensureRequiredToolsInstalled } from '../services/tool-installer';
 import {
   createAndStartContainer,
   stopAndRemoveContainer,
@@ -551,6 +552,19 @@ router.post('/:id/start', requireRole('admin'), async (req: Request, res: Respon
       pidsLimit: agent.pids_limit,
       env: [...akmEnv, ...modelRouterEnv],
     });
+
+    // Phase 6B: ensure required tools are installed for assigned skills.
+    // Installation writes persistent status to agent_tool_installs.
+    try {
+      await ensureRequiredToolsInstalled(agent.id, agent.agent_id);
+    } catch (installErr: any) {
+      try {
+        await stopAndRemoveContainer(agent.agent_id);
+      } catch (cleanupErr) {
+        console.error('[agents] Cleanup failed after tool install error:', cleanupErr);
+      }
+      throw new Error(`Tool installation failed: ${installErr?.message || installErr}`);
+    }
 
     // Store AKM JTI + exp for revocation on stop
     if (akmJti) {

--- a/services/api/src/services/docker.ts
+++ b/services/api/src/services/docker.ts
@@ -85,6 +85,7 @@ export async function createAndStartContainer(opts: CreateAgentContainerOpts): P
     Env: [
       `AGENT_ID=${opts.agentId}`,
       `AGENT_CONFIG=/etc/agentbox/agent.yml`,
+      'PATH=/data/tools/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
       ...(opts.env || []),
     ],
     Labels: {
@@ -243,6 +244,66 @@ export async function execInContainer(
   });
   rawStream.pipe(demux);
   return demux;
+}
+
+export async function execInContainerWithExit(
+  agentId: string,
+  cmd: string[],
+): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+  const containerName = `${CONTAINER_PREFIX}${agentId}`;
+  assertAgentboxName(containerName);
+
+  const container = docker.getContainer(containerName);
+  const info = await container.inspect();
+  assertManagedLabel(info.Config.Labels);
+
+  const exec = await container.exec({
+    Cmd: cmd,
+    AttachStdout: true,
+    AttachStderr: true,
+    Tty: false,
+  });
+
+  const rawStream = await exec.start({ hijack: true, stdin: false });
+
+  const stdoutChunks: Buffer[] = [];
+  const stderrChunks: Buffer[] = [];
+  let remainder: Buffer | null = null;
+
+  await new Promise<void>((resolve, reject) => {
+    rawStream.on('data', (chunk: Buffer) => {
+      let buf: Buffer = remainder ? Buffer.concat([remainder, chunk]) : chunk;
+      remainder = null;
+      let offset = 0;
+      while (offset < buf.length) {
+        if (offset + 8 > buf.length) {
+          remainder = buf.slice(offset);
+          break;
+        }
+        const payloadSize = buf.readUInt32BE(offset + 4);
+        const frameEnd = offset + 8 + payloadSize;
+        if (frameEnd > buf.length) {
+          remainder = buf.slice(offset);
+          break;
+        }
+        const streamType = buf[offset];
+        const payload = buf.slice(offset + 8, frameEnd);
+        if (streamType === 1) stdoutChunks.push(payload);
+        else if (streamType === 2) stderrChunks.push(payload);
+        offset = frameEnd;
+      }
+    });
+    rawStream.on('error', reject);
+    rawStream.on('end', () => resolve());
+    rawStream.on('close', () => resolve());
+  });
+
+  const inspect = await exec.inspect();
+  return {
+    exitCode: inspect.ExitCode ?? 1,
+    stdout: Buffer.concat(stdoutChunks).toString('utf8'),
+    stderr: Buffer.concat(stderrChunks).toString('utf8'),
+  };
 }
 
 export async function removeAgentVolumes(agentId: string): Promise<void> {

--- a/services/api/src/services/tool-installer.ts
+++ b/services/api/src/services/tool-installer.ts
@@ -1,0 +1,135 @@
+import { getPool } from '../db/pool';
+import { execInContainerWithExit } from './docker';
+
+type InstallMethod = 'builtin' | 'apt' | 'binary';
+
+interface ToolRow {
+  id: string;
+  name: string;
+  install_method: InstallMethod;
+  install_ref: string;
+}
+
+const DEFAULT_BINARY_VERSIONS: Record<string, string> = {
+  gh: process.env.HILL90_GH_VERSION || '2.74.2',
+  docker: process.env.HILL90_DOCKER_CLI_VERSION || '28.0.1',
+};
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+async function upsertInstallStatus(
+  agentDbId: string,
+  toolId: string,
+  status: 'pending' | 'installed' | 'failed',
+  installMessage: string,
+  setInstalledAt = false
+): Promise<void> {
+  await getPool().query(
+    `INSERT INTO agent_tool_installs (agent_id, tool_id, status, install_message, installed_at, updated_at)
+     VALUES ($1, $2, $3, $4, CASE WHEN $5 THEN NOW() ELSE NULL END, NOW())
+     ON CONFLICT (agent_id, tool_id)
+     DO UPDATE SET
+       status = EXCLUDED.status,
+       install_message = EXCLUDED.install_message,
+       installed_at = CASE
+         WHEN EXCLUDED.status = 'installed' THEN NOW()
+         ELSE agent_tool_installs.installed_at
+       END,
+       updated_at = NOW()`,
+    [agentDbId, toolId, status, installMessage, setInstalledAt]
+  );
+}
+
+async function installBuiltin(agentSlug: string, tool: ToolRow): Promise<void> {
+  const cmd = ['bash', '-lc', `command -v ${tool.name}`];
+  const result = await execInContainerWithExit(agentSlug, cmd);
+  if (result.exitCode !== 0) {
+    throw new Error(`Builtin tool "${tool.name}" not found in container PATH`);
+  }
+}
+
+async function installApt(agentSlug: string, tool: ToolRow): Promise<void> {
+  const pkg = tool.install_ref?.trim() || tool.name;
+  const cmd = [
+    'bash',
+    '-lc',
+    `command -v ${tool.name} >/dev/null 2>&1 || (apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ${shellQuote(pkg)})`,
+  ];
+  const result = await execInContainerWithExit(agentSlug, cmd);
+  if (result.exitCode !== 0) {
+    throw new Error(`APT install failed for "${tool.name}": ${result.stderr || result.stdout}`.trim());
+  }
+  await installBuiltin(agentSlug, tool);
+}
+
+function binaryInstallScript(tool: ToolRow): string {
+  const version = DEFAULT_BINARY_VERSIONS[tool.name];
+  if (!version) {
+    throw new Error(`Binary install is not supported for tool "${tool.name}"`);
+  }
+  const url = tool.install_ref.replaceAll('{version}', version);
+  if (tool.name === 'gh') {
+    return `
+set -euo pipefail
+mkdir -p /data/tools/bin /tmp/hill90-tools
+if [ -x /data/tools/bin/gh ]; then exit 0; fi
+curl -fsSL ${shellQuote(url)} -o /tmp/hill90-tools/gh.tgz
+tar -xzf /tmp/hill90-tools/gh.tgz -C /tmp/hill90-tools
+cp /tmp/hill90-tools/gh_${version}_linux_amd64/bin/gh /data/tools/bin/gh
+chmod +x /data/tools/bin/gh
+`;
+  }
+  if (tool.name === 'docker') {
+    return `
+set -euo pipefail
+mkdir -p /data/tools/bin /tmp/hill90-tools
+if [ -x /data/tools/bin/docker ]; then exit 0; fi
+curl -fsSL ${shellQuote(url)} -o /tmp/hill90-tools/docker.tgz
+tar -xzf /tmp/hill90-tools/docker.tgz -C /tmp/hill90-tools
+cp /tmp/hill90-tools/docker/docker /data/tools/bin/docker
+chmod +x /data/tools/bin/docker
+`;
+  }
+  throw new Error(`No binary install script available for "${tool.name}"`);
+}
+
+async function installBinary(agentSlug: string, tool: ToolRow): Promise<void> {
+  const script = binaryInstallScript(tool);
+  const result = await execInContainerWithExit(agentSlug, ['bash', '-lc', script]);
+  if (result.exitCode !== 0) {
+    throw new Error(`Binary install failed for "${tool.name}": ${result.stderr || result.stdout}`.trim());
+  }
+}
+
+async function installTool(agentSlug: string, tool: ToolRow): Promise<void> {
+  if (tool.install_method === 'builtin') return installBuiltin(agentSlug, tool);
+  if (tool.install_method === 'apt') return installApt(agentSlug, tool);
+  return installBinary(agentSlug, tool);
+}
+
+export async function ensureRequiredToolsInstalled(agentDbId: string, agentSlug: string): Promise<void> {
+  const { rows } = await getPool().query(
+    `SELECT DISTINCT t.id, t.name, t.install_method, t.install_ref
+     FROM agent_skills asks
+     JOIN skill_tools st ON st.skill_id = asks.skill_id
+     JOIN tools t ON t.id = st.tool_id
+     WHERE asks.agent_id = $1
+     ORDER BY t.name ASC`,
+    [agentDbId]
+  );
+
+  for (const row of rows as ToolRow[]) {
+    await upsertInstallStatus(agentDbId, row.id, 'pending', 'installing');
+    try {
+      await installTool(agentSlug, row);
+      await upsertInstallStatus(agentDbId, row.id, 'installed', 'installed', true);
+    } catch (err: any) {
+      const msg = err?.message || 'installation failed';
+      await upsertInstallStatus(agentDbId, row.id, 'failed', msg);
+      throw new Error(`Failed installing required tool "${row.name}": ${msg}`);
+    }
+  }
+}
+


### PR DESCRIPTION
## Summary
- add `agent_tool_installs` migration for persistent per-agent tool install state
- install required tools from assigned skills during `/agents/:id/start`
- fail start and clean up container if a required tool install fails
- add installer service tests and start failure-path regression test

## Validation
- `cd services/api && npx jest src/__tests__/tool-installer.test.ts --verbose`
- `cd services/api && node_modules/.bin/jest src/__tests__/routes-agents.test.ts src/__tests__/routes-agents-skill.test.ts --verbose`
- `cd services/api && node_modules/.bin/jest --runInBand --verbose`
- `cd services/api && npx tsc --noEmit`
- `cd services/api && node_modules/.bin/jest src/__tests__/docs.test.ts --verbose`
