### PR TITLE
feat: activity status badges and latest activity banner

### DIFF
--- a/services/ui/src/__tests__/EventTimeline.test.tsx
+++ b/services/ui/src/__tests__/EventTimeline.test.tsx
@@ -15,7 +15,7 @@ vi.mock('lucide-react', () => ({
   ChevronRight: (props: any) => <span data-testid="icon-chevron-right" {...props} />,
 }))
 
-import EventTimeline, { computeGroups } from '@/app/agents/[id]/EventTimeline'
+import EventTimeline, { computeGroups, deriveGroupStatus } from '@/app/agents/[id]/EventTimeline'
 import EventCard from '@/app/agents/[id]/EventCard'
 import type { AgentEvent } from '@/app/agents/[id]/EventCard'
 
@@ -287,7 +287,9 @@ describe('EventTimeline', () => {
     await waitFor(() => {
       expect(screen.getAllByTestId('event-card')).toHaveLength(1)
     })
-    expect(screen.getByText('inference')).toBeInTheDocument()
+    // "inference" appears in both EventCard and banner — verify via event card
+    const card = screen.getByTestId('event-card')
+    expect(card).toHaveTextContent('inference')
   })
 })
 
@@ -605,5 +607,256 @@ describe('EventTimeline — group rendering', () => {
     })
     // No runtime events visible → no Signal B → no spine
     expect(screen.queryByTestId('group-spine')).not.toBeInTheDocument()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// deriveGroupStatus — pure function tests (GS1-GS8)
