### PR TITLE
feat: activity timeline related-to hints for agent steps

### DIFF
--- a/services/ui/src/__tests__/EventTimeline.test.tsx
+++ b/services/ui/src/__tests__/EventTimeline.test.tsx
@@ -15,7 +15,7 @@ vi.mock('lucide-react', () => ({
   ChevronRight: (props: any) => <span data-testid="icon-chevron-right" {...props} />,
 }))
 
-import EventTimeline from '@/app/agents/[id]/EventTimeline'
+import EventTimeline, { computeGroups } from '@/app/agents/[id]/EventTimeline'
 import EventCard from '@/app/agents/[id]/EventCard'
 import type { AgentEvent } from '@/app/agents/[id]/EventCard'
 
@@ -288,5 +288,322 @@ describe('EventTimeline', () => {
       expect(screen.getAllByTestId('event-card')).toHaveLength(1)
     })
     expect(screen.getByText('inference')).toBeInTheDocument()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Helper: create events at specific timestamps for grouping tests
+// ---------------------------------------------------------------------------
+const T0 = new Date('2026-01-01T00:00:00.000Z').getTime()
+
+function makeEvent(
+  overrides: Partial<AgentEvent> & { id: string; tool: string; type: string },
+  offsetMs: number = 0,
+): AgentEvent {
+  return {
+    timestamp: new Date(T0 + offsetMs).toISOString(),
+    input_summary: 'test',
+    output_summary: null,
+    duration_ms: null,
+    success: null,
+    ...overrides,
+  }
+}
+
+function inf(id: string, offsetMs: number): AgentEvent {
+  return makeEvent({ id, tool: 'inference', type: 'inference_complete' }, offsetMs)
+}
+
+function wr(id: string, offsetMs: number, workId?: string): AgentEvent {
+  return makeEvent(
+    { id, tool: 'runtime', type: 'work_received', ...(workId ? { metadata: { work_id: workId } } : {}) },
+    offsetMs,
+  )
+}
+
+function wc(id: string, offsetMs: number, workId?: string): AgentEvent {
+  return makeEvent(
+    { id, tool: 'runtime', type: 'work_completed', ...(workId ? { metadata: { work_id: workId } } : {}) },
+    offsetMs,
+  )
+}
+
+function shell(id: string, offsetMs: number): AgentEvent {
+  return makeEvent({ id, tool: 'shell', type: 'command_start' }, offsetMs)
+}
+
+function fs(id: string, offsetMs: number): AgentEvent {
+  return makeEvent({ id, tool: 'filesystem', type: 'file_read' }, offsetMs)
+}
+
+function wf(id: string, offsetMs: number): AgentEvent {
+  return makeEvent({ id, tool: 'runtime', type: 'work_failed' }, offsetMs)
+}
+
+// ---------------------------------------------------------------------------
+// computeGroups — positive tests (strong signal present → grouped)
+// ---------------------------------------------------------------------------
+describe('computeGroups — positive (grouped)', () => {
+  it('G1: shared work_id groups runtime events', () => {
+    const events = [wr('a', 0, 'X'), wc('b', 100, 'X')]
+    const groups = computeGroups(events)
+    expect(groups.size).toBe(2)
+    expect(groups.get('a')).toBe(groups.get('b'))
+  })
+
+  it('G2: shared work_id groups across large gap (non-adjacent)', () => {
+    const events = [wr('a', 0, 'X'), shell('s', 5000), wc('b', 10000, 'X')]
+    const groups = computeGroups(events)
+    expect(groups.get('a')).toBe(groups.get('b'))
+    expect(groups.has('s')).toBe(false) // shell is solo
+  })
+
+  it('G3: inference → work_received ≤3s, adjacent', () => {
+    const events = [inf('a', 0), wr('b', 500)]
+    const groups = computeGroups(events)
+    expect(groups.size).toBe(2)
+    expect(groups.get('a')).toBe(groups.get('b'))
+  })
+
+  it('G4: inference → work_completed ≤3s, adjacent', () => {
+    const events = [inf('a', 0), wc('b', 300)]
+    const groups = computeGroups(events)
+    expect(groups.size).toBe(2)
+    expect(groups.get('a')).toBe(groups.get('b'))
+  })
+
+  it('G5: full step: inference + work_received + work_completed (transitive)', () => {
+    const events = [inf('a', 0), wr('b', 300, 'X'), wc('c', 500, 'X')]
+    const groups = computeGroups(events)
+    expect(groups.size).toBe(3)
+    const groupId = groups.get('a')
+    expect(groups.get('b')).toBe(groupId)
+    expect(groups.get('c')).toBe(groupId)
+  })
+
+  it('G6: two separate steps with gap', () => {
+    const events = [
+      inf('a1', 0), wr('b1', 300, 'A'), wc('c1', 500, 'A'),
+      inf('a2', 5000), wr('b2', 5300, 'B'), wc('c2', 5500, 'B'),
+    ]
+    const groups = computeGroups(events)
+    expect(groups.size).toBe(6)
+    // First step grouped together
+    expect(groups.get('a1')).toBe(groups.get('b1'))
+    expect(groups.get('b1')).toBe(groups.get('c1'))
+    // Second step grouped together
+    expect(groups.get('a2')).toBe(groups.get('b2'))
+    expect(groups.get('b2')).toBe(groups.get('c2'))
+    // Different groups
+    expect(groups.get('a1')).not.toBe(groups.get('a2'))
+  })
+
+  it('G7: non-adjacent work_id linking via index', () => {
+    const events = [wr('a', 0, 'X'), inf('i', 500), shell('s', 1000), wc('b', 1500, 'X')]
+    const groups = computeGroups(events)
+    expect(groups.get('a')).toBe(groups.get('b'))
+    // inf and shell are NOT in any group (no signal links them)
+    expect(groups.has('i')).toBe(false)
+    expect(groups.has('s')).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// computeGroups — negative tests (no strong signal → NOT grouped)
+// ---------------------------------------------------------------------------
+describe('computeGroups — negative (not grouped)', () => {
+  it('N1: two inference events ≤3s → NOT grouped', () => {
+    const events = [inf('a', 0), inf('b', 1000)]
+    const groups = computeGroups(events)
+    expect(groups.size).toBe(0)
+  })
+
+  it('N2: three rapid inference events → NOT grouped', () => {
+    const events = [inf('a', 0), inf('b', 500), inf('c', 1000)]
+    const groups = computeGroups(events)
+    expect(groups.size).toBe(0)
+  })
+
+  it('N3: inference → shell ≤3s → NOT grouped', () => {
+    const events = [inf('a', 0), shell('b', 500)]
+    const groups = computeGroups(events)
+    expect(groups.size).toBe(0)
+  })
+
+  it('N4: inference → filesystem ≤3s → NOT grouped', () => {
+    const events = [inf('a', 0), fs('b', 500)]
+    const groups = computeGroups(events)
+    expect(groups.size).toBe(0)
+  })
+
+  it('N5: runtime → inference ≤3s → NOT grouped (wrong direction)', () => {
+    const events = [wr('a', 0), inf('b', 500)]
+    const groups = computeGroups(events)
+    expect(groups.size).toBe(0)
+  })
+
+  it('N6: shell → runtime ≤3s → NOT grouped', () => {
+    const events = [shell('a', 0), wr('b', 500)]
+    const groups = computeGroups(events)
+    expect(groups.size).toBe(0)
+  })
+
+  it('N7: inference → work_received >3s → NOT grouped', () => {
+    const events = [inf('a', 0), wr('b', 4000)]
+    const groups = computeGroups(events)
+    expect(groups.size).toBe(0)
+  })
+
+  it('N8: inference → work_received ≤3s but NOT adjacent → NOT grouped', () => {
+    const events = [inf('a', 0), shell('s', 200), wr('b', 500)]
+    const groups = computeGroups(events)
+    // inf and wr NOT linked (shell is between them)
+    expect(groups.has('a')).toBe(false)
+    expect(groups.has('b')).toBe(false)
+  })
+
+  it('N9: inference → work_failed ≤3s, adjacent → NOT grouped', () => {
+    const events = [inf('a', 0), wf('b', 300)]
+    const groups = computeGroups(events)
+    expect(groups.size).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// computeGroups — edge cases
+// ---------------------------------------------------------------------------
+describe('computeGroups — edge cases', () => {
+  it('E1: empty events array', () => {
+    const groups = computeGroups([])
+    expect(groups.size).toBe(0)
+  })
+
+  it('E2: single event', () => {
+    const groups = computeGroups([inf('a', 0)])
+    expect(groups.size).toBe(0)
+  })
+
+  it('E3: events with identical timestamps (inf + wr)', () => {
+    const events = [inf('a', 0), wr('b', 0)]
+    const groups = computeGroups(events)
+    expect(groups.size).toBe(2)
+    expect(groups.get('a')).toBe(groups.get('b'))
+  })
+
+  it('E4: missing metadata on runtime event (Signal B still works)', () => {
+    const events = [inf('a', 0), wr('b', 500)]
+    // wr has no metadata/work_id, but Signal B (adjacency) should still fire
+    const groups = computeGroups(events)
+    expect(groups.size).toBe(2)
+    expect(groups.get('a')).toBe(groups.get('b'))
+  })
+
+  it('E5: work_id on only one of two runtime events → NOT grouped via Signal A', () => {
+    const events = [
+      wr('a', 0, 'X'),
+      makeEvent({ id: 'b', tool: 'runtime', type: 'work_completed' }, 100), // no work_id
+    ]
+    const groups = computeGroups(events)
+    // No shared work_id → Signal A doesn't fire
+    // runtime→runtime is not a Signal B pattern (requires inference→runtime)
+    expect(groups.has('a')).toBe(false)
+    expect(groups.has('b')).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Rendering tests — group spine and layout
+// ---------------------------------------------------------------------------
+describe('EventTimeline — group rendering', () => {
+  function setupSSEAndSendEvents(events: AgentEvent[]) {
+    let capturedOnMessage: ((msg: MessageEvent) => void) | null = null
+    vi.stubGlobal('EventSource', vi.fn(() => {
+      const instance = {
+        onmessage: null as any,
+        addEventListener: vi.fn(),
+        close: vi.fn(),
+      }
+      setTimeout(() => { capturedOnMessage = instance.onmessage }, 0)
+      return instance
+    }))
+
+    render(<EventTimeline agentId="uuid-1" agentStatus="running" />)
+
+    return waitFor(() => expect(capturedOnMessage).toBeTruthy()).then(() => {
+      for (const e of events) {
+        capturedOnMessage!(new MessageEvent('message', { data: JSON.stringify(e) }))
+      }
+      return capturedOnMessage!
+    })
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    Element.prototype.scrollIntoView = vi.fn()
+  })
+  afterEach(() => cleanup())
+
+  it('R1: multi-event group shows spine', async () => {
+    await setupSSEAndSendEvents([inf('a', 0), wr('b', 500)])
+    await waitFor(() => {
+      expect(screen.getAllByTestId('event-card')).toHaveLength(2)
+    })
+    expect(screen.getByTestId('group-spine')).toBeInTheDocument()
+  })
+
+  it('R2: solo event has no spine', async () => {
+    await setupSSEAndSendEvents([inf('a', 0)])
+    await waitFor(() => {
+      expect(screen.getAllByTestId('event-card')).toHaveLength(1)
+    })
+    expect(screen.queryByTestId('group-spine')).not.toBeInTheDocument()
+  })
+
+  it('R3: group wrapper has pl-3 class', async () => {
+    await setupSSEAndSendEvents([inf('a', 0), wr('b', 500)])
+    await waitFor(() => {
+      expect(screen.getAllByTestId('event-card')).toHaveLength(2)
+    })
+    const spine = screen.getByTestId('group-spine')
+    expect(spine.parentElement).toHaveClass('pl-3')
+  })
+
+  it('R4: existing EventCard/EventTimeline tests pass (no regression)', async () => {
+    // This is validated by the full test suite running without failures
+    // Included here as an explicit marker
+    await setupSSEAndSendEvents([
+      { ...MOCK_EVENTS[0], id: 'reg-1' },
+      { ...MOCK_EVENTS[1], id: 'reg-2' },
+    ])
+    await waitFor(() => {
+      expect(screen.getAllByTestId('event-card')).toHaveLength(2)
+    })
+  })
+
+  it('R5: outer container uses space-y-3', async () => {
+    await setupSSEAndSendEvents([inf('a', 0)])
+    await waitFor(() => {
+      expect(screen.getAllByTestId('event-card')).toHaveLength(1)
+    })
+    const container = screen.getByTestId('event-card').closest('.space-y-3')
+    expect(container).toBeInTheDocument()
+  })
+
+  it('R6: filter change recomputes — inference-only filter shows no spine', async () => {
+    const onMessage = await setupSSEAndSendEvents([inf('a', 0), wr('b', 500)])
+    await waitFor(() => {
+      expect(screen.getAllByTestId('event-card')).toHaveLength(2)
+    })
+    // Spine should be visible with All filter
+    expect(screen.getByTestId('group-spine')).toBeInTheDocument()
+
+    // Switch to Inference filter
+    fireEvent.click(screen.getByText('Inference'))
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('event-card')).toHaveLength(1)
+    })
+    // No runtime events visible → no Signal B → no spine
+    expect(screen.queryByTestId('group-spine')).not.toBeInTheDocument()
   })
 })

--- a/services/ui/src/app/agents/[id]/EventTimeline.tsx
+++ b/services/ui/src/app/agents/[id]/EventTimeline.tsx
@@ -1,11 +1,140 @@
 'use client'
 
-import { useState, useEffect, useRef, useCallback } from 'react'
+import { useState, useEffect, useRef, useCallback, useMemo } from 'react'
 import EventCard, { type AgentEvent } from './EventCard'
 
 const MAX_EVENTS = 500
+const MAX_STEP_GAP_MS = 3000
 const TOOL_FILTERS = ['All', 'Shell', 'Filesystem', 'Runtime', 'Inference'] as const
 type ToolFilter = typeof TOOL_FILTERS[number]
+
+// ---------------------------------------------------------------------------
+// Union-Find for O(n) grouping
+// ---------------------------------------------------------------------------
+class UnionFind {
+  private parent: Map<number, number> = new Map()
+  private rank: Map<number, number> = new Map()
+
+  find(x: number): number {
+    if (!this.parent.has(x)) {
+      this.parent.set(x, x)
+      this.rank.set(x, 0)
+    }
+    let root = x
+    while (this.parent.get(root) !== root) {
+      root = this.parent.get(root)!
+    }
+    // Path compression
+    let curr = x
+    while (curr !== root) {
+      const next = this.parent.get(curr)!
+      this.parent.set(curr, root)
+      curr = next
+    }
+    return root
+  }
+
+  union(x: number, y: number): void {
+    const rx = this.find(x)
+    const ry = this.find(y)
+    if (rx === ry) return
+    const rankX = this.rank.get(rx)!
+    const rankY = this.rank.get(ry)!
+    if (rankX < rankY) {
+      this.parent.set(rx, ry)
+    } else if (rankX > rankY) {
+      this.parent.set(ry, rx)
+    } else {
+      this.parent.set(ry, rx)
+      this.rank.set(rx, rankX + 1)
+    }
+  }
+}
+
+/**
+ * Compute event groups using a three-phase algorithm.
+ * Returns Map<eventId, groupId> — only events in groups of size >= 2 appear.
+ */
+export function computeGroups(events: AgentEvent[]): Map<string, string> {
+  if (events.length < 2) return new Map()
+
+  const uf = new UnionFind()
+
+  // Phase 1 (Signal A): Index events by metadata.work_id
+  const workIdIndex = new Map<string, number[]>()
+  for (let i = 0; i < events.length; i++) {
+    const wid = events[i].metadata?.work_id
+    if (typeof wid === 'string') {
+      const list = workIdIndex.get(wid)
+      if (list) {
+        list.push(i)
+      } else {
+        workIdIndex.set(wid, [i])
+      }
+    }
+  }
+  for (const indices of workIdIndex.values()) {
+    if (indices.length >= 2) {
+      for (let k = 1; k < indices.length; k++) {
+        uf.union(indices[0], indices[k])
+      }
+    }
+  }
+
+  // Phase 2 (Signal B): Adjacent inference→runtime scan
+  const SIGNAL_B_TYPES = new Set(['work_received', 'work_completed'])
+  for (let i = 0; i < events.length - 1; i++) {
+    const a = events[i]
+    const b = events[i + 1]
+    if (
+      a.tool === 'inference' &&
+      b.tool === 'runtime' &&
+      SIGNAL_B_TYPES.has(b.type) &&
+      new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime() <= MAX_STEP_GAP_MS
+    ) {
+      uf.union(i, i + 1)
+    }
+  }
+
+  // Phase 3: Collect components, discard size 1
+  const components = new Map<number, number[]>()
+  for (let i = 0; i < events.length; i++) {
+    const root = uf.find(i)
+    const list = components.get(root)
+    if (list) {
+      list.push(i)
+    } else {
+      components.set(root, [i])
+    }
+  }
+
+  const result = new Map<string, string>()
+  for (const [root, indices] of components) {
+    if (indices.length < 2) continue
+    const groupId = `group-${root}`
+    for (const idx of indices) {
+      result.set(events[idx].id, groupId)
+    }
+  }
+
+  return result
+}
+
+type Segment = { groupId: string | null; events: AgentEvent[] }
+
+function buildSegments(events: AgentEvent[], groups: Map<string, string>): Segment[] {
+  const segments: Segment[] = []
+  for (const event of events) {
+    const gid = groups.get(event.id) ?? null
+    const last = segments[segments.length - 1]
+    if (last && last.groupId === gid && gid !== null) {
+      last.events.push(event)
+    } else {
+      segments.push({ groupId: gid, events: [event] })
+    }
+  }
+  return segments
+}
 
 export default function EventTimeline({
   agentId,
@@ -72,6 +201,9 @@ export default function EventTimeline({
       ? events
       : events.filter((e) => e.tool === filter.toLowerCase())
 
+  const groups = useMemo(() => computeGroups(filtered), [filtered])
+  const segments = useMemo(() => buildSegments(filtered, groups), [filtered, groups])
+
   return (
     <div className="rounded-lg border border-navy-700 bg-navy-800 p-5">
       <div className="flex items-center justify-between mb-3">
@@ -96,14 +228,31 @@ export default function EventTimeline({
       <div
         ref={containerRef}
         onScroll={handleScroll}
-        className="space-y-1 max-h-96 overflow-y-auto"
+        className="space-y-3 max-h-96 overflow-y-auto"
       >
         {filtered.length === 0 ? (
           <p className="text-sm text-mountain-500 py-4 text-center" data-testid="no-events">
             {events.length === 0 ? 'Waiting for events...' : 'No events match the current filter.'}
           </p>
         ) : (
-          filtered.map((e) => <EventCard key={e.id} event={e} />)
+          segments.map((seg) =>
+            seg.groupId !== null ? (
+              <div key={seg.groupId} className="relative pl-3">
+                <div
+                  className="absolute left-0 top-3 bottom-3 w-0.5 bg-navy-600 rounded-full"
+                  aria-hidden="true"
+                  data-testid="group-spine"
+                />
+                <div className="space-y-0.5">
+                  {seg.events.map((e) => (
+                    <EventCard key={e.id} event={e} />
+                  ))}
+                </div>
+              </div>
+            ) : (
+              <EventCard key={seg.events[0].id} event={seg.events[0]} />
+            ),
+          )
         )}
         <div ref={bottomRef} />
       </div>


### PR DESCRIPTION
## Summary

- Add conservative, fail-closed visual grouping of related events in the Activity timeline
- Two strong signals: shared `metadata.work_id` (Signal A) and adjacent inference→runtime temporal adjacency ≤3s (Signal B)
- Events without a strong signal render identically to today — no false positives
- O(n) three-phase union-find algorithm wrapped in `useMemo`
- Pure UI rendering logic — no API, schema, or backend changes

Closes AI-98

## Test plan

- [x] 7 positive grouping tests (G1-G7): Signal A, Signal B, transitive, multi-step
- [x] 9 negative grouping tests (N1-N9): inference↔inference, wrong direction, wrong tool, gap too large, non-adjacent, work_failed excluded
- [x] 5 edge case tests (E1-E5): empty, single, identical timestamps, missing metadata, partial work_id
- [x] 6 rendering tests (R1-R6): spine presence/absence, layout classes, filter recomputation
- [x] 17 existing tests pass (no regression)
- [x] Full UI test suite: 321/321 passing
- [x] TypeScript: no errors in changed files (pre-existing errors elsewhere unchanged)
- [ ] VPS runtime: V1-V6 (UI deploy, visual verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)