### PR TITLE
feat: robust tool installs with timeout, retry, reconcile (Phase 6B)

### DIFF
--- a/docs/site/openapi.yaml
+++ b/docs/site/openapi.yaml
@@ -126,7 +126,7 @@ components:
           type: string
         status:
           type: string
-          enum: [pending, installed, failed]
+          enum: [pending, installing, installed, failed]
         install_message:
           type: string
         installed_at:
@@ -996,6 +996,55 @@ paths:
           description: Requires user role
         "404":
           description: Agent not found
+
+  /agents/{id}/reconcile-tools:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    post:
+      summary: Reconcile tool installations
+      description: >
+        Re-evaluates required tools from assigned skills and installs any missing
+        tools in the running agent container. Already-installed tools are skipped.
+        Stale install records for unassigned tools are cleaned up.
+        Requires admin role. Agent must be running.
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Reconcile result
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  installed:
+                    type: array
+                    items:
+                      type: string
+                    description: Tools newly installed during this reconcile
+                  alreadyInstalled:
+                    type: array
+                    items:
+                      type: string
+                    description: Tools that were already installed
+                  failed:
+                    type: array
+                    items:
+                      type: string
+                    description: Tools that failed to install
+        "401":
+          description: Not authenticated
+        "403":
+          description: Requires admin role
+        "404":
+          description: Agent not found
+        "409":
+          description: Agent is not running
 
   /agents/{id}/events:
     parameters:

--- a/services/api/src/__tests__/docs.test.ts
+++ b/services/api/src/__tests__/docs.test.ts
@@ -148,6 +148,7 @@ const EXPECTED_PATHS = [
   '/agents/{id}/stop',
   '/agents/{id}/status',
   '/agents/{id}/tool-installs',
+  '/agents/{id}/reconcile-tools',
   '/agents/{id}/events',
   '/agents/{id}/logs',
   '/model-policies',

--- a/services/api/src/__tests__/routes-agents.test.ts
+++ b/services/api/src/__tests__/routes-agents.test.ts
@@ -36,8 +36,10 @@ jest.mock('../services/agent-files', () => ({
   writeAgentFiles: jest.fn().mockReturnValue('/data/agentbox/test-agent'),
   removeAgentFiles: jest.fn(),
 }));
+const mockReconcileToolInstalls = jest.fn().mockResolvedValue({ installed: [], alreadyInstalled: [], failed: [] });
 jest.mock('../services/tool-installer', () => ({
   ensureRequiredToolsInstalled: (...args: any[]) => mockEnsureRequiredToolsInstalled(...args),
+  reconcileToolInstalls: (...args: any[]) => mockReconcileToolInstalls(...args),
 }));
 
 const app = createApp({
@@ -312,5 +314,64 @@ describe('Agent lifecycle routes', () => {
       .get('/agents/some-id/logs')
       .set('Authorization', `Bearer ${userToken}`);
     expect(res.status).toBe(403);
+  });
+});
+
+describe('POST /agents/:id/reconcile-tools', () => {
+  beforeEach(() => {
+    mockQuery.mockReset();
+    mockReconcileToolInstalls.mockReset();
+    mockReconcileToolInstalls.mockResolvedValue({ installed: ['gh'], alreadyInstalled: [], failed: [] });
+    process.env.DATABASE_URL = 'postgresql://test:test@localhost:5432/test';
+  });
+
+  afterEach(() => {
+    delete process.env.DATABASE_URL;
+  });
+
+  it('returns 401 without auth', async () => {
+    const res = await request(app).post('/agents/uuid-1/reconcile-tools');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 for non-admin', async () => {
+    const res = await request(app)
+      .post('/agents/uuid-1/reconcile-tools')
+      .set('Authorization', `Bearer ${userToken}`);
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 404 for unknown agent', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    const res = await request(app)
+      .post('/agents/uuid-1/reconcile-tools')
+      .set('Authorization', `Bearer ${adminToken}`);
+    expect(res.status).toBe(404);
+    expect(res.body.error).toContain('Agent not found');
+  });
+
+  it('returns 409 when agent is not running', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: 'uuid-1', agent_id: 'test-agent', status: 'stopped' }] });
+
+    const res = await request(app)
+      .post('/agents/uuid-1/reconcile-tools')
+      .set('Authorization', `Bearer ${adminToken}`);
+    expect(res.status).toBe(409);
+    expect(res.body.error).toContain('running');
+  });
+
+  it('returns 200 with reconcile result for running agent', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: 'uuid-1', agent_id: 'test-agent', status: 'running' }] });
+
+    const res = await request(app)
+      .post('/agents/uuid-1/reconcile-tools')
+      .set('Authorization', `Bearer ${adminToken}`);
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('installed');
+    expect(res.body).toHaveProperty('alreadyInstalled');
+    expect(res.body).toHaveProperty('failed');
+    expect(Array.isArray(res.body.installed)).toBe(true);
+    expect(mockReconcileToolInstalls).toHaveBeenCalledWith('uuid-1', 'test-agent');
   });
 });

--- a/services/api/src/__tests__/tool-installer.test.ts
+++ b/services/api/src/__tests__/tool-installer.test.ts
@@ -228,3 +228,42 @@ describe('tool-installer service', () => {
     expect(deleteCalls[0][1]).toEqual(['agent-db-id', 'tool-old']);
   });
 });
