### PR TITLE
fix: remove remaining legacy shell/filesystem/health UI surfaces

### DIFF
--- a/services/ui/src/__tests__/AgentDetailClient.test.tsx
+++ b/services/ui/src/__tests__/AgentDetailClient.test.tsx
@@ -181,7 +181,7 @@ describe('AgentDetailClient', () => {
     cleanup()
   })
 
-  it('renders overview tab with status and config summary', async () => {
+  it('renders overview tab without legacy tool access summary', async () => {
     render(<AgentDetailClient agentId="uuid-1" session={ADMIN_SESSION as any} />)
 
     await waitFor(() => {
@@ -192,16 +192,14 @@ describe('AgentDetailClient', () => {
     expect(screen.getByText('Overview')).toBeInTheDocument()
     // Status info
     expect(screen.getByText('stopped')).toBeInTheDocument()
-    // Tool badges
-    expect(screen.getByText('Shell')).toBeInTheDocument()
-    expect(screen.getByText('Filesystem')).toBeInTheDocument()
-    expect(screen.getByText('Health')).toBeInTheDocument()
+    // Legacy overview tool summary removed
+    expect(screen.queryByText('Tool Access')).not.toBeInTheDocument()
     expect(screen.getByText('Tool Install Status')).toBeInTheDocument()
     expect(screen.getByText('gh')).toBeInTheDocument()
     expect(screen.getAllByText('installed').length).toBeGreaterThan(0)
   })
 
-  it('clicking Configuration tab shows tool details', async () => {
+  it('clicking Configuration tab shows skills runtime summary', async () => {
     render(<AgentDetailClient agentId="uuid-1" session={ADMIN_SESSION as any} />)
 
     await waitFor(() => {
@@ -211,12 +209,11 @@ describe('AgentDetailClient', () => {
     // Click Configuration tab
     fireEvent.click(screen.getByRole('button', { name: 'Configuration' }))
 
-    // Should show detailed tool config
+    // Should show skills runtime summary (no legacy tool config detail)
     await waitFor(() => {
-      expect(screen.getByText('bash')).toBeInTheDocument()
+      expect(screen.getByText('Skills Runtime')).toBeInTheDocument()
     })
-    expect(screen.getByText('python3')).toBeInTheDocument()
-    expect(screen.getByText('/workspace')).toBeInTheDocument()
+    expect(screen.queryByText('Tool Configuration')).not.toBeInTheDocument()
   })
 
   it('fetches usage data only when Model Access tab clicked', async () => {
@@ -317,7 +314,7 @@ describe('AgentDetailClient', () => {
     expect(screen.getByTestId('raw-logs-toggle')).toBeInTheDocument()
   })
 
-  it('Configuration tab displays allowed_binaries', async () => {
+  it('Configuration tab displays resources', async () => {
     render(<AgentDetailClient agentId="uuid-1" session={ADMIN_SESSION as any} />)
 
     await waitFor(() => {
@@ -327,8 +324,7 @@ describe('AgentDetailClient', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Configuration' }))
 
     await waitFor(() => {
-      expect(screen.getByText('bash')).toBeInTheDocument()
-      expect(screen.getByText('python3')).toBeInTheDocument()
+      expect(screen.getByText('Resources')).toBeInTheDocument()
     })
   })
 

--- a/services/ui/src/__tests__/AgentFormClient.test.tsx
+++ b/services/ui/src/__tests__/AgentFormClient.test.tsx
@@ -3,14 +3,12 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react'
 import '@testing-library/jest-dom/vitest'
 
-// Mock next/navigation
 const mockPush = vi.fn()
 const mockBack = vi.fn()
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: mockPush, back: mockBack }),
 }))
 
-// Mock global fetch
 const mockFetch = vi.fn()
 vi.stubGlobal('fetch', mockFetch)
 
@@ -20,82 +18,22 @@ const MOCK_POLICIES = [
   { id: 'policy-1', name: 'Default Policy', allowed_models: ['gpt-4o-mini'] },
   { id: 'policy-2', name: 'Restricted Policy', allowed_models: ['claude-sonnet'] },
 ]
-const MOCK_USER_MODELS = [
-  { id: 'um-1', name: 'my-custom-model' },
-]
-
-const MOCK_PRESETS = [
-  {
-    id: 'preset-min',
-    name: 'Minimal',
-    description: 'Health monitoring only',
-    scope: 'container_local',
-    tools_config: {
-      shell: { enabled: false, allowed_binaries: [], denied_patterns: [], max_timeout: 300 },
-      filesystem: { enabled: false, read_only: false, allowed_paths: ['/workspace'], denied_paths: ['/etc/shadow', '/etc/passwd', '/root'] },
-      health: { enabled: true },
-    },
-    instructions_md: 'You have no shell or filesystem access.',
-    is_platform: true,
-    tools: [],
-  },
-  {
-    id: 'preset-dev',
-    name: 'Developer',
-    description: 'Full dev environment',
-    scope: 'container_local',
-    tools_config: {
-      shell: { enabled: true, allowed_binaries: ['bash', 'git', 'make', 'curl', 'jq'], denied_patterns: ['rm -rf /', ':(){ :|:& };:'], max_timeout: 300 },
-      filesystem: { enabled: true, read_only: false, allowed_paths: ['/workspace', '/data'], denied_paths: ['/etc/shadow', '/etc/passwd', '/root'] },
-      health: { enabled: true },
-    },
-    instructions_md: 'You have full developer access with bash, git, make, curl, and jq available.',
-    is_platform: true,
-    tools: [],
-  },
-  {
-    id: 'preset-docker',
-    name: 'Docker Access',
-    description: 'Docker socket access',
-    scope: 'host_docker',
-    tools_config: {
-      shell: { enabled: true, allowed_binaries: ['bash', 'docker'], denied_patterns: [], max_timeout: 300 },
-      filesystem: { enabled: true, read_only: false, allowed_paths: ['/workspace'], denied_paths: [] },
-      health: { enabled: true },
-    },
-    instructions_md: 'You have Docker socket access.',
-    is_platform: false,
-    tools: [{ id: 'tool-docker', name: 'docker' }],
-  },
+const MOCK_USER_MODELS = [{ id: 'um-1', name: 'my-custom-model' }]
+const MOCK_SKILLS = [
+  { id: 'skill-min', name: 'Minimal', description: 'Min', scope: 'container_local', tools_config: {}, instructions_md: '', is_platform: true, tools: [] },
+  { id: 'skill-dev', name: 'Developer', description: 'Dev', scope: 'container_local', tools_config: {}, instructions_md: '', is_platform: true, tools: [{ id: 'tool-git', name: 'git' }] },
+  { id: 'skill-docker', name: 'Docker', description: 'Docker', scope: 'host_docker', tools_config: {}, instructions_md: '', is_platform: false, tools: [{ id: 'tool-docker', name: 'docker' }] },
 ]
 
 function mockFetchDefaults() {
   mockFetch.mockImplementation((url: string, opts?: any) => {
-    if (url === '/api/model-policies') {
-      return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_POLICIES) })
-    }
-    if (url === '/api/user-models') {
-      return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_USER_MODELS) })
-    }
-    if (url === '/api/skills') {
-      return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_PRESETS) })
-    }
-    if (url === '/api/agents' && opts?.method === 'POST') {
-      return Promise.resolve({ ok: true, json: () => Promise.resolve({ id: 'new-uuid' }) })
-    }
-    if (typeof url === 'string' && url.startsWith('/api/agents/') && opts?.method === 'PUT') {
-      return Promise.resolve({ ok: true, json: () => Promise.resolve({ id: 'existing-uuid' }) })
-    }
+    if (url === '/api/model-policies') return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_POLICIES) })
+    if (url === '/api/user-models') return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_USER_MODELS) })
+    if (url === '/api/skills') return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_SKILLS) })
+    if (url === '/api/agents' && opts?.method === 'POST') return Promise.resolve({ ok: true, json: () => Promise.resolve({ id: 'new-uuid' }) })
+    if (typeof url === 'string' && url.startsWith('/api/agents/') && opts?.method === 'PUT') return Promise.resolve({ ok: true, json: () => Promise.resolve({ id: 'existing-uuid' }) })
     return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
   })
