### PR TITLE
fix: target skills detail tool dependency section

### DIFF
--- a/services/ui/src/__tests__/SkillsClient.test.tsx
+++ b/services/ui/src/__tests__/SkillsClient.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react'
+import { render, screen, fireEvent, cleanup, waitFor, within } from '@testing-library/react'
 import '@testing-library/jest-dom/vitest'
 
 // Mock next-auth/react
@@ -229,8 +229,15 @@ describe('SkillsClient', () => {
       expect(screen.getByText('CI Runner')).toBeInTheDocument()
     })
 
-    expect(screen.getByText('gh')).toBeInTheDocument()
-    expect(screen.getByText('git')).toBeInTheDocument()
+    fireEvent.click(screen.getByText('CI Runner'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Tool Dependencies')).toBeInTheDocument()
+    })
+
+    const card = screen.getByText('CI Runner').closest('[class*="rounded-lg"]')!
+    expect(within(card).getByText('gh')).toBeInTheDocument()
+    expect(within(card).getByText('git')).toBeInTheDocument()
   })
 
   // U3: Create form has tool checkboxes

--- a/services/ui/src/app/harness/skills/SkillsClient.tsx
+++ b/services/ui/src/app/harness/skills/SkillsClient.tsx
@@ -443,18 +443,6 @@ export default function SkillsClient() {
                             <Heart className="w-3 h-3" /> Health
                           </span>
                         )}
-                        {skill.tools?.length > 0 && (
-                          <div className="inline-flex items-center gap-1">
-                            {skill.tools.map((tool) => (
-                              <span
-                                key={`${skill.id}-tool-${tool.id}`}
-                                className="px-2 py-0.5 text-xs rounded-md bg-navy-800 text-mountain-300 border border-navy-600 font-mono"
-                              >
-                                {tool.name}
-                              </span>
-                            ))}
-                          </div>
-                        )}
                       </div>
                     </div>
                     {skill.description && (
@@ -491,23 +479,22 @@ export default function SkillsClient() {
                     )}
 
                     <dl className="grid grid-cols-1 sm:grid-cols-2 gap-4 text-sm mb-4">
-                      {/* Shell config */}
+                      {/* Tool dependencies */}
                       <div>
-                        <dt className="text-mountain-400 mb-1">Shell</dt>
+                        <dt className="text-mountain-400 mb-1">Tool Dependencies</dt>
                         <dd className="text-white">
-                          {tc.shell.enabled ? (
+                          {(skill.tools?.length || 0) > 0 ? (
                             <div className="space-y-1">
                               <div className="flex flex-wrap gap-1">
-                                {tc.shell.allowed_binaries.map((b) => (
-                                  <span key={b} className="px-2 py-0.5 text-xs rounded-md bg-navy-900 text-brand-400 border border-navy-700">
-                                    {b}
+                                {skill.tools!.map((tool) => (
+                                  <span key={tool.id} className="px-2 py-0.5 text-xs rounded-md bg-navy-900 text-brand-400 border border-navy-700 font-mono">
+                                    {tool.name}
                                   </span>
                                 ))}
                               </div>
-                              <div className="text-xs text-mountain-500">Timeout: {tc.shell.max_timeout}s</div>
                             </div>
                           ) : (
-                            <span className="text-mountain-500">Disabled</span>
+                            <span className="text-mountain-500">None declared</span>
                           )}
                         </dd>
                       </div>


### PR DESCRIPTION
## Summary
- remove top-row tool chips on skill summary cards (the yellow-circled area)
- render declared tool dependencies in the expanded skills detail section (the green-circled area)
- keep this patch scoped to `SkillsClient` UI + tests only

## Validation
- [x] `cd services/ui && npx vitest run src/__tests__/SkillsClient.test.tsx src/__tests__/AgentDetailClient.test.tsx`
- [x] `cd services/ui && npx vitest run`

## Scope
- no API changes
- no schema/migration changes
- no agent detail page behavior changes in this patch