+
+// T13 (unit): invalid HILL90_TOOL_INSTALL_RETRIES still retries (defaults to 1)
+describe('tool-installer retry env safety', () => {
+  it('invalid HILL90_TOOL_INSTALL_RETRIES defaults to 1 retry', async () => {
+    const origEnv = process.env.HILL90_TOOL_INSTALL_RETRIES;
+    process.env.HILL90_TOOL_INSTALL_RETRIES = 'not-a-number';
+
+    // Re-import the module with fresh env
+    jest.resetModules();
+    const mockQueryInner = jest.fn();
+    const mockExecInner = jest.fn();
+    jest.doMock('../db/pool', () => ({ getPool: () => ({ query: mockQueryInner }) }));
+    jest.doMock('../services/docker', () => ({
+      execInContainerWithExit: (...args: any[]) => mockExecInner(...args),
+    }));
+
+    const { ensureRequiredToolsInstalled: ensureFresh } = require('../services/tool-installer');
+
+    mockQueryInner
+      .mockResolvedValueOnce({
+        rows: [{ id: 'tool-gh', name: 'gh', install_method: 'binary', install_ref: 'https://example.com/gh_{version}.tar.gz' }],
+      })
+      .mockResolvedValue({ rowCount: 1 });
+    mockExecInner
+      .mockResolvedValueOnce({ exitCode: 1, stdout: '', stderr: 'fail' }) // first attempt
+      .mockResolvedValue({ exitCode: 0, stdout: '', stderr: '' }); // retry
+
+    await ensureFresh('agent-db-id', 'agent-slug');
+    // Should have retried (2 exec calls), proving NaN didn't yield 0 retries
+    expect(mockExecInner).toHaveBeenCalledTimes(2);
+
+    // Restore
+    if (origEnv === undefined) {
+      delete process.env.HILL90_TOOL_INSTALL_RETRIES;
+    } else {
+      process.env.HILL90_TOOL_INSTALL_RETRIES = origEnv;
+    }
+  });
+});

--- a/services/api/src/__tests__/tool-installer.test.ts
+++ b/services/api/src/__tests__/tool-installer.test.ts
@@ -1,4 +1,4 @@
-import { ensureRequiredToolsInstalled } from '../services/tool-installer';
+import { ensureRequiredToolsInstalled, reconcileToolInstalls, binaryInstallScript } from '../services/tool-installer';
 
 const mockQuery = jest.fn();
 const mockExec = jest.fn();
@@ -36,7 +36,7 @@ describe('tool-installer service', () => {
 
     await ensureRequiredToolsInstalled('agent-db-id', 'agent-slug');
 
-    expect(mockExec).toHaveBeenCalledWith('agent-slug', ['bash', '-lc', 'command -v bash']);
+    expect(mockExec).toHaveBeenCalledWith('agent-slug', ['bash', '-lc', 'command -v bash'], 30000);
     expect(mockQuery).toHaveBeenCalled();
   });
 
@@ -55,7 +55,7 @@ describe('tool-installer service', () => {
     expect(call[0]).toBe('agent-slug');
     expect(call[1][0]).toBe('bash');
     expect(call[1][1]).toBe('-lc');
-    expect(call[1][2]).toContain('/data/tools/bin/gh');
+    expect(call[1][2]).toContain("/data/tools/bin/'gh'");
   });
 
   it('marks tool failed and throws on install error', async () => {
@@ -70,5 +70,161 @@ describe('tool-installer service', () => {
       /Failed installing required tool "bash"/
     );
   });
-});
 
