### PR TITLE
refactor: remove policies harness surface from nav

### DIFF
--- a/services/ui/src/__tests__/Sidebar.test.tsx
+++ b/services/ui/src/__tests__/Sidebar.test.tsx
@@ -127,7 +127,6 @@ describe('Sidebar', () => {
 
     expect(screen.getByRole('link', { name: /connections/i })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /models/i })).toBeInTheDocument()
-    expect(screen.getByRole('link', { name: /policies/i })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /usage/i })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /^knowledge$/i })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /shared knowledge/i })).toBeInTheDocument()

--- a/services/ui/src/app/harness/models/ModelsClient.tsx
+++ b/services/ui/src/app/harness/models/ModelsClient.tsx
@@ -121,7 +121,7 @@ export default function ModelsClient() {
   }
 
   const handleDelete = async (model: UserModel) => {
-    if (!confirm(`Delete model "${model.name}"? Policies referencing this model will need to be updated.`)) return
+    if (!confirm(`Delete model "${model.name}"? Agents and internal model access config referencing this model will need updates.`)) return
     setActionLoading(model.id)
     try {
       const res = await fetch(`/api/user-models/${model.id}`, { method: 'DELETE' })

--- a/services/ui/src/app/harness/policies/page.tsx
+++ b/services/ui/src/app/harness/policies/page.tsx
@@ -1,7 +1,5 @@
 import { redirect } from 'next/navigation'
 import { auth } from '@/auth'
-import AppShell from '@/components/AppShell'
-import PoliciesClient from './PoliciesClient'
 
 export default async function PoliciesPage() {
   const session = await auth()
@@ -10,11 +8,6 @@ export default async function PoliciesPage() {
     redirect('/api/auth/signin')
   }
 
-  return (
-    <AppShell>
-      <main className="flex-1 px-6 py-12 max-w-6xl mx-auto w-full">
-        <PoliciesClient />
-      </main>
-    </AppShell>
-  )
+  // Deprecated user-facing surface: direct users to model management.
+  redirect('/harness/models')
 }

--- a/services/ui/src/components/nav-items.ts
+++ b/services/ui/src/components/nav-items.ts
@@ -1,4 +1,4 @@
-import { Home, LayoutDashboard, Bot, FileText, Book, ExternalLink, KeyRound, Cpu, Shield, BarChart3, BookOpen, Library, Wrench, Layers, Settings, Server } from 'lucide-react'
+import { Home, LayoutDashboard, Bot, FileText, Book, ExternalLink, KeyRound, Cpu, BarChart3, BookOpen, Library, Wrench, Layers, Settings, Server } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
 
 export interface NavLink {
@@ -34,7 +34,6 @@ export const NAV_ITEMS: NavItem[] = [
     children: [
       { type: 'link', id: 'connections', label: 'Connections', href: '/harness/connections', icon: KeyRound },
       { type: 'link', id: 'models', label: 'Models', href: '/harness/models', icon: Cpu },
-      { type: 'link', id: 'policies', label: 'Policies', href: '/harness/policies', icon: Shield },
       { type: 'link', id: 'skills', label: 'Skills', href: '/harness/skills', icon: Wrench },
       { type: 'link', id: 'tools', label: 'Tools', href: '/harness/tools', icon: Settings, adminOnly: true },
       { type: 'link', id: 'usage', label: 'Usage', href: '/harness/usage', icon: BarChart3 },


### PR DESCRIPTION
## Summary
- remove Policies from Harness navigation so users no longer see it as a product surface
- redirect /harness/policies to /harness/models
- update model-delete confirmation copy to avoid policy terminology
- update sidebar nav test expectations

## Validation
- cd services/ui && npx vitest run src/__tests__/Sidebar.test.tsx src/__tests__/ModelsClient.test.tsx
- cd services/ui && npx vitest run
