### PR TITLE
refactor: shift skills tool policy to RBAC-first defaults

### DIFF
--- a/services/api/src/__tests__/merge-tools-config.test.ts
+++ b/services/api/src/__tests__/merge-tools-config.test.ts
@@ -11,7 +11,7 @@ describe('mergeToolsConfigs', () => {
     expect(result.shell.max_timeout).toBe(300);
     expect(result.filesystem.read_only).toBe(false);
     expect(result.filesystem.allowed_paths).toEqual(['/workspace']);
-    expect(result.filesystem.denied_paths).toEqual(['/etc/shadow', '/etc/passwd', '/root']);
+    expect(result.filesystem.denied_paths).toEqual([]);
   });
 
   // M2: Single config returns itself

--- a/services/api/src/db/migrations/025_clear_denied_patterns_and_paths.sql
+++ b/services/api/src/db/migrations/025_clear_denied_patterns_and_paths.sql
@@ -1,0 +1,20 @@
+-- RBAC-first cleanup: remove command/path deny-list defaults from persisted configs.
+-- Elevated capability boundaries are enforced via skill scopes and RBAC, not deny patterns.
+
+UPDATE skills
+SET tools_config = jsonb_set(
+  jsonb_set(COALESCE(tools_config, '{}'::jsonb), '{shell,denied_patterns}', '[]'::jsonb, true),
+  '{filesystem,denied_paths}',
+  '[]'::jsonb,
+  true
+)
+WHERE tools_config IS NOT NULL;
+
+UPDATE agents
+SET tools_config = jsonb_set(
+  jsonb_set(COALESCE(tools_config, '{}'::jsonb), '{shell,denied_patterns}', '[]'::jsonb, true),
+  '{filesystem,denied_paths}',
+  '[]'::jsonb,
+  true
+)
+WHERE tools_config IS NOT NULL;

--- a/services/api/src/services/merge-tools-config.ts
+++ b/services/api/src/services/merge-tools-config.ts
@@ -25,11 +25,10 @@ export interface ToolsConfig {
 // No-skills default: matches routes/agents.ts:140 and agentbox config.py Pydantic defaults.
 // Shell disabled, filesystem disabled, health enabled.
 // Sub-field defaults from agentbox Pydantic: allowed_binaries=[], denied_patterns=[],
-// max_timeout=300, read_only=false, allowed_paths=['/workspace'],
-// denied_paths=['/etc/shadow','/etc/passwd','/root'].
+// max_timeout=300, read_only=false, allowed_paths=['/workspace'], denied_paths=[].
 export const DEFAULT_TOOLS_CONFIG: ToolsConfig = {
   shell: { enabled: false, allowed_binaries: [], denied_patterns: [], max_timeout: 300 },
-  filesystem: { enabled: false, read_only: false, allowed_paths: ['/workspace'], denied_paths: ['/etc/shadow', '/etc/passwd', '/root'] },
+  filesystem: { enabled: false, read_only: false, allowed_paths: ['/workspace'], denied_paths: [] },
   health: { enabled: true },
 };
 

--- a/services/ui/src/__tests__/AgentDetailClient.test.tsx
+++ b/services/ui/src/__tests__/AgentDetailClient.test.tsx
@@ -229,7 +229,6 @@ describe('AgentDetailClient', () => {
       expect(screen.getByText('bash')).toBeInTheDocument()
     })
     expect(screen.getByText('python3')).toBeInTheDocument()
-    expect(screen.getByText('rm -rf')).toBeInTheDocument()
     expect(screen.getByText('/workspace')).toBeInTheDocument()
   })
 
@@ -331,7 +330,7 @@ describe('AgentDetailClient', () => {
     expect(screen.getByTestId('raw-logs-toggle')).toBeInTheDocument()
   })
 
-  it('Configuration tab displays allowed_binaries and denied_patterns', async () => {
+  it('Configuration tab displays allowed_binaries', async () => {
     render(<AgentDetailClient agentId="uuid-1" session={ADMIN_SESSION as any} />)
 
     await waitFor(() => {
@@ -343,7 +342,6 @@ describe('AgentDetailClient', () => {
     await waitFor(() => {
       expect(screen.getByText('bash')).toBeInTheDocument()
       expect(screen.getByText('python3')).toBeInTheDocument()
-      expect(screen.getByText('rm -rf')).toBeInTheDocument()
     })
   })
 

--- a/services/ui/src/__tests__/AgentFormClient.test.tsx
+++ b/services/ui/src/__tests__/AgentFormClient.test.tsx
@@ -145,7 +145,6 @@ describe('AgentFormClient', () => {
     fireEvent.click(advancedLink)
 
     expect(screen.getByText('Allowed Binaries')).toBeInTheDocument()
-    expect(screen.getByText('Denied Patterns')).toBeInTheDocument()
     expect(screen.getByLabelText('Max Timeout (seconds)')).toBeInTheDocument()
   })
 
@@ -160,7 +159,6 @@ describe('AgentFormClient', () => {
     fireEvent.click(advancedLinks[0])
 
     expect(screen.getByText('Allowed Paths')).toBeInTheDocument()
-    expect(screen.getByText('Denied Paths')).toBeInTheDocument()
   })
 
   it('submit body includes model_policy_id', async () => {

--- a/services/ui/src/app/agents/[id]/AgentDetailClient.tsx
+++ b/services/ui/src/app/agents/[id]/AgentDetailClient.tsx
@@ -577,7 +577,7 @@ export default function AgentDetailClient({
           <div className="rounded-lg border border-navy-700 bg-navy-800 p-5">
             <h2 className="text-lg font-semibold text-white mb-3">Tool Access</h2>
             <div className="flex flex-wrap gap-2">
-              <ToolBadge label="Shell" enabled={tc.shell?.enabled} summary={tc.shell?.enabled ? `${tc.shell.allowed_binaries?.length || 0} binaries, ${tc.shell.denied_patterns?.length || 0} patterns` : undefined} />
+              <ToolBadge label="Shell" enabled={tc.shell?.enabled} summary={tc.shell?.enabled ? `${tc.shell.allowed_binaries?.length || 0} binaries` : undefined} />
               <ToolBadge label="Filesystem" enabled={tc.filesystem?.enabled} summary={tc.filesystem?.enabled ? (tc.filesystem.read_only ? 'Read-only' : 'Read-write') : undefined} />
               <ToolBadge label="Health" enabled={tc.health?.enabled} />
             </div>
@@ -650,14 +650,6 @@ export default function AgentDetailClient({
                       </dd>
                     </div>
                     <div>
-                      <dt className="text-mountain-400 mb-1">Denied Patterns</dt>
-                      <dd className="flex flex-wrap gap-1">
-                        {(tc.shell.denied_patterns || []).length > 0
-                          ? tc.shell.denied_patterns.map((p: string) => <Badge key={p} variant="red">{p}</Badge>)
-                          : <span className="text-mountain-500 text-xs">None</span>}
-                      </dd>
-                    </div>
-                    <div>
                       <dt className="text-mountain-400 mb-1">Max Timeout</dt>
                       <dd className="text-white">{tc.shell.max_timeout || 300}s</dd>
                     </div>
@@ -677,14 +669,6 @@ export default function AgentDetailClient({
                       <dt className="text-mountain-400 mb-1">Allowed Paths</dt>
                       <dd className="flex flex-wrap gap-1">
                         {(tc.filesystem.allowed_paths || []).map((p: string) => <Badge key={p}>{p}</Badge>)}
-                      </dd>
-                    </div>
-                    <div>
-                      <dt className="text-mountain-400 mb-1">Denied Paths</dt>
-                      <dd className="flex flex-wrap gap-1">
-                        {(tc.filesystem.denied_paths || []).length > 0
-                          ? tc.filesystem.denied_paths.map((p: string) => <Badge key={p} variant="red">{p}</Badge>)
-                          : <span className="text-mountain-500 text-xs">None</span>}
                       </dd>
                     </div>
                   </dl>

--- a/services/ui/src/app/agents/new/AgentFormClient.tsx
+++ b/services/ui/src/app/agents/new/AgentFormClient.tsx
@@ -13,7 +13,7 @@ interface ToolsConfig {
 
 const defaultTools: ToolsConfig = {
   shell: { enabled: false, allowed_binaries: [], denied_patterns: [], max_timeout: 300 },
-  filesystem: { enabled: false, read_only: false, allowed_paths: ['/workspace'], denied_paths: ['/etc/shadow', '/etc/passwd', '/root'] },
+  filesystem: { enabled: false, read_only: false, allowed_paths: ['/workspace'], denied_paths: [] },
   health: { enabled: true },
 }
 
@@ -390,13 +390,6 @@ export default function AgentFormClient({
                       placeholder="Add binary (e.g. bash)..."
                       disabled={disabled}
                     />
-                    <TagInput
-                      label="Denied Patterns"
-                      value={tools.shell.denied_patterns}
-                      onChange={(v) => updateToolsCustom({ ...tools, shell: { ...tools.shell, denied_patterns: v } })}
-                      placeholder="Add pattern (e.g. rm -rf)..."
-                      disabled={disabled}
-                    />
                     <div>
                       <label htmlFor="max_timeout" className="block text-xs font-medium text-mountain-500 uppercase tracking-wide mb-1">
                         Max Timeout (seconds)
@@ -453,14 +446,6 @@ export default function AgentFormClient({
                       onChange={(v) => updateToolsCustom({ ...tools, filesystem: { ...tools.filesystem, allowed_paths: v } })}
                       validate={pathValidate}
                       placeholder="Add path (e.g. /workspace)..."
-                      disabled={disabled}
-                    />
-                    <TagInput
-                      label="Denied Paths"
-                      value={tools.filesystem.denied_paths}
-                      onChange={(v) => updateToolsCustom({ ...tools, filesystem: { ...tools.filesystem, denied_paths: v } })}
-                      validate={pathValidate}
-                      placeholder="Add path (e.g. /etc/shadow)..."
                       disabled={disabled}
                     />
                   </div>

--- a/services/ui/src/app/harness/skills/SkillsClient.tsx
+++ b/services/ui/src/app/harness/skills/SkillsClient.tsx
@@ -66,9 +66,7 @@ export default function SkillsClient() {
     readOnly: false,
     healthEnabled: true,
     allowed_binaries: '' ,
-    denied_patterns: '',
     allowed_paths: '/workspace',
-    denied_paths: '/etc/shadow, /etc/passwd, /root',
     max_timeout: '300',
   })
   const [formError, setFormError] = useState('')
@@ -102,9 +100,7 @@ export default function SkillsClient() {
       readOnly: false,
       healthEnabled: true,
       allowed_binaries: '',
-      denied_patterns: '',
       allowed_paths: '/workspace',
-      denied_paths: '/etc/shadow, /etc/passwd, /root',
       max_timeout: '300',
     })
     setSelectedToolIds([])
@@ -126,14 +122,14 @@ export default function SkillsClient() {
       shell: {
         enabled: formData.shellEnabled,
         allowed_binaries: formData.allowed_binaries ? formData.allowed_binaries.split(',').map((s) => s.trim()).filter(Boolean) : [],
-        denied_patterns: formData.denied_patterns ? formData.denied_patterns.split(',').map((s) => s.trim()).filter(Boolean) : [],
+        denied_patterns: [],
         max_timeout: parseInt(formData.max_timeout, 10) || 300,
       },
       filesystem: {
         enabled: formData.filesystemEnabled,
         read_only: formData.readOnly,
         allowed_paths: formData.allowed_paths ? formData.allowed_paths.split(',').map((s) => s.trim()).filter(Boolean) : [],
-        denied_paths: formData.denied_paths ? formData.denied_paths.split(',').map((s) => s.trim()).filter(Boolean) : [],
+        denied_paths: [],
       },
       health: { enabled: formData.healthEnabled },
     }
@@ -199,9 +195,7 @@ export default function SkillsClient() {
       readOnly: tc.filesystem.read_only,
       healthEnabled: tc.health.enabled,
       allowed_binaries: tc.shell.allowed_binaries.join(', '),
-      denied_patterns: tc.shell.denied_patterns.join(', '),
       allowed_paths: tc.filesystem.allowed_paths.join(', '),
-      denied_paths: tc.filesystem.denied_paths.join(', '),
       max_timeout: tc.shell.max_timeout.toString(),
     })
     setSelectedToolIds(skill.tools?.map(t => t.id) || [])
@@ -503,15 +497,6 @@ export default function SkillsClient() {
                                   </span>
                                 ))}
                               </div>
-                              {tc.shell.denied_patterns.length > 0 && (
-                                <div className="text-xs text-mountain-400">
-                                  Denied: {tc.shell.denied_patterns.map((p) => (
-                                    <span key={p} className="px-1.5 py-0.5 rounded bg-red-900/30 text-red-400 border border-red-700/50 mr-1">
-                                      {p}
-                                    </span>
-                                  ))}
-                                </div>
-                              )}
                               <div className="text-xs text-mountain-500">Timeout: {tc.shell.max_timeout}s</div>
                             </div>
                           ) : (


### PR DESCRIPTION
Clear denied command/path defaults in persisted tool configs and remove denied-pattern/path controls from Skills/Agent UI. Keep scope+RBAC as the capability boundary while preserving existing tools_config schema compatibility.