+  // T1: installing status set before install attempt
+  it('sets installing status before install attempt', async () => {
+    mockQuery
+      .mockResolvedValueOnce({
+        rows: [{ id: 'tool-gh', name: 'gh', install_method: 'binary', install_ref: 'https://example.com/gh_{version}.tar.gz' }],
+      })
+      .mockResolvedValue({ rowCount: 1 });
+    mockExec.mockResolvedValue({ exitCode: 0, stdout: '', stderr: '' });
+
+    await ensureRequiredToolsInstalled('agent-db-id', 'agent-slug');
+
+    // First upsert should use 'installing'
+    const upsertCalls = mockQuery.mock.calls.filter((c: any) => c[0].includes('INSERT INTO agent_tool_installs'));
+    expect(upsertCalls.length).toBeGreaterThan(0);
+    expect(upsertCalls[0][1][2]).toBe('installing');
+  });
+
+  // T2: retry once on transient binary failure, then succeed
+  it('retries once on binary install failure then succeeds', async () => {
+    mockQuery
+      .mockResolvedValueOnce({
+        rows: [{ id: 'tool-gh', name: 'gh', install_method: 'binary', install_ref: 'https://example.com/gh_{version}.tar.gz' }],
+      })
+      .mockResolvedValue({ rowCount: 1 });
+    mockExec
+      .mockResolvedValueOnce({ exitCode: 1, stdout: '', stderr: 'network timeout' }) // first attempt fails
+      .mockResolvedValue({ exitCode: 0, stdout: '', stderr: '' }); // retry succeeds
+
+    await ensureRequiredToolsInstalled('agent-db-id', 'agent-slug');
+    expect(mockExec).toHaveBeenCalledTimes(2);
+  });
+
+  // T3: no retry for builtin
+  it('does not retry builtin tool failure', async () => {
+    mockQuery
+      .mockResolvedValueOnce({
+        rows: [{ id: 'tool-bash', name: 'bash', install_method: 'builtin', install_ref: '' }],
+      })
+      .mockResolvedValue({ rowCount: 1 });
+    mockExec.mockResolvedValue({ exitCode: 1, stdout: '', stderr: 'not found' });
+
+    await expect(ensureRequiredToolsInstalled('agent-db-id', 'agent-slug')).rejects.toThrow();
+    expect(mockExec).toHaveBeenCalledTimes(1); // no retry
+  });
+
+  // T4: timeout passed to exec for binary
+  it('passes timeout to execInContainerWithExit for binary installs', async () => {
+    mockQuery
+      .mockResolvedValueOnce({
+        rows: [{ id: 'tool-gh', name: 'gh', install_method: 'binary', install_ref: 'https://example.com/gh_{version}.tar.gz' }],
+      })
+      .mockResolvedValue({ rowCount: 1 });
+    mockExec.mockResolvedValue({ exitCode: 0, stdout: '', stderr: '' });
+
+    await ensureRequiredToolsInstalled('agent-db-id', 'agent-slug');
+
+    expect(mockExec).toHaveBeenCalledWith('agent-slug', expect.any(Array), 300000);
+  });
+
+  // T5: deterministic binary path for gh
+  it('gh binary path resolves to gh_{v}_linux_amd64/bin/gh', () => {
+    const tool = { id: 't1', name: 'gh', install_method: 'binary' as const, install_ref: 'https://example.com/gh_{version}.tar.gz' };
+    const script = binaryInstallScript(tool);
+    expect(script).toContain('gh_2.74.2_linux_amd64/bin/gh');
+    expect(script).not.toContain('find');
+  });
+
+  // T6: deterministic binary path for docker
+  it('docker binary path resolves to docker/docker', () => {
+    const tool = { id: 't2', name: 'docker', install_method: 'binary' as const, install_ref: 'https://example.com/docker-{version}.tgz' };
+    const script = binaryInstallScript(tool);
+    expect(script).toContain('docker/docker');
+    expect(script).not.toContain('find');
+  });
+
+  // T7: no version configured throws clear error
+  it('throws clear error when no version configured for binary tool', () => {
+    const tool = { id: 't3', name: 'rg', install_method: 'binary' as const, install_ref: 'https://example.com/rg-{version}.tgz' };
+    expect(() => binaryInstallScript(tool)).toThrow(/No version configured for binary tool "rg"/);
+  });
+
+  // T8: binary install uses cp with deterministic path (no find)
+  it('binary install script uses cp with deterministic path, no find', () => {
+    const tool = { id: 't1', name: 'gh', install_method: 'binary' as const, install_ref: 'https://example.com/gh_{version}.tar.gz' };
+    const script = binaryInstallScript(tool);
+    expect(script).toMatch(/cp \/tmp\/hill90-tools\/gh_.*\/bin\/gh \/data\/tools\/bin/);
+    expect(script).not.toContain('find');
+    expect(script).not.toContain('head');
+  });
+
+  // T9: reconcile skips already-installed tools
+  it('reconcile skips already-installed tools', async () => {
+    mockQuery
+      .mockResolvedValueOnce({
+        rows: [{ id: 'tool-gh', name: 'gh', install_method: 'binary', install_ref: 'https://example.com/gh.tar.gz' }],
+      }) // required tools
+      .mockResolvedValueOnce({
+        rows: [{ tool_id: 'tool-gh', status: 'installed' }],
+      }); // existing installs
+
+    const result = await reconcileToolInstalls('agent-db-id', 'agent-slug');
+    expect(result.alreadyInstalled).toEqual(['gh']);
+    expect(result.installed).toEqual([]);
+    expect(result.failed).toEqual([]);
+    expect(mockExec).not.toHaveBeenCalled();
+  });
+
+  // T10: reconcile installs missing tools
+  it('reconcile installs missing tools', async () => {
+    mockQuery
+      .mockResolvedValueOnce({
+        rows: [{ id: 'tool-gh', name: 'gh', install_method: 'binary', install_ref: 'https://example.com/gh_{version}.tar.gz' }],
+      }) // required tools
+      .mockResolvedValueOnce({ rows: [] }) // no existing installs
+      .mockResolvedValue({ rowCount: 1 }); // upserts
+    mockExec.mockResolvedValue({ exitCode: 0, stdout: '', stderr: '' });
+
+    const result = await reconcileToolInstalls('agent-db-id', 'agent-slug');
+    expect(result.installed).toEqual(['gh']);
+    expect(mockExec).toHaveBeenCalled();
+  });
+
+  // T11: reconcile reports failures without throwing
+  it('reconcile reports failures without throwing', async () => {
+    mockQuery
+      .mockResolvedValueOnce({
+        rows: [{ id: 'tool-gh', name: 'gh', install_method: 'binary', install_ref: 'https://example.com/gh_{version}.tar.gz' }],
+      }) // required tools
+      .mockResolvedValueOnce({ rows: [] }) // no existing installs
+      .mockResolvedValue({ rowCount: 1 }); // upserts
+    // Both attempts fail (initial + 1 retry)
+    mockExec.mockResolvedValue({ exitCode: 1, stdout: '', stderr: 'download failed' });
+
+    const result = await reconcileToolInstalls('agent-db-id', 'agent-slug');
+    expect(result.failed).toEqual(['gh']);
+    expect(result.installed).toEqual([]);
+  });
+
+  // T12: reconcile cleans up stale install records
+  it('reconcile cleans up stale install records', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [] }) // no required tools (skill was removed)
+      .mockResolvedValueOnce({
+        rows: [{ tool_id: 'tool-old', status: 'installed' }],
+      }) // stale install from previously-assigned skill
+      .mockResolvedValue({ rowCount: 1 }); // DELETE
+
+    const result = await reconcileToolInstalls('agent-db-id', 'agent-slug');
+    expect(result.installed).toEqual([]);
+    expect(result.alreadyInstalled).toEqual([]);
+
+    // Verify DELETE was called for the stale tool
+    const deleteCalls = mockQuery.mock.calls.filter((c: any) => c[0].includes('DELETE FROM agent_tool_installs'));
+    expect(deleteCalls.length).toBe(1);
+    expect(deleteCalls[0][1]).toEqual(['agent-db-id', 'tool-old']);
+  });
+});

