### PR TITLE
feat: activity command lifecycle cards with exit code badges

### DIFF
--- a/services/ui/src/__tests__/EventTimeline.test.tsx
+++ b/services/ui/src/__tests__/EventTimeline.test.tsx
@@ -16,7 +16,7 @@ vi.mock('lucide-react', () => ({
 }))
 
 import EventTimeline, { computeGroups, deriveGroupStatus } from '@/app/agents/[id]/EventTimeline'
-import EventCard from '@/app/agents/[id]/EventCard'
+import EventCard, { getLifecycleInfo, parseExitCode } from '@/app/agents/[id]/EventCard'
 import type { AgentEvent } from '@/app/agents/[id]/EventCard'
 
 const MOCK_EVENTS: AgentEvent[] = [
@@ -80,14 +80,14 @@ describe('EventCard', () => {
     expect(screen.getByText('echo hello')).toBeInTheDocument()
   })
 
-  it('shows success indicator', () => {
-    render(<EventCard event={MOCK_EVENTS[1]} />)
+  it('shows success indicator on non-lifecycle events', () => {
+    render(<EventCard event={MOCK_EVENTS[2]} />)
     expect(screen.getByText('OK')).toBeInTheDocument()
   })
 
-  it('shows failure indicator', () => {
+  it('shows failure indicator on non-lifecycle events', () => {
     const failedEvent: AgentEvent = {
-      ...MOCK_EVENTS[1],
+      ...MOCK_EVENTS[2],
       id: 'evt-fail',
       success: false,
     }
@@ -848,15 +848,183 @@ describe('EventTimeline — group status badges', () => {
     expect(screen.queryByTestId('group-status-badge')).not.toBeInTheDocument()
   })
 
-  it('SB6: existing OK/FAIL indicators unchanged', async () => {
-    const completedEvent = makeEvent(
-      { id: 'ok1', tool: 'shell', type: 'command_complete', success: true, input_summary: 'echo hi' },
+  it('SB6: existing OK/FAIL indicators unchanged on non-lifecycle events', async () => {
+    const fsEvent = makeEvent(
+      { id: 'ok1', tool: 'filesystem', type: 'file_read', success: true, input_summary: '/tmp/data.txt' },
       0,
     )
-    await setupSSEAndSendEvents([completedEvent])
+    await setupSSEAndSendEvents([fsEvent])
     await waitFor(() => {
       expect(screen.getAllByTestId('event-card')).toHaveLength(1)
     })
     expect(screen.getByText('OK')).toBeInTheDocument()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// getLifecycleInfo — pure function tests (LC1-LC9)
+// ---------------------------------------------------------------------------
+describe('getLifecycleInfo', () => {
+  it('LC1: shell command_start → Running', () => {
+    const event = makeEvent({ id: 'lc1', tool: 'shell', type: 'command_start' })
+    expect(getLifecycleInfo(event)).toEqual({
+      label: 'Running', color: 'text-yellow-400', pulse: true,
+    })
+  })
+
+  it('LC2: shell command_complete success → Completed', () => {
+    const event = makeEvent({ id: 'lc2', tool: 'shell', type: 'command_complete', success: true })
+    expect(getLifecycleInfo(event)).toEqual({
+      label: 'Completed', color: 'text-brand-400', pulse: false,
+    })
+  })
+
+  it('LC3: shell command_complete failure → Failed', () => {
+    const event = makeEvent({ id: 'lc3', tool: 'shell', type: 'command_complete', success: false })
+    expect(getLifecycleInfo(event)).toEqual({
+      label: 'Failed', color: 'text-red-400', pulse: false,
+    })
+  })
+
+  it('LC4: runtime work_received → Received', () => {
+    const event = makeEvent({ id: 'lc4', tool: 'runtime', type: 'work_received' })
+    expect(getLifecycleInfo(event)).toEqual({
+      label: 'Received', color: 'text-yellow-400', pulse: true,
+    })
+  })
+
+  it('LC5: runtime work_completed → Completed', () => {
+    const event = makeEvent({ id: 'lc5', tool: 'runtime', type: 'work_completed', success: true })
+    expect(getLifecycleInfo(event)).toEqual({
+      label: 'Completed', color: 'text-brand-400', pulse: false,
+    })
+  })
+
+  it('LC6: runtime work_failed → Failed', () => {
+    const event = makeEvent({ id: 'lc6', tool: 'runtime', type: 'work_failed', success: false })
+    expect(getLifecycleInfo(event)).toEqual({
+      label: 'Failed', color: 'text-red-400', pulse: false,
+    })
+  })
+
+  it('LC7: filesystem event → null (no label)', () => {
+    const event = makeEvent({ id: 'lc7', tool: 'filesystem', type: 'file_read' })
+    expect(getLifecycleInfo(event)).toBeNull()
+  })
+
+  it('LC8: inference event → null (no label)', () => {
+    const event = makeEvent({ id: 'lc8', tool: 'inference', type: 'inference_complete' })
+    expect(getLifecycleInfo(event)).toBeNull()
+  })
+
+  it('LC9: unknown shell type → null (fail-closed)', () => {
+    const event = makeEvent({ id: 'lc9', tool: 'shell', type: 'unknown_type' })
+    expect(getLifecycleInfo(event)).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// parseExitCode — pure function tests (EC1-EC5)
+// ---------------------------------------------------------------------------
+describe('parseExitCode', () => {
+  it('EC1: standard exit 0', () => {
+    expect(parseExitCode('exit 0, 6 bytes stdout')).toBe(0)
+  })
+
+  it('EC2: non-zero exit', () => {
+    expect(parseExitCode('exit 1, 0 bytes stdout')).toBe(1)
+  })
+
+  it('EC3: large exit code', () => {
+    expect(parseExitCode('exit 137, 100 bytes stdout')).toBe(137)
+  })
+
+  it('EC4: null output_summary', () => {
+    expect(parseExitCode(null)).toBeNull()
+  })
+
+  it('EC5: non-matching format', () => {
+    expect(parseExitCode('some other output')).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// EventCard — lifecycle rendering tests (R1-R9)
+// ---------------------------------------------------------------------------
+describe('EventCard — lifecycle rendering', () => {
+  afterEach(() => cleanup())
+
+  it('R1: command_start card shows "Running" label', () => {
+    render(<EventCard event={MOCK_EVENTS[0]} />)
+    expect(screen.getByText('Running')).toBeInTheDocument()
+  })
+
+  it('R2: command_start card shows pulsing dot', () => {
+    render(<EventCard event={MOCK_EVENTS[0]} />)
+    const card = screen.getByTestId('event-card')
+    const pulse = card.querySelector('.animate-pulse')
+    expect(pulse).toBeInTheDocument()
+  })
+
+  it('R3: command_complete (success) shows "Completed" + exit code badge', () => {
+    render(<EventCard event={MOCK_EVENTS[1]} />)
+    expect(screen.getByText('Completed')).toBeInTheDocument()
+    expect(screen.getByText('exit 0')).toBeInTheDocument()
+  })
+
+  it('R4: command_complete (failure) shows "Failed" + exit code badge', () => {
+    const failedEvent: AgentEvent = {
+      ...MOCK_EVENTS[1],
+      id: 'fail-1',
+      success: false,
+      output_summary: 'exit 1, 0 bytes stdout',
+    }
+    render(<EventCard event={failedEvent} />)
+    expect(screen.getByText('Failed')).toBeInTheDocument()
+    expect(screen.getByText('exit 1')).toBeInTheDocument()
+  })
+
+  it('R5: command_start card does NOT show OK/FAIL', () => {
+    render(<EventCard event={MOCK_EVENTS[0]} />)
+    expect(screen.queryByText('OK')).not.toBeInTheDocument()
+    expect(screen.queryByText('FAIL')).not.toBeInTheDocument()
+  })
+
+  it('R6: filesystem event still shows OK/FAIL (not lifecycle label)', () => {
+    render(<EventCard event={MOCK_EVENTS[2]} />)
+    expect(screen.getByText('OK')).toBeInTheDocument()
+    expect(screen.queryByText('Completed')).not.toBeInTheDocument()
+  })
+
+  it('R7: inference event still shows OK/FAIL (not lifecycle label)', () => {
+    render(<EventCard event={MOCK_INFERENCE_EVENT} />)
+    expect(screen.getByText('OK')).toBeInTheDocument()
+    expect(screen.queryByText('Completed')).not.toBeInTheDocument()
+  })
+
+  it('R8: exit code in expanded details for command_complete', () => {
+    render(<EventCard event={MOCK_EVENTS[1]} />)
+    fireEvent.click(screen.getByTestId('event-card'))
+    const details = screen.getByTestId('event-details')
+    expect(details).toHaveTextContent('Exit Code:')
+    expect(details.textContent).toMatch(/Exit Code:\s*0/)
+  })
+
+  it('R9: work_received shows "Received" with pulsing dot', () => {
+    const wrEvent: AgentEvent = {
+      id: 'wr-1',
+      timestamp: new Date().toISOString(),
+      type: 'work_received',
+      tool: 'runtime',
+      input_summary: 'type=verify',
+      output_summary: null,
+      duration_ms: null,
+      success: null,
+    }
+    render(<EventCard event={wrEvent} />)
+    expect(screen.getByText('Received')).toBeInTheDocument()
+    const card = screen.getByTestId('event-card')
+    const pulse = card.querySelector('.animate-pulse')
+    expect(pulse).toBeInTheDocument()
   })
 })

--- a/services/ui/src/app/agents/[id]/EventCard.tsx
+++ b/services/ui/src/app/agents/[id]/EventCard.tsx
@@ -15,6 +15,31 @@ export interface AgentEvent {
   metadata?: Record<string, unknown>
 }
 
+export type LifecycleInfo = { label: string; color: string; pulse: boolean }
+
+export function parseExitCode(outputSummary: string | null): number | null {
+  if (!outputSummary) return null
+  const match = outputSummary.match(/^exit (\d+)/)
+  return match ? parseInt(match[1], 10) : null
+}
+
+export function getLifecycleInfo(event: AgentEvent): LifecycleInfo | null {
+  if (event.tool === 'shell') {
+    if (event.type === 'command_start') return { label: 'Running', color: 'text-yellow-400', pulse: true }
+    if (event.type === 'command_complete') {
+      return event.success === false
+        ? { label: 'Failed', color: 'text-red-400', pulse: false }
+        : { label: 'Completed', color: 'text-brand-400', pulse: false }
+    }
+  }
+  if (event.tool === 'runtime') {
+    if (event.type === 'work_received') return { label: 'Received', color: 'text-yellow-400', pulse: true }
+    if (event.type === 'work_completed') return { label: 'Completed', color: 'text-brand-400', pulse: false }
+    if (event.type === 'work_failed') return { label: 'Failed', color: 'text-red-400', pulse: false }
+  }
+  return null
+}
+
 const TOOL_ICONS: Record<string, typeof Terminal> = {
   shell: Terminal,
   filesystem: FolderOpen,
@@ -51,8 +76,37 @@ export default function EventCard({ event }: { event: AgentEvent }) {
         <Icon className="h-4 w-4 text-mountain-400 shrink-0" />
         <span className="text-mountain-300 font-medium">{event.tool}</span>
         <span className="text-mountain-500 text-xs truncate flex-1">{event.input_summary}</span>
-        {event.success === true && <span className="text-brand-400 text-xs">OK</span>}
-        {event.success === false && <span className="text-red-400 text-xs">FAIL</span>}
+        {(() => {
+          const lifecycle = getLifecycleInfo(event)
+          if (lifecycle) {
+            const exitCode = event.type === 'command_complete' ? parseExitCode(event.output_summary) : null
+            return (
+              <>
+                <span className={`text-xs flex items-center gap-1 ${lifecycle.color}`}>
+                  {lifecycle.pulse && (
+                    <span className="h-1.5 w-1.5 rounded-full bg-yellow-400 animate-pulse" />
+                  )}
+                  {lifecycle.label}
+                </span>
+                {exitCode !== null && (
+                  <span className={`text-xs px-1.5 py-0.5 rounded font-mono ${
+                    exitCode === 0
+                      ? 'text-brand-400 bg-brand-900/30'
+                      : 'text-red-400 bg-red-900/30'
+                  }`}>
+                    exit {exitCode}
+                  </span>
+                )}
+              </>
+            )
+          }
+          return (
+            <>
+              {event.success === true && <span className="text-brand-400 text-xs">OK</span>}
+              {event.success === false && <span className="text-red-400 text-xs">FAIL</span>}
+            </>
+          )
+        })()}
         {event.duration_ms !== null && (
           <span className="text-mountain-500 text-xs">{event.duration_ms}ms</span>
         )}
@@ -83,6 +137,14 @@ export default function EventCard({ event }: { event: AgentEvent }) {
       {expanded && event.tool !== 'inference' && (
         <div className="mt-2 pl-6 text-xs space-y-1" data-testid="event-details">
           <div><span className="text-mountain-400">Type:</span> <span className="text-mountain-300">{event.type}</span></div>
+          {event.type === 'command_complete' && parseExitCode(event.output_summary) !== null && (
+            <div>
+              <span className="text-mountain-400">Exit Code:</span>{' '}
+              <span className={parseExitCode(event.output_summary) === 0 ? 'text-brand-400' : 'text-red-400'}>
+                {parseExitCode(event.output_summary)}
+              </span>
+            </div>
+          )}
           {event.output_summary && (
             <div><span className="text-mountain-400">Output:</span> <span className="text-mountain-300">{event.output_summary}</span></div>
           )}


### PR DESCRIPTION
## Summary
- Shell and runtime events now show lifecycle-phase labels (Running, Completed, Failed, Received) instead of generic OK/FAIL indicators
- Shell `command_complete` events display a parsed exit code badge (green for exit 0, red for non-zero)
- In-flight events (`command_start`, `work_received`) show a pulsing yellow dot animation
- Non-lifecycle events (filesystem, inference) preserve existing OK/FAIL rendering unchanged
- EventTimeline.tsx is zero diff — all changes are in EventCard.tsx rendering only

## Linear
- Issue: AI-98 (Agents lane — Activity tab)

## Known Issue (pre-existing)
- Runtime filter shows inference events — pre-existing in PR #241, not introduced here. Follow-up: #243

## Validation Evidence
- UI: 367/367 vitest tests pass (344 existing + 23 new)
- UI: `tsc --noEmit` clean (no new errors)
- UI: EventTimeline.tsx zero diff confirmed via `git diff --stat`

### Runtime Verification (V1-V8) — All PASS
- V1: Deploy UI from feature branch — UI container started
- V2: POST /work → `{"accepted":true,"work_id":"e1941d71-...","type":"v2-audit"}`, events.jsonl confirms work_received + work_completed
- V3: work_received shows "Received" + pulsing dot (screenshot)
- V4: work_completed shows "Completed" in green (screenshot)
- V5: Banner shows metadata-only `input_summary` — no sensitive payload
- V6: API `/api/agents/:id/events?tail=3` returns 9 allowed fields only, zero forbidden keys (prompt/completion/stdout/stderr/raw_output/raw_input/request_body/response_body)
- V7: Runtime lifecycle labels render correctly; filter showing inference events is pre-existing on main (baseline screenshot `v7-baseline-main-runtime-filter-shows-inference.png`), tracked in #243
- V8: VPS restored to main at `a486eed`, UI redeployed

### Files Changed (2 files)
| File | Change |
|------|--------|
| `services/ui/src/app/agents/[id]/EventCard.tsx` | +64/-2: `parseExitCode()`, `getLifecycleInfo()`, lifecycle label JSX, exit code badge, pulsing dot |
| `services/ui/src/__tests__/EventTimeline.test.tsx` | +177/-9: 23 new tests (LC1-LC9, EC1-EC5, R1-R9), 3 updated existing tests |

## Test plan
- [x] `npx vitest run` — 367/367 pass
- [x] `npx vitest run src/__tests__/EventTimeline.test.tsx` — 84/84 pass
- [x] `npx tsc --noEmit` — no new errors
- [x] EventTimeline.tsx zero diff
- [x] CI checks pass (Run Tests, Agent Loop Advisory, Agent Loop Infra, Snyk)
- [x] VPS runtime V1-V8 all PASS

## Workaround Classification
**merge now** — no ad-hoc workarounds required during verification.

## Notes
- 3 existing tests updated: shell `command_complete` events now show lifecycle labels instead of OK/FAIL, so tests that checked OK/FAIL on shell events were updated to use filesystem events (which still show OK/FAIL)
- `parseExitCode()` and `getLifecycleInfo()` are exported for direct unit testing
- Exit code parsing uses regex anchored to shell.py:67 format (`exit N, M bytes stdout`); returns null on no match (fail-closed)
- Plan: `~/.claude/plans/activity-command-lifecycle.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)