### PR TITLE
feat: expose agent tool install status and seed github/docker skills

### DIFF
--- a/docs/site/openapi.yaml
+++ b/docs/site/openapi.yaml
@@ -109,6 +109,29 @@ components:
           type: string
           nullable: true
 
+    AgentToolInstallStatus:
+      type: object
+      properties:
+        tool_id:
+          type: string
+          format: uuid
+        tool_name:
+          type: string
+        tool_description:
+          type: string
+        status:
+          type: string
+          enum: [pending, installed, failed]
+        install_message:
+          type: string
+        installed_at:
+          type: string
+          format: date-time
+          nullable: true
+        updated_at:
+          type: string
+          format: date-time
+
     UserProfile:
       type: object
       properties:
@@ -923,6 +946,35 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/AgentStatus"
+        "401":
+          description: Not authenticated
+        "403":
+          description: Requires user role
+        "404":
+          description: Agent not found
+
+  /agents/{id}/tool-installs:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    get:
+      summary: Get agent tool install statuses
+      description: Returns per-tool installation status for the agent. Scoped to ownership.
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Tool install status rows
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/AgentToolInstallStatus"
         "401":
           description: Not authenticated
         "403":

--- a/services/api/src/__tests__/docs.test.ts
+++ b/services/api/src/__tests__/docs.test.ts
@@ -147,6 +147,7 @@ const EXPECTED_PATHS = [
   '/agents/{id}/start',
   '/agents/{id}/stop',
   '/agents/{id}/status',
+  '/agents/{id}/tool-installs',
   '/agents/{id}/events',
   '/agents/{id}/logs',
   '/model-policies',

--- a/services/api/src/__tests__/routes-agents.test.ts
+++ b/services/api/src/__tests__/routes-agents.test.ts
@@ -271,6 +271,42 @@ describe('Agent lifecycle routes', () => {
     expect(call[0]).toContain('created_by = $');
   });
 
+  it('GET /agents/:id/tool-installs returns install statuses for owned agent', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ id: 'uuid-1' }] }) // ownership check
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            tool_id: 'tool-gh',
+            tool_name: 'gh',
+            tool_description: 'GitHub CLI',
+            status: 'installed',
+            install_message: 'installed',
+            installed_at: '2026-03-01T00:00:00Z',
+            updated_at: '2026-03-01T00:00:00Z',
+          },
+        ],
+      });
+
+    const res = await request(app)
+      .get('/agents/uuid-1/tool-installs')
+      .set('Authorization', `Bearer ${userToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+    expect(res.body[0].tool_name).toBe('gh');
+  });
+
+  it('GET /agents/:id/tool-installs returns 404 for unowned agent', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    const res = await request(app)
+      .get('/agents/uuid-1/tool-installs')
+      .set('Authorization', `Bearer ${userToken}`);
+
+    expect(res.status).toBe(404);
+  });
+
   it('GET /agents/:id/logs requires admin role', async () => {
     const res = await request(app)
       .get('/agents/some-id/logs')

--- a/services/api/src/db/migrations/023_seed_github_and_docker_skills.sql
+++ b/services/api/src/db/migrations/023_seed_github_and_docker_skills.sql
@@ -1,0 +1,43 @@
+-- Phase 6C: add concrete GitHub and Docker capability skills.
+
+INSERT INTO skills (name, description, tools_config, instructions_md, scope, is_platform)
+VALUES
+(
+  'GitHub',
+  'Work with repositories, pull requests, and releases using GitHub CLI.',
+  '{"shell":{"enabled":true,"allowed_binaries":["bash","git","gh","curl","jq"],"denied_patterns":["rm -rf /"],"max_timeout":300},"filesystem":{"enabled":true,"read_only":false,"allowed_paths":["/workspace","/data"],"denied_paths":["/etc/shadow","/etc/passwd","/root"]},"health":{"enabled":true}}',
+  E'Use GitHub workflows from inside the agent container.\n- clone, branch, commit, push\n- create and review pull requests\n- inspect and rerun workflow checks\n- use least-privilege credentials for repository operations',
+  'container_local',
+  true
+),
+(
+  'Docker',
+  'Operate Docker on the host through Docker CLI and daemon access.',
+  '{"shell":{"enabled":true,"allowed_binaries":["bash","docker","curl","jq"],"denied_patterns":["rm -rf /"],"max_timeout":600},"filesystem":{"enabled":true,"read_only":false,"allowed_paths":["/workspace","/data"],"denied_paths":["/etc/shadow","/etc/passwd","/root"]},"health":{"enabled":true}}',
+  E'Operate Docker workloads with host-level access.\n- inspect containers, images, volumes, and networks\n- start, stop, restart, and remove containers\n- troubleshoot runtime failures and logs\n- treat as elevated capability requiring admin assignment',
+  'host_docker',
+  true
+)
+ON CONFLICT (name) DO UPDATE SET
+  description = EXCLUDED.description,
+  tools_config = EXCLUDED.tools_config,
+  instructions_md = EXCLUDED.instructions_md,
+  scope = EXCLUDED.scope,
+  is_platform = true;
+
+-- Ensure mappings are canonical for seeded skills.
+DELETE FROM skill_tools st
+USING skills s
+WHERE st.skill_id = s.id
+  AND s.name IN ('GitHub', 'Docker')
+  AND s.is_platform = true;
+
+INSERT INTO skill_tools (skill_id, tool_id)
+SELECT s.id, t.id
+FROM (VALUES
+  ('GitHub', 'gh'), ('GitHub', 'git'), ('GitHub', 'bash'), ('GitHub', 'curl'), ('GitHub', 'jq'),
+  ('Docker', 'docker'), ('Docker', 'bash'), ('Docker', 'curl'), ('Docker', 'jq')
+) AS mappings(skill_name, tool_name)
+JOIN skills s ON s.name = mappings.skill_name
+JOIN tools t ON t.name = mappings.tool_name
+ON CONFLICT DO NOTHING;

--- a/services/api/src/openapi/openapi.yaml
+++ b/services/api/src/openapi/openapi.yaml
@@ -109,6 +109,29 @@ components:
           type: string
           nullable: true
 
+    AgentToolInstallStatus:
+      type: object
+      properties:
+        tool_id:
+          type: string
+          format: uuid
+        tool_name:
+          type: string
+        tool_description:
+          type: string
+        status:
+          type: string
+          enum: [pending, installed, failed]
+        install_message:
+          type: string
+        installed_at:
+          type: string
+          format: date-time
+          nullable: true
+        updated_at:
+          type: string
+          format: date-time
+
     UserProfile:
       type: object
       properties:
@@ -923,6 +946,35 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/AgentStatus"
+        "401":
+          description: Not authenticated
+        "403":
+          description: Requires user role
+        "404":
+          description: Agent not found
+
+  /agents/{id}/tool-installs:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    get:
+      summary: Get agent tool install statuses
+      description: Returns per-tool installation status for the agent. Scoped to ownership.
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Tool install status rows
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/AgentToolInstallStatus"
         "401":
           description: Not authenticated
         "403":

--- a/services/api/src/routes/agents.ts
+++ b/services/api/src/routes/agents.ts
@@ -664,6 +664,36 @@ router.get('/:id/status', requireRole('user'), async (req: Request, res: Respons
   }
 });
 
+// Get per-agent tool installation statuses
+router.get('/:id/tool-installs', requireRole('user'), async (req: Request, res: Response) => {
+  try {
+    const scope = scopeToOwner(req);
+    const paramOffset = scope.params.length + 1;
+    const { rows: agentRows } = await getPool().query(
+      `SELECT id FROM agents WHERE id = $${paramOffset} AND ${scope.where}`,
+      [...scope.params, req.params.id]
+    );
+    if (agentRows.length === 0) {
+      res.status(404).json({ error: 'Agent not found' });
+      return;
+    }
+
+    const { rows } = await getPool().query(
+      `SELECT ati.tool_id, t.name AS tool_name, t.description AS tool_description,
+              ati.status, ati.install_message, ati.installed_at, ati.updated_at
+       FROM agent_tool_installs ati
+       JOIN tools t ON t.id = ati.tool_id
+       WHERE ati.agent_id = $1
+       ORDER BY t.name ASC`,
+      [req.params.id]
+    );
+    res.json(rows);
+  } catch (err) {
+    console.error('[agents] Tool install status error:', err);
+    res.status(500).json({ error: 'Failed to get tool install status' });
+  }
+});
+
 // Get agent events (structured activity timeline)
 router.get('/:id/events', requireRole('user'), async (req: Request, res: Response) => {
   try {

--- a/services/ui/src/__tests__/AgentDetailClient.test.tsx
+++ b/services/ui/src/__tests__/AgentDetailClient.test.tsx
@@ -109,6 +109,18 @@ const MOCK_ALL_SKILLS = [
   { id: 'skill-vps', name: 'VPS Admin', scope: 'vps_system', tools: [], instructions_md: 'VPS instructions' },
 ]
 
+const MOCK_TOOL_INSTALLS = [
+  {
+    tool_id: 'tool-gh',
+    tool_name: 'gh',
+    tool_description: 'GitHub CLI',
+    status: 'installed',
+    install_message: 'installed',
+    installed_at: '2026-03-01T00:00:00Z',
+    updated_at: '2026-03-01T00:00:00Z',
+  },
+]
+
 const MOCK_AGENT_WITH_MULTI_SKILLS = {
   ...MOCK_AGENT,
   skills: [
@@ -153,6 +165,9 @@ function mockFetchDefaults(agentOverride?: typeof MOCK_AGENT) {
     if (url === '/api/skills') {
       return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_ALL_SKILLS) })
     }
+    if (typeof url === 'string' && url.includes('/api/agents/uuid-1/tool-installs')) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_TOOL_INSTALLS) })
+    }
     if (typeof url === 'string' && url.includes('/api/usage')) {
       return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_USAGE) })
     }
@@ -194,6 +209,9 @@ describe('AgentDetailClient', () => {
     expect(screen.getByText('Shell')).toBeInTheDocument()
     expect(screen.getByText('Filesystem')).toBeInTheDocument()
     expect(screen.getByText('Health')).toBeInTheDocument()
+    expect(screen.getByText('Tool Install Status')).toBeInTheDocument()
+    expect(screen.getByText('gh')).toBeInTheDocument()
+    expect(screen.getAllByText('installed').length).toBeGreaterThan(0)
   })
 
   it('clicking Configuration tab shows tool details', async () => {

--- a/services/ui/src/app/agents/[id]/AgentDetailClient.tsx
+++ b/services/ui/src/app/agents/[id]/AgentDetailClient.tsx
@@ -44,6 +44,16 @@ interface SkillRecord {
   instructions_md?: string
 }
 
+interface ToolInstallStatus {
+  tool_id: string
+  tool_name: string
+  tool_description: string
+  status: 'pending' | 'installed' | 'failed'
+  install_message: string
+  installed_at: string | null
+  updated_at: string
+}
+
 const ELEVATED_SCOPES = ['host_docker', 'vps_system']
 
 function scopeBadge(scope: string): { label: string; colorClasses: string } {
@@ -93,6 +103,8 @@ export default function AgentDetailClient({
   const [allSkills, setAllSkills] = useState<SkillRecord[]>([])
   const [showAssignPicker, setShowAssignPicker] = useState(false)
   const [expandedSkillInstructions, setExpandedSkillInstructions] = useState<Set<string>>(new Set())
+  const [toolInstalls, setToolInstalls] = useState<ToolInstallStatus[]>([])
+  const [toolInstallsLoading, setToolInstallsLoading] = useState(false)
 
   // Activity sub-view state
   const [activityView, setActivityView] = useState<'events' | 'logs'>('events')
@@ -136,11 +148,26 @@ export default function AgentDetailClient({
     }
   }, [])
 
+  const fetchToolInstalls = useCallback(async () => {
+    setToolInstallsLoading(true)
+    try {
+      const res = await fetch(`/api/agents/${agentId}/tool-installs`)
+      if (res.ok) {
+        setToolInstalls(await res.json())
+      }
+    } catch (err) {
+      console.error('Failed to fetch tool installs:', err)
+    } finally {
+      setToolInstallsLoading(false)
+    }
+  }, [agentId])
+
   useEffect(() => {
     fetchAgent()
     fetchPolicies()
     fetchAllSkills()
-  }, [fetchAgent, fetchPolicies, fetchAllSkills])
+    fetchToolInstalls()
+  }, [fetchAgent, fetchPolicies, fetchAllSkills, fetchToolInstalls])
 
   // Poll status while running
   useEffect(() => {
@@ -202,6 +229,7 @@ export default function AgentDetailClient({
         alert(data.error || `Failed to ${action} agent`)
       }
       await fetchAgent()
+      await fetchToolInstalls()
     } catch (err) {
       console.error(`Failed to ${action}:`, err)
     } finally {
@@ -267,6 +295,7 @@ export default function AgentDetailClient({
       }
       setShowAssignPicker(false)
       await fetchAgent()
+      await fetchToolInstalls()
     } catch (err) {
       console.error('Failed to assign skill:', err)
     }
@@ -284,6 +313,7 @@ export default function AgentDetailClient({
         return
       }
       await fetchAgent()
+      await fetchToolInstalls()
     } catch (err) {
       console.error('Failed to remove skill:', err)
     }
@@ -508,6 +538,38 @@ export default function AgentDetailClient({
               </div>
             ) : (
               <p className="text-sm text-mountain-500">No skills assigned</p>
+            )}
+          </div>
+
+          {/* Tool Install Status */}
+          <div className="rounded-lg border border-navy-700 bg-navy-800 p-5">
+            <h2 className="text-lg font-semibold text-white mb-3">Tool Install Status</h2>
+            {toolInstallsLoading ? (
+              <p className="text-sm text-mountain-400">Loading…</p>
+            ) : toolInstalls.length === 0 ? (
+              <p className="text-sm text-mountain-500">No tool installs recorded for this agent yet.</p>
+            ) : (
+              <div className="space-y-2">
+                {toolInstalls.map((row) => (
+                  <div key={row.tool_id} className="rounded-md border border-navy-700 bg-navy-900 px-3 py-2">
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <span className="text-sm font-medium text-white">{row.tool_name}</span>
+                      <span className={`px-2 py-0.5 text-xs rounded-md border ${
+                        row.status === 'installed'
+                          ? 'bg-brand-900/50 text-brand-400 border-brand-700'
+                          : row.status === 'failed'
+                            ? 'bg-red-900/40 text-red-400 border-red-700'
+                            : 'bg-amber-900/40 text-amber-400 border-amber-700'
+                      }`}>
+                        {row.status}
+                      </span>
+                    </div>
+                    {row.install_message && (
+                      <p className="text-xs text-mountain-500 mt-1">{row.install_message}</p>
+                    )}
+                  </div>
+                ))}
+              </div>
             )}
           </div>
 


### PR DESCRIPTION
## Summary
- add `GET /agents/{id}/tool-installs` endpoint to expose per-agent tool installation status
- show tool install status in Agent Detail overview UI
- add migration `023_seed_github_and_docker_skills.sql` to seed real GitHub and Docker skills with canonical tool mappings
- update OpenAPI source + docs mirror and docs drift expectations

## Validation
- `cd services/api && node_modules/.bin/jest src/__tests__/routes-agents.test.ts src/__tests__/docs.test.ts --verbose`
- `cd services/api && node_modules/.bin/jest --runInBand --verbose`
- `cd services/api && npx tsc --noEmit`
- `cd services/ui && npx vitest run src/__tests__/AgentDetailClient.test.tsx`
- `cd services/ui && npx vitest run`
- `cd services/ui && npx tsc --noEmit` (9 pre-existing test typing errors unchanged)
- `diff services/api/src/openapi/openapi.yaml docs/site/openapi.yaml`