--- a/services/api/src/db/migrations/027_add_installing_status.sql
+++ b/services/api/src/db/migrations/027_add_installing_status.sql
@@ -1,0 +1,13 @@
+-- Phase 6B: Widen agent_tool_installs status to include 'installing'.
+-- Existing rows (pending/installed/failed) remain valid.
+-- Uses deterministic constraint name for idempotent DROP + re-add.
+--
+-- Rollback: UPDATE agent_tool_installs SET status = 'pending' WHERE status = 'installing';
+--           then DROP CONSTRAINT IF EXISTS + re-add narrower CHECK.
+
+ALTER TABLE agent_tool_installs
+  DROP CONSTRAINT IF EXISTS agent_tool_installs_status_check;
+
+ALTER TABLE agent_tool_installs
+  ADD CONSTRAINT agent_tool_installs_status_check
+  CHECK (status IN ('pending', 'installing', 'installed', 'failed'));

--- a/services/api/src/openapi/openapi.yaml
+++ b/services/api/src/openapi/openapi.yaml
@@ -126,7 +126,7 @@ components:
           type: string
         status:
           type: string
-          enum: [pending, installed, failed]
+          enum: [pending, installing, installed, failed]
         install_message:
           type: string
         installed_at:
@@ -996,6 +996,55 @@ paths:
           description: Requires user role
         "404":
           description: Agent not found
+
+  /agents/{id}/reconcile-tools:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    post:
+      summary: Reconcile tool installations
+      description: >
+        Re-evaluates required tools from assigned skills and installs any missing
+        tools in the running agent container. Already-installed tools are skipped.
+        Stale install records for unassigned tools are cleaned up.
+        Requires admin role. Agent must be running.
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Reconcile result
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  installed:
+                    type: array
+                    items:
+                      type: string
+                    description: Tools newly installed during this reconcile
+                  alreadyInstalled:
+                    type: array
+                    items:
+                      type: string
+                    description: Tools that were already installed
+                  failed:
+                    type: array
+                    items:
+                      type: string
+                    description: Tools that failed to install
+        "401":
+          description: Not authenticated
+        "403":
+          description: Requires admin role
+        "404":
+          description: Agent not found
+        "409":
+          description: Agent is not running
 
   /agents/{id}/events:
     parameters:

--- a/services/api/src/routes/agents.ts
+++ b/services/api/src/routes/agents.ts
@@ -4,7 +4,7 @@ import { requireRole } from '../middleware/role';
 import { scopeToOwner } from '../helpers/scope';
 import { writeAgentFiles, removeAgentFiles } from '../services/agent-files';
 import { mergeToolsConfigs, DEFAULT_TOOLS_CONFIG } from '../services/merge-tools-config';
-import { ensureRequiredToolsInstalled } from '../services/tool-installer';
+import { ensureRequiredToolsInstalled, reconcileToolInstalls } from '../services/tool-installer';
 import {
   createAndStartContainer,
   stopAndRemoveContainer,
@@ -865,6 +865,31 @@ router.get('/:id/tool-installs', requireRole('user'), async (req: Request, res: 
   } catch (err) {
     console.error('[agents] Tool install status error:', err);
     res.status(500).json({ error: 'Failed to get tool install status' });
+  }
+});
+
+// Reconcile tool installations for a running agent
+router.post('/:id/reconcile-tools', requireRole('admin'), async (req: Request, res: Response) => {
+  try {
+    const user = (req as any).user;
+    const { rows } = await getPool().query('SELECT id, agent_id, status FROM agents WHERE id = $1', [req.params.id]);
+    if (rows.length === 0) {
+      res.status(404).json({ error: 'Agent not found' });
+      return;
+    }
+
+    const agent = rows[0];
+    if (agent.status !== 'running') {
+      res.status(409).json({ error: 'Agent must be running to reconcile tools. Use start instead.' });
+      return;
+    }
+
+    const result = await reconcileToolInstalls(agent.id, agent.agent_id);
+    auditLog('reconcile_tools', agent.agent_id, user.sub, result);
+    res.json(result);
+  } catch (err: any) {
+    console.error('[agents] Reconcile tools error:', err);
+    res.status(500).json({ error: 'Failed to reconcile tools', detail: err.message });
   }
 });
 