-}
-
-/** Helper: switch to Custom mode via radio toggle */
-async function selectCustomMode() {
-  await waitFor(() => {
-    expect(screen.getByLabelText('Custom')).toBeInTheDocument()
-  })
-  fireEvent.click(screen.getByLabelText('Custom'))
 }
 
 describe('AgentFormClient', () => {
@@ -104,338 +42,66 @@ describe('AgentFormClient', () => {
     mockFetchDefaults()
   })
 
-  afterEach(() => {
-    cleanup()
-  })
+  afterEach(() => cleanup())
 
-  it('renders basic info, tools, models, resources, identity sections', async () => {
+  it('renders basic sections and skill selection', async () => {
     render(<AgentFormClient />)
-
-    await waitFor(() => {
-      expect(screen.getByText('Basic Info')).toBeInTheDocument()
-    })
-
+    await waitFor(() => expect(screen.getByText('Basic Info')).toBeInTheDocument())
     expect(screen.getByText('Tools')).toBeInTheDocument()
-    expect(screen.getAllByText('Models').length).toBeGreaterThan(0)
+    expect(screen.getByText('Models')).toBeInTheDocument()
     expect(screen.getByText('Resources')).toBeInTheDocument()
     expect(screen.getByText('Identity')).toBeInTheDocument()
+    expect(screen.getByText('Minimal')).toBeInTheDocument()
+    expect(screen.getByText('Developer')).toBeInTheDocument()
+    expect(screen.queryByLabelText('Custom')).not.toBeInTheDocument()
   })
 
-  it('fetches model sources and renders model checklist', async () => {
-    render(<AgentFormClient />)
-
-    await waitFor(() => {
-      expect(screen.getByText('gpt-4o-mini')).toBeInTheDocument()
-    })
-
-    expect(screen.getByText('claude-sonnet')).toBeInTheDocument()
-    expect(screen.getByText('my-custom-model')).toBeInTheDocument()
-    expect(screen.getByText('Assign Models')).toBeInTheDocument()
+  it('non-admin does not see elevated skills', async () => {
+    render(<AgentFormClient isAdmin={false} />)
+    await waitFor(() => expect(screen.getByText('Minimal')).toBeInTheDocument())
+    expect(screen.queryByText('Docker')).not.toBeInTheDocument()
   })
 
-  it('custom mode hides direct shell/filesystem/health toggles', async () => {
-    render(<AgentFormClient />)
-    await selectCustomMode()
-
-    expect(screen.getByText(/does not expose direct tool policy toggles/i)).toBeInTheDocument()
-    expect(screen.queryByLabelText('Shell access')).not.toBeInTheDocument()
-    expect(screen.queryByLabelText('Filesystem access')).not.toBeInTheDocument()
-    expect(screen.queryByLabelText('Health endpoint')).not.toBeInTheDocument()
-  })
-
-  it('switching modes still works with custom informational view', async () => {
-    render(<AgentFormClient />)
-    await waitFor(() => {
-      expect(screen.getByLabelText('Skills')).toBeInTheDocument()
-    })
-    fireEvent.click(screen.getByLabelText('Custom'))
-    expect(screen.getByText(/runtime access is governed by assigned skills and rbac scope/i)).toBeInTheDocument()
-    fireEvent.click(screen.getByLabelText('Skills'))
-    await waitFor(() => {
-      expect(screen.getAllByText(/Minimal/).length).toBeGreaterThan(0)
-    })
-  })
-
-  it('submit body includes model_names', async () => {
-    render(<AgentFormClient />)
-    await selectCustomMode()
-
-    await waitFor(() => {
-      expect(screen.getByText('gpt-4o-mini')).toBeInTheDocument()
-    })
-
-    fireEvent.change(screen.getByLabelText('Agent ID (slug)'), { target: { value: 'test-agent' } })
-    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Test Agent' } })
-
-    fireEvent.click(screen.getByLabelText('gpt-4o-mini'))
-    fireEvent.click(screen.getByLabelText('my-custom-model'))
-
-    fireEvent.click(screen.getByRole('button', { name: /create agent/i }))
-
-    await waitFor(() => {
-      expect(mockFetch).toHaveBeenCalledWith('/api/agents', expect.objectContaining({
-        method: 'POST',
-      }))
-    })
-
-    const postCall = mockFetch.mock.calls.find(
-      (c: any[]) => c[0] === '/api/agents' && c[1]?.method === 'POST'
-    )!
-    const body = JSON.parse(postCall[1].body)
-    expect(body.model_names).toEqual(['gpt-4o-mini', 'my-custom-model'])
-  })
-
-  it('custom mode submit still includes tools_config', async () => {
-    render(<AgentFormClient />)
-    await selectCustomMode()
-
-    fireEvent.change(screen.getByLabelText('Agent ID (slug)'), { target: { value: 'test-agent' } })
-    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Test Agent' } })
-
-    fireEvent.click(screen.getByRole('button', { name: /create agent/i }))
-
-    await waitFor(() => {
-      expect(mockFetch).toHaveBeenCalledWith('/api/agents', expect.objectContaining({
-        method: 'POST',
-      }))
-    })
-
-    const postCall = mockFetch.mock.calls.find(
-      (c: any[]) => c[0] === '/api/agents' && c[1]?.method === 'POST'
-    )!
-    const body = JSON.parse(postCall[1].body)
-    expect(body.tools_config).toBeDefined()
-    expect(body.tools_config.shell).toBeDefined()
-  })
-
-  it('edit mode without skills starts in Custom informational mode', async () => {
-    const initial = {
-      agent_id: 'existing',
-      name: 'Existing Agent',
-      description: 'Test',
-      tools_config: {
-        shell: { enabled: true, allowed_binaries: ['bash', 'node'], denied_patterns: ['rm -rf'], max_timeout: 600 },
-        filesystem: { enabled: true, read_only: false, allowed_paths: ['/workspace', '/tmp'], denied_paths: ['/etc/shadow'] },
-        health: { enabled: true },
-      },
-      cpus: '2.0',
-      mem_limit: '2g',
-      pids_limit: 300,
-      soul_md: 'soul text',
-      rules_md: 'rules text',
-      models: ['gpt-4o-mini'],
-    }
-
-    render(<AgentFormClient initial={initial} agentUuid="uuid-1" />)
-
-    await waitFor(() => {
-      expect(screen.getByText('Tools')).toBeInTheDocument()
-    })
-
-    expect(screen.getByText(/does not expose direct tool policy toggles/i)).toBeInTheDocument()
-    expect(screen.queryByLabelText('Shell access')).not.toBeInTheDocument()
-
-    const modelCheckbox = screen.getByLabelText('gpt-4o-mini') as HTMLInputElement
-    expect(modelCheckbox.checked).toBe(true)
-  })
-
-  it('disables all inputs when disabled prop is true', async () => {
-    const initial = {
-      agent_id: 'existing',
-      name: 'Existing Agent',
-      description: 'Test',
-      tools_config: {
-        shell: { enabled: false, allowed_binaries: [], denied_patterns: [], max_timeout: 300 },
-        filesystem: { enabled: false, read_only: false, allowed_paths: ['/workspace'], denied_paths: [] },
-        health: { enabled: true },
-      },
-      cpus: '1.0',
-      mem_limit: '1g',
-      pids_limit: 200,
-      soul_md: '',
-      rules_md: '',
-    }
-
-    render(<AgentFormClient initial={initial} agentUuid="uuid-1" disabled />)
-
-    await waitFor(() => {
-      expect(screen.getByText('This agent is running. Stop it before making changes.')).toBeInTheDocument()
-    })
-
-    const submitBtn = screen.getByRole('button', { name: /update agent/i })
-    expect(submitBtn).toBeDisabled()
-  })
-
-  it('shows character count for identity fields', async () => {
-    render(<AgentFormClient />)
-
-    await waitFor(() => {
-      expect(screen.getByText('Identity')).toBeInTheDocument()
-    })
-
-    const soulTextarea = screen.getByLabelText('SOUL.md')
-    fireEvent.change(soulTextarea, { target: { value: 'Hello world' } })
-
-    expect(screen.getByText('11 characters')).toBeInTheDocument()
-  })
-
-  // U1: Form renders radio toggle and checkboxes (not dropdown) for skills
-  it('renders radio toggle for Custom/Skills mode', async () => {
-    render(<AgentFormClient />)
-
-    await waitFor(() => {
-      expect(screen.getByLabelText('Skills')).toBeInTheDocument()
-    })
-
-    expect(screen.getByLabelText('Custom')).toBeInTheDocument()
-    // No dropdown (combobox) for skills
-    expect(screen.queryByRole('combobox', { name: /skill/i })).not.toBeInTheDocument()
-  })
-
-  // U2: Form Custom/Skills toggle switches mode
-  it('Custom/Skills toggle switches mode', async () => {
-    render(<AgentFormClient />)
-
-    await waitFor(() => {
-      expect(screen.getByLabelText('Skills')).toBeInTheDocument()
-    })
-
-    // Default: Skills mode -- skill checkboxes visible
-    await waitFor(() => {
-      expect(screen.getAllByText(/Minimal/).length).toBeGreaterThan(0)
-    })
-
-    // Switch to Custom -- informational panel visible
-    fireEvent.click(screen.getByLabelText('Custom'))
-
-    await waitFor(() => {
-      expect(screen.getByText(/does not expose direct tool policy toggles/i)).toBeInTheDocument()
-    })
-  })
-
-  // U3: Form Custom mode: manual tools editors shown, skill_ids: [] submitted
-  it('Custom mode submits skill_ids: [] with tools_config', async () => {
-    render(<AgentFormClient />)
-    await selectCustomMode()
-
-    fireEvent.change(screen.getByLabelText('Agent ID (slug)'), { target: { value: 'test-agent' } })
-    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Test Agent' } })
-
-    fireEvent.click(screen.getByRole('button', { name: /create agent/i }))
-
-    await waitFor(() => {
-      expect(mockFetch).toHaveBeenCalledWith('/api/agents', expect.objectContaining({
-        method: 'POST',
-      }))
-    })
-
-    const postCall = mockFetch.mock.calls.find(
-      (c: any[]) => c[0] === '/api/agents' && c[1]?.method === 'POST'
-    )!
-    const body = JSON.parse(postCall[1].body)
-    expect(body.skill_ids).toEqual([])
-    expect(body.tools_config).toBeDefined()
-  })
-
-  // U4 (old): Form Skills mode: checkboxes shown, skill_ids submitted
-  it('Skills mode submits checked skill_ids', async () => {
+  it('admin sees elevated skills', async () => {
     render(<AgentFormClient isAdmin />)
+    await waitFor(() => expect(screen.getByText('Docker')).toBeInTheDocument())
+  })
 
-    await waitFor(() => {
-      expect(screen.getByText(/Minimal/)).toBeInTheDocument()
-    })
-
-    // Fill required fields
+  it('requires at least one skill before submit', async () => {
+    render(<AgentFormClient />)
+    await waitFor(() => expect(screen.getByText('Minimal')).toBeInTheDocument())
     fireEvent.change(screen.getByLabelText('Agent ID (slug)'), { target: { value: 'test-agent' } })
     fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Test Agent' } })
+    fireEvent.click(screen.getByRole('button', { name: /create agent/i }))
+    await waitFor(() => expect(screen.getByText(/please select at least one skill/i)).toBeInTheDocument())
+  })
 
-    // Check two skills using role query to match partial label text
+  it('submits selected skill_ids and omits tools_config', async () => {
+    render(<AgentFormClient isAdmin />)
+    await waitFor(() => expect(screen.getByText('Minimal')).toBeInTheDocument())
+    fireEvent.change(screen.getByLabelText('Agent ID (slug)'), { target: { value: 'test-agent' } })
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Test Agent' } })
     const checkboxes = screen.getAllByRole('checkbox')
     const minCheckbox = checkboxes.find(cb => cb.closest('label')?.textContent?.includes('Minimal'))!
-    const devCheckbox = checkboxes.find(cb => cb.closest('label')?.textContent?.includes('Developer'))!
     fireEvent.click(minCheckbox)
-    fireEvent.click(devCheckbox)
-
     fireEvent.click(screen.getByRole('button', { name: /create agent/i }))
-
     await waitFor(() => {
-      expect(mockFetch).toHaveBeenCalledWith('/api/agents', expect.objectContaining({
-        method: 'POST',
-      }))
-    })
-
-    const postCall = mockFetch.mock.calls.find(
-      (c: any[]) => c[0] === '/api/agents' && c[1]?.method === 'POST'
-    )!
-    const body = JSON.parse(postCall[1].body)
-    expect(body.skill_ids).toHaveLength(2)
-    expect(body.skill_ids).toContain('preset-min')
-    expect(body.skill_ids).toContain('preset-dev')
-  })
-
-  // U5: Form non-admin: elevated skills not shown in checkboxes
-  it('non-admin checkboxes exclude elevated skills', async () => {
-    render(<AgentFormClient isAdmin={false} />)
-
-    await waitFor(() => {
-      expect(screen.getByText(/Minimal/)).toBeInTheDocument()
-    })
-
-    // Non-admin should see Minimal and Developer (container_local) but NOT Docker Access (host_docker)
-    const checkboxes = screen.getAllByRole('checkbox')
-    expect(checkboxes.some(cb => cb.closest('label')?.textContent?.includes('Minimal'))).toBe(true)
-    expect(checkboxes.some(cb => cb.closest('label')?.textContent?.includes('Developer'))).toBe(true)
-    expect(checkboxes.some(cb => cb.closest('label')?.textContent?.includes('Docker Access'))).toBe(false)
-  })
-
-  // U6: Switching between modes has no overwrite confirmation
-  it('switching from Custom to Skills does not require confirmation', async () => {
-    render(<AgentFormClient />)
-    await selectCustomMode()
-
-    // Switch back to Skills mode
-    fireEvent.click(screen.getByLabelText('Skills'))
-
-    await waitFor(() => {
-      expect(screen.getAllByText(/Minimal/).length).toBeGreaterThan(0)
+      const postCall = mockFetch.mock.calls.find((c: any[]) => c[0] === '/api/agents' && c[1]?.method === 'POST')
+      expect(postCall).toBeTruthy()
+      const body = JSON.parse(postCall[1].body)
+      expect(body.skill_ids).toEqual(['skill-min'])
+      expect(body.tools_config).toBeUndefined()
     })
   })
 
-  // Skills mode validation: requires at least one skill selected
-  it('submit blocked when no skills selected in Skills mode', async () => {
-    render(<AgentFormClient />)
-
-    await waitFor(() => {
-      expect(screen.getByLabelText('Skills')).toBeInTheDocument()
-    })
-
-    // Fill required fields
-    fireEvent.change(screen.getByLabelText('Agent ID (slug)'), { target: { value: 'test-agent' } })
-    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Test Agent' } })
-
-    // Submit without selecting any skill
-    const form = screen.getByRole('button', { name: /create agent/i }).closest('form')!
-    fireEvent.submit(form)
-
-    await waitFor(() => {
-      expect(screen.getByText(/please select at least one skill/i)).toBeInTheDocument()
-    })
-
-    const postCalls = mockFetch.mock.calls.filter(
-      (c: any[]) => c[0] === '/api/agents' && c[1]?.method === 'POST'
-    )
-    expect(postCalls).toHaveLength(0)
-  })
-
-  // Edit form pre-selects skills and starts in Skills mode
-  it('pre-selects skills when initial has skills array', async () => {
+  it('edit mode pre-selects skills from initial props', async () => {
     const initial = {
-      agent_id: 'existing',
+      agent_id: 'existing-agent',
       name: 'Existing Agent',
-      description: 'Test',
+      description: 'desc',
       tools_config: {
-        shell: { enabled: true, allowed_binaries: ['bash', 'git', 'make', 'curl', 'jq'], denied_patterns: ['rm -rf /', ':(){ :|:& };:'], max_timeout: 300 },
-        filesystem: { enabled: true, read_only: false, allowed_paths: ['/workspace', '/data'], denied_paths: ['/etc/shadow', '/etc/passwd', '/root'] },
+        shell: { enabled: true, allowed_binaries: [], denied_patterns: [], max_timeout: 300 },
+        filesystem: { enabled: true, read_only: false, allowed_paths: ['/workspace'], denied_paths: [] },
         health: { enabled: true },
       },
       cpus: '1.0',
@@ -445,47 +111,17 @@ describe('AgentFormClient', () => {
       rules_md: '',
       models: [],
       skills: [
-        { id: 'preset-dev', name: 'Developer', scope: 'container_local' },
-        { id: 'preset-min', name: 'Minimal', scope: 'container_local' },
+        { id: 'skill-min', name: 'Minimal', scope: 'container_local' },
+        { id: 'skill-dev', name: 'Developer', scope: 'container_local' },
       ],
     }
-
-    render(<AgentFormClient initial={initial} agentUuid="uuid-1" />)
-
-    await waitFor(() => {
-      expect(screen.getByText(/Minimal/)).toBeInTheDocument()
-    })
-
-    // Both skills should be checked
+    render(<AgentFormClient initial={initial} agentUuid="uuid-1" isAdmin />)
+    await waitFor(() => expect(screen.getByText('Minimal')).toBeInTheDocument())
     const checkboxes = screen.getAllByRole('checkbox')
-    const minCheckbox = checkboxes.find(cb => cb.closest('label')?.textContent?.includes('Minimal'))! as HTMLInputElement
+    const minCheckbox = checkboxes.find(cb => cb.closest('label')?.textContent?.includes('Minimal')) as HTMLInputElement
+    const devCheckbox = checkboxes.find(cb => cb.closest('label')?.textContent?.includes('Developer')) as HTMLInputElement
     expect(minCheckbox.checked).toBe(true)
-
-    const devCheckbox = checkboxes.find(cb => cb.closest('label')?.textContent?.includes('Developer'))! as HTMLInputElement
     expect(devCheckbox.checked).toBe(true)
   })
-
-  // Scope badges shown on skill checkboxes
-  it('skill checkboxes show scope badges', async () => {
-    render(<AgentFormClient isAdmin />)
-
-    await waitFor(() => {
-      expect(screen.getByText(/Minimal/)).toBeInTheDocument()
-    })
-
-    // Should show scope labels in checkbox list (multiple skills may have Container scope)
-    expect(screen.getAllByText('Container').length).toBeGreaterThan(0)
-  })
-
-  // U4 (original): Form Skills mode shows no separate profiles/skills groups
-  it('Skills mode shows no separate profiles and skills group headings', async () => {
-    render(<AgentFormClient isAdmin />)
-
-    await waitFor(() => {
-      expect(screen.getByText(/Minimal/)).toBeInTheDocument()
-    })
-
-    // Should NOT have separate group headings
-    expect(screen.queryByText('Profiles (sandbox presets)')).not.toBeInTheDocument()
-  })
 })
+

--- a/services/ui/src/__tests__/AgentsClient.test.tsx
+++ b/services/ui/src/__tests__/AgentsClient.test.tsx
@@ -208,20 +208,16 @@ describe('AgentsClient', () => {
     expect(mockFetch).toHaveBeenCalledWith('/api/agents')
   })
 
-  it('renders tool capability badges from tools_config', async () => {
+  it('does not render legacy tool capability badges', async () => {
     render(<AgentsClient session={MOCK_SESSION as any} />)
 
     await waitFor(() => {
       expect(screen.getByText('ResearchBot')).toBeInTheDocument()
     })
 
-    // ResearchBot has shell + filesystem enabled, so should have both tool badges
-    // Look for the Terminal and Folder icons via their aria-labels
-    const shellBadges = screen.getAllByLabelText('Shell access')
-    expect(shellBadges.length).toBeGreaterThan(0)
-
-    const fsBadges = screen.getAllByLabelText('Filesystem access')
-    expect(fsBadges.length).toBeGreaterThan(0)
+    expect(screen.queryByLabelText('Shell access')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Filesystem access')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Health endpoint')).not.toBeInTheDocument()
   })
 
   it('status filter shows only matching agents', async () => {
@@ -254,17 +250,16 @@ describe('AgentsClient', () => {
     expect(screen.getAllByText(/Container/).length).toBeGreaterThan(0)
   })
 
-  // T10: Agent list card shows Custom when no skill
-  it('agent card shows Custom when no skill', async () => {
+  // T10: Agent list card shows "No skills" when no skill
+  it('agent card shows No skills when no skill', async () => {
     render(<AgentsClient session={MOCK_SESSION as any} />)
 
     await waitFor(() => {
       expect(screen.getByText('WriterBot')).toBeInTheDocument()
     })
 
-    // WriterBot has no skills → should show "Custom" badge
-    const customBadges = screen.getAllByText('Custom')
-    expect(customBadges.length).toBeGreaterThan(0)
+    const noSkillBadges = screen.getAllByText('No skills')
+    expect(noSkillBadges.length).toBeGreaterThan(0)
   })
 
   // U9: Agent list shows multiple skill badges

--- a/services/ui/src/app/agents/AgentsClient.tsx
+++ b/services/ui/src/app/agents/AgentsClient.tsx
@@ -2,7 +2,6 @@
 
 import { useState, useEffect, useCallback } from 'react'
 import Link from 'next/link'
-import { Terminal, Folder, Heart } from 'lucide-react'
 import type { Session } from 'next-auth'
 
 interface Agent {
@@ -14,7 +13,6 @@ interface Agent {
   cpus: string
   mem_limit: string
   pids_limit: number
-  tools_config: Record<string, any> | null
   models: string[]
   skills: Array<{ id: string; name: string; scope: string }>
   created_at: string
@@ -144,7 +142,6 @@ export default function AgentsClient({ session }: { session: Session }) {
       ) : (
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
           {filteredAgents.map((agent) => {
-            const tc = agent.tools_config || {}
             return (
               <div
                 key={agent.id}
@@ -164,25 +161,6 @@ export default function AgentsClient({ session }: { session: Session }) {
                   {agent.description || 'No description'}
                 </p>
 
-                {/* Tool Badges */}
-                <div className="flex items-center gap-1.5 mb-3">
-                  {tc.shell?.enabled && (
-                    <span aria-label="Shell access" className="inline-flex items-center px-1.5 py-0.5 rounded-md bg-navy-900 border border-navy-600" title="Shell access">
-                      <Terminal className="h-3.5 w-3.5 text-brand-400" />
-                    </span>
-                  )}
-                  {tc.filesystem?.enabled && (
-                    <span aria-label="Filesystem access" className="inline-flex items-center px-1.5 py-0.5 rounded-md bg-navy-900 border border-navy-600" title="Filesystem access">
-                      <Folder className="h-3.5 w-3.5 text-brand-400" />
-                    </span>
-                  )}
-                  {tc.health?.enabled && (
-                    <span aria-label="Health endpoint" className="inline-flex items-center px-1.5 py-0.5 rounded-md bg-navy-900 border border-navy-600" title="Health endpoint">
-                      <Heart className="h-3.5 w-3.5 text-mountain-400" />
-                    </span>
-                  )}
-                </div>
-
                 {/* Skill Badges */}
                 <div className="mb-3 flex flex-wrap gap-1">
                   {agent.skills && agent.skills.length > 0 ? (
@@ -201,7 +179,7 @@ export default function AgentsClient({ session }: { session: Session }) {
                     </>
                   ) : (
                     <span className="inline-flex items-center px-2 py-0.5 text-xs font-medium rounded-md bg-navy-900 text-mountain-400 border border-navy-700">
-                      Custom
+                      No skills
                     </span>
                   )}
                 </div>

--- a/services/ui/src/app/agents/[id]/AgentDetailClient.tsx
+++ b/services/ui/src/app/agents/[id]/AgentDetailClient.tsx
@@ -274,7 +274,6 @@ export default function AgentDetailClient({
 
   const modelNames = agent.models || []
   const agentSkills = agent.skills || []
-  const tc = agent.tools_config || {}
 
   const handleAssignSkill = async (skillId: string) => {
     try {
@@ -588,16 +587,6 @@ export default function AgentDetailClient({
             )}
           </div>
 
-          {/* Quick Tool Summary */}
-          <div className="rounded-lg border border-navy-700 bg-navy-800 p-5">
-            <h2 className="text-lg font-semibold text-white mb-3">Tool Access</h2>
-            <div className="flex flex-wrap gap-2">
-              <ToolBadge label="Shell" enabled={tc.shell?.enabled} summary={tc.shell?.enabled ? `${tc.shell.allowed_binaries?.length || 0} binaries` : undefined} />
-              <ToolBadge label="Filesystem" enabled={tc.filesystem?.enabled} summary={tc.filesystem?.enabled ? (tc.filesystem.read_only ? 'Read-only' : 'Read-write') : undefined} />
-              <ToolBadge label="Health" enabled={tc.health?.enabled} />
-            </div>
-          </div>
-
           {/* Resource Grid */}
           <div className="rounded-lg border border-navy-700 bg-navy-800 p-5">
             <h2 className="text-lg font-semibold text-white mb-3">Resources</h2>
@@ -643,10 +632,9 @@ export default function AgentDetailClient({
 
       {activeTab === 'configuration' && (
         <div className="space-y-6">
-          {/* Tool Details */}
           <div className="rounded-lg border border-navy-700 bg-navy-800 p-5">
-            <div className="flex items-center justify-between mb-4">
-              <h2 className="text-lg font-semibold text-white">Tool Configuration</h2>
+            <div className="flex items-center justify-between mb-2">
+              <h2 className="text-lg font-semibold text-white">Skills Runtime</h2>
               {agent.status !== 'running' && (
                 <Link
                   href={`/agents/${agent.id}/edit`}
@@ -656,49 +644,9 @@ export default function AgentDetailClient({
                 </Link>
               )}
             </div>
-
-            <div className="space-y-4">
-              {/* Shell */}
-              <ConfigSection title="Shell" enabled={tc.shell?.enabled}>
-                {tc.shell?.enabled && (
-                  <dl className="grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm">
-                    <div>
-                      <dt className="text-mountain-400 mb-1">Allowed Binaries</dt>
-                      <dd className="flex flex-wrap gap-1">
-                        {(tc.shell.allowed_binaries || []).length > 0
-                          ? tc.shell.allowed_binaries.map((b: string) => <Badge key={b}>{b}</Badge>)
-                          : <span className="text-mountain-500 text-xs">All allowed</span>}
-                      </dd>
-                    </div>
-                    <div>
-                      <dt className="text-mountain-400 mb-1">Max Timeout</dt>
-                      <dd className="text-white">{tc.shell.max_timeout || 300}s</dd>
-                    </div>
-                  </dl>
-                )}
-              </ConfigSection>
-
-              {/* Filesystem */}
-              <ConfigSection title="Filesystem" enabled={tc.filesystem?.enabled}>
-                {tc.filesystem?.enabled && (
-                  <dl className="grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm">
-                    <div>
-                      <dt className="text-mountain-400 mb-1">Mode</dt>
-                      <dd className="text-white">{tc.filesystem.read_only ? 'Read-only' : 'Read-write'}</dd>
-                    </div>
-                    <div>
-                      <dt className="text-mountain-400 mb-1">Allowed Paths</dt>
-                      <dd className="flex flex-wrap gap-1">
-                        {(tc.filesystem.allowed_paths || []).map((p: string) => <Badge key={p}>{p}</Badge>)}
-                      </dd>
-                    </div>
-                  </dl>
-                )}
-              </ConfigSection>
-
-              {/* Health */}
-              <ConfigSection title="Health" enabled={tc.health?.enabled} />
-            </div>
+            <p className="text-sm text-mountain-400">
+              Runtime capabilities are derived from assigned skills and RBAC scope.
+            </p>
           </div>
 
           {/* Resources */}
@@ -936,39 +884,4 @@ function StatusDot({ status }: { status: string }) {
     : status === 'error' ? 'bg-red-500'
     : 'bg-mountain-500'
   return <span className={`h-2 w-2 rounded-full ${color} inline-block`} />
-}
-
-function ToolBadge({ label, enabled, summary }: { label: string; enabled?: boolean; summary?: string }) {
-  return (
-    <span className={`inline-flex items-center gap-1.5 px-2.5 py-1 text-xs rounded-md ${
-      enabled
-        ? 'bg-brand-900/50 text-brand-400 border border-brand-700'
-        : 'bg-navy-900 text-mountain-500 border border-navy-700'
-    }`}>
-      {label}
-      {summary && <span className="text-mountain-400">({summary})</span>}
-    </span>
-  )
-}
-
-function ConfigSection({ title, enabled, children }: { title: string; enabled?: boolean; children?: React.ReactNode }) {
-  return (
-    <div className="rounded-md border border-navy-700 bg-navy-900 p-4">
-      <div className="flex items-center gap-2 mb-2">
-        <span className={`h-2 w-2 rounded-full ${enabled ? 'bg-brand-500' : 'bg-mountain-600'}`} />
-        <h3 className="text-sm font-medium text-white">{title}</h3>
-        <span className={`text-xs ${enabled ? 'text-brand-400' : 'text-mountain-500'}`}>
-          {enabled ? 'Enabled' : 'Disabled'}
-        </span>
-      </div>
-      {children}
-    </div>
-  )
-}
-
-function Badge({ children, variant }: { children: React.ReactNode; variant?: 'red' }) {
-  const cls = variant === 'red'
-    ? 'bg-red-900/30 text-red-400 border border-red-800'
-    : 'bg-navy-800 text-mountain-300 border border-navy-600'
-  return <span className={`px-2 py-0.5 text-xs rounded-md ${cls}`}>{children}</span>
 }

--- a/services/ui/src/app/agents/new/AgentFormClient.tsx
+++ b/services/ui/src/app/agents/new/AgentFormClient.tsx
@@ -10,12 +10,6 @@ interface ToolsConfig {
   health: { enabled: boolean }
 }
 
-const defaultTools: ToolsConfig = {
-  shell: { enabled: false, allowed_binaries: [], denied_patterns: [], max_timeout: 300 },
-  filesystem: { enabled: false, read_only: false, allowed_paths: ['/workspace'], denied_paths: [] },
-  health: { enabled: true },
-}
-
 interface SkillOption {
   id: string
   name: string
@@ -78,7 +72,6 @@ export default function AgentFormClient({
   const [agentId, setAgentId] = useState(initial?.agent_id || '')
   const [name, setName] = useState(initial?.name || '')
   const [description, setDescription] = useState(initial?.description || '')
-  const [tools, setTools] = useState<ToolsConfig>(initial?.tools_config || defaultTools)
   const [cpus, setCpus] = useState(initial?.cpus || '1.0')
   const [memLimit, setMemLimit] = useState(initial?.mem_limit || '1g')
   const [pidsLimit, setPidsLimit] = useState(initial?.pids_limit || 200)
@@ -87,11 +80,6 @@ export default function AgentFormClient({
   const [availableModels, setAvailableModels] = useState<PolicyOption[]>([])
   const [selectedModels, setSelectedModels] = useState<string[]>(initial?.models || [])
   const [skills, setSkills] = useState<SkillOption[]>([])
-  // Mode: 'custom' = manual tools_config; 'skills' = checkbox multi-select
-  const hasInitialSkills = (initial?.skills?.length ?? 0) > 0
-  const [mode, setMode] = useState<'custom' | 'skills'>(
-    initial ? (hasInitialSkills ? 'skills' : 'custom') : 'skills'
-  )
   const [selectedSkillIds, setSelectedSkillIds] = useState<Set<string>>(
     new Set(initial?.skills?.map(s => s.id) || [])
   )
@@ -120,16 +108,6 @@ export default function AgentFormClient({
       .catch(() => {})
   }, [])
 
-  const handleModeChange = (newMode: 'custom' | 'skills') => {
-    if (newMode === mode) return
-
-    if (newMode === 'custom') {
-      setSelectedSkillIds(new Set())
-    }
-
-    setMode(newMode)
-  }
-
   const handleSkillToggle = (skillId: string) => {
     setSelectedSkillIds(prev => {
       const next = new Set(prev)
@@ -140,8 +118,8 @@ export default function AgentFormClient({
   }
 
   const validateForm = (): boolean => {
-    if (mode === 'skills' && selectedSkillIds.size === 0) {
-      setValidationError('Please select at least one skill or switch to Custom mode')
+    if (selectedSkillIds.size === 0) {
+      setValidationError('Please select at least one skill')
       return false
     }
     setValidationError('')
@@ -159,14 +137,13 @@ export default function AgentFormClient({
       agent_id: agentId,
       name,
       description,
-      tools_config: mode === 'custom' ? tools : undefined,
       cpus,
       mem_limit: memLimit,
       pids_limit: pidsLimit,
       soul_md: soulMd,
       rules_md: rulesMd,
       model_names: selectedModels,
-      skill_ids: mode === 'skills' ? [...selectedSkillIds] : [],
+      skill_ids: [...selectedSkillIds],
     }
 
     try {
@@ -266,93 +243,53 @@ export default function AgentFormClient({
         </div>
       </fieldset>
 
-      {/* Tools — Custom/Skills mode toggle */}
+      {/* Skills */}
       <fieldset disabled={disabled} className="space-y-4">
         <legend className="text-lg font-semibold text-white mb-4">Tools</legend>
-
-        {/* Mode radio toggle */}
-        <div className="flex items-center gap-4" role="radiogroup" aria-label="Tools mode">
-          <label className="flex items-center gap-2 cursor-pointer">
-            <input
-              type="radio"
-              name="tools-mode"
-              value="skills"
-              checked={mode === 'skills'}
-              onChange={() => handleModeChange('skills')}
-              className="text-brand-500"
-            />
-            <span className="text-sm text-white">Skills</span>
-          </label>
-          <label className="flex items-center gap-2 cursor-pointer">
-            <input
-              type="radio"
-              name="tools-mode"
-              value="custom"
-              checked={mode === 'custom'}
-              onChange={() => handleModeChange('custom')}
-              className="text-brand-500"
-            />
-            <span className="text-sm text-white">Custom</span>
-          </label>
-        </div>
-
-        {mode === 'skills' ? (
-          /* Skills mode — checkbox multi-select */
-          <div className="rounded-lg border border-navy-700 bg-navy-800 p-4 space-y-3">
-            <p className="text-xs text-mountain-400 mb-2">
-              Select one or more skills. Tool configurations are merged from all selected skills.
-            </p>
-            {(() => {
-              const visibleSkills = isAdmin ? skills : skills.filter(s => !ELEVATED_SCOPES.includes(s.scope))
-              return (
-                <div className="space-y-2">
-                  {visibleSkills.map((skill) => {
-                    const badge = scopeBadge(skill.scope)
-                    return (
-                      <label key={skill.id} className="flex items-center gap-3 cursor-pointer py-1">
-                        <input
-                          type="checkbox"
-                          checked={selectedSkillIds.has(skill.id)}
-                          onChange={() => handleSkillToggle(skill.id)}
-                          className="rounded border-navy-600"
-                        />
-                        <span className="text-sm text-white">{skill.name}</span>
-                        <span className={`px-1.5 py-0.5 text-xs rounded-md ${badge.colorClasses}`}>
-                          {badge.label}
+        <div className="rounded-lg border border-navy-700 bg-navy-800 p-4 space-y-3">
+          <p className="text-xs text-mountain-400 mb-2">
+            Select one or more skills. Runtime access is derived from skill dependencies and RBAC scope.
+          </p>
+          {(() => {
+            const visibleSkills = isAdmin ? skills : skills.filter(s => !ELEVATED_SCOPES.includes(s.scope))
+            return (
+              <div className="space-y-2">
+                {visibleSkills.map((skill) => {
+                  const badge = scopeBadge(skill.scope)
+                  return (
+                    <label key={skill.id} className="flex items-center gap-3 cursor-pointer py-1">
+                      <input
+                        type="checkbox"
+                        checked={selectedSkillIds.has(skill.id)}
+                        onChange={() => handleSkillToggle(skill.id)}
+                        className="rounded border-navy-600"
+                      />
+                      <span className="text-sm text-white">{skill.name}</span>
+                      <span className={`px-1.5 py-0.5 text-xs rounded-md ${badge.colorClasses}`}>
+                        {badge.label}
+                      </span>
+                      {skill.tools && skill.tools.length > 0 && (
+                        <span className="px-1.5 py-0.5 text-xs rounded-md bg-navy-800 text-mountain-300 border border-navy-600 font-mono">
+                          {skill.tools.map(t => t.name).join(', ')}
                         </span>
-                        {skill.tools && skill.tools.length > 0 && (
-                          <span className="px-1.5 py-0.5 text-xs rounded-md bg-navy-800 text-mountain-300 border border-navy-600 font-mono">
-                            {skill.tools.map(t => t.name).join(', ')}
-                          </span>
-                        )}
-                      </label>
-                    )
-                  })}
-                  {visibleSkills.length === 0 && (
-                    <p className="text-xs text-mountain-500">No skills available</p>
-                  )}
-                </div>
-              )
-            })()}
-            {selectedSkillIds.size > 0 && (
-              <div className="border-t border-navy-700 pt-3">
-                <p className="text-xs text-mountain-500">
-                  {selectedSkillIds.size} skill{selectedSkillIds.size !== 1 ? 's' : ''} selected. Tools config will be merged at save time.
-                </p>
+                      )}
+                    </label>
+                  )
+                })}
+                {visibleSkills.length === 0 && (
+                  <p className="text-xs text-mountain-500">No skills available</p>
+                )}
               </div>
-            )}
-          </div>
-        ) : (
-          /* Custom mode — no direct tool policy editing */
-          <div className="rounded-lg border border-navy-700 bg-navy-800 p-4 space-y-3">
-            <p className="text-sm text-mountain-300">
-              Custom mode does not expose direct tool policy toggles.
-            </p>
-            <p className="text-xs text-mountain-500">
-              Runtime access is governed by assigned skills and RBAC scope.
-            </p>
-          </div>
-        )}
+            )
+          })()}
+          {selectedSkillIds.size > 0 && (
+            <div className="border-t border-navy-700 pt-3">
+              <p className="text-xs text-mountain-500">
+                {selectedSkillIds.size} skill{selectedSkillIds.size !== 1 ? 's' : ''} selected.
+              </p>
+            </div>
+          )}
+        </div>
       </fieldset>
 
       {/* Models */}

--- a/services/ui/src/app/harness/skills/SkillsClient.tsx
+++ b/services/ui/src/app/harness/skills/SkillsClient.tsx
@@ -2,7 +2,6 @@
 
 import { useState, useEffect, useCallback } from 'react'
 import { useSession } from 'next-auth/react'
-import { Terminal, FolderOpen, Heart } from 'lucide-react'
 
 interface ToolsConfig {
   shell: { enabled: boolean; allowed_binaries: string[]; denied_patterns: string[]; max_timeout: number }
@@ -322,7 +321,6 @@ export default function SkillsClient() {
         <div className="space-y-3">
           {skills.map((skill) => {
             const isExpanded = expandedId === skill.id
-            const tc = skill.tools_config
 
             return (
               <div
@@ -351,24 +349,6 @@ export default function SkillsClient() {
                           {scopeBadge(skill.scope).label}
                         </span>
                       )}
-                      <div className="flex flex-wrap gap-1">
-                        {tc.shell.enabled && (
-                          <span className="inline-flex items-center gap-1 px-2 py-0.5 text-xs rounded-md bg-brand-900/50 text-brand-400 border border-brand-700">
-                            <Terminal className="w-3 h-3" /> Shell
-                          </span>
-                        )}
-                        {tc.filesystem.enabled && (
-                          <span className="inline-flex items-center gap-1 px-2 py-0.5 text-xs rounded-md bg-brand-900/50 text-brand-400 border border-brand-700">
-                            <FolderOpen className="w-3 h-3" /> Filesystem
-                            {tc.filesystem.read_only && <span className="text-mountain-400">(ro)</span>}
-                          </span>
-                        )}
-                        {tc.health.enabled && (
-                          <span className="inline-flex items-center gap-1 px-2 py-0.5 text-xs rounded-md bg-brand-900/50 text-brand-400 border border-brand-700">
-                            <Heart className="w-3 h-3" /> Health
-                          </span>
-                        )}
-                      </div>
                     </div>
                     {skill.description && (
                       <p className="text-xs text-mountain-400 mt-1 truncate">{skill.description}</p>
@@ -420,29 +400,6 @@ export default function SkillsClient() {
                             </div>
                           ) : (
                             <span className="text-mountain-500">None declared</span>
-                          )}
-                        </dd>
-                      </div>
-
-                      {/* Filesystem config */}
-                      <div>
-                        <dt className="text-mountain-400 mb-1">Filesystem</dt>
-                        <dd className="text-white">
-                          {tc.filesystem.enabled ? (
-                            <div className="space-y-1">
-                              <div className="text-xs">
-                                {tc.filesystem.read_only ? 'Read-only' : 'Read-write'}
-                              </div>
-                              <div className="flex flex-wrap gap-1">
-                                {tc.filesystem.allowed_paths.map((p) => (
-                                  <span key={p} className="px-2 py-0.5 text-xs rounded-md bg-navy-900 text-brand-400 border border-navy-700">
-                                    {p}
-                                  </span>
-                                ))}
-                              </div>
-                            </div>
-                          ) : (
-                            <span className="text-mountain-500">Disabled</span>
                           )}
                         </dd>
                       </div>


### PR DESCRIPTION
Summary:
- remove remaining legacy shell/filesystem/health panels from Agent detail pages
- remove custom-mode runtime access editing from Agent form (skills-only capability assignment)
- remove legacy tool-status chips from Skills and Agent list cards
- align labels to skills-driven runtime model (no legacy tool-access framing)

Validation:
- cd services/ui && npx vitest run src/__tests__/AgentDetailClient.test.tsx src/__tests__/AgentFormClient.test.tsx src/__tests__/AgentsClient.test.tsx
- cd services/ui && npx vitest run