### PR TITLE
fix: move binary tool downloads to API service for isolated containers

### DIFF
--- a/services/api/src/__tests__/docker-service.test.ts
+++ b/services/api/src/__tests__/docker-service.test.ts
@@ -8,5 +8,7 @@ describe('Docker service module', () => {
     expect(dockerModule.removeAgentVolumes).toBeDefined();
     expect(dockerModule.reconcileAgentStatuses).toBeDefined();
     expect(dockerModule.execInContainer).toBeDefined();
+    expect(dockerModule.execInContainerWithExit).toBeDefined();
+    expect(dockerModule.execWithStdin).toBeDefined();
   });
 });

--- a/services/api/src/__tests__/tool-installer.test.ts
+++ b/services/api/src/__tests__/tool-installer.test.ts
@@ -1,7 +1,12 @@
-import { ensureRequiredToolsInstalled, reconcileToolInstalls, binaryInstallScript } from '../services/tool-installer';
+import { ensureRequiredToolsInstalled, reconcileToolInstalls, binaryInstallScript, validateDownloadUrl } from '../services/tool-installer';
 
 const mockQuery = jest.fn();
 const mockExec = jest.fn();
+const mockExecStdin = jest.fn();
+const mockFetch = jest.fn();
+
+// Save original fetch
+const originalFetch = global.fetch;
 
 jest.mock('../db/pool', () => ({
   getPool: () => ({ query: mockQuery }),
@@ -9,12 +14,29 @@ jest.mock('../db/pool', () => ({
 
 jest.mock('../services/docker', () => ({
   execInContainerWithExit: (...args: any[]) => mockExec(...args),
+  execWithStdin: (...args: any[]) => mockExecStdin(...args),
 }));
+
+function mockFetchResponse(status: number, body?: ArrayBuffer, headers?: Record<string, string>) {
+  return {
+    status,
+    ok: status >= 200 && status < 300,
+    headers: new Headers(headers || {}),
+    arrayBuffer: () => Promise.resolve(body || new ArrayBuffer(0)),
+  };
+}
 
 describe('tool-installer service', () => {
   beforeEach(() => {
     mockQuery.mockReset();
     mockExec.mockReset();
+    mockExecStdin.mockReset();
+    mockFetch.mockReset();
+    global.fetch = mockFetch as any;
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
   });
 
   it('no-ops when agent has no required tools', async () => {
@@ -46,16 +68,26 @@ describe('tool-installer service', () => {
         rows: [{ id: 'tool-gh', name: 'gh', install_method: 'binary', install_ref: 'https://github.com/cli/cli/releases/download/v{version}/gh_{version}_linux_amd64.tar.gz' }],
       }) // required tools
       .mockResolvedValue({ rowCount: 1 }); // status upserts
-    mockExec.mockResolvedValue({ exitCode: 0, stdout: '', stderr: '' });
+    // Idempotency check: not installed
+    mockExec.mockResolvedValue({ exitCode: 1, stdout: '', stderr: '' });
+    // Download
+    mockFetch.mockResolvedValue(mockFetchResponse(200, new ArrayBuffer(100)));
+    // Extract via stdin
+    mockExecStdin.mockResolvedValue({ exitCode: 0, stdout: '', stderr: '' });
 
     await ensureRequiredToolsInstalled('agent-db-id', 'agent-slug');
 
-    expect(mockExec).toHaveBeenCalledTimes(1);
-    const call = mockExec.mock.calls[0];
-    expect(call[0]).toBe('agent-slug');
-    expect(call[1][0]).toBe('bash');
-    expect(call[1][1]).toBe('-lc');
-    expect(call[1][2]).toContain("/data/tools/bin/'gh'");
+    // Idempotency check
+    expect(mockExec).toHaveBeenCalledWith(
+      'agent-slug', ['test', '-x', '/data/tools/bin/gh'], 30000
+    );
+    // Extract: stdin called with Buffer
+    expect(mockExecStdin).toHaveBeenCalledTimes(1);
+    const stdinCall = mockExecStdin.mock.calls[0];
+    expect(stdinCall[0]).toBe('agent-slug');
+    expect(stdinCall[1][0]).toBe('bash');
+    expect(stdinCall[1][1]).toBe('-lc');
+    expect(Buffer.isBuffer(stdinCall[2])).toBe(true);
   });
 
   it('marks tool failed and throws on install error', async () => {
@@ -75,10 +107,12 @@ describe('tool-installer service', () => {
   it('sets installing status before install attempt', async () => {
     mockQuery
       .mockResolvedValueOnce({
-        rows: [{ id: 'tool-gh', name: 'gh', install_method: 'binary', install_ref: 'https://example.com/gh_{version}.tar.gz' }],
+        rows: [{ id: 'tool-gh', name: 'gh', install_method: 'binary', install_ref: 'https://github.com/cli/cli/releases/download/v{version}/gh_{version}_linux_amd64.tar.gz' }],
       })
       .mockResolvedValue({ rowCount: 1 });
-    mockExec.mockResolvedValue({ exitCode: 0, stdout: '', stderr: '' });
+    mockExec.mockResolvedValue({ exitCode: 1, stdout: '', stderr: '' }); // not installed
+    mockFetch.mockResolvedValue(mockFetchResponse(200, new ArrayBuffer(100)));
+    mockExecStdin.mockResolvedValue({ exitCode: 0, stdout: '', stderr: '' });
 
     await ensureRequiredToolsInstalled('agent-db-id', 'agent-slug');
 
@@ -92,15 +126,22 @@ describe('tool-installer service', () => {
   it('retries once on binary install failure then succeeds', async () => {
     mockQuery
       .mockResolvedValueOnce({
-        rows: [{ id: 'tool-gh', name: 'gh', install_method: 'binary', install_ref: 'https://example.com/gh_{version}.tar.gz' }],
+        rows: [{ id: 'tool-gh', name: 'gh', install_method: 'binary', install_ref: 'https://github.com/cli/cli/releases/download/v{version}/gh_{version}_linux_amd64.tar.gz' }],
       })
       .mockResolvedValue({ rowCount: 1 });
-    mockExec
-      .mockResolvedValueOnce({ exitCode: 1, stdout: '', stderr: 'network timeout' }) // first attempt fails
-      .mockResolvedValue({ exitCode: 0, stdout: '', stderr: '' }); // retry succeeds
+    // Idempotency check: not installed (both attempts)
+    mockExec.mockResolvedValue({ exitCode: 1, stdout: '', stderr: '' });
+    // Download succeeds both times
+    mockFetch.mockResolvedValue(mockFetchResponse(200, new ArrayBuffer(100)));
+    // Extract: first attempt fails, retry succeeds
+    mockExecStdin
+      .mockResolvedValueOnce({ exitCode: 1, stdout: '', stderr: 'tar error' })
+      .mockResolvedValue({ exitCode: 0, stdout: '', stderr: '' });
 
     await ensureRequiredToolsInstalled('agent-db-id', 'agent-slug');
+    // 2 idempotency checks + 2 extract attempts
     expect(mockExec).toHaveBeenCalledTimes(2);
+    expect(mockExecStdin).toHaveBeenCalledTimes(2);
   });
 
   // T3: no retry for builtin
@@ -116,23 +157,25 @@ describe('tool-installer service', () => {
     expect(mockExec).toHaveBeenCalledTimes(1); // no retry
   });
 
-  // T4: timeout passed to exec for binary
-  it('passes timeout to execInContainerWithExit for binary installs', async () => {
+  // T4: timeout passed to execWithStdin for binary
+  it('passes timeout to execWithStdin for binary installs', async () => {
     mockQuery
       .mockResolvedValueOnce({
-        rows: [{ id: 'tool-gh', name: 'gh', install_method: 'binary', install_ref: 'https://example.com/gh_{version}.tar.gz' }],
+        rows: [{ id: 'tool-gh', name: 'gh', install_method: 'binary', install_ref: 'https://github.com/cli/cli/releases/download/v{version}/gh_{version}_linux_amd64.tar.gz' }],
       })
       .mockResolvedValue({ rowCount: 1 });
-    mockExec.mockResolvedValue({ exitCode: 0, stdout: '', stderr: '' });
+    mockExec.mockResolvedValue({ exitCode: 1, stdout: '', stderr: '' }); // not installed
+    mockFetch.mockResolvedValue(mockFetchResponse(200, new ArrayBuffer(100)));
+    mockExecStdin.mockResolvedValue({ exitCode: 0, stdout: '', stderr: '' });
 
     await ensureRequiredToolsInstalled('agent-db-id', 'agent-slug');
 
-    expect(mockExec).toHaveBeenCalledWith('agent-slug', expect.any(Array), 300000);
+    expect(mockExecStdin).toHaveBeenCalledWith('agent-slug', expect.any(Array), expect.any(Buffer), 300000);
   });
 
   // T5: deterministic binary path for gh
   it('gh binary path resolves to gh_{v}_linux_amd64/bin/gh', () => {
-    const tool = { id: 't1', name: 'gh', install_method: 'binary' as const, install_ref: 'https://example.com/gh_{version}.tar.gz' };
+    const tool = { id: 't1', name: 'gh', install_method: 'binary' as const, install_ref: 'https://github.com/cli/cli/releases/download/v{version}/gh_{version}_linux_amd64.tar.gz' };
     const script = binaryInstallScript(tool);
     expect(script).toContain('gh_2.74.2_linux_amd64/bin/gh');
     expect(script).not.toContain('find');
@@ -140,7 +183,7 @@ describe('tool-installer service', () => {
 
   // T6: deterministic binary path for docker
   it('docker binary path resolves to docker/docker', () => {
-    const tool = { id: 't2', name: 'docker', install_method: 'binary' as const, install_ref: 'https://example.com/docker-{version}.tgz' };
+    const tool = { id: 't2', name: 'docker', install_method: 'binary' as const, install_ref: 'https://download.docker.com/linux/static/stable/x86_64/docker-{version}.tgz' };
     const script = binaryInstallScript(tool);
     expect(script).toContain('docker/docker');
     expect(script).not.toContain('find');
@@ -148,13 +191,13 @@ describe('tool-installer service', () => {
 
   // T7: no version configured throws clear error
   it('throws clear error when no version configured for binary tool', () => {
-    const tool = { id: 't3', name: 'rg', install_method: 'binary' as const, install_ref: 'https://example.com/rg-{version}.tgz' };
+    const tool = { id: 't3', name: 'rg', install_method: 'binary' as const, install_ref: 'https://github.com/BurntSushi/ripgrep/releases/download/{version}/rg-{version}.tgz' };
     expect(() => binaryInstallScript(tool)).toThrow(/No version configured for binary tool "rg"/);
   });
 
   // T8: binary install uses cp with deterministic path (no find)
   it('binary install script uses cp with deterministic path, no find', () => {
-    const tool = { id: 't1', name: 'gh', install_method: 'binary' as const, install_ref: 'https://example.com/gh_{version}.tar.gz' };
+    const tool = { id: 't1', name: 'gh', install_method: 'binary' as const, install_ref: 'https://github.com/cli/cli/releases/download/v{version}/gh_{version}_linux_amd64.tar.gz' };
     const script = binaryInstallScript(tool);
     expect(script).toMatch(/cp \/tmp\/hill90-tools\/gh_.*\/bin\/gh \/data\/tools\/bin/);
     expect(script).not.toContain('find');
@@ -165,7 +208,7 @@ describe('tool-installer service', () => {
   it('reconcile skips already-installed tools', async () => {
     mockQuery
       .mockResolvedValueOnce({
-        rows: [{ id: 'tool-gh', name: 'gh', install_method: 'binary', install_ref: 'https://example.com/gh.tar.gz' }],
+        rows: [{ id: 'tool-gh', name: 'gh', install_method: 'binary', install_ref: 'https://github.com/cli/cli/releases/download/v{version}/gh_{version}_linux_amd64.tar.gz' }],
       }) // required tools
       .mockResolvedValueOnce({
         rows: [{ tool_id: 'tool-gh', status: 'installed' }],
@@ -182,27 +225,31 @@ describe('tool-installer service', () => {
   it('reconcile installs missing tools', async () => {
     mockQuery
       .mockResolvedValueOnce({
-        rows: [{ id: 'tool-gh', name: 'gh', install_method: 'binary', install_ref: 'https://example.com/gh_{version}.tar.gz' }],
+        rows: [{ id: 'tool-gh', name: 'gh', install_method: 'binary', install_ref: 'https://github.com/cli/cli/releases/download/v{version}/gh_{version}_linux_amd64.tar.gz' }],
       }) // required tools
       .mockResolvedValueOnce({ rows: [] }) // no existing installs
       .mockResolvedValue({ rowCount: 1 }); // upserts
-    mockExec.mockResolvedValue({ exitCode: 0, stdout: '', stderr: '' });
+    mockExec.mockResolvedValue({ exitCode: 1, stdout: '', stderr: '' }); // not installed
+    mockFetch.mockResolvedValue(mockFetchResponse(200, new ArrayBuffer(100)));
+    mockExecStdin.mockResolvedValue({ exitCode: 0, stdout: '', stderr: '' });
 
     const result = await reconcileToolInstalls('agent-db-id', 'agent-slug');
     expect(result.installed).toEqual(['gh']);
-    expect(mockExec).toHaveBeenCalled();
+    expect(mockExecStdin).toHaveBeenCalled();
   });
 
   // T11: reconcile reports failures without throwing
   it('reconcile reports failures without throwing', async () => {
     mockQuery
       .mockResolvedValueOnce({
-        rows: [{ id: 'tool-gh', name: 'gh', install_method: 'binary', install_ref: 'https://example.com/gh_{version}.tar.gz' }],
+        rows: [{ id: 'tool-gh', name: 'gh', install_method: 'binary', install_ref: 'https://github.com/cli/cli/releases/download/v{version}/gh_{version}_linux_amd64.tar.gz' }],
       }) // required tools
       .mockResolvedValueOnce({ rows: [] }) // no existing installs
       .mockResolvedValue({ rowCount: 1 }); // upserts
-    // Both attempts fail (initial + 1 retry)
-    mockExec.mockResolvedValue({ exitCode: 1, stdout: '', stderr: 'download failed' });
+    mockExec.mockResolvedValue({ exitCode: 1, stdout: '', stderr: '' }); // not installed
+    mockFetch.mockResolvedValue(mockFetchResponse(200, new ArrayBuffer(100)));
+    // Both extract attempts fail (initial + 1 retry)
+    mockExecStdin.mockResolvedValue({ exitCode: 1, stdout: '', stderr: 'extract failed' });
 
     const result = await reconcileToolInstalls('agent-db-id', 'agent-slug');
     expect(result.failed).toEqual(['gh']);
@@ -227,6 +274,166 @@ describe('tool-installer service', () => {
     expect(deleteCalls.length).toBe(1);
     expect(deleteCalls[0][1]).toEqual(['agent-db-id', 'tool-old']);
   });
+
+  // T21: installBinary skips download when tool already installed
+  it('skips download when binary tool already installed in container', async () => {
+    mockQuery
+      .mockResolvedValueOnce({
+        rows: [{ id: 'tool-gh', name: 'gh', install_method: 'binary', install_ref: 'https://github.com/cli/cli/releases/download/v{version}/gh_{version}_linux_amd64.tar.gz' }],
+      })
+      .mockResolvedValue({ rowCount: 1 });
+    // Idempotency check: already installed
+    mockExec.mockResolvedValue({ exitCode: 0, stdout: '', stderr: '' });
+
+    await ensureRequiredToolsInstalled('agent-db-id', 'agent-slug');
+
+    expect(mockExec).toHaveBeenCalledWith(
+      'agent-slug', ['test', '-x', '/data/tools/bin/gh'], 30000
+    );
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(mockExecStdin).not.toHaveBeenCalled();
+  });
+
+  // T22: binaryInstallScript does not contain curl
+  it('binaryInstallScript does not contain curl', () => {
+    const tool = { id: 't1', name: 'gh', install_method: 'binary' as const, install_ref: 'https://github.com/cli/cli/releases/download/v{version}/gh_{version}_linux_amd64.tar.gz' };
+    const script = binaryInstallScript(tool);
+    expect(script).not.toContain('curl');
+  });
+
+  // T23: binaryInstallScript reads from stdin (tar -xzf -)
+  it('binaryInstallScript reads tar from stdin', () => {
+    const tool = { id: 't1', name: 'gh', install_method: 'binary' as const, install_ref: 'https://github.com/cli/cli/releases/download/v{version}/gh_{version}_linux_amd64.tar.gz' };
+    const script = binaryInstallScript(tool);
+    expect(script).toContain('tar -xzf - -C /tmp/hill90-tools');
+  });
+
+  // T24: validateDownloadUrl rejects HTTP URLs
+  it('validateDownloadUrl rejects HTTP URLs', () => {
+    expect(() => validateDownloadUrl('http://github.com/foo.tar.gz')).toThrow(
+      /Download URL must use HTTPS/
+    );
+  });
+
+  // T25: validateDownloadUrl rejects non-allowlisted hostname
+  it('validateDownloadUrl rejects non-allowlisted hostname', () => {
+    expect(() => validateDownloadUrl('https://evil.com/malicious.tgz')).toThrow(
+      /not in allowlist/
+    );
+  });
+
+  // T26: validateDownloadUrl accepts github.com HTTPS
+  it('validateDownloadUrl accepts github.com HTTPS', () => {
+    expect(() => validateDownloadUrl('https://github.com/cli/cli/releases/download/v2.74.2/gh_2.74.2_linux_amd64.tar.gz')).not.toThrow();
+  });
+
+  // T27: validateDownloadUrl accepts download.docker.com HTTPS
+  it('validateDownloadUrl accepts download.docker.com HTTPS', () => {
+    expect(() => validateDownloadUrl('https://download.docker.com/linux/static/stable/x86_64/docker-28.0.1.tgz')).not.toThrow();
+  });
+
+  // T28: validateDownloadUrl rejects malformed URL
+  it('validateDownloadUrl rejects malformed URL', () => {
+    expect(() => validateDownloadUrl('not-a-url')).toThrow(/Invalid download URL/);
+  });
+
+  // T29: installBinary rejects tool with disallowed install_ref host
+  it('rejects binary tool with disallowed install_ref host', async () => {
+    mockQuery
+      .mockResolvedValueOnce({
+        rows: [{ id: 'tool-gh', name: 'gh', install_method: 'binary', install_ref: 'https://evil.com/gh_{version}.tar.gz' }],
+      })
+      .mockResolvedValue({ rowCount: 1 });
+    // Idempotency check: not installed
+    mockExec.mockResolvedValue({ exitCode: 1, stdout: '', stderr: '' });
+
+    await expect(ensureRequiredToolsInstalled('agent-db-id', 'agent-slug')).rejects.toThrow(
+      /not in allowlist/
+    );
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  // T30: execWithStdin called with Buffer stdinData on success
+  it('execWithStdin receives Buffer stdinData on successful binary install', async () => {
+    const tarballBody = new ArrayBuffer(256);
+    mockQuery
+      .mockResolvedValueOnce({
+        rows: [{ id: 'tool-gh', name: 'gh', install_method: 'binary', install_ref: 'https://github.com/cli/cli/releases/download/v{version}/gh_{version}_linux_amd64.tar.gz' }],
+      })
+      .mockResolvedValue({ rowCount: 1 });
+    mockExec.mockResolvedValue({ exitCode: 1, stdout: '', stderr: '' }); // not installed
+    mockFetch.mockResolvedValue(mockFetchResponse(200, tarballBody));
+    mockExecStdin.mockResolvedValue({ exitCode: 0, stdout: '', stderr: '' });
+
+    await ensureRequiredToolsInstalled('agent-db-id', 'agent-slug');
+
+    expect(mockExecStdin).toHaveBeenCalledTimes(1);
+    const stdinData = mockExecStdin.mock.calls[0][2];
+    expect(Buffer.isBuffer(stdinData)).toBe(true);
+    expect(stdinData.length).toBe(256);
+  });
+
+  // T31: Allowed host redirecting to disallowed host fails before body download
+  it('fails when redirect goes to disallowed host', async () => {
+    mockQuery
+      .mockResolvedValueOnce({
+        rows: [{ id: 'tool-gh', name: 'gh', install_method: 'binary', install_ref: 'https://github.com/cli/cli/releases/download/v{version}/gh_{version}_linux_amd64.tar.gz' }],
+      })
+      .mockResolvedValue({ rowCount: 1 });
+    mockExec.mockResolvedValue({ exitCode: 1, stdout: '', stderr: '' }); // not installed
+    // First fetch returns redirect to disallowed host
+    mockFetch.mockResolvedValue(
+      mockFetchResponse(302, undefined, { location: 'https://evil.com/malicious.tgz' })
+    );
+
+    await expect(ensureRequiredToolsInstalled('agent-db-id', 'agent-slug')).rejects.toThrow(
+      /not in allowlist/
+    );
+    // 2 attempts (initial + 1 retry), each does 1 fetch then fails on redirect validation
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  // T32: Allowed-to-allowed redirect succeeds (github.com → objects.githubusercontent.com)
+  it('follows redirect from allowed to allowed host', async () => {
+    mockQuery
+      .mockResolvedValueOnce({
+        rows: [{ id: 'tool-gh', name: 'gh', install_method: 'binary', install_ref: 'https://github.com/cli/cli/releases/download/v{version}/gh_{version}_linux_amd64.tar.gz' }],
+      })
+      .mockResolvedValue({ rowCount: 1 });
+    mockExec.mockResolvedValue({ exitCode: 1, stdout: '', stderr: '' }); // not installed
+    // First fetch: redirect to allowed CDN
+    mockFetch
+      .mockResolvedValueOnce(
+        mockFetchResponse(302, undefined, { location: 'https://objects.githubusercontent.com/gh.tar.gz' })
+      )
+      .mockResolvedValueOnce(mockFetchResponse(200, new ArrayBuffer(100)));
+    mockExecStdin.mockResolvedValue({ exitCode: 0, stdout: '', stderr: '' });
+
+    await ensureRequiredToolsInstalled('agent-db-id', 'agent-slug');
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(mockExecStdin).toHaveBeenCalledTimes(1);
+  });
+
+  // T33: Excessive redirects (> MAX_DOWNLOAD_REDIRECTS) fails deterministically
+  it('fails on excessive redirects', async () => {
+    mockQuery
+      .mockResolvedValueOnce({
+        rows: [{ id: 'tool-gh', name: 'gh', install_method: 'binary', install_ref: 'https://github.com/cli/cli/releases/download/v{version}/gh_{version}_linux_amd64.tar.gz' }],
+      })
+      .mockResolvedValue({ rowCount: 1 });
+    mockExec.mockResolvedValue({ exitCode: 1, stdout: '', stderr: '' }); // not installed
+    // Always redirect (loop)
+    mockFetch.mockResolvedValue(
+      mockFetchResponse(302, undefined, { location: 'https://github.com/loop' })
+    );
+
+    await expect(ensureRequiredToolsInstalled('agent-db-id', 'agent-slug')).rejects.toThrow(
+      /Too many redirects \(max 5\)/
+    );
+    // 2 attempts (initial + 1 retry), each exhausts 6 fetches (1 initial + 5 redirect hops)
+    expect(mockFetch).toHaveBeenCalledTimes(12);
+  });
 });
 
 // T13 (unit): invalid HILL90_TOOL_INSTALL_RETRIES still retries (defaults to 1)
@@ -239,25 +446,34 @@ describe('tool-installer retry env safety', () => {
     jest.resetModules();
     const mockQueryInner = jest.fn();
     const mockExecInner = jest.fn();
+    const mockExecStdinInner = jest.fn();
+    const mockFetchInner = jest.fn();
     jest.doMock('../db/pool', () => ({ getPool: () => ({ query: mockQueryInner }) }));
     jest.doMock('../services/docker', () => ({
       execInContainerWithExit: (...args: any[]) => mockExecInner(...args),
+      execWithStdin: (...args: any[]) => mockExecStdinInner(...args),
     }));
+    global.fetch = mockFetchInner as any;
 
     const { ensureRequiredToolsInstalled: ensureFresh } = require('../services/tool-installer');
 
     mockQueryInner
       .mockResolvedValueOnce({
-        rows: [{ id: 'tool-gh', name: 'gh', install_method: 'binary', install_ref: 'https://example.com/gh_{version}.tar.gz' }],
+        rows: [{ id: 'tool-gh', name: 'gh', install_method: 'binary', install_ref: 'https://github.com/cli/cli/releases/download/v{version}/gh_{version}_linux_amd64.tar.gz' }],
       })
       .mockResolvedValue({ rowCount: 1 });
-    mockExecInner
-      .mockResolvedValueOnce({ exitCode: 1, stdout: '', stderr: 'fail' }) // first attempt
-      .mockResolvedValue({ exitCode: 0, stdout: '', stderr: '' }); // retry
+    // Idempotency check: not installed (all attempts)
+    mockExecInner.mockResolvedValue({ exitCode: 1, stdout: '', stderr: '' });
+    // Download succeeds
+    mockFetchInner.mockResolvedValue(mockFetchResponse(200, new ArrayBuffer(100)));
+    // Extract: first attempt fails, retry succeeds
+    mockExecStdinInner
+      .mockResolvedValueOnce({ exitCode: 1, stdout: '', stderr: 'fail' })
+      .mockResolvedValue({ exitCode: 0, stdout: '', stderr: '' });
 
     await ensureFresh('agent-db-id', 'agent-slug');
-    // Should have retried (2 exec calls), proving NaN didn't yield 0 retries
-    expect(mockExecInner).toHaveBeenCalledTimes(2);
+    // Should have retried (2 execStdin calls), proving NaN didn't yield 0 retries
+    expect(mockExecStdinInner).toHaveBeenCalledTimes(2);
 
     // Restore
     if (origEnv === undefined) {

--- a/services/api/src/services/docker.ts
+++ b/services/api/src/services/docker.ts
@@ -319,6 +319,85 @@ export async function execInContainerWithExit(
   };
 }
 
+export async function execWithStdin(
+  agentId: string,
+  cmd: string[],
+  stdinData: Buffer,
+  timeoutMs?: number,
+): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+  const containerName = `${CONTAINER_PREFIX}${agentId}`;
+  assertAgentboxName(containerName);
+
+  const container = docker.getContainer(containerName);
+  const info = await container.inspect();
+  assertManagedLabel(info.Config.Labels);
+
+  const exec = await container.exec({
+    Cmd: cmd,
+    AttachStdin: true,
+    AttachStdout: true,
+    AttachStderr: true,
+    Tty: false,
+  });
+
+  const rawStream = await exec.start({ hijack: true, stdin: true });
+
+  // Write stdin data and close the write side
+  rawStream.write(stdinData);
+  rawStream.end();
+
+  const stdoutChunks: Buffer[] = [];
+  const stderrChunks: Buffer[] = [];
+  let remainder: Buffer | null = null;
+
+  const streamPromise = new Promise<void>((resolve, reject) => {
+    rawStream.on('data', (chunk: Buffer) => {
+      let buf: Buffer = remainder ? Buffer.concat([remainder, chunk]) : chunk;
+      remainder = null;
+      let offset = 0;
+      while (offset < buf.length) {
+        if (offset + 8 > buf.length) {
+          remainder = buf.slice(offset);
+          break;
+        }
+        const payloadSize = buf.readUInt32BE(offset + 4);
+        const frameEnd = offset + 8 + payloadSize;
+        if (frameEnd > buf.length) {
+          remainder = buf.slice(offset);
+          break;
+        }
+        const streamType = buf[offset];
+        const payload = buf.slice(offset + 8, frameEnd);
+        if (streamType === 1) stdoutChunks.push(payload);
+        else if (streamType === 2) stderrChunks.push(payload);
+        offset = frameEnd;
+      }
+    });
+    rawStream.on('error', reject);
+    rawStream.on('end', () => resolve());
+    rawStream.on('close', () => resolve());
+  });
+
+  if (timeoutMs && timeoutMs > 0) {
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      setTimeout(() => {
+        rawStream.destroy();
+        reject(new Error(`Command timed out after ${Math.round(timeoutMs / 1000)}s`));
+      }, timeoutMs);
+    });
+    await Promise.race([streamPromise, timeoutPromise]);
+  } else {
+    await streamPromise;
+  }
+
+  const inspect = await exec.inspect();
+  return {
+    exitCode: inspect.ExitCode ?? 1,
+    stdout: Buffer.concat(stdoutChunks).toString('utf8'),
+    stderr: Buffer.concat(stderrChunks).toString('utf8'),
+  };
+}
+
 export async function removeAgentVolumes(agentId: string): Promise<void> {
   for (const suffix of VOLUME_SUFFIXES) {
     const volumeName = `${CONTAINER_PREFIX}${agentId}-${suffix}`;

--- a/services/api/src/services/tool-installer.ts
+++ b/services/api/src/services/tool-installer.ts
@@ -1,5 +1,5 @@
 import { getPool } from '../db/pool';
-import { execInContainerWithExit } from './docker';
+import { execInContainerWithExit, execWithStdin } from './docker';
 
 type InstallMethod = 'builtin' | 'apt' | 'binary';
 
@@ -25,6 +25,76 @@ const INSTALL_TIMEOUTS: Record<InstallMethod, number> = {
   apt: 120_000,
   binary: 300_000,
 };
+
+const ALLOWED_DOWNLOAD_HOSTS = new Set([
+  'github.com',
+  'objects.githubusercontent.com',
+  'download.docker.com',
+]);
+
+const MAX_DOWNLOAD_REDIRECTS = 5;
+
+export function validateDownloadUrl(url: string): void {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error(`Invalid download URL: ${url}`);
+  }
+  if (parsed.protocol !== 'https:') {
+    throw new Error(
+      `Download URL must use HTTPS (got ${parsed.protocol}): ${url}`
+    );
+  }
+  if (!ALLOWED_DOWNLOAD_HOSTS.has(parsed.hostname)) {
+    throw new Error(
+      `Download URL hostname "${parsed.hostname}" not in allowlist. ` +
+      `Allowed: ${[...ALLOWED_DOWNLOAD_HOSTS].join(', ')}`
+    );
+  }
+}
+
+async function downloadTarball(url: string, timeoutMs: number): Promise<Buffer> {
+  validateDownloadUrl(url);
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    let currentUrl = url;
+
+    for (let hop = 0; hop <= MAX_DOWNLOAD_REDIRECTS; hop++) {
+      const resp = await fetch(currentUrl, {
+        signal: controller.signal,
+        redirect: 'manual',
+      });
+
+      if (resp.status >= 300 && resp.status < 400) {
+        const location = resp.headers.get('location');
+        if (!location) {
+          throw new Error(`Redirect from ${currentUrl} missing Location header`);
+        }
+        const resolved = new URL(location, currentUrl).href;
+        validateDownloadUrl(resolved);
+        currentUrl = resolved;
+        continue;
+      }
+
+      if (!resp.ok) {
+        throw new Error(`Download failed: HTTP ${resp.status} from ${currentUrl}`);
+      }
+
+      const buf = Buffer.from(await resp.arrayBuffer());
+      if (buf.length === 0) throw new Error(`Empty response from ${currentUrl}`);
+      return buf;
+    }
+
+    throw new Error(
+      `Too many redirects (max ${MAX_DOWNLOAD_REDIRECTS}) downloading ${url}`
+    );
+  } finally {
+    clearTimeout(timer);
+  }
+}
 
 const MAX_INSTALL_RETRIES = (() => {
   const parsed = parseInt(process.env.HILL90_TOOL_INSTALL_RETRIES || '1', 10);
@@ -88,16 +158,13 @@ export function binaryInstallScript(tool: ToolRow): string {
       `Set HILL90_${tool.name.toUpperCase()}_VERSION or add to DEFAULT_BINARY_VERSIONS.`
     );
   }
-  const url = tool.install_ref.replaceAll('{version}', version);
   const binPath = BINARY_PATH_OVERRIDES[tool.name]
     ? BINARY_PATH_OVERRIDES[tool.name](version)
     : `${tool.name}/${tool.name}`;
   return `
 set -euo pipefail
 mkdir -p /data/tools/bin /tmp/hill90-tools
-if [ -x /data/tools/bin/${shellQuote(tool.name)} ]; then exit 0; fi
-curl -fsSL ${shellQuote(url)} -o /tmp/hill90-tools/${shellQuote(tool.name)}.tgz
-tar -xzf /tmp/hill90-tools/${shellQuote(tool.name)}.tgz -C /tmp/hill90-tools
+tar -xzf - -C /tmp/hill90-tools
 cp /tmp/hill90-tools/${binPath} /data/tools/bin/${shellQuote(tool.name)}
 chmod +x /data/tools/bin/${shellQuote(tool.name)}
 rm -rf /tmp/hill90-tools
@@ -105,8 +172,30 @@ rm -rf /tmp/hill90-tools
 }
 
 async function installBinary(agentSlug: string, tool: ToolRow): Promise<void> {
+  // Idempotency: skip if binary already exists in container
+  const check = await execInContainerWithExit(
+    agentSlug, ['test', '-x', `/data/tools/bin/${tool.name}`], INSTALL_TIMEOUTS.builtin,
+  );
+  if (check.exitCode === 0) return;
+
+  // Resolve version + URL on API side
+  const version = DEFAULT_BINARY_VERSIONS[tool.name];
+  if (!version) {
+    throw new Error(
+      `No version configured for binary tool "${tool.name}". ` +
+      `Set HILL90_${tool.name.toUpperCase()}_VERSION or add to DEFAULT_BINARY_VERSIONS.`
+    );
+  }
+  const url = tool.install_ref.replaceAll('{version}', version);
+
+  // Download on API side (redirect-safe, HTTPS + allowlist validated per hop)
+  const tarball = await downloadTarball(url, INSTALL_TIMEOUTS.binary);
+
+  // Pipe tarball into container via exec stdin
   const script = binaryInstallScript(tool);
-  const result = await execInContainerWithExit(agentSlug, ['bash', '-lc', script], INSTALL_TIMEOUTS.binary);
+  const result = await execWithStdin(
+    agentSlug, ['bash', '-lc', script], tarball, INSTALL_TIMEOUTS.binary,
+  );
   if (result.exitCode !== 0) {
     throw new Error(`Binary install failed for "${tool.name}": ${result.stderr || result.stdout}`.trim());
   }


### PR DESCRIPTION
## Summary
- **Root cause**: Agentbox containers run on `hill90_agent_internal` (`internal: true` Docker bridge) which blocks ALL outbound traffic. Binary tool installs via in-container `curl` always fail with SERVFAIL.
- **Fix**: API service (on `edge` network) downloads tarballs with redirect-safe URL validation, then pipes bytes into containers via `execWithStdin` (exec stdin, POST-based — allowed by docker-proxy).
- Agent network isolation is preserved — no changes to `agent_internal`, docker-proxy, or network topology.

### Changes
| File | Change |
|------|--------|
| `services/api/src/services/docker.ts` | Add `execWithStdin()` — same safety guards as `execInContainerWithExit`, writes Buffer to stdin |
| `services/api/src/services/tool-installer.ts` | HTTPS-only hostname allowlist (`github.com`, `objects.githubusercontent.com`, `download.docker.com`), redirect-safe download (manual redirect + per-hop re-validation), `binaryInstallScript` reads tar from stdin (no curl), `installBinary` with idempotency check |
| `services/api/src/__tests__/tool-installer.test.ts` | 13 new tests (T21–T33), 6 updated tests |
| `services/api/src/__tests__/docker-service.test.ts` | Add `execWithStdin` + `execInContainerWithExit` to exports check |

### Security
- HTTPS-only + hostname allowlist enforced on initial URL AND every redirect hop (fail-closed)
- Manual redirect following (`redirect: 'manual'`) — Node fetch never auto-follows
- Max 5 redirect hops — deterministic error on overflow
- Agent containers stay on `internal: true` network — no external access granted
- No RBAC, route, auth, or network topology changes

## Test plan
- [x] All 350 tests pass (29 suites)
- [x] 13 new tests: URL validation (T24-T28), idempotency (T21), no-curl (T22), stdin tar (T23), disallowed host rejection (T29), Buffer verification (T30), redirect safety (T31-T33)
- [x] 6 existing tests updated for new mock structure
- [x] S1: No RBAC/route/API changes (code review)
- [x] S2: Allowlist matches seeded tool URLs
- [x] S3: OpenAPI source = mirror (diff empty)
- [x] S4: No seeded tools use `apt` (migration 021 static proof)
- [ ] V4: GitHub skill installs gh binary (post-deploy)
- [ ] V5: `gh --version` works in agent container (post-deploy)
- [ ] V6: Docker skill installs docker binary (post-deploy)
- [ ] V9: Idempotent — stop/start skips re-download (post-deploy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)