+// ---------------------------------------------------------------------------
+describe('deriveGroupStatus', () => {
+  it('GS1: work_received + work_completed → completed', () => {
+    const events = [wr('a', 0), wc('b', 100)]
+    expect(deriveGroupStatus(events)).toBe('completed')
+  })
+
+  it('GS2: work_received + work_failed → failed', () => {
+    const events = [wr('a', 0), wf('b', 100)]
+    expect(deriveGroupStatus(events)).toBe('failed')
+  })
+
+  it('GS3: work_received only → in_progress', () => {
+    const events = [wr('a', 0)]
+    expect(deriveGroupStatus(events)).toBe('in_progress')
+  })
+
+  it('GS4: work_failed takes precedence over work_completed', () => {
+    const events = [wr('a', 0), wc('b', 100), wf('c', 200)]
+    expect(deriveGroupStatus(events)).toBe('failed')
+  })
+
+  it('GS5: realistic full step: inference + work_received + work_completed → completed', () => {
+    const events = [inf('a', 0), wr('b', 300), wc('c', 500)]
+    expect(deriveGroupStatus(events)).toBe('completed')
+  })
+
+  it('GS6: no runtime work-step events → null (no badge)', () => {
+    const events = [inf('a', 0), shell('b', 100)]
+    expect(deriveGroupStatus(events)).toBeNull()
+  })
+
+  it('GS7: inference_error + work_completed → completed NOT failed', () => {
+    const inferenceError = makeEvent(
+      { id: 'ie', tool: 'inference', type: 'inference_error', success: false },
+      50,
+    )
+    const events = [wr('a', 0), inferenceError, wc('b', 100)]
+    expect(deriveGroupStatus(events)).toBe('completed')
+  })
+
+  it('GS8: shell command_complete (success=false) does NOT affect group status', () => {
+    const shellFail = makeEvent(
+      { id: 'sf', tool: 'shell', type: 'command_complete', success: false },
+      50,
+    )
+    const events = [wr('a', 0), shellFail, wc('b', 100)]
+    expect(deriveGroupStatus(events)).toBe('completed')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Latest Activity banner rendering tests (LA1-LA5)
+// ---------------------------------------------------------------------------
+describe('EventTimeline — Latest Activity banner', () => {
+  function setupSSEAndSendEvents(events: AgentEvent[]) {
+    let capturedOnMessage: ((msg: MessageEvent) => void) | null = null
+    vi.stubGlobal('EventSource', vi.fn(() => {
+      const instance = {
+        onmessage: null as any,
+        addEventListener: vi.fn(),
+        close: vi.fn(),
+      }
+      setTimeout(() => { capturedOnMessage = instance.onmessage }, 0)
+      return instance
+    }))
+
+    render(<EventTimeline agentId="uuid-1" agentStatus="running" />)
+
+    return waitFor(() => expect(capturedOnMessage).toBeTruthy()).then(() => {
+      for (const e of events) {
+        capturedOnMessage!(new MessageEvent('message', { data: JSON.stringify(e) }))
+      }
+      return capturedOnMessage!
+    })
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    Element.prototype.scrollIntoView = vi.fn()
+  })
+  afterEach(() => cleanup())
+
+  it('LA1: banner shows when events exist', async () => {
+    await setupSSEAndSendEvents([
+      makeEvent({ id: 'e1', tool: 'shell', type: 'command_start', input_summary: 'echo hello' }, 0),
+    ])
+    await waitFor(() => {
+      expect(screen.getByTestId('latest-activity')).toBeInTheDocument()
+    })
+  })
+
+  it('LA2: banner not shown when no events', () => {
+    vi.stubGlobal('EventSource', vi.fn(() => ({
+      onmessage: null,
+      addEventListener: vi.fn(),
+      close: vi.fn(),
+    })))
+    render(<EventTimeline agentId="uuid-1" agentStatus="running" />)
+    expect(screen.queryByTestId('latest-activity')).not.toBeInTheDocument()
+  })
+
+  it('LA3: banner shows most recent event tool', async () => {
+    await setupSSEAndSendEvents([
+      makeEvent({ id: 'e1', tool: 'shell', type: 'command_start', input_summary: 'echo hello' }, 0),
+      makeEvent({ id: 'e2', tool: 'filesystem', type: 'file_read', input_summary: '/tmp/data.txt' }, 100),
+    ])
+    await waitFor(() => {
+      const banner = screen.getByTestId('latest-activity')
+      expect(banner).toHaveTextContent('filesystem')
+    })
+  })
+
+  it('LA4: banner shows input_summary', async () => {
+    await setupSSEAndSendEvents([
+      makeEvent({ id: 'e1', tool: 'shell', type: 'command_start', input_summary: 'npm run build' }, 0),
+    ])
+    await waitFor(() => {
+      const banner = screen.getByTestId('latest-activity')
+      expect(banner).toHaveTextContent('npm run build')
+    })
+  })
+
+  it('LA5: banner updates when new event arrives via SSE', async () => {
+    const onMessage = await setupSSEAndSendEvents([
+      makeEvent({ id: 'e1', tool: 'shell', type: 'command_start', input_summary: 'first command' }, 0),
+    ])
+    await waitFor(() => {
+      expect(screen.getByTestId('latest-activity')).toHaveTextContent('first command')
+    })
+    // Send a second event
+    onMessage(new MessageEvent('message', {
+      data: JSON.stringify(
+        makeEvent({ id: 'e2', tool: 'runtime', type: 'work_received', input_summary: 'second event' }, 200),
+      ),
+    }))
+    await waitFor(() => {
+      expect(screen.getByTestId('latest-activity')).toHaveTextContent('second event')
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Group status badge rendering tests (SB1-SB6)
+// ---------------------------------------------------------------------------
+describe('EventTimeline — group status badges', () => {
+  function setupSSEAndSendEvents(events: AgentEvent[]) {
+    let capturedOnMessage: ((msg: MessageEvent) => void) | null = null
+    vi.stubGlobal('EventSource', vi.fn(() => {
+      const instance = {
+        onmessage: null as any,
+        addEventListener: vi.fn(),
+        close: vi.fn(),
+      }
+      setTimeout(() => { capturedOnMessage = instance.onmessage }, 0)
+      return instance
+    }))
+
+    render(<EventTimeline agentId="uuid-1" agentStatus="running" />)
+
+    return waitFor(() => expect(capturedOnMessage).toBeTruthy()).then(() => {
+      for (const e of events) {
+        capturedOnMessage!(new MessageEvent('message', { data: JSON.stringify(e) }))
+      }
+      return capturedOnMessage!
+    })
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    Element.prototype.scrollIntoView = vi.fn()
+  })
+  afterEach(() => cleanup())
+
+  it('SB1: completed group shows Completed badge', async () => {
+    // Full step: inference → work_received → work_completed (grouped via Signal A + B)
+    await setupSSEAndSendEvents([inf('a', 0), wr('b', 300, 'W1'), wc('c', 500, 'W1')])
+    await waitFor(() => {
+      expect(screen.getAllByTestId('event-card')).toHaveLength(3)
+    })
+    const badge = screen.getByTestId('group-status-badge')
+    expect(badge).toHaveTextContent('Completed')
+  })
+
+  it('SB2: badge has brand-400 color for completed', async () => {
+    await setupSSEAndSendEvents([inf('a', 0), wr('b', 300, 'W1'), wc('c', 500, 'W1')])
+    await waitFor(() => {
+      expect(screen.getAllByTestId('event-card')).toHaveLength(3)
+    })
+    const badge = screen.getByTestId('group-status-badge')
+    expect(badge.className).toContain('text-brand-400')
+  })
+
+  it('SB3: in_progress badge has pulsing dot', async () => {
+    // Only work_received, no closing event — need to be grouped (so add inference for Signal B)
+    await setupSSEAndSendEvents([inf('a', 0), wr('b', 300)])
+    await waitFor(() => {
+      expect(screen.getAllByTestId('event-card')).toHaveLength(2)
+    })
+    const badge = screen.getByTestId('group-status-badge')
+    expect(badge).toHaveTextContent('In Progress')
+    const dot = badge.querySelector('.animate-pulse')
+    expect(dot).toBeInTheDocument()
+  })
+
+  it('SB4: no badge on ungrouped events', async () => {
+    // Solo shell event — not grouped
+    await setupSSEAndSendEvents([
+      makeEvent({ id: 'solo', tool: 'shell', type: 'command_start', input_summary: 'ls' }, 0),
+    ])
+    await waitFor(() => {
+      expect(screen.getAllByTestId('event-card')).toHaveLength(1)
+    })
+    expect(screen.queryByTestId('group-status-badge')).not.toBeInTheDocument()
+  })
+
+  it('SB5: no badge on group without runtime work-step events', async () => {
+    // Two inference events sharing a work_id — grouped but no runtime work-step events
+    const i1 = makeEvent(
+      { id: 'i1', tool: 'inference', type: 'inference_complete', metadata: { work_id: 'Z' } },
+      0,
+    )
+    const i2 = makeEvent(
+      { id: 'i2', tool: 'inference', type: 'inference_complete', metadata: { work_id: 'Z' } },
+      100,
+    )
+    await setupSSEAndSendEvents([i1, i2])
+    await waitFor(() => {
+      expect(screen.getAllByTestId('event-card')).toHaveLength(2)
+    })
+    // They share work_id so they ARE grouped (spine visible)
+    expect(screen.getByTestId('group-spine')).toBeInTheDocument()
+    // But no runtime work-step events → no badge
+    expect(screen.queryByTestId('group-status-badge')).not.toBeInTheDocument()
+  })
+
+  it('SB6: existing OK/FAIL indicators unchanged', async () => {
+    const completedEvent = makeEvent(
+      { id: 'ok1', tool: 'shell', type: 'command_complete', success: true, input_summary: 'echo hi' },
+      0,
+    )
+    await setupSSEAndSendEvents([completedEvent])
+    await waitFor(() => {
+      expect(screen.getAllByTestId('event-card')).toHaveLength(1)
+    })
+    expect(screen.getByText('OK')).toBeInTheDocument()
   })
 })

--- a/services/ui/src/app/agents/[id]/EventTimeline.tsx
+++ b/services/ui/src/app/agents/[id]/EventTimeline.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState, useEffect, useRef, useCallback, useMemo } from 'react'
+import { Terminal, FolderOpen, Cog, User, HeartPulse, Sparkles } from 'lucide-react'
 import EventCard, { type AgentEvent } from './EventCard'
 
 const MAX_EVENTS = 500
@@ -136,6 +137,48 @@ function buildSegments(events: AgentEvent[], groups: Map<string, string>): Segme
   return segments
 }
 
+// ---------------------------------------------------------------------------
+// Group status derivation — scoped to runtime work-step events only
+// ---------------------------------------------------------------------------
+export type GroupStatus = 'completed' | 'failed' | 'in_progress'
+
+const WORK_STEP_TYPES = new Set(['work_received', 'work_completed', 'work_failed'])
+
+export function deriveGroupStatus(groupEvents: AgentEvent[]): GroupStatus | null {
+  let hasWorkReceived = false
+  let hasWorkCompleted = false
+  let hasWorkFailed = false
+
+  for (const event of groupEvents) {
+    if (event.tool !== 'runtime' || !WORK_STEP_TYPES.has(event.type)) continue
+    if (event.type === 'work_received') hasWorkReceived = true
+    else if (event.type === 'work_completed') hasWorkCompleted = true
+    else if (event.type === 'work_failed') hasWorkFailed = true
+  }
+
+  if (!hasWorkReceived && !hasWorkCompleted && !hasWorkFailed) return null
+
+  if (hasWorkFailed) return 'failed'
+  if (hasWorkCompleted) return 'completed'
+  return 'in_progress'
+}
+
+// Local icon map — duplicated from EventCard to avoid coupling
+const BANNER_ICONS: Record<string, typeof Terminal> = {
+  shell: Terminal,
+  filesystem: FolderOpen,
+  runtime: Cog,
+  identity: User,
+  health: HeartPulse,
+  inference: Sparkles,
+}
+
+const GROUP_STATUS_CONFIG = {
+  completed: { css: 'bg-brand-900/50 text-brand-400 border-brand-700', label: 'Completed' },
+  failed: { css: 'bg-red-900/40 text-red-400 border-red-700', label: 'Failed' },
+  in_progress: { css: 'bg-navy-700 text-mountain-400 border-navy-600', label: 'In Progress' },
+} as const
+
 export default function EventTimeline({
   agentId,
   agentStatus,
@@ -225,6 +268,24 @@ export default function EventTimeline({
         </div>
       </div>
 
+      {events.length > 0 && (() => {
+        const last = events[events.length - 1]
+        const BannerIcon = BANNER_ICONS[last.tool] || Terminal
+        const summary = last.input_summary.length > 60
+          ? last.input_summary.slice(0, 57) + '...'
+          : last.input_summary
+        return (
+          <div
+            className="flex items-center gap-2 bg-navy-700/50 border border-navy-600 rounded-md px-3 py-2 mb-3"
+            data-testid="latest-activity"
+          >
+            <BannerIcon className="h-4 w-4 text-mountain-400 shrink-0" />
+            <span className="text-xs text-mountain-400">{last.tool}</span>
+            <span className="text-sm text-mountain-300 truncate">{summary}</span>
+          </div>
+        )
+      })()}
+
       <div
         ref={containerRef}
         onScroll={handleScroll}
@@ -238,6 +299,22 @@ export default function EventTimeline({
           segments.map((seg) =>
             seg.groupId !== null ? (
               <div key={seg.groupId} className="relative pl-3">
+                {(() => {
+                  const status = deriveGroupStatus(seg.events)
+                  if (status === null) return null
+                  const cfg = GROUP_STATUS_CONFIG[status]
+                  return (
+                    <div
+                      className={`inline-flex items-center gap-1.5 px-2 py-0.5 text-xs rounded-md border mb-1 ${cfg.css}`}
+                      data-testid="group-status-badge"
+                    >
+                      {status === 'in_progress' && (
+                        <span className="h-1.5 w-1.5 rounded-full bg-mountain-400 animate-pulse" />
+                      )}
+                      {cfg.label}
+                    </div>
+                  )
+                })()}
                 <div
                   className="absolute left-0 top-3 bottom-3 w-0.5 bg-navy-600 rounded-full"
                   aria-hidden="true"


### PR DESCRIPTION
## Summary
- Adds **group status badges** (Completed / Failed / In Progress) on grouped event segments in the Activity timeline
- Adds **Latest Activity banner** showing the most recent SSE event at the top of the event list
- Status derivation scoped exclusively to runtime work-step events (`work_received`, `work_completed`, `work_failed`) — inference errors and shell failures do not poison group badges (false-failure prevention proven by GS7)
- No backend changes, no new dependencies, EventCard.tsx unchanged

## Test plan
- [x] 19 new tests (GS1-GS8 + LA1-LA5 + SB1-SB6) all pass
- [x] 42 existing EventTimeline tests remain green (no regression)
- [x] Full UI test suite: 344/344 pass across 34 test files
- [x] No new TypeScript errors (pre-existing only)
- [x] `deriveGroupStatus` pure function: false-failure prevention (GS7), no-signal fail-closed (GS6)
- [x] Latest Activity banner updates live via SSE (LA5)
- [x] In Progress badge has pulsing dot animation (SB3)
- [x] EventCard.tsx zero diff

## Verification evidence
```
Test Files  34 passed (34)
Tests  344 passed (344)
```

```
git diff --stat main...HEAD
services/ui/src/__tests__/EventTimeline.test.tsx  | 257 +++
services/ui/src/app/agents/[id]/EventTimeline.tsx  |  77 +++
2 files changed, 332 insertions(+), 2 deletions(-)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)