### PR TITLE
fix: remove legacy tools_config controls from Skills and Agent forms

### DIFF
--- a/services/ui/src/__tests__/AgentFormClient.test.tsx
+++ b/services/ui/src/__tests__/AgentFormClient.test.tsx
@@ -14,10 +14,6 @@ vi.mock('next/navigation', () => ({
 const mockFetch = vi.fn()
 vi.stubGlobal('fetch', mockFetch)
 
-// Mock confirm for overwrite protection tests
-const mockConfirm = vi.fn(() => true)
-vi.stubGlobal('confirm', mockConfirm)
-
 import AgentFormClient from '@/app/agents/new/AgentFormClient'
 
 const MOCK_POLICIES = [
@@ -105,7 +101,6 @@ async function selectCustomMode() {
 describe('AgentFormClient', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mockConfirm.mockReturnValue(true)
     mockFetchDefaults()
   })
 
@@ -138,31 +133,27 @@ describe('AgentFormClient', () => {
     expect(screen.getByText('Assign Models')).toBeInTheDocument()
   })
 
-  it('shows shell advanced fields when shell enabled', async () => {
+  it('custom mode hides direct shell/filesystem/health toggles', async () => {
     render(<AgentFormClient />)
     await selectCustomMode()
 
-    const shellCheckbox = screen.getByLabelText('Shell access')
-    fireEvent.click(shellCheckbox)
-
-    const advancedLink = screen.getByText('Advanced settings', { selector: 'button' })
-    fireEvent.click(advancedLink)
-
-    expect(screen.getByText('Allowed Binaries')).toBeInTheDocument()
-    expect(screen.getByLabelText('Max Timeout (seconds)')).toBeInTheDocument()
+    expect(screen.getByText(/does not expose direct tool policy toggles/i)).toBeInTheDocument()
+    expect(screen.queryByLabelText('Shell access')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Filesystem access')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Health endpoint')).not.toBeInTheDocument()
   })
 
-  it('shows filesystem advanced fields when filesystem enabled', async () => {
+  it('switching modes still works with custom informational view', async () => {
     render(<AgentFormClient />)
-    await selectCustomMode()
-
-    const fsCheckbox = screen.getByLabelText('Filesystem access')
-    fireEvent.click(fsCheckbox)
-
-    const advancedLinks = screen.getAllByText('Advanced settings', { selector: 'button' })
-    fireEvent.click(advancedLinks[0])
-
-    expect(screen.getByText('Allowed Paths')).toBeInTheDocument()
+    await waitFor(() => {
+      expect(screen.getByLabelText('Skills')).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByLabelText('Custom'))
+    expect(screen.getByText(/runtime access is governed by assigned skills and rbac scope/i)).toBeInTheDocument()
+    fireEvent.click(screen.getByLabelText('Skills'))
+    await waitFor(() => {
+      expect(screen.getAllByText(/Minimal/).length).toBeGreaterThan(0)
+    })
   })
 
   it('submit body includes model_names', async () => {
@@ -194,14 +185,12 @@ describe('AgentFormClient', () => {
     expect(body.model_names).toEqual(['gpt-4o-mini', 'my-custom-model'])
   })
 
-  it('submit body includes advanced tools_config fields', async () => {
+  it('custom mode submit still includes tools_config', async () => {
     render(<AgentFormClient />)
     await selectCustomMode()
 
     fireEvent.change(screen.getByLabelText('Agent ID (slug)'), { target: { value: 'test-agent' } })
     fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Test Agent' } })
-
-    fireEvent.click(screen.getByLabelText('Shell access'))
 
     fireEvent.click(screen.getByRole('button', { name: /create agent/i }))
 
@@ -215,54 +204,11 @@ describe('AgentFormClient', () => {
       (c: any[]) => c[0] === '/api/agents' && c[1]?.method === 'POST'
     )!
     const body = JSON.parse(postCall[1].body)
-    expect(body.tools_config.shell.enabled).toBe(true)
-    expect(body.tools_config.shell.allowed_binaries).toEqual([])
-    expect(body.tools_config.shell.denied_patterns).toEqual([])
-    expect(body.tools_config.shell.max_timeout).toBe(300)
+    expect(body.tools_config).toBeDefined()
+    expect(body.tools_config.shell).toBeDefined()
   })
 
-  it('rejects max_timeout less than 1', async () => {
-    render(<AgentFormClient />)
-    await selectCustomMode()
-
-    fireEvent.change(screen.getByLabelText('Agent ID (slug)'), { target: { value: 'test-agent' } })
-    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Test Agent' } })
-
-    fireEvent.click(screen.getByLabelText('Shell access'))
-    fireEvent.click(screen.getByText('Advanced settings', { selector: 'button' }))
-
-    const timeoutInput = screen.getByLabelText('Max Timeout (seconds)')
-    fireEvent.change(timeoutInput, { target: { value: '0' } })
-
-    const form = screen.getByRole('button', { name: /create agent/i }).closest('form')!
-    fireEvent.submit(form)
-
-    await waitFor(() => {
-      expect(screen.getByText(/timeout must be at least 1/i)).toBeInTheDocument()
-    })
-
-    const postCalls = mockFetch.mock.calls.filter(
-      (c: any[]) => c[0] === '/api/agents' && c[1]?.method === 'POST'
-    )
-    expect(postCalls).toHaveLength(0)
-  })
-
-  it('rejects path not starting with /', async () => {
-    render(<AgentFormClient />)
-    await selectCustomMode()
-
-    fireEvent.click(screen.getByLabelText('Filesystem access'))
-    const advancedLinks = screen.getAllByText('Advanced settings', { selector: 'button' })
-    fireEvent.click(advancedLinks[0])
-
-    const pathInputs = screen.getAllByPlaceholderText(/add/i)
-    fireEvent.change(pathInputs[0], { target: { value: 'nope' } })
-    fireEvent.keyDown(pathInputs[0], { key: 'Enter' })
-
-    expect(screen.getByText(/must start with \//i)).toBeInTheDocument()
-  })
-
-  it('pre-fills advanced tools_config from initial prop', async () => {
+  it('edit mode without skills starts in Custom informational mode', async () => {
     const initial = {
       agent_id: 'existing',
       name: 'Existing Agent',
@@ -286,12 +232,8 @@ describe('AgentFormClient', () => {
       expect(screen.getByText('Tools')).toBeInTheDocument()
     })
 
-    // Edit mode with no skills -> Custom mode, tool toggles visible
-    const shellCheckbox = screen.getByLabelText('Shell access') as HTMLInputElement
-    expect(shellCheckbox.checked).toBe(true)
-
-    const fsCheckbox = screen.getByLabelText('Filesystem access') as HTMLInputElement
-    expect(fsCheckbox.checked).toBe(true)
+    expect(screen.getByText(/does not expose direct tool policy toggles/i)).toBeInTheDocument()
+    expect(screen.queryByLabelText('Shell access')).not.toBeInTheDocument()
 
     const modelCheckbox = screen.getByLabelText('gpt-4o-mini') as HTMLInputElement
     expect(modelCheckbox.checked).toBe(true)
@@ -363,14 +305,12 @@ describe('AgentFormClient', () => {
       expect(screen.getAllByText(/Minimal/).length).toBeGreaterThan(0)
     })
 
-    // Switch to Custom -- manual tool editors visible
+    // Switch to Custom -- informational panel visible
     fireEvent.click(screen.getByLabelText('Custom'))
 
     await waitFor(() => {
-      expect(screen.getByLabelText('Shell access')).toBeInTheDocument()
+      expect(screen.getByText(/does not expose direct tool policy toggles/i)).toBeInTheDocument()
     })
-    expect(screen.getByLabelText('Filesystem access')).toBeInTheDocument()
-    expect(screen.getByLabelText('Health endpoint')).toBeInTheDocument()
   })
 
   // U3: Form Custom mode: manual tools editors shown, skill_ids: [] submitted
@@ -448,50 +388,17 @@ describe('AgentFormClient', () => {
     expect(checkboxes.some(cb => cb.closest('label')?.textContent?.includes('Docker Access'))).toBe(false)
   })
 
-  // U6: Overwrite warning when switching from Custom to Skills with dirty tools
-  it('dirty custom state prompts confirmation before switching to Skills', async () => {
+  // U6: Switching between modes has no overwrite confirmation
+  it('switching from Custom to Skills does not require confirmation', async () => {
     render(<AgentFormClient />)
     await selectCustomMode()
 
-    // Make a manual change in Custom mode (enable shell = dirty)
-    fireEvent.click(screen.getByLabelText('Shell access'))
-
-    // Now try to switch back to Skills mode
+    // Switch back to Skills mode
     fireEvent.click(screen.getByLabelText('Skills'))
 
-    // confirm() should have been called
-    expect(mockConfirm).toHaveBeenCalledWith(
-      expect.stringMatching(/overwrite/i)
-    )
-  })
-
-  it('cancel on overwrite confirmation keeps Custom mode', async () => {
-    mockConfirm.mockReturnValue(false)
-
-    render(<AgentFormClient />)
-    await selectCustomMode()
-
-    // Make a manual change (enable shell)
-    fireEvent.click(screen.getByLabelText('Shell access'))
-
-    // Try to switch to Skills -- user cancels
-    fireEvent.click(screen.getByLabelText('Skills'))
-
-    // Should still be in Custom mode -- tool toggles visible
-    expect(screen.getByLabelText('Shell access')).toBeInTheDocument()
-    const shellCheckbox = screen.getByLabelText('Shell access') as HTMLInputElement
-    expect(shellCheckbox.checked).toBe(true)
-  })
-
-  it('no confirmation when switching from unmodified Custom to Skills', async () => {
-    render(<AgentFormClient />)
-    await selectCustomMode()
-
-    // Don't make any changes -- just switch back to Skills
-    fireEvent.click(screen.getByLabelText('Skills'))
-
-    // confirm() should NOT have been called
-    expect(mockConfirm).not.toHaveBeenCalled()
+    await waitFor(() => {
+      expect(screen.getAllByText(/Minimal/).length).toBeGreaterThan(0)
+    })
   })
 
   // Skills mode validation: requires at least one skill selected

--- a/services/ui/src/app/agents/new/AgentFormClient.tsx
+++ b/services/ui/src/app/agents/new/AgentFormClient.tsx
@@ -1,8 +1,7 @@
 'use client'
 
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
-import TagInput from '@/components/TagInput'
 
 // Mirrors agentbox Pydantic ToolsConfig (services/agentbox/app/config.py)
 interface ToolsConfig {
@@ -96,10 +95,6 @@ export default function AgentFormClient({
   const [selectedSkillIds, setSelectedSkillIds] = useState<Set<string>>(
     new Set(initial?.skills?.map(s => s.id) || [])
   )
-  const toolsCustomDirty = useRef(false)
-
-  const [shellAdvanced, setShellAdvanced] = useState(false)
-  const [fsAdvanced, setFsAdvanced] = useState(false)
   const [soulPreview, setSoulPreview] = useState(false)
   const [rulesPreview, setRulesPreview] = useState(false)
 
@@ -125,26 +120,11 @@ export default function AgentFormClient({
       .catch(() => {})
   }, [])
 
-  // Wrapper: marks tools as user-modified when editing in Custom mode
-  const updateToolsCustom = (newTools: ToolsConfig) => {
-    setTools(newTools)
-    toolsCustomDirty.current = true
-  }
-
   const handleModeChange = (newMode: 'custom' | 'skills') => {
     if (newMode === mode) return
 
-    if (newMode === 'skills' && toolsCustomDirty.current) {
-      if (!confirm('Switching to Skills mode will overwrite your custom tool configuration. Continue?')) {
-        return
-      }
-    }
-
     if (newMode === 'custom') {
       setSelectedSkillIds(new Set())
-      toolsCustomDirty.current = false
-    } else {
-      toolsCustomDirty.current = false
     }
 
     setMode(newMode)
@@ -162,10 +142,6 @@ export default function AgentFormClient({
   const validateForm = (): boolean => {
     if (mode === 'skills' && selectedSkillIds.size === 0) {
       setValidationError('Please select at least one skill or switch to Custom mode')
-      return false
-    }
-    if (mode === 'custom' && tools.shell.enabled && tools.shell.max_timeout < 1) {
-      setValidationError('Timeout must be at least 1 second')
       return false
     }
     setValidationError('')
@@ -216,8 +192,6 @@ export default function AgentFormClient({
       setSaving(false)
     }
   }
-
-  const pathValidate = (v: string) => (v.startsWith('/') ? null : 'Must start with /')
 
   return (
     <form onSubmit={handleSubmit} className="space-y-8">
@@ -369,110 +343,14 @@ export default function AgentFormClient({
             )}
           </div>
         ) : (
-          /* Custom mode — show manual tool toggles */
+          /* Custom mode — no direct tool policy editing */
           <div className="rounded-lg border border-navy-700 bg-navy-800 p-4 space-y-3">
-            {/* Shell */}
-            <label className="flex items-center gap-2 cursor-pointer">
-              <input
-                type="checkbox"
-                checked={tools.shell.enabled}
-                onChange={(e) => updateToolsCustom({ ...tools, shell: { ...tools.shell, enabled: e.target.checked } })}
-                className="rounded border-navy-600"
-              />
-              <span className="text-sm text-white">Shell access</span>
-            </label>
-
-            {tools.shell.enabled && (
-              <div className="ml-6 space-y-3">
-                <button
-                  type="button"
-                  onClick={() => setShellAdvanced(!shellAdvanced)}
-                  className="text-xs text-brand-400 hover:text-brand-300 transition-colors"
-                >
-                  Advanced settings
-                </button>
-                {shellAdvanced && (
-                  <div className="space-y-3 border-l-2 border-navy-600 pl-4">
-                    <TagInput
-                      label="Allowed Binaries"
-                      value={tools.shell.allowed_binaries}
-                      onChange={(v) => updateToolsCustom({ ...tools, shell: { ...tools.shell, allowed_binaries: v } })}
-                      placeholder="Add binary (e.g. bash)..."
-                      disabled={disabled}
-                    />
-                    <div>
-                      <label htmlFor="max_timeout" className="block text-xs font-medium text-mountain-500 uppercase tracking-wide mb-1">
-                        Max Timeout (seconds)
-                      </label>
-                      <input
-                        id="max_timeout"
-                        type="number"
-                        value={tools.shell.max_timeout}
-                        onChange={(e) => updateToolsCustom({ ...tools, shell: { ...tools.shell, max_timeout: parseInt(e.target.value) || 0 } })}
-                        min={1}
-                        className="w-32 rounded-lg border border-navy-600 bg-navy-900 px-3 py-1.5 text-white text-sm focus:border-brand-500 focus:outline-none disabled:opacity-50"
-                      />
-                    </div>
-                  </div>
-                )}
-              </div>
-            )}
-
-            {/* Filesystem */}
-            <label className="flex items-center gap-2 cursor-pointer">
-              <input
-                type="checkbox"
-                checked={tools.filesystem.enabled}
-                onChange={(e) => updateToolsCustom({ ...tools, filesystem: { ...tools.filesystem, enabled: e.target.checked } })}
-                className="rounded border-navy-600"
-              />
-              <span className="text-sm text-white">Filesystem access</span>
-            </label>
-
-            {tools.filesystem.enabled && (
-              <div className="ml-6 space-y-3">
-                <label className="flex items-center gap-2 cursor-pointer">
-                  <input
-                    type="checkbox"
-                    checked={tools.filesystem.read_only}
-                    onChange={(e) => updateToolsCustom({ ...tools, filesystem: { ...tools.filesystem, read_only: e.target.checked } })}
-                    className="rounded border-navy-600"
-                  />
-                  <span className="text-sm text-mountain-400">Read-only filesystem</span>
-                </label>
-
-                <button
-                  type="button"
-                  onClick={() => setFsAdvanced(!fsAdvanced)}
-                  className="text-xs text-brand-400 hover:text-brand-300 transition-colors"
-                >
-                  Advanced settings
-                </button>
-                {fsAdvanced && (
-                  <div className="space-y-3 border-l-2 border-navy-600 pl-4">
-                    <TagInput
-                      label="Allowed Paths"
-                      value={tools.filesystem.allowed_paths}
-                      onChange={(v) => updateToolsCustom({ ...tools, filesystem: { ...tools.filesystem, allowed_paths: v } })}
-                      validate={pathValidate}
-                      placeholder="Add path (e.g. /workspace)..."
-                      disabled={disabled}
-                    />
-                  </div>
-                )}
-              </div>
-            )}
-
-            {/* Health */}
-            <label className="flex items-center gap-2 cursor-pointer">
-              <input
-                type="checkbox"
-                checked={tools.health.enabled}
-                onChange={(e) => updateToolsCustom({ ...tools, health: { ...tools.health, enabled: e.target.checked } })}
-                className="rounded border-navy-600"
-              />
-              <span className="text-sm text-white">Health endpoint</span>
-            </label>
+            <p className="text-sm text-mountain-300">
+              Custom mode does not expose direct tool policy toggles.
+            </p>
+            <p className="text-xs text-mountain-500">
+              Runtime access is governed by assigned skills and RBAC scope.
+            </p>
           </div>
         )}
       </fieldset>

--- a/services/ui/src/app/harness/skills/SkillsClient.tsx
+++ b/services/ui/src/app/harness/skills/SkillsClient.tsx
@@ -61,13 +61,6 @@ export default function SkillsClient() {
     name: '',
     description: '',
     instructions_md: '',
-    shellEnabled: false,
-    filesystemEnabled: false,
-    readOnly: false,
-    healthEnabled: true,
-    allowed_binaries: '' ,
-    allowed_paths: '/workspace',
-    max_timeout: '300',
   })
   const [formError, setFormError] = useState('')
 
@@ -95,13 +88,6 @@ export default function SkillsClient() {
       name: '',
       description: '',
       instructions_md: '',
-      shellEnabled: false,
-      filesystemEnabled: false,
-      readOnly: false,
-      healthEnabled: true,
-      allowed_binaries: '',
-      allowed_paths: '/workspace',
-      max_timeout: '300',
     })
     setSelectedToolIds([])
     setFormError('')
@@ -118,20 +104,23 @@ export default function SkillsClient() {
       return
     }
 
+    const selectedToolNames = allTools
+      .filter((tool) => selectedToolIds.includes(tool.id))
+      .map((tool) => tool.name)
     const tools_config: ToolsConfig = {
       shell: {
-        enabled: formData.shellEnabled,
-        allowed_binaries: formData.allowed_binaries ? formData.allowed_binaries.split(',').map((s) => s.trim()).filter(Boolean) : [],
+        enabled: true,
+        allowed_binaries: selectedToolNames,
         denied_patterns: [],
-        max_timeout: parseInt(formData.max_timeout, 10) || 300,
+        max_timeout: 300,
       },
       filesystem: {
-        enabled: formData.filesystemEnabled,
-        read_only: formData.readOnly,
-        allowed_paths: formData.allowed_paths ? formData.allowed_paths.split(',').map((s) => s.trim()).filter(Boolean) : [],
+        enabled: true,
+        read_only: false,
+        allowed_paths: ['/workspace', '/data'],
         denied_paths: [],
       },
-      health: { enabled: formData.healthEnabled },
+      health: { enabled: true },
     }
 
     const body: Record<string, unknown> = {
@@ -185,18 +174,10 @@ export default function SkillsClient() {
   }
 
   const handleEdit = (skill: Skill) => {
-    const tc = skill.tools_config
     setFormData({
       name: skill.name,
       description: skill.description || '',
       instructions_md: skill.instructions_md || '',
-      shellEnabled: tc.shell.enabled,
-      filesystemEnabled: tc.filesystem.enabled,
-      readOnly: tc.filesystem.read_only,
-      healthEnabled: tc.health.enabled,
-      allowed_binaries: tc.shell.allowed_binaries.join(', '),
-      allowed_paths: tc.filesystem.allowed_paths.join(', '),
-      max_timeout: tc.shell.max_timeout.toString(),
     })
     setSelectedToolIds(skill.tools?.map(t => t.id) || [])
     setEditingId(skill.id)
@@ -308,65 +289,9 @@ export default function SkillsClient() {
               </div>
             )}
 
-            {/* Tool toggles */}
-            <div className="space-y-3">
-              <label className="block text-sm text-mountain-400">Tools</label>
-              <div className="flex flex-wrap gap-4">
-                <label className="flex items-center gap-2 text-sm text-white cursor-pointer">
-                  <input
-                    type="checkbox"
-                    checked={formData.shellEnabled}
-                    onChange={(e) => setFormData({ ...formData, shellEnabled: e.target.checked })}
-                    className="rounded border-navy-600"
-                  />
-                  Shell
-                </label>
-                <label className="flex items-center gap-2 text-sm text-white cursor-pointer">
-                  <input
-                    type="checkbox"
-                    checked={formData.filesystemEnabled}
-                    onChange={(e) => setFormData({ ...formData, filesystemEnabled: e.target.checked })}
-                    className="rounded border-navy-600"
-                  />
-                  Filesystem
-                </label>
-                <label className="flex items-center gap-2 text-sm text-white cursor-pointer">
-                  <input
-                    type="checkbox"
-                    checked={formData.healthEnabled}
-                    onChange={(e) => setFormData({ ...formData, healthEnabled: e.target.checked })}
-                    className="rounded border-navy-600"
-                  />
-                  Health
-                </label>
-              </div>
-            </div>
-
-            {formData.shellEnabled && (
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                <div>
-                  <label className="block text-sm text-mountain-400 mb-1">Allowed Binaries (comma-separated)</label>
-                  <input
-                    type="text"
-                    value={formData.allowed_binaries}
-                    onChange={(e) => setFormData({ ...formData, allowed_binaries: e.target.value })}
-                    className="w-full rounded-md border border-navy-600 bg-navy-900 px-3 py-2 text-sm text-white placeholder-mountain-500 focus:border-brand-500 focus:outline-none"
-                    placeholder="bash, git, curl"
-                  />
-                </div>
-                <div>
-                  <label className="block text-sm text-mountain-400 mb-1">Timeout (seconds)</label>
-                  <input
-                    type="number"
-                    min="1"
-                    value={formData.max_timeout}
-                    onChange={(e) => setFormData({ ...formData, max_timeout: e.target.value })}
-                    className="w-full rounded-md border border-navy-600 bg-navy-900 px-3 py-2 text-sm text-white placeholder-mountain-500 focus:border-brand-500 focus:outline-none"
-                    placeholder="300"
-                  />
-                </div>
-              </div>
-            )}
+            <p className="text-xs text-mountain-500">
+              Runtime access controls are managed internally from skill dependencies and RBAC scope.
+            </p>
 
             {formError && (
               <p className="text-sm text-red-400">{formError}</p>


### PR DESCRIPTION
Summary:
- remove direct shell/filesystem/health policy controls from Skills edit/create form
- remove direct tool policy toggles from Agent Custom mode panel
- keep skill dependency selection as the user-facing tool mechanism
- update AgentForm tests to assert the new UI contract

Validation:
- cd services/ui && npx vitest run src/__tests__/SkillsClient.test.tsx src/__tests__/AgentFormClient.test.tsx
- cd services/ui && npx vitest run