--- a/services/api/src/services/docker.ts
+++ b/services/api/src/services/docker.ts
@@ -249,6 +249,7 @@ export async function execInContainer(
 export async function execInContainerWithExit(
   agentId: string,
   cmd: string[],
+  timeoutMs?: number,
 ): Promise<{ exitCode: number; stdout: string; stderr: string }> {
   const containerName = `${CONTAINER_PREFIX}${agentId}`;
   assertAgentboxName(containerName);
@@ -270,7 +271,7 @@ export async function execInContainerWithExit(
   const stderrChunks: Buffer[] = [];
   let remainder: Buffer | null = null;
 
-  await new Promise<void>((resolve, reject) => {
+  const streamPromise = new Promise<void>((resolve, reject) => {
     rawStream.on('data', (chunk: Buffer) => {
       let buf: Buffer = remainder ? Buffer.concat([remainder, chunk]) : chunk;
       remainder = null;
@@ -297,6 +298,18 @@ export async function execInContainerWithExit(
     rawStream.on('end', () => resolve());
     rawStream.on('close', () => resolve());
   });
+
+  if (timeoutMs && timeoutMs > 0) {
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      setTimeout(() => {
+        rawStream.destroy();
+        reject(new Error(`Command timed out after ${Math.round(timeoutMs / 1000)}s`));
+      }, timeoutMs);
+    });
+    await Promise.race([streamPromise, timeoutPromise]);
+  } else {
+    await streamPromise;
+  }
 
   const inspect = await exec.inspect();
   return {

--- a/services/api/src/services/tool-installer.ts
+++ b/services/api/src/services/tool-installer.ts
@@ -15,6 +15,19 @@ const DEFAULT_BINARY_VERSIONS: Record<string, string> = {
   docker: process.env.HILL90_DOCKER_CLI_VERSION || '28.0.1',
 };
 
+const BINARY_PATH_OVERRIDES: Record<string, (version: string) => string> = {
+  gh: (v) => `gh_${v}_linux_amd64/bin/gh`,
+  docker: () => `docker/docker`,
+};
+
+const INSTALL_TIMEOUTS: Record<InstallMethod, number> = {
+  builtin: 30_000,
+  apt: 120_000,
+  binary: 300_000,
+};
+
+const MAX_INSTALL_RETRIES = parseInt(process.env.HILL90_TOOL_INSTALL_RETRIES || '1', 10);
+
 function shellQuote(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`;
 }
@@ -22,7 +35,7 @@ function shellQuote(value: string): string {
 async function upsertInstallStatus(
   agentDbId: string,
   toolId: string,
-  status: 'pending' | 'installed' | 'failed',
+  status: 'pending' | 'installing' | 'installed' | 'failed',
   installMessage: string,
   setInstalledAt = false
 ): Promise<void> {
@@ -44,7 +57,7 @@ async function upsertInstallStatus(
 
 async function installBuiltin(agentSlug: string, tool: ToolRow): Promise<void> {
   const cmd = ['bash', '-lc', `command -v ${tool.name}`];
-  const result = await execInContainerWithExit(agentSlug, cmd);
+  const result = await execInContainerWithExit(agentSlug, cmd, INSTALL_TIMEOUTS.builtin);
   if (result.exitCode !== 0) {
     throw new Error(`Builtin tool "${tool.name}" not found in container PATH`);
   }
@@ -57,47 +70,40 @@ async function installApt(agentSlug: string, tool: ToolRow): Promise<void> {
     '-lc',
     `command -v ${tool.name} >/dev/null 2>&1 || (apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ${shellQuote(pkg)})`,
   ];
-  const result = await execInContainerWithExit(agentSlug, cmd);
+  const result = await execInContainerWithExit(agentSlug, cmd, INSTALL_TIMEOUTS.apt);
   if (result.exitCode !== 0) {
     throw new Error(`APT install failed for "${tool.name}": ${result.stderr || result.stdout}`.trim());
   }
   await installBuiltin(agentSlug, tool);
 }
 
-function binaryInstallScript(tool: ToolRow): string {
+export function binaryInstallScript(tool: ToolRow): string {
   const version = DEFAULT_BINARY_VERSIONS[tool.name];
   if (!version) {
-    throw new Error(`Binary install is not supported for tool "${tool.name}"`);
+    throw new Error(
+      `No version configured for binary tool "${tool.name}". ` +
+      `Set HILL90_${tool.name.toUpperCase()}_VERSION or add to DEFAULT_BINARY_VERSIONS.`
+    );
   }
   const url = tool.install_ref.replaceAll('{version}', version);
-  if (tool.name === 'gh') {
-    return `
+  const binPath = BINARY_PATH_OVERRIDES[tool.name]
+    ? BINARY_PATH_OVERRIDES[tool.name](version)
+    : `${tool.name}/${tool.name}`;
+  return `
 set -euo pipefail
 mkdir -p /data/tools/bin /tmp/hill90-tools
-if [ -x /data/tools/bin/gh ]; then exit 0; fi
-curl -fsSL ${shellQuote(url)} -o /tmp/hill90-tools/gh.tgz
-tar -xzf /tmp/hill90-tools/gh.tgz -C /tmp/hill90-tools
-cp /tmp/hill90-tools/gh_${version}_linux_amd64/bin/gh /data/tools/bin/gh
-chmod +x /data/tools/bin/gh
+if [ -x /data/tools/bin/${shellQuote(tool.name)} ]; then exit 0; fi
+curl -fsSL ${shellQuote(url)} -o /tmp/hill90-tools/${shellQuote(tool.name)}.tgz
+tar -xzf /tmp/hill90-tools/${shellQuote(tool.name)}.tgz -C /tmp/hill90-tools
+cp /tmp/hill90-tools/${binPath} /data/tools/bin/${shellQuote(tool.name)}
+chmod +x /data/tools/bin/${shellQuote(tool.name)}
+rm -rf /tmp/hill90-tools
 `;
-  }
-  if (tool.name === 'docker') {
-    return `
-set -euo pipefail
-mkdir -p /data/tools/bin /tmp/hill90-tools
-if [ -x /data/tools/bin/docker ]; then exit 0; fi
-curl -fsSL ${shellQuote(url)} -o /tmp/hill90-tools/docker.tgz
-tar -xzf /tmp/hill90-tools/docker.tgz -C /tmp/hill90-tools
-cp /tmp/hill90-tools/docker/docker /data/tools/bin/docker
-chmod +x /data/tools/bin/docker
-`;
-  }
-  throw new Error(`No binary install script available for "${tool.name}"`);
 }
 
 async function installBinary(agentSlug: string, tool: ToolRow): Promise<void> {
   const script = binaryInstallScript(tool);
-  const result = await execInContainerWithExit(agentSlug, ['bash', '-lc', script]);
+  const result = await execInContainerWithExit(agentSlug, ['bash', '-lc', script], INSTALL_TIMEOUTS.binary);
   if (result.exitCode !== 0) {
     throw new Error(`Binary install failed for "${tool.name}": ${result.stderr || result.stdout}`.trim());
   }
@@ -109,27 +115,107 @@ async function installTool(agentSlug: string, tool: ToolRow): Promise<void> {
   return installBinary(agentSlug, tool);
 }
 
+const REQUIRED_TOOLS_QUERY = `
+  SELECT DISTINCT t.id, t.name, t.install_method, t.install_ref
+  FROM agent_skills asks
+  JOIN skill_tools st ON st.skill_id = asks.skill_id
+  JOIN tools t ON t.id = st.tool_id
+  WHERE asks.agent_id = $1
+  ORDER BY t.name ASC`;
+
 export async function ensureRequiredToolsInstalled(agentDbId: string, agentSlug: string): Promise<void> {
-  const { rows } = await getPool().query(
-    `SELECT DISTINCT t.id, t.name, t.install_method, t.install_ref
-     FROM agent_skills asks
-     JOIN skill_tools st ON st.skill_id = asks.skill_id
-     JOIN tools t ON t.id = st.tool_id
-     WHERE asks.agent_id = $1
-     ORDER BY t.name ASC`,
-    [agentDbId]
-  );
+  const { rows } = await getPool().query(REQUIRED_TOOLS_QUERY, [agentDbId]);
 
   for (const row of rows as ToolRow[]) {
-    await upsertInstallStatus(agentDbId, row.id, 'pending', 'installing');
-    try {
-      await installTool(agentSlug, row);
-      await upsertInstallStatus(agentDbId, row.id, 'installed', 'installed', true);
-    } catch (err: any) {
-      const msg = err?.message || 'installation failed';
+    await upsertInstallStatus(agentDbId, row.id, 'installing', 'starting installation');
+
+    const maxRetries = row.install_method === 'builtin' ? 0 : MAX_INSTALL_RETRIES;
+    let lastError: Error | null = null;
+
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
+      try {
+        await installTool(agentSlug, row);
+        await upsertInstallStatus(agentDbId, row.id, 'installed', 'installed', true);
+        lastError = null;
+        break;
+      } catch (err: any) {
+        lastError = err;
+        if (attempt < maxRetries) {
+          const msg = `attempt ${attempt + 1} failed, retrying: ${err?.message || 'unknown'}`;
+          await upsertInstallStatus(agentDbId, row.id, 'installing', msg);
+        }
+      }
+    }
+
+    if (lastError) {
+      const msg = lastError.message || 'installation failed';
       await upsertInstallStatus(agentDbId, row.id, 'failed', msg);
       throw new Error(`Failed installing required tool "${row.name}": ${msg}`);
     }
   }
 }
 
+export async function reconcileToolInstalls(agentDbId: string, agentSlug: string): Promise<{
+  installed: string[];
+  alreadyInstalled: string[];
+  failed: string[];
+}> {
+  const { rows: requiredTools } = await getPool().query(REQUIRED_TOOLS_QUERY, [agentDbId]);
+
+  const { rows: existingInstalls } = await getPool().query(
+    `SELECT tool_id, status FROM agent_tool_installs WHERE agent_id = $1`,
+    [agentDbId]
+  );
+  const installedSet = new Set(
+    existingInstalls
+      .filter((r: any) => r.status === 'installed')
+      .map((r: any) => r.tool_id)
+  );
+
+  const result = { installed: [] as string[], alreadyInstalled: [] as string[], failed: [] as string[] };
+
+  for (const row of requiredTools as ToolRow[]) {
+    if (installedSet.has(row.id)) {
+      result.alreadyInstalled.push(row.name);
+      continue;
+    }
+
+    await upsertInstallStatus(agentDbId, row.id, 'installing', 'reconcile: starting installation');
+
+    const maxRetries = row.install_method === 'builtin' ? 0 : MAX_INSTALL_RETRIES;
+    let lastError: Error | null = null;
+
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
+      try {
+        await installTool(agentSlug, row);
+        await upsertInstallStatus(agentDbId, row.id, 'installed', 'installed', true);
+        result.installed.push(row.name);
+        lastError = null;
+        break;
+      } catch (err: any) {
+        lastError = err;
+        if (attempt < maxRetries) {
+          await upsertInstallStatus(agentDbId, row.id, 'installing', `reconcile: attempt ${attempt + 1} failed, retrying`);
+        }
+      }
+    }
+
+    if (lastError) {
+      await upsertInstallStatus(agentDbId, row.id, 'failed', lastError.message || 'installation failed');
+      result.failed.push(row.name);
+    }
+  }
+
+  // Clean up stale installs for tools no longer required
+  const requiredIds = new Set((requiredTools as ToolRow[]).map(t => t.id));
+  for (const existing of existingInstalls as any[]) {
+    if (!requiredIds.has(existing.tool_id)) {
+      await getPool().query(
+        `DELETE FROM agent_tool_installs WHERE agent_id = $1 AND tool_id = $2`,
+        [agentDbId, existing.tool_id]
+      );
+    }
+  }
+
+  return result;
+}

--- a/services/api/src/services/tool-installer.ts
+++ b/services/api/src/services/tool-installer.ts
@@ -26,7 +26,10 @@ const INSTALL_TIMEOUTS: Record<InstallMethod, number> = {
   binary: 300_000,
 };
 
-const MAX_INSTALL_RETRIES = parseInt(process.env.HILL90_TOOL_INSTALL_RETRIES || '1', 10);
+const MAX_INSTALL_RETRIES = (() => {
+  const parsed = parseInt(process.env.HILL90_TOOL_INSTALL_RETRIES || '1', 10);
+  return Number.isNaN(parsed) || parsed < 0 ? 1 : parsed;
+})();
 
 function shellQuote(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`;

--- a/services/ui/src/__tests__/AgentDetailClient.test.tsx
+++ b/services/ui/src/__tests__/AgentDetailClient.test.tsx
@@ -574,4 +574,77 @@ describe('AgentDetailClient', () => {
     expect(within(skillCard).getByText('git')).toBeInTheDocument()
   })
 
+  // T18: installing status renders blue badge
+  it('installing status renders blue badge', async () => {
+    const installingToolInstalls = [
+      {
+        tool_id: 'tool-gh',
+        tool_name: 'gh',
+        tool_description: 'GitHub CLI',
+        status: 'installing',
+        install_message: 'downloading...',
+        installed_at: null,
+        updated_at: '2026-03-01T00:00:00Z',
+      },
+    ]
+
+    mockFetch.mockImplementation((url: string, opts?: any) => {
+      if (url === `/api/agents/uuid-1` && (!opts || !opts.method || opts.method === 'GET')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_AGENT) })
+      }
+      if (url === '/api/skills') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_ALL_SKILLS) })
+      }
+      if (typeof url === 'string' && url.includes('/api/agents/uuid-1/tool-installs')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(installingToolInstalls) })
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+    })
+
+    render(<AgentDetailClient agentId="uuid-1" session={ADMIN_SESSION as any} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('ResearchBot')).toBeInTheDocument()
+    })
+
+    // The installing badge should have blue styling
+    await waitFor(() => {
+      const badge = screen.getByText('installing')
+      expect(badge).toBeInTheDocument()
+      expect(badge.className).toContain('bg-blue-900/40')
+      expect(badge.className).toContain('text-blue-400')
+    })
+  })
+
+  // T19: Reconcile button visible for admin on running agent
+  it('reconcile button visible for admin on running agent', async () => {
+    const runningAgent = { ...MOCK_AGENT, status: 'running', container_id: 'abc-123' }
+    mockFetchDefaults(runningAgent as any)
+
+    render(<AgentDetailClient agentId="uuid-1" session={ADMIN_SESSION as any} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('ResearchBot')).toBeInTheDocument()
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('Reconcile')).toBeInTheDocument()
+    })
+  })
+
+  // T20: Reconcile button hidden for non-admin
+  it('reconcile button hidden for non-admin', async () => {
+    const runningAgent = { ...MOCK_AGENT, status: 'running', container_id: 'abc-123' }
+    mockFetchDefaults(runningAgent as any)
+
+    render(<AgentDetailClient agentId="uuid-1" session={USER_SESSION as any} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('ResearchBot')).toBeInTheDocument()
+    })
+
+    // Non-admin should NOT see Reconcile button even on running agent
+    expect(screen.queryByText('Reconcile')).not.toBeInTheDocument()
+  })
+
 })

--- a/services/ui/src/app/agents/[id]/AgentDetailClient.tsx
+++ b/services/ui/src/app/agents/[id]/AgentDetailClient.tsx
@@ -40,7 +40,7 @@ interface ToolInstallStatus {
   tool_id: string
   tool_name: string
   tool_description: string
-  status: 'pending' | 'installed' | 'failed'
+  status: 'pending' | 'installing' | 'installed' | 'failed'
   install_message: string
   installed_at: string | null
   updated_at: string
@@ -211,6 +211,22 @@ export default function AgentDetailClient({
       await fetchToolInstalls()
     } catch (err) {
       console.error(`Failed to ${action}:`, err)
+    } finally {
+      setActionLoading(false)
+    }
+  }
+
+  const handleReconcileTools = async () => {
+    setActionLoading(true)
+    try {
+      const res = await fetch(`/api/agents/${agentId}/reconcile-tools`, { method: 'POST' })
+      if (!res.ok) {
+        const data = await res.json()
+        alert(data.error || 'Failed to reconcile tools')
+      }
+      await fetchToolInstalls()
+    } catch (err) {
+      console.error('Failed to reconcile tools:', err)
     } finally {
       setActionLoading(false)
     }
@@ -529,7 +545,18 @@ export default function AgentDetailClient({
 
           {/* Tool Install Status */}
           <div className="rounded-lg border border-navy-700 bg-navy-800 p-5">
-            <h2 className="text-lg font-semibold text-white mb-3">Tool Install Status</h2>
+            <div className="flex items-center justify-between mb-3">
+              <h2 className="text-lg font-semibold text-white">Tool Install Status</h2>
+              {isAdmin && agent.status === 'running' && (
+                <button
+                  onClick={handleReconcileTools}
+                  disabled={actionLoading}
+                  className="px-3 py-1.5 text-xs font-medium rounded-md border border-navy-600 text-mountain-400 hover:text-white hover:border-navy-500 transition-colors cursor-pointer disabled:opacity-50"
+                >
+                  Reconcile
+                </button>
+              )}
+            </div>
             {toolInstallsLoading ? (
               <p className="text-sm text-mountain-400">Loading…</p>
             ) : toolInstalls.length === 0 ? (
@@ -545,7 +572,9 @@ export default function AgentDetailClient({
                           ? 'bg-brand-900/50 text-brand-400 border-brand-700'
                           : row.status === 'failed'
                             ? 'bg-red-900/40 text-red-400 border-red-700'
-                            : 'bg-amber-900/40 text-amber-400 border-amber-700'
+                            : row.status === 'installing'
+                              ? 'bg-blue-900/40 text-blue-400 border-blue-700'
+                              : 'bg-amber-900/40 text-amber-400 border-amber-700'
                       }`}>
                         {row.status}
                       </span>


### PR DESCRIPTION
## Summary

- Add exec timeout to `execInContainerWithExit` (30s builtin, 120s apt, 300s binary) preventing indefinite hangs
- Add retry semantics for non-builtin tools (1 retry, configurable via `HILL90_TOOL_INSTALL_RETRIES`)
- Replace hardcoded binary install scripts with code-driven `BINARY_PATH_OVERRIDES` contract (deterministic, no `find`)
- Add `installing` status to `agent_tool_installs` (migration 027, widened CHECK constraint)
- Add `POST /agents/:id/reconcile-tools` endpoint for running agents (admin-only, best-effort)
- UI: blue `installing` badge + admin-only Reconcile button on running agents

## Plan

Closed-loop plan at `.claude/plans/quirky-cuddling-harbor.md` — approved after 3 revision rounds.

## Risks

| Risk | Mitigation |
|------|-----------|
| Timeout destroys stream, leaves zombie exec | Container is ephemeral, cleaned up on agent stop |
| BINARY_PATH_OVERRIDES wrong for future tool | `cp` fails deterministically — clear error, no silent wrong binary |
| Reconcile called while install in progress | `ON CONFLICT DO UPDATE` — last writer wins, acceptable for single-admin |

## Rollback

Migration 027 rollback: `UPDATE agent_tool_installs SET status = 'pending' WHERE status = 'installing';` then drop and re-add narrower constraint. Code changes are backwards compatible — removing the reconcile endpoint or retry logic has no side effects.

## Validation Evidence

### Tests (all pass locally)

**API (jest):** 29 suites, 336 tests — 0 failures
```
Test Suites: 29 passed, 29 total
Tests:       336 passed, 336 total
```

**UI (vitest):** 34 suites, 304 tests — 0 failures
```
Test Files  34 passed (34)
     Tests  304 passed (304)
```

### New Test Coverage (T1–T20)

| ID | Test | File |
|----|------|------|
| T1 | `installing` status set before install attempt | tool-installer.test.ts |
| T2 | Retry once on transient binary failure | tool-installer.test.ts |
| T3 | No retry for builtin tool failure | tool-installer.test.ts |
| T4 | Timeout passed to exec for binary | tool-installer.test.ts |
| T5 | Deterministic gh path (`gh_{v}_linux_amd64/bin/gh`) | tool-installer.test.ts |
| T6 | Deterministic docker path (`docker/docker`) | tool-installer.test.ts |
| T7 | No version configured throws clear error | tool-installer.test.ts |
| T8 | Binary script uses `cp` with deterministic path, no `find` | tool-installer.test.ts |
| T9 | Reconcile skips already-installed tools | tool-installer.test.ts |
| T10 | Reconcile installs missing tools | tool-installer.test.ts |
| T11 | Reconcile reports failures without throwing | tool-installer.test.ts |
| T12 | Reconcile cleans up stale install records | tool-installer.test.ts |
| T13 | POST reconcile-tools 401 | routes-agents.test.ts |
| T14 | POST reconcile-tools 403 non-admin | routes-agents.test.ts |
| T15 | POST reconcile-tools 404 unknown agent | routes-agents.test.ts |
| T16 | POST reconcile-tools 409 not running | routes-agents.test.ts |
| T17 | POST reconcile-tools 200 success | routes-agents.test.ts |
| T18 | `installing` blue badge renders | AgentDetailClient.test.tsx |
| T19 | Reconcile button visible for admin+running | AgentDetailClient.test.tsx |
| T20 | Reconcile button hidden for non-admin | AgentDetailClient.test.tsx |

### Pre-existing RBAC Guards (E1–E4, unchanged)

| ID | Test | File |
|----|------|------|
| E1 | Non-admin host_docker assignment → 403 | routes-agents-skills.test.ts |
| E2 | Non-admin vps_system assignment → 403 | routes-agents-skills.test.ts |
| E3 | Admin host_docker assignment → 201 | routes-agents-skills.test.ts |
| E4 | Non-admin host_docker removal → 403 | routes-agents-skills.test.ts |

### Static Checks

| ID | Check | Result |
|----|-------|--------|
| S1 | Elevated scope rules unchanged | Confirmed — no edits to scope gating logic |
| S2 | BINARY_PATH_OVERRIDES matches tarballs | gh: `gh_{v}_linux_amd64/bin/gh`, docker: `docker/docker` |
| S3 | OpenAPI source = mirror | `diff` empty (byte-identical) |

## Test plan

- [x] T1–T12 tool-installer unit tests pass
- [x] T13–T17 reconcile-tools route tests pass
- [x] T18–T20 UI tests pass
- [x] E1–E4 pre-existing RBAC guards pass unchanged
- [x] S1–S3 static checks pass
- [x] OpenAPI source/mirror byte-identical
- [x] All 29 API test suites pass (336 tests)
- [x] All 34 UI test suites pass (304 tests)
- [ ] V1–V10 runtime verification (post-deploy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)