### PR TITLE
refactor: assign agent models directly

### DIFF
--- a/docs/site/openapi.yaml
+++ b/docs/site/openapi.yaml
@@ -55,7 +55,12 @@ components:
           type: string
           format: uuid
           nullable: true
-          description: ID of the model policy controlling LLM access. Users can assign own or platform policies to own agents; admins can assign any.
+          description: Internal policy reference used by backend model-router plumbing.
+        models:
+          type: array
+          items:
+            type: string
+          description: User-facing model names assigned to this agent.
         skills:
           type: array
           items:
@@ -725,7 +730,12 @@ paths:
                   type: string
                   format: uuid
                   nullable: true
-                  description: ID of a model policy to assign at creation. Users can assign own or platform policies; admins can assign any.
+                  description: Internal-only override. Prefer model_names for user-facing model assignment.
+                model_names:
+                  type: array
+                  items:
+                    type: string
+                  description: User-facing model names to assign directly to this agent (one or many).
                 skill_ids:
                   type: array
                   items:
@@ -808,7 +818,12 @@ paths:
                   type: string
                   format: uuid
                   nullable: true
-                  description: Model policy ID. Users can assign own or platform policies; admins can assign any. Set to null to remove.
+                  description: Internal-only override. Prefer model_names for user-facing model assignment.
+                model_names:
+                  type: array
+                  items:
+                    type: string
+                  description: User-facing model names to assign directly to this agent (one or many).
                 skill_ids:
                   type: array
                   items:

--- a/services/api/src/__tests__/routes-agents-policy.test.ts
+++ b/services/api/src/__tests__/routes-agents-policy.test.ts
@@ -74,6 +74,8 @@ describe('Agent PUT model_policy_id behavior', () => {
     mockQuery.mockResolvedValueOnce({ rows: [{ ...agentRow, model_policy_id: 'policy-1' }] });
     // SELECT skills for response
     mockQuery.mockResolvedValueOnce({ rows: [] });
+    // Resolve models
+    mockQuery.mockResolvedValueOnce({ rows: [{ allowed_models: ['gpt-4o-mini'] }] });
 
     const res = await request(app)
       .put('/agents/uuid-1')
@@ -93,6 +95,8 @@ describe('Agent PUT model_policy_id behavior', () => {
     mockQuery.mockResolvedValueOnce({ rows: [{ ...agentRow, model_policy_id: 'platform-policy' }] });
     // SELECT skills for response
     mockQuery.mockResolvedValueOnce({ rows: [] });
+    // Resolve models
+    mockQuery.mockResolvedValueOnce({ rows: [{ allowed_models: ['gpt-4o-mini'] }] });
 
     const res = await request(app)
       .put('/agents/uuid-1')
@@ -122,7 +126,8 @@ describe('Agent PUT model_policy_id behavior', () => {
       .mockResolvedValueOnce({ rows: [agentRow] }) // ownership check
       .mockResolvedValueOnce({ rows: [{ id: 'policy-1', created_by: 'someone' }] }) // FK validation
       .mockResolvedValueOnce({ rows: [{ ...agentRow, model_policy_id: 'policy-1' }] }) // UPDATE
-      .mockResolvedValueOnce({ rows: [] }); // SELECT skills for response
+      .mockResolvedValueOnce({ rows: [] }) // SELECT skills for response
+      .mockResolvedValueOnce({ rows: [{ allowed_models: ['gpt-4o-mini'] }] }); // Resolve models
 
     const res = await request(app)
       .put('/agents/uuid-1')
@@ -173,7 +178,8 @@ describe('Agent PUT model_policy_id behavior', () => {
     mockQuery
       .mockResolvedValueOnce({ rows: [agentRow] }) // ownership check
       .mockResolvedValueOnce({ rows: [agentRow] }) // UPDATE
-      .mockResolvedValueOnce({ rows: [] }); // SELECT skills for response
+      .mockResolvedValueOnce({ rows: [] }) // SELECT skills for response
+      .mockResolvedValueOnce({ rows: [] }); // Resolve models
 
     const res = await request(app)
       .put('/agents/uuid-1')
@@ -190,7 +196,8 @@ describe('Agent PUT model_policy_id behavior', () => {
     mockQuery
       .mockResolvedValueOnce({ rows: [agentRow] }) // ownership check
       .mockResolvedValueOnce({ rows: [{ ...agentRow, name: 'New Name' }] }) // UPDATE
-      .mockResolvedValueOnce({ rows: [] }); // SELECT skills for response
+      .mockResolvedValueOnce({ rows: [] }) // SELECT skills for response
+      .mockResolvedValueOnce({ rows: [] }); // Resolve models
 
     const res = await request(app)
       .put('/agents/uuid-1')
@@ -227,6 +234,8 @@ describe('Agent POST model_policy_id behavior', () => {
     });
     // SELECT skills for response
     mockQuery.mockResolvedValueOnce({ rows: [] });
+    // Resolve models
+    mockQuery.mockResolvedValueOnce({ rows: [{ allowed_models: ['gpt-4o-mini'] }] });
 
     const res = await request(app)
       .post('/agents')
@@ -265,6 +274,8 @@ describe('Agent POST model_policy_id behavior', () => {
     });
     // SELECT skills for response
     mockQuery.mockResolvedValueOnce({ rows: [] });
+    // Resolve models
+    mockQuery.mockResolvedValueOnce({ rows: [{ allowed_models: ['gpt-4o-mini'] }] });
 
     const res = await request(app)
       .post('/agents')

--- a/services/api/src/openapi/openapi.yaml
+++ b/services/api/src/openapi/openapi.yaml
@@ -55,7 +55,12 @@ components:
           type: string
           format: uuid
           nullable: true
-          description: ID of the model policy controlling LLM access. Users can assign own or platform policies to own agents; admins can assign any.
+          description: Internal policy reference used by backend model-router plumbing.
+        models:
+          type: array
+          items:
+            type: string
+          description: User-facing model names assigned to this agent.
         skills:
           type: array
           items:
@@ -725,7 +730,12 @@ paths:
                   type: string
                   format: uuid
                   nullable: true
-                  description: ID of a model policy to assign at creation. Users can assign own or platform policies; admins can assign any.
+                  description: Internal-only override. Prefer model_names for user-facing model assignment.
+                model_names:
+                  type: array
+                  items:
+                    type: string
+                  description: User-facing model names to assign directly to this agent (one or many).
                 skill_ids:
                   type: array
                   items:
@@ -808,7 +818,12 @@ paths:
                   type: string
                   format: uuid
                   nullable: true
-                  description: Model policy ID. Users can assign own or platform policies; admins can assign any. Set to null to remove.
+                  description: Internal-only override. Prefer model_names for user-facing model assignment.
+                model_names:
+                  type: array
+                  items:
+                    type: string
+                  description: User-facing model names to assign directly to this agent (one or many).
                 skill_ids:
                   type: array
                   items:

--- a/services/api/src/routes/agents.ts
+++ b/services/api/src/routes/agents.ts
@@ -49,6 +49,75 @@ function dbHealthCheck(_req: Request, res: Response, next: () => void) {
 
 router.use(dbHealthCheck);
 
+function isAutoAgentModelsPolicy(description: string | null): boolean {
+  return (description || '').startsWith('[auto-agent-models]');
+}
+
+async function validateModelNames(modelNames: string[], userSub: string, admin: boolean): Promise<string | null> {
+  if (admin) return null;
+  for (const modelName of modelNames) {
+    const { rows: userRows } = await getPool().query(
+      `SELECT id FROM user_models WHERE name = $1 AND created_by = $2`,
+      [modelName, userSub]
+    );
+    if (userRows.length > 0) continue;
+
+    const { rows: platformRows } = await getPool().query(
+      `SELECT name FROM model_catalog WHERE name = $1 AND is_active = true`,
+      [modelName]
+    );
+    if (platformRows.length > 0) continue;
+
+    return `Model '${modelName}' not found`;
+  }
+  return null;
+}
+
+async function upsertAutoAgentModelsPolicy(
+  agentDbId: string,
+  agentSlug: string,
+  ownerSub: string,
+  updatedBy: string,
+  modelNames: string[]
+): Promise<string> {
+  const name = `agent-models-${agentDbId}`;
+  const description = `[auto-agent-models] ${agentSlug}`;
+  const existing = await getPool().query(
+    `SELECT id FROM model_policies WHERE name = $1 AND created_by = $2`,
+    [name, ownerSub]
+  );
+  if (existing.rows.length > 0) {
+    await getPool().query(
+      `UPDATE model_policies
+       SET description = $1,
+           allowed_models = $2,
+           model_aliases = $3,
+           updated_by = $4,
+           updated_at = NOW()
+       WHERE id = $5`,
+      [description, JSON.stringify(modelNames), JSON.stringify({}), updatedBy, existing.rows[0].id]
+    );
+    return existing.rows[0].id;
+  }
+
+  const inserted = await getPool().query(
+    `INSERT INTO model_policies (name, description, allowed_models, model_aliases, updated_by, created_by)
+     VALUES ($1, $2, $3, $4, $5, $6)
+     RETURNING id`,
+    [name, description, JSON.stringify(modelNames), JSON.stringify({}), updatedBy, ownerSub]
+  );
+  return inserted.rows[0].id;
+}
+
+async function resolveAgentModels(policyId: string | null): Promise<string[]> {
+  if (!policyId) return [];
+  const { rows } = await getPool().query(
+    `SELECT allowed_models FROM model_policies WHERE id = $1`,
+    [policyId]
+  );
+  return rows[0]?.allowed_models || [];
+}
+
 // ---------------------------------------------------------------------------
 // CRUD (user role)
 // ---------------------------------------------------------------------------
@@ -60,12 +129,14 @@ router.get('/', requireRole('user'), async (req: Request, res: Response) => {
     const { rows } = await getPool().query(
       `SELECT a.id, a.agent_id, a.name, a.description, a.status, a.tools_config,
               a.cpus, a.mem_limit, a.pids_limit, a.model_policy_id,
+              COALESCE(mp.allowed_models, '[]'::jsonb) AS models,
               a.created_at, a.updated_at, a.created_by,
               COALESCE(
                 json_agg(json_build_object('id', s.id, 'name', s.name, 'scope', s.scope))
                 FILTER (WHERE s.id IS NOT NULL), '[]'
               ) AS skills
        FROM agents a
+       LEFT JOIN model_policies mp ON mp.id = a.model_policy_id
        LEFT JOIN agent_skills asks ON asks.agent_id = a.id
        LEFT JOIN skills s ON s.id = asks.skill_id
        WHERE ${scope.where.replace(/created_by/g, 'a.created_by')}
@@ -84,7 +155,7 @@ router.get('/', requireRole('user'), async (req: Request, res: Response) => {
 router.post('/', requireRole('user'), async (req: Request, res: Response) => {
   try {
     const user = (req as any).user;
-    const { agent_id, name, description, tools_config, cpus, mem_limit, pids_limit, soul_md, rules_md, model_policy_id, skill_ids } = req.body;
+    const { agent_id, name, description, tools_config, cpus, mem_limit, pids_limit, soul_md, rules_md, model_policy_id, model_names, skill_ids } = req.body;
 
     // Reject legacy field
     if (req.body.tool_preset_id !== undefined) {
@@ -110,8 +181,16 @@ router.post('/', requireRole('user'), async (req: Request, res: Response) => {
         return;
       }
     }
+    if (model_names !== undefined && !Array.isArray(model_names)) {
+      res.status(400).json({ error: 'model_names must be an array' });
+      return;
+    }
+    if (model_names !== undefined && model_policy_id !== undefined) {
+      res.status(400).json({ error: 'Use either model_names or model_policy_id, not both' });
+      return;
+    }
 
-    // Validate model_policy_id ownership (same logic as PUT handler)
+    // Validate model_policy_id ownership (legacy/internal path)
     let validatedPolicyId: string | null = null;
     if (model_policy_id) {
       const { rows: policyRows } = await getPool().query(
@@ -132,6 +211,21 @@ router.post('/', requireRole('user'), async (req: Request, res: Response) => {
         }
       }
       validatedPolicyId = model_policy_id;
+    }
+
+    // Direct model assignment (preferred user-facing path)
+    let normalizedModelNames: string[] | undefined = undefined;
+    if (model_names !== undefined) {
+      normalizedModelNames = [...new Set((model_names as string[]).filter(Boolean))];
+      const roles: string[] = user.realm_roles || [];
+      const admin = roles.includes('admin');
+      const modelError = await validateModelNames(normalizedModelNames, user.sub, admin);
+      if (modelError) {
+        res.status(400).json({ error: modelError });
+        return;
+      }
+      // Policy id is derived after insert via auto policy upsert.
+      validatedPolicyId = null;
     }
 
     // Resolve tools_config from explicit payload or assigned skills
@@ -179,6 +273,28 @@ router.post('/', requireRole('user'), async (req: Request, res: Response) => {
 
     const createdAgent = rows[0];
 
+    if (normalizedModelNames !== undefined) {
+      if (normalizedModelNames.length > 0) {
+        const autoPolicyId = await upsertAutoAgentModelsPolicy(
+          createdAgent.id,
+          createdAgent.agent_id,
+          user.sub,
+          user.sub,
+          normalizedModelNames
+        );
+        await getPool().query(
+          `UPDATE agents SET model_policy_id = $1, updated_at = NOW() WHERE id = $2`,
+          [autoPolicyId, createdAgent.id]
+        );
+        createdAgent.model_policy_id = autoPolicyId;
+        createdAgent.models = normalizedModelNames;
+      } else {
+        createdAgent.models = [];
+      }
+    } else {
+      createdAgent.models = await resolveAgentModels(createdAgent.model_policy_id);
+    }
+
     // Insert skill assignments into agent_skills
     for (const skillId of validatedSkillIds) {
       await getPool().query(
@@ -213,10 +329,13 @@ router.get('/:id', requireRole('user'), async (req: Request, res: Response) => {
     const scope = scopeToOwner(req);
     const paramOffset = scope.params.length + 1;
     const { rows } = await getPool().query(
-      `SELECT id, agent_id, name, description, status, tools_config,
+      `SELECT a.id, a.agent_id, a.name, a.description, a.status, a.tools_config,
               cpus, mem_limit, pids_limit, soul_md, rules_md, container_id,
-              model_policy_id, error_message, created_at, updated_at, created_by
-       FROM agents WHERE id = $${paramOffset} AND ${scope.where}`,
+              model_policy_id, COALESCE(mp.allowed_models, '[]'::jsonb) AS models,
+              error_message, created_at, updated_at, created_by
+       FROM agents a
+       LEFT JOIN model_policies mp ON mp.id = a.model_policy_id
+       WHERE a.id = $${paramOffset} AND ${scope.where.replace(/created_by/g, 'a.created_by')}`,
       [...scope.params, req.params.id]
     );
     if (rows.length === 0) {
@@ -269,7 +388,7 @@ router.put('/:id', requireRole('user'), async (req: Request, res: Response) => {
     }
 
     const user = (req as any).user;
-    const { name, description, tools_config, cpus, mem_limit, pids_limit, soul_md, rules_md, model_policy_id, skill_ids } = req.body;
+    const { name, description, tools_config, cpus, mem_limit, pids_limit, soul_md, rules_md, model_policy_id, model_names, skill_ids } = req.body;
 
     // Validate skill_ids
     if (skill_ids !== undefined) {
@@ -277,6 +396,14 @@ router.put('/:id', requireRole('user'), async (req: Request, res: Response) => {
         res.status(400).json({ error: 'skill_ids must be an array' });
         return;
       }
+    }
+    if (model_names !== undefined && !Array.isArray(model_names)) {
+      res.status(400).json({ error: 'model_names must be an array' });
+      return;
+    }
+    if (model_names !== undefined && model_policy_id !== undefined) {
+      res.status(400).json({ error: 'Use either model_names or model_policy_id, not both' });
+      return;
     }
 
     // model_policy_id assignment: admins can assign any, users can assign own or platform
@@ -302,6 +429,51 @@ router.put('/:id', requireRole('user'), async (req: Request, res: Response) => {
             res.status(403).json({ error: "Cannot assign another user's policy" });
             return;
           }
+        }
+      }
+    }
+
+    const userRoles: string[] = user.realm_roles || [];
+    const admin = userRoles.includes('admin');
+    let resolvedModelPolicyId: string | null | undefined = undefined;
+    if (model_names !== undefined) {
+      const normalizedModelNames = [...new Set((model_names as string[]).filter(Boolean))];
+      const modelError = await validateModelNames(normalizedModelNames, existing[0].created_by, admin);
+      if (modelError) {
+        res.status(400).json({ error: modelError });
+        return;
+      }
+
+      if (normalizedModelNames.length === 0) {
+        resolvedModelPolicyId = null;
+      } else {
+        let reusePolicyId: string | null = null;
+        if (existing[0].model_policy_id) {
+          const { rows: policyRows } = await getPool().query(
+            `SELECT id, description FROM model_policies WHERE id = $1`,
+            [existing[0].model_policy_id]
+          );
+          if (policyRows.length > 0 && isAutoAgentModelsPolicy(policyRows[0].description)) {
+            reusePolicyId = policyRows[0].id;
+          }
+        }
+
+        if (reusePolicyId) {
+          await getPool().query(
+            `UPDATE model_policies
+             SET allowed_models = $1, model_aliases = $2, updated_by = $3, updated_at = NOW()
+             WHERE id = $4`,
+            [JSON.stringify(normalizedModelNames), JSON.stringify({}), user.sub, reusePolicyId]
+          );
+          resolvedModelPolicyId = reusePolicyId;
+        } else {
+          resolvedModelPolicyId = await upsertAutoAgentModelsPolicy(
+            existing[0].id,
+            existing[0].agent_id,
+            existing[0].created_by,
+            user.sub,
+            normalizedModelNames
+          );
         }
       }
     }
@@ -346,7 +518,8 @@ router.put('/:id', requireRole('user'), async (req: Request, res: Response) => {
     }
 
     // Build SET clause: model_policy_id uses explicit flag to allow clearing to NULL
-    const modelPolicyProvided = model_policy_id !== undefined;
+    const modelPolicyProvided = model_policy_id !== undefined || model_names !== undefined;
+    const effectiveModelPolicyId = model_names !== undefined ? resolvedModelPolicyId : model_policy_id;
     const { rows } = await getPool().query(
       `UPDATE agents SET
         name = COALESCE($1, name),
@@ -373,7 +546,7 @@ router.put('/:id', requireRole('user'), async (req: Request, res: Response) => {
         soul_md ?? null,
         rules_md ?? null,
         modelPolicyProvided,
-        modelPolicyProvided ? (model_policy_id ?? null) : null,
+        modelPolicyProvided ? (effectiveModelPolicyId ?? null) : null,
         req.params.id,
       ]
     );
@@ -401,6 +574,7 @@ router.put('/:id', requireRole('user'), async (req: Request, res: Response) => {
       [req.params.id]
     );
     updatedAgent.skills = agentSkills;
+    updatedAgent.models = await resolveAgentModels(updatedAgent.model_policy_id);
 
     res.json(updatedAgent);
   } catch (err) {

--- a/services/ui/src/__tests__/AgentDetailClient.test.tsx
+++ b/services/ui/src/__tests__/AgentDetailClient.test.tsx
@@ -51,6 +51,7 @@ const MOCK_AGENT = {
   rules_md: 'Always cite sources.',
   container_id: null,
   model_policy_id: 'policy-1',
+  models: ['gpt-4o-mini', 'claude-sonnet-4-5-20250929'],
   skills: [],
   error_message: null,
   created_at: '2026-01-01T00:00:00Z',
@@ -70,17 +71,6 @@ const MOCK_AGENT_WITH_SKILL = {
     },
   ],
 }
-
-const MOCK_POLICIES = [
-  {
-    id: 'policy-1',
-    name: 'Default Policy',
-    allowed_models: ['gpt-4o-mini', 'claude-sonnet-4-5-20250929'],
-    max_requests_per_minute: 60,
-    max_tokens_per_day: 100000,
-    created_by: null,
-  },
-]
 
 const MOCK_USAGE = {
   total_requests: 150,
@@ -158,9 +148,6 @@ function mockFetchDefaults(agentOverride?: typeof MOCK_AGENT) {
   mockFetch.mockImplementation((url: string, opts?: any) => {
     if (url === `/api/agents/uuid-1` && (!opts || !opts.method || opts.method === 'GET')) {
       return Promise.resolve({ ok: true, json: () => Promise.resolve(agentOverride || MOCK_AGENT) })
-    }
-    if (url === '/api/model-policies') {
-      return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_POLICIES) })
     }
     if (url === '/api/skills') {
       return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_ALL_SKILLS) })
@@ -345,7 +332,7 @@ describe('AgentDetailClient', () => {
     })
   })
 
-  it('Model Access tab shows allowed models and limits', async () => {
+  it('Model Access tab shows assigned models', async () => {
     render(<AgentDetailClient agentId="uuid-1" session={ADMIN_SESSION as any} />)
 
     await waitFor(() => {
@@ -355,7 +342,7 @@ describe('AgentDetailClient', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Model Access' }))
 
     await waitFor(() => {
-      expect(screen.getByText('Default Policy')).toBeInTheDocument()
+      expect(screen.getByText('Assigned Models')).toBeInTheDocument()
     })
     expect(screen.getByText('gpt-4o-mini')).toBeInTheDocument()
     expect(screen.getByText('claude-sonnet-4-5-20250929')).toBeInTheDocument()

--- a/services/ui/src/__tests__/AgentFormClient.test.tsx
+++ b/services/ui/src/__tests__/AgentFormClient.test.tsx
@@ -21,8 +21,11 @@ vi.stubGlobal('confirm', mockConfirm)
 import AgentFormClient from '@/app/agents/new/AgentFormClient'
 
 const MOCK_POLICIES = [
-  { id: 'policy-1', name: 'Default Policy' },
-  { id: 'policy-2', name: 'Restricted Policy' },
+  { id: 'policy-1', name: 'Default Policy', allowed_models: ['gpt-4o-mini'] },
+  { id: 'policy-2', name: 'Restricted Policy', allowed_models: ['claude-sonnet'] },
+]
+const MOCK_USER_MODELS = [
+  { id: 'um-1', name: 'my-custom-model' },
 ]
 
 const MOCK_PRESETS = [
@@ -75,6 +78,9 @@ function mockFetchDefaults() {
     if (url === '/api/model-policies') {
       return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_POLICIES) })
     }
+    if (url === '/api/user-models') {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_USER_MODELS) })
+    }
     if (url === '/api/skills') {
       return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_PRESETS) })
     }
@@ -107,7 +113,7 @@ describe('AgentFormClient', () => {
     cleanup()
   })
 
-  it('renders basic info, tools, model policy, resources, identity sections', async () => {
+  it('renders basic info, tools, models, resources, identity sections', async () => {
     render(<AgentFormClient />)
 
     await waitFor(() => {
@@ -115,23 +121,21 @@ describe('AgentFormClient', () => {
     })
 
     expect(screen.getByText('Tools')).toBeInTheDocument()
-    expect(screen.getAllByText('Model Policy').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('Models').length).toBeGreaterThan(0)
     expect(screen.getByText('Resources')).toBeInTheDocument()
     expect(screen.getByText('Identity')).toBeInTheDocument()
   })
 
-  it('fetches policies and renders selector with None option', async () => {
+  it('fetches model sources and renders model checklist', async () => {
     render(<AgentFormClient />)
 
     await waitFor(() => {
-      expect(screen.getByText('Default Policy')).toBeInTheDocument()
+      expect(screen.getByText('gpt-4o-mini')).toBeInTheDocument()
     })
 
-    expect(screen.getByText('Restricted Policy')).toBeInTheDocument()
-    const selectEl = screen.getByRole('combobox', { name: /model policy/i })
-    expect(selectEl).toBeInTheDocument()
-    const noneOption = screen.getByRole('option', { name: 'None' })
-    expect(noneOption).toBeInTheDocument()
+    expect(screen.getByText('claude-sonnet')).toBeInTheDocument()
+    expect(screen.getByText('my-custom-model')).toBeInTheDocument()
+    expect(screen.getByText('Assign Models')).toBeInTheDocument()
   })
 
   it('shows shell advanced fields when shell enabled', async () => {
@@ -161,19 +165,19 @@ describe('AgentFormClient', () => {
     expect(screen.getByText('Allowed Paths')).toBeInTheDocument()
   })
 
-  it('submit body includes model_policy_id', async () => {
+  it('submit body includes model_names', async () => {
     render(<AgentFormClient />)
     await selectCustomMode()
 
     await waitFor(() => {
-      expect(screen.getByText('Default Policy')).toBeInTheDocument()
+      expect(screen.getByText('gpt-4o-mini')).toBeInTheDocument()
     })
 
     fireEvent.change(screen.getByLabelText('Agent ID (slug)'), { target: { value: 'test-agent' } })
     fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Test Agent' } })
 
-    const policySelect = screen.getByRole('combobox', { name: /model policy/i })
-    fireEvent.change(policySelect, { target: { value: 'policy-1' } })
+    fireEvent.click(screen.getByLabelText('gpt-4o-mini'))
+    fireEvent.click(screen.getByLabelText('my-custom-model'))
 
     fireEvent.click(screen.getByRole('button', { name: /create agent/i }))
 
@@ -187,7 +191,7 @@ describe('AgentFormClient', () => {
       (c: any[]) => c[0] === '/api/agents' && c[1]?.method === 'POST'
     )!
     const body = JSON.parse(postCall[1].body)
-    expect(body.model_policy_id).toBe('policy-1')
+    expect(body.model_names).toEqual(['gpt-4o-mini', 'my-custom-model'])
   })
 
   it('submit body includes advanced tools_config fields', async () => {
@@ -273,7 +277,7 @@ describe('AgentFormClient', () => {
       pids_limit: 300,
       soul_md: 'soul text',
       rules_md: 'rules text',
-      model_policy_id: 'policy-1',
+      models: ['gpt-4o-mini'],
     }
 
     render(<AgentFormClient initial={initial} agentUuid="uuid-1" />)
@@ -289,10 +293,8 @@ describe('AgentFormClient', () => {
     const fsCheckbox = screen.getByLabelText('Filesystem access') as HTMLInputElement
     expect(fsCheckbox.checked).toBe(true)
 
-    await waitFor(() => {
-      const policySelect = screen.getByRole('combobox', { name: /model policy/i }) as HTMLSelectElement
-      expect(policySelect.value).toBe('policy-1')
-    })
+    const modelCheckbox = screen.getByLabelText('gpt-4o-mini') as HTMLInputElement
+    expect(modelCheckbox.checked).toBe(true)
   })
 
   it('disables all inputs when disabled prop is true', async () => {
@@ -534,7 +536,7 @@ describe('AgentFormClient', () => {
       pids_limit: 200,
       soul_md: '',
       rules_md: '',
-      model_policy_id: null,
+      models: [],
       skills: [
         { id: 'preset-dev', name: 'Developer', scope: 'container_local' },
         { id: 'preset-min', name: 'Minimal', scope: 'container_local' },

--- a/services/ui/src/__tests__/AgentsClient.test.tsx
+++ b/services/ui/src/__tests__/AgentsClient.test.tsx
@@ -36,7 +36,7 @@ const MOCK_AGENTS = [
       filesystem: { enabled: true, read_only: false, allowed_paths: ['/workspace'], denied_paths: [] },
       health: { enabled: true },
     },
-    model_policy_id: 'policy-1',
+    models: ['gpt-4o-mini', 'claude-sonnet'],
     skills: [{ id: 'skill-dev', name: 'Developer', scope: 'container_local' }],
     created_at: '2026-01-01T00:00:00Z',
     updated_at: '2026-01-01T00:00:00Z',
@@ -56,7 +56,7 @@ const MOCK_AGENTS = [
       filesystem: { enabled: false, read_only: false, allowed_paths: [], denied_paths: [] },
       health: { enabled: true },
     },
-    model_policy_id: null,
+    models: [],
     skills: [],
     created_at: '2026-02-01T00:00:00Z',
     updated_at: '2026-02-01T00:00:00Z',
@@ -76,7 +76,7 @@ const MOCK_AGENTS = [
       filesystem: { enabled: false, read_only: false, allowed_paths: [], denied_paths: [] },
       health: { enabled: false },
     },
-    model_policy_id: null,
+    models: [],
     skills: [],
     created_at: '2026-03-01T00:00:00Z',
     updated_at: '2026-03-01T00:00:00Z',
@@ -96,7 +96,7 @@ const MOCK_AGENTS = [
       filesystem: { enabled: true, read_only: false, allowed_paths: ['/workspace'], denied_paths: [] },
       health: { enabled: true },
     },
-    model_policy_id: null,
+    models: [],
     skills: [
       { id: 'skill-dev', name: 'Developer', scope: 'container_local' },
       { id: 'skill-reader', name: 'Data Reader', scope: 'container_local' },
@@ -107,18 +107,10 @@ const MOCK_AGENTS = [
   },
 ]
 
-const MOCK_POLICIES = [
-  { id: 'policy-1', name: 'Default Policy' },
-  { id: 'policy-2', name: 'Restricted Policy' },
-]
-
 function mockFetchDefaults() {
   mockFetch.mockImplementation((url: string) => {
     if (url === '/api/agents') {
       return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_AGENTS) })
-    }
-    if (url === '/api/model-policies') {
-      return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_POLICIES) })
     }
     return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
   })
@@ -148,25 +140,25 @@ describe('AgentsClient', () => {
     expect(screen.getByText('4 agents')).toBeInTheDocument()
   })
 
-  it('shows policy name badge on agents with assigned policy', async () => {
+  it('shows model badges on agents with assigned models', async () => {
     render(<AgentsClient session={MOCK_SESSION as any} />)
 
     await waitFor(() => {
       expect(screen.getByText('ResearchBot')).toBeInTheDocument()
     })
 
-    expect(screen.getByText('Default Policy')).toBeInTheDocument()
+    expect(screen.getByText('gpt-4o-mini')).toBeInTheDocument()
   })
 
-  it('does not show policy badge on agents without policy', async () => {
+  it('does not show model badges on agents without assigned models', async () => {
     render(<AgentsClient session={MOCK_SESSION as any} />)
 
     await waitFor(() => {
       expect(screen.getByText('WriterBot')).toBeInTheDocument()
     })
 
-    const policyBadges = screen.queryAllByText('Restricted Policy')
-    expect(policyBadges.length).toBe(0)
+    const modelBadges = screen.queryAllByText('gpt-4o-mini')
+    expect(modelBadges.length).toBe(1)
   })
 
   it('shows resource info on agent cards', async () => {
@@ -183,9 +175,6 @@ describe('AgentsClient', () => {
   it('shows empty state when no agents', async () => {
     mockFetch.mockImplementation((url: string) => {
       if (url === '/api/agents') {
-        return Promise.resolve({ ok: true, json: () => Promise.resolve([]) })
-      }
-      if (url === '/api/model-policies') {
         return Promise.resolve({ ok: true, json: () => Promise.resolve([]) })
       }
       return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
@@ -209,7 +198,7 @@ describe('AgentsClient', () => {
     expect(screen.getAllByText('Start').length).toBeGreaterThan(0)
   })
 
-  it('fetches both agents and policies on mount', async () => {
+  it('fetches agents on mount', async () => {
     render(<AgentsClient session={MOCK_SESSION as any} />)
 
     await waitFor(() => {
@@ -217,7 +206,6 @@ describe('AgentsClient', () => {
     })
 
     expect(mockFetch).toHaveBeenCalledWith('/api/agents')
-    expect(mockFetch).toHaveBeenCalledWith('/api/model-policies')
   })
 
   it('renders tool capability badges from tools_config', async () => {

--- a/services/ui/src/app/agents/AgentsClient.tsx
+++ b/services/ui/src/app/agents/AgentsClient.tsx
@@ -15,7 +15,7 @@ interface Agent {
   mem_limit: string
   pids_limit: number
   tools_config: Record<string, any> | null
-  model_policy_id: string | null
+  models: string[]
   skills: Array<{ id: string; name: string; scope: string }>
   created_at: string
   updated_at: string
@@ -35,37 +35,22 @@ function scopeBadge(scope: string): { label: string; colorClasses: string } {
   }
 }
 
-interface ModelPolicy {
-  id: string
-  name: string
-}
-
 type StatusFilter = 'all' | 'running' | 'stopped' | 'error'
 
 const STATUS_ORDER: Record<string, number> = { running: 0, error: 1, stopped: 2 }
 
 export default function AgentsClient({ session }: { session: Session }) {
   const [agents, setAgents] = useState<Agent[]>([])
-  const [policies, setPolicies] = useState<ModelPolicy[]>([])
   const [loading, setLoading] = useState(true)
   const [actionLoading, setActionLoading] = useState<string | null>(null)
   const [statusFilter, setStatusFilter] = useState<StatusFilter>('all')
 
   const isAdmin = session.user?.roles?.includes('admin')
 
-  const policyName = useCallback((id: string | null) => {
-    if (!id) return null
-    return policies.find((p) => p.id === id)?.name ?? null
-  }, [policies])
-
   const fetchData = useCallback(async () => {
     try {
-      const [agentsRes, policiesRes] = await Promise.all([
-        fetch('/api/agents'),
-        fetch('/api/model-policies'),
-      ])
+      const agentsRes = await fetch('/api/agents')
       if (agentsRes.ok) setAgents(await agentsRes.json())
-      if (policiesRes.ok) setPolicies(await policiesRes.json())
     } catch (err) {
       console.error('Failed to fetch agents:', err)
     } finally {
@@ -159,7 +144,6 @@ export default function AgentsClient({ session }: { session: Session }) {
       ) : (
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
           {filteredAgents.map((agent) => {
-            const policy = policyName(agent.model_policy_id)
             const tc = agent.tools_config || {}
             return (
               <div
@@ -228,11 +212,20 @@ export default function AgentsClient({ session }: { session: Session }) {
                   <span>{agent.pids_limit} PIDs</span>
                 </div>
 
-                {policy && (
+                {agent.models && agent.models.length > 0 && (
                   <div className="mb-3">
-                    <span className="inline-flex items-center px-2 py-0.5 text-xs font-medium rounded-md bg-brand-900/30 text-brand-400 border border-brand-800">
-                      {policy}
-                    </span>
+                    <div className="flex flex-wrap gap-1">
+                      {agent.models.slice(0, 2).map((m) => (
+                        <span key={m} className="inline-flex items-center px-2 py-0.5 text-xs font-medium rounded-md bg-brand-900/30 text-brand-400 border border-brand-800">
+                          {m}
+                        </span>
+                      ))}
+                      {agent.models.length > 2 && (
+                        <span className="inline-flex items-center px-2 py-0.5 text-xs font-medium rounded-md bg-navy-900 text-mountain-400 border border-navy-700">
+                          +{agent.models.length - 2}
+                        </span>
+                      )}
+                    </div>
                   </div>
                 )}
 

--- a/services/ui/src/app/agents/[id]/AgentDetailClient.tsx
+++ b/services/ui/src/app/agents/[id]/AgentDetailClient.tsx
@@ -20,20 +20,12 @@ interface Agent {
   rules_md: string
   container_id: string | null
   model_policy_id: string | null
+  models: string[]
   skills: Array<{ id: string; name: string; scope: string; tools?: Array<{ id: string; name: string }>; instructions_md?: string }>
   error_message: string | null
   created_at: string
   updated_at: string
   created_by: string
-}
-
-interface ModelPolicy {
-  id: string
-  name: string
-  allowed_models: string[]
-  max_requests_per_minute: number | null
-  max_tokens_per_day: number | null
-  created_by: string | null
 }
 
 interface SkillRecord {
@@ -80,7 +72,6 @@ export default function AgentDetailClient({
 }) {
   const router = useRouter()
   const [agent, setAgent] = useState<Agent | null>(null)
-  const [policies, setPolicies] = useState<ModelPolicy[]>([])
   const [loading, setLoading] = useState(true)
   const [actionLoading, setActionLoading] = useState(false)
   const [activeTab, setActiveTab] = useState<TabId>('overview')
@@ -126,17 +117,6 @@ export default function AgentDetailClient({
     }
   }, [agentId, router])
 
-  const fetchPolicies = useCallback(async () => {
-    try {
-      const res = await fetch('/api/model-policies')
-      if (res.ok) {
-        setPolicies(await res.json())
-      }
-    } catch (err) {
-      console.error('Failed to fetch policies:', err)
-    }
-  }, [])
-
   const fetchAllSkills = useCallback(async () => {
     try {
       const res = await fetch('/api/skills')
@@ -164,10 +144,9 @@ export default function AgentDetailClient({
 
   useEffect(() => {
     fetchAgent()
-    fetchPolicies()
     fetchAllSkills()
     fetchToolInstalls()
-  }, [fetchAgent, fetchPolicies, fetchAllSkills, fetchToolInstalls])
+  }, [fetchAgent, fetchAllSkills, fetchToolInstalls])
 
   // Poll status while running
   useEffect(() => {
@@ -277,7 +256,7 @@ export default function AgentDetailClient({
 
   if (!agent) return null
 
-  const currentPolicy = policies.find((p) => p.id === agent.model_policy_id)
+  const modelNames = agent.models || []
   const agentSkills = agent.skills || []
   const tc = agent.tools_config || {}
 
@@ -602,14 +581,20 @@ export default function AgentDetailClient({
             </dl>
           </div>
 
-          {/* Policy Summary */}
-          {currentPolicy && (
+          {/* Models Summary */}
+          {modelNames.length > 0 && (
             <div className="rounded-lg border border-navy-700 bg-navy-800 p-5">
-              <h2 className="text-lg font-semibold text-white mb-2">Model Policy</h2>
-              <p className="text-sm text-mountain-300">
-                {currentPolicy.name} — {currentPolicy.allowed_models.length} model{currentPolicy.allowed_models.length !== 1 ? 's' : ''}
-                {currentPolicy.max_requests_per_minute ? `, ${currentPolicy.max_requests_per_minute} req/min` : ''}
-              </p>
+              <h2 className="text-lg font-semibold text-white mb-2">Models</h2>
+              <div className="flex flex-wrap gap-1">
+                {modelNames.map((model) => (
+                  <span
+                    key={model}
+                    className="px-2 py-0.5 text-xs rounded-md bg-brand-900/50 text-brand-400 border border-brand-700"
+                  >
+                    {model}
+                  </span>
+                ))}
+              </div>
             </div>
           )}
 
@@ -726,37 +711,15 @@ export default function AgentDetailClient({
 
       {activeTab === 'model-access' && (
         <div className="space-y-6">
-          {/* Policy Detail */}
+          {/* Model Access */}
           <div className="rounded-lg border border-navy-700 bg-navy-800 p-5">
-            <h2 className="text-lg font-semibold text-white mb-3">Model Policy</h2>
-            {currentPolicy ? (
+            <h2 className="text-lg font-semibold text-white mb-3">Models</h2>
+            {modelNames.length > 0 ? (
               <div className="space-y-3">
-                <dl className="grid grid-cols-1 sm:grid-cols-3 gap-4 text-sm">
-                  <div>
-                    <dt className="text-mountain-400">Policy</dt>
-                    <dd className="text-white mt-1">{currentPolicy.name}</dd>
-                  </div>
-                  <div>
-                    <dt className="text-mountain-400">Rate Limit</dt>
-                    <dd className="text-white mt-1">
-                      {currentPolicy.max_requests_per_minute
-                        ? `${currentPolicy.max_requests_per_minute} req/min`
-                        : 'Unlimited'}
-                    </dd>
-                  </div>
-                  <div>
-                    <dt className="text-mountain-400">Token Budget</dt>
-                    <dd className="text-white mt-1">
-                      {currentPolicy.max_tokens_per_day
-                        ? `${Number(currentPolicy.max_tokens_per_day).toLocaleString()} tokens/day`
-                        : 'Unlimited'}
-                    </dd>
-                  </div>
-                </dl>
                 <div>
-                  <dt className="text-mountain-400 text-sm">Allowed Models</dt>
+                  <dt className="text-mountain-400 text-sm">Assigned Models</dt>
                   <dd className="mt-1 flex flex-wrap gap-1">
-                    {currentPolicy.allowed_models.map((m) => (
+                    {modelNames.map((m) => (
                       <span
                         key={m}
                         className="px-2 py-0.5 text-xs rounded-md bg-brand-900/50 text-brand-400 border border-brand-700"
@@ -768,7 +731,7 @@ export default function AgentDetailClient({
                 </div>
               </div>
             ) : (
-              <p className="text-sm text-mountain-500">No model policy assigned</p>
+              <p className="text-sm text-mountain-500">No models assigned</p>
             )}
           </div>
 

--- a/services/ui/src/app/agents/[id]/edit/AgentEditClient.tsx
+++ b/services/ui/src/app/agents/[id]/edit/AgentEditClient.tsx
@@ -49,7 +49,7 @@ export default function AgentEditClient({ agentId, isAdmin = false }: { agentId:
         pids_limit: agent.pids_limit,
         soul_md: agent.soul_md,
         rules_md: agent.rules_md,
-        model_policy_id: agent.model_policy_id,
+        models: agent.models,
         skills: agent.skills,
       }}
       agentUuid={agent.id}

--- a/services/ui/src/app/agents/new/AgentFormClient.tsx
+++ b/services/ui/src/app/agents/new/AgentFormClient.tsx
@@ -44,7 +44,6 @@ function scopeBadge(scope: string): { label: string; colorClasses: string } {
 }
 
 interface PolicyOption {
-  id: string
   name: string
 }
 
@@ -64,7 +63,7 @@ export default function AgentFormClient({
     pids_limit: number
     soul_md: string
     rules_md: string
-    model_policy_id?: string | null
+    models?: string[]
     skills?: Array<{ id: string; name: string; scope: string }>
   }
   agentUuid?: string
@@ -86,8 +85,8 @@ export default function AgentFormClient({
   const [pidsLimit, setPidsLimit] = useState(initial?.pids_limit || 200)
   const [soulMd, setSoulMd] = useState(initial?.soul_md || '')
   const [rulesMd, setRulesMd] = useState(initial?.rules_md || '')
-  const [modelPolicyId, setModelPolicyId] = useState(initial?.model_policy_id || '')
-  const [policies, setPolicies] = useState<PolicyOption[]>([])
+  const [availableModels, setAvailableModels] = useState<PolicyOption[]>([])
+  const [selectedModels, setSelectedModels] = useState<string[]>(initial?.models || [])
   const [skills, setSkills] = useState<SkillOption[]>([])
   // Mode: 'custom' = manual tools_config; 'skills' = checkbox multi-select
   const hasInitialSkills = (initial?.skills?.length ?? 0) > 0
@@ -105,9 +104,20 @@ export default function AgentFormClient({
   const [rulesPreview, setRulesPreview] = useState(false)
 
   useEffect(() => {
-    fetch('/api/model-policies')
-      .then((res) => (res.ok ? res.json() : []))
-      .then((data) => setPolicies(data))
+    Promise.all([
+      fetch('/api/model-policies').then((res) => (res.ok ? res.json() : [])),
+      fetch('/api/user-models').then((res) => (res.ok ? res.json() : [])),
+    ])
+      .then(([policiesData, userModelsData]) => {
+        const names = new Set<string>()
+        for (const p of policiesData as Array<{ allowed_models?: string[] }>) {
+          for (const n of p.allowed_models || []) names.add(n)
+        }
+        for (const m of userModelsData as Array<{ name?: string }>) {
+          if (m.name) names.add(m.name)
+        }
+        setAvailableModels([...names].sort().map((name) => ({ name })))
+      })
       .catch(() => {})
     fetch('/api/skills')
       .then((res) => (res.ok ? res.json() : []))
@@ -179,7 +189,7 @@ export default function AgentFormClient({
       pids_limit: pidsLimit,
       soul_md: soulMd,
       rules_md: rulesMd,
-      model_policy_id: modelPolicyId || null,
+      model_names: selectedModels,
       skill_ids: mode === 'skills' ? [...selectedSkillIds] : [],
     }
 
@@ -467,27 +477,39 @@ export default function AgentFormClient({
         )}
       </fieldset>
 
-      {/* Model Policy */}
+      {/* Models */}
       <fieldset disabled={disabled} className="space-y-4">
-        <legend className="text-lg font-semibold text-white mb-4">Model Policy</legend>
+        <legend className="text-lg font-semibold text-white mb-4">Models</legend>
 
         <div>
-          <label htmlFor="model_policy_id" className="block text-xs font-medium text-mountain-500 uppercase tracking-wide mb-1">
-            Model Policy
+          <label className="block text-xs font-medium text-mountain-500 uppercase tracking-wide mb-1">
+            Assign Models
           </label>
-          <select
-            id="model_policy_id"
-            value={modelPolicyId}
-            onChange={(e) => setModelPolicyId(e.target.value)}
-            className="rounded-lg border border-navy-600 bg-navy-900 px-3 py-2 text-sm text-white focus:border-brand-500 focus:outline-none disabled:opacity-50"
-          >
-            <option value="">None</option>
-            {policies.map((p) => (
-              <option key={p.id} value={p.id}>{p.name}</option>
-            ))}
-          </select>
+          <div className="max-h-48 overflow-y-auto rounded-lg border border-navy-700 bg-navy-800 p-3 space-y-2">
+            {availableModels.length === 0 ? (
+              <p className="text-xs text-mountain-500">No models available yet</p>
+            ) : (
+              availableModels.map((m) => (
+                <label key={m.name} className="flex items-center gap-2 text-sm text-white cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={selectedModels.includes(m.name)}
+                    onChange={() => {
+                      setSelectedModels((prev) => (
+                        prev.includes(m.name)
+                          ? prev.filter((v) => v !== m.name)
+                          : [...prev, m.name]
+                      ))
+                    }}
+                    className="rounded border-navy-600"
+                  />
+                  {m.name}
+                </label>
+              ))
+            )}
+          </div>
           <p className="text-xs text-mountain-500 mt-1">
-            Controls which LLM models this agent can access.
+            Select one or more models this agent can access.
           </p>
         </div>
       </fieldset>


### PR DESCRIPTION
## Summary
- replace the user-facing agent model policy picker with direct model assignment (`model_names`)
- return `models` on agent list/detail/update responses so UI renders assigned model names directly
- keep `model_policy_id` internal as compatibility plumbing via per-agent auto policies
- fix auto-policy upsert logic so it matches current DB uniqueness semantics and does not fail at runtime
- sync OpenAPI source and docs mirror, plus update API/UI tests to direct-model behavior

## Validation
- `cd services/ui && npx vitest run` (34 files, 301 tests passed)
- `cd services/ui && npx vitest run src/__tests__/AgentFormClient.test.tsx src/__tests__/AgentsClient.test.tsx src/__tests__/AgentDetailClient.test.tsx` (58 passed)
- `cd services/api && npx jest --runInBand` (29 suites, 319 tests passed)
- `cd services/api && npx jest src/__tests__/docs.test.ts --runInBand` (13 passed)
- `cd services/api && npx tsc --noEmit` (clean)
- `cd services/ui && npx tsc --noEmit` (9 pre-existing errors only: `middleware.test.ts` + `UsageClient.test.tsx`)
- `diff services/api/src/openapi/openapi.yaml docs/site/openapi.yaml` (no diff)
