### PR TITLE
refactor: drop legacy sandbox_profile column

### DIFF
--- a/services/api/src/db/migrations/024_drop_sandbox_profile_column.sql
+++ b/services/api/src/db/migrations/024_drop_sandbox_profile_column.sql
@@ -1,0 +1,5 @@
+-- Cleanup: remove legacy sandbox_profile column from agents.
+-- The profile concept is no longer part of the active Skills model.
+
+ALTER TABLE agents
+    DROP COLUMN IF EXISTS sandbox_profile;


### PR DESCRIPTION
Remove the residual agents.sandbox_profile column introduced during the profile-to-skills transition. The column is no longer read by API/UI and keeping it preserves obsolete profile semantics in the live schema.
