### PR TITLE
fix: render skill tools as chips

### DIFF
--- a/services/ui/src/__tests__/AgentDetailClient.test.tsx
+++ b/services/ui/src/__tests__/AgentDetailClient.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react'
+import { render, screen, cleanup, fireEvent, waitFor, within } from '@testing-library/react'
 import '@testing-library/jest-dom/vitest'
 
 // Mock next/link
@@ -553,8 +553,9 @@ describe('AgentDetailClient', () => {
     expect(skillCard.textContent).not.toMatch(/\bSkill\b/)
     expect(skillCard.textContent).not.toContain('Profile')
 
-    // Should show tools
-    expect(screen.getByText('Tools: gh, git')).toBeInTheDocument()
+    // Should show tools as badges on the skill card
+    expect(within(skillCard).getByText('gh')).toBeInTheDocument()
+    expect(within(skillCard).getByText('git')).toBeInTheDocument()
   })
 
   // U6: Detail shows tools on skill cards
@@ -567,8 +568,10 @@ describe('AgentDetailClient', () => {
       expect(screen.getByText('Developer')).toBeInTheDocument()
     })
 
-    // Should show tool names
-    expect(screen.getByText('Tools: gh, git')).toBeInTheDocument()
+    // Should show tool names as badges on the skill card
+    const skillCard = screen.getByText('Developer').closest('[class*="rounded-md"]')!
+    expect(within(skillCard).getByText('gh')).toBeInTheDocument()
+    expect(within(skillCard).getByText('git')).toBeInTheDocument()
   })
 
 })

--- a/services/ui/src/__tests__/SkillsClient.test.tsx
+++ b/services/ui/src/__tests__/SkillsClient.test.tsx
@@ -221,15 +221,16 @@ describe('SkillsClient', () => {
     expect(screen.getByText('CI Runner')).toBeInTheDocument()
   })
 
-  // U2: Skill with tools shows Tools badges
-  it('Skill with tools shows Tools badges', async () => {
+  // U2: Skill with tools shows tool badges
+  it('Skill with tools shows tool badges', async () => {
     render(<SkillsClient />)
 
     await waitFor(() => {
       expect(screen.getByText('CI Runner')).toBeInTheDocument()
     })
 
-    expect(screen.getByText('Tools: gh, git')).toBeInTheDocument()
+    expect(screen.getByText('gh')).toBeInTheDocument()
+    expect(screen.getByText('git')).toBeInTheDocument()
   })
 
   // U3: Create form has tool checkboxes

--- a/services/ui/src/app/agents/[id]/AgentDetailClient.tsx
+++ b/services/ui/src/app/agents/[id]/AgentDetailClient.tsx
@@ -482,9 +482,16 @@ export default function AgentDetailClient({
                             {badge.label}
                           </span>
                           {skill.tools && skill.tools.length > 0 && (
-                            <span className="px-1.5 py-0.5 text-xs rounded-md bg-navy-800 text-mountain-300 border border-navy-600 font-mono">
-                              Tools: {skill.tools.map(t => t.name).join(', ')}
-                            </span>
+                            <div className="inline-flex items-center gap-1">
+                              {skill.tools.map((tool) => (
+                                <span
+                                  key={`${skill.id}-tool-${tool.id}`}
+                                  className="px-1.5 py-0.5 text-xs rounded-md bg-navy-800 text-mountain-300 border border-navy-600 font-mono"
+                                >
+                                  {tool.name}
+                                </span>
+                              ))}
+                            </div>
                           )}
                         </div>
                         <div className="flex items-center gap-2">

--- a/services/ui/src/app/harness/skills/SkillsClient.tsx
+++ b/services/ui/src/app/harness/skills/SkillsClient.tsx
@@ -444,9 +444,16 @@ export default function SkillsClient() {
                           </span>
                         )}
                         {skill.tools?.length > 0 && (
-                          <span className="inline-flex items-center gap-1 px-2 py-0.5 text-xs rounded-md bg-navy-800 text-mountain-300 border border-navy-600 font-mono">
-                            Tools: {skill.tools.map(t => t.name).join(', ')}
-                          </span>
+                          <div className="inline-flex items-center gap-1">
+                            {skill.tools.map((tool) => (
+                              <span
+                                key={`${skill.id}-tool-${tool.id}`}
+                                className="px-2 py-0.5 text-xs rounded-md bg-navy-800 text-mountain-300 border border-navy-600 font-mono"
+                              >
+                                {tool.name}
+                              </span>
+                            ))}
+                          </div>
                         )}
                       </div>
                     </div>


### PR DESCRIPTION
## Summary
- replace inline `Tools: ...` text with individual tool chips on Skills cards
- apply the same chip treatment on Agent Detail skill cards
- update Skills/AgentDetail tests to assert tool badge rendering

## Validation
- [x] `cd services/ui && npx vitest run src/__tests__/SkillsClient.test.tsx src/__tests__/AgentDetailClient.test.tsx`
- [x] `cd services/ui && npx vitest run`

## Scope
- UI-only presentation cleanup
- no API/schema/runtime behavior changes
