### PR TITLE
refactor: remove model policy wording from UX copy

### DIFF
--- a/docs/site/getting-started/quickstart.mdx
+++ b/docs/site/getting-started/quickstart.mdx
@@ -109,36 +109,20 @@ curl -X POST https://api.hill90.com/user-models \
   }'
 ```
 
-## 6. Create a Model Policy
+## 6. Assign Models to Your Agent
 
-Define which models the agent can access, with optional rate limits:
-
-```bash
-curl -X POST https://api.hill90.com/model-policies \
-  -H "Authorization: Bearer $TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "name": "standard-access",
-    "allowed_models": ["my-gpt4o"],
-    "max_requests_per_minute": 10,
-    "max_tokens_per_day": 100000
-  }'
-```
-
-## 7. Assign the Policy to Your Agent
-
-Update the agent to use the model policy:
+Update the agent with direct model assignment:
 
 ```bash
 curl -X PUT https://api.hill90.com/agents/550e8400-e29b-41d4-a716-446655440000 \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
-    "model_policy_id": "POLICY_UUID_FROM_STEP_6"
+    "model_names": ["my-gpt4o"]
   }'
 ```
 
-## 8. Start the Agent
+## 7. Start the Agent
 
 Start the agent container (requires admin role):
 
@@ -154,9 +138,9 @@ curl -X POST https://api.hill90.com/agents/550e8400-e29b-41d4-a716-446655440000/
 }
 ```
 
-The agent is now running in a sandboxed container with access to LLM inference (via the model policy) and persistent knowledge storage.
+The agent is now running in a sandboxed container with access to LLM inference (via assigned models) and persistent knowledge storage.
 
-## 9. Browse Agent Knowledge
+## 8. Browse Agent Knowledge
 
 After the agent runs, browse what it has learned:
 
@@ -174,7 +158,7 @@ curl -H "Authorization: Bearer $TOKEN" \
   "https://api.hill90.com/knowledge/search?q=research+findings"
 ```
 
-## 10. Query Usage
+## 9. Query Usage
 
 Check how much the agent has consumed:
 

--- a/services/ui/src/__tests__/DashboardClient.test.tsx
+++ b/services/ui/src/__tests__/DashboardClient.test.tsx
@@ -30,9 +30,9 @@ const MOCK_AGENTS = [
   { id: 'a4', status: 'error' },
 ]
 
-const MOCK_POLICIES = [
-  { id: 'p1', name: 'Default Policy' },
-  { id: 'p2', name: 'Restricted Policy' },
+const MOCK_MODELS = [
+  { id: 'm1', name: 'gpt-4o-mini' },
+  { id: 'm2', name: 'claude-sonnet' },
 ]
 
 const MOCK_USAGE = {
@@ -49,8 +49,8 @@ function mockFetchDefaults() {
     if (url === '/api/agents') {
       return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_AGENTS) })
     }
-    if (url === '/api/model-policies') {
-      return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_POLICIES) })
+    if (url === '/api/user-models') {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_MODELS) })
     }
     if (typeof url === 'string' && url.startsWith('/api/usage')) {
       return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_USAGE) })
@@ -91,14 +91,14 @@ describe('DashboardClient', () => {
     expect(screen.getByText(/2 stopped/)).toBeInTheDocument()
   })
 
-  it('renders harness overview with policy count', async () => {
+  it('renders harness overview with model count', async () => {
     render(<DashboardClient session={MOCK_SESSION as any} />)
 
     await waitFor(() => {
       expect(screen.getByText('Harness Overview')).toBeInTheDocument()
     })
 
-    expect(screen.getByText('Policies')).toBeInTheDocument()
+    expect(screen.getByText('Models')).toBeInTheDocument()
     expect(screen.getByText('2')).toBeInTheDocument()
   })
 
@@ -135,7 +135,7 @@ describe('DashboardClient', () => {
       if (url === '/api/agents') {
         return Promise.resolve({ ok: true, json: () => Promise.resolve([]) })
       }
-      if (url === '/api/model-policies') {
+      if (url === '/api/user-models') {
         return Promise.resolve({ ok: false, json: () => Promise.resolve({}) })
       }
       if (typeof url === 'string' && url.startsWith('/api/usage')) {

--- a/services/ui/src/app/dashboard/DashboardClient.tsx
+++ b/services/ui/src/app/dashboard/DashboardClient.tsx
@@ -12,7 +12,7 @@ interface ServiceHealth {
 
 interface HarnessOverview {
   agents: { total: number; running: number; stopped: number; error: number }
-  policies: number
+  models: number
   usage: { requests: number; tokens: number; cost: number }
 }
 
@@ -51,14 +51,14 @@ export default function DashboardClient({ session }: { session: Session }) {
 
   const fetchHarness = useCallback(async () => {
     try {
-      const [agentsRes, policiesRes, usageRes] = await Promise.all([
+      const [agentsRes, modelsRes, usageRes] = await Promise.all([
         fetch('/api/agents'),
-        fetch('/api/model-policies'),
+        fetch('/api/user-models'),
         fetch(`/api/usage?from=${sevenDaysAgo()}`),
       ])
 
       const agents = agentsRes.ok ? await agentsRes.json() : []
-      const policies = policiesRes.ok ? await policiesRes.json() : []
+      const models = modelsRes.ok ? await modelsRes.json() : []
       const usage = usageRes.ok ? await usageRes.json() : null
 
       const agentCounts = { total: 0, running: 0, stopped: 0, error: 0 }
@@ -71,7 +71,7 @@ export default function DashboardClient({ session }: { session: Session }) {
 
       setHarness({
         agents: agentCounts,
-        policies: policies.length,
+        models: models.length,
         usage: {
           requests: Number(usage?.total_requests ?? 0),
           tokens: Number(usage?.total_tokens ?? 0),
@@ -139,8 +139,8 @@ export default function DashboardClient({ session }: { session: Session }) {
               </dd>
             </div>
             <div>
-              <dt className="text-mountain-400">Policies</dt>
-              <dd className="text-2xl font-bold text-white mt-1">{harness.policies}</dd>
+              <dt className="text-mountain-400">Models</dt>
+              <dd className="text-2xl font-bold text-white mt-1">{harness.models}</dd>
             </div>
             <div>
               <dt className="text-mountain-400">Requests (7d)</dt>
@@ -194,4 +194,3 @@ export default function DashboardClient({ session }: { session: Session }) {
     </>
   )
 }
-

--- a/services/ui/src/app/harness/usage/UsageClient.tsx
+++ b/services/ui/src/app/harness/usage/UsageClient.tsx
@@ -189,7 +189,7 @@ export default function UsageClient() {
         <div className="rounded-lg border border-navy-700 bg-navy-800 p-12 text-center">
           <p className="text-mountain-400 mb-4">No usage data yet</p>
           <p className="text-sm text-mountain-500">
-            Start an agent with a model policy to begin tracking usage.
+            Assign one or more models to an agent and run it to begin tracking usage.
           </p>
         </div>
       ) : (


### PR DESCRIPTION
## Summary
- replace remaining user-facing "model policy" copy with direct model-assignment language
- dashboard overview now reports "Models" count from `/api/user-models` instead of policy count
- usage empty-state copy now points users to assign models directly to agents
- quickstart docs updated to use `model_names` assignment flow (no policy creation step)

## Validation
- `cd services/ui && npx vitest run src/__tests__/DashboardClient.test.tsx src/__tests__/UsageClient.test.tsx`
- `cd services/ui && npx vitest run`
