### PR TITLE
feat: activity timing clarity — human-readable durations + group time spans

### DIFF
--- a/services/ui/src/__tests__/EventTimeline.test.tsx
+++ b/services/ui/src/__tests__/EventTimeline.test.tsx
@@ -15,8 +15,8 @@ vi.mock('lucide-react', () => ({
   ChevronRight: (props: any) => <span data-testid="icon-chevron-right" {...props} />,
 }))
 
-import EventTimeline, { computeGroups, deriveGroupStatus } from '@/app/agents/[id]/EventTimeline'
-import EventCard, { getLifecycleInfo, parseExitCode } from '@/app/agents/[id]/EventCard'
+import EventTimeline, { computeGroups, deriveGroupStatus, computeGroupSpan } from '@/app/agents/[id]/EventTimeline'
+import EventCard, { getLifecycleInfo, parseExitCode, formatDuration } from '@/app/agents/[id]/EventCard'
 import type { AgentEvent } from '@/app/agents/[id]/EventCard'
 
 const MOCK_EVENTS: AgentEvent[] = [
@@ -1026,5 +1026,196 @@ describe('EventCard — lifecycle rendering', () => {
     const card = screen.getByTestId('event-card')
     const pulse = card.querySelector('.animate-pulse')
     expect(pulse).toBeInTheDocument()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// formatDuration — pure function tests (FD1-FD11)
+// ---------------------------------------------------------------------------
+describe('formatDuration', () => {
+  it('FD1: sub-second exact ms', () => {
+    expect(formatDuration(450)).toBe('450ms')
+  })
+
+  it('FD2: zero ms', () => {
+    expect(formatDuration(0)).toBe('0ms')
+  })
+
+  it('FD3: boundary 999ms stays ms', () => {
+    expect(formatDuration(999)).toBe('999ms')
+  })
+
+  it('FD4: boundary 1000ms → whole second, no trailing .0', () => {
+    expect(formatDuration(1000)).toBe('1s')
+  })
+
+  it('FD5: seconds with decimal', () => {
+    expect(formatDuration(1500)).toBe('1.5s')
+  })
+
+  it('FD6: large whole seconds, no trailing .0', () => {
+    expect(formatDuration(45000)).toBe('45s')
+  })
+
+  it('FD7: fractional seconds', () => {
+    expect(formatDuration(7800)).toBe('7.8s')
+  })
+
+  it('FD8: boundary 60000ms → minutes', () => {
+    expect(formatDuration(60000)).toBe('1m 0s')
+  })
+
+  it('FD9: minutes + seconds', () => {
+    expect(formatDuration(123000)).toBe('2m 3s')
+  })
+
+  it('FD10: boundary 3600000ms → hours', () => {
+    expect(formatDuration(3600000)).toBe('1h 0m')
+  })
+
+  it('FD11: hours + minutes', () => {
+    expect(formatDuration(3900000)).toBe('1h 5m')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// computeGroupSpan — pure function tests (GS1-GS6)
+// ---------------------------------------------------------------------------
+describe('computeGroupSpan', () => {
+  it('GS1: two events 1500ms apart', () => {
+    const events = [
+      makeEvent({ id: 'gs1a', tool: 'runtime', type: 'work_received' }, 0),
+      makeEvent({ id: 'gs1b', tool: 'runtime', type: 'work_completed' }, 1500),
+    ]
+    expect(computeGroupSpan(events)).toBe(1500)
+  })
+
+  it('GS2: same timestamp (back-to-back)', () => {
+    const events = [
+      makeEvent({ id: 'gs2a', tool: 'runtime', type: 'work_received' }, 0),
+      makeEvent({ id: 'gs2b', tool: 'runtime', type: 'work_completed' }, 0),
+    ]
+    expect(computeGroupSpan(events)).toBe(0)
+  })
+
+  it('GS3: single event → null', () => {
+    const events = [makeEvent({ id: 'gs3a', tool: 'runtime', type: 'work_received' }, 0)]
+    expect(computeGroupSpan(events)).toBeNull()
+  })
+
+  it('GS4: empty array → null', () => {
+    expect(computeGroupSpan([])).toBeNull()
+  })
+
+  it('GS5: three events, span from min to max', () => {
+    const events = [
+      makeEvent({ id: 'gs5a', tool: 'inference', type: 'inference_complete' }, 0),
+      makeEvent({ id: 'gs5b', tool: 'runtime', type: 'work_received' }, 500),
+      makeEvent({ id: 'gs5c', tool: 'runtime', type: 'work_completed' }, 1200),
+    ]
+    expect(computeGroupSpan(events)).toBe(1200)
+  })
+
+  it('GS6: out-of-order timestamps → min/max, not first/last', () => {
+    const events = [
+      makeEvent({ id: 'gs6a', tool: 'runtime', type: 'work_completed' }, 1200),
+      makeEvent({ id: 'gs6b', tool: 'inference', type: 'inference_complete' }, 0),
+      makeEvent({ id: 'gs6c', tool: 'runtime', type: 'work_received' }, 500),
+    ]
+    expect(computeGroupSpan(events)).toBe(1200)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Activity Timing Clarity — rendering tests (RD1-RD4)
+// ---------------------------------------------------------------------------
+describe('Activity Timing Clarity — rendering', () => {
+  afterEach(() => cleanup())
+
+  it('RD1: EventCard shows formatted duration (1500ms → "1.5s")', () => {
+    const event: AgentEvent = {
+      id: 'rd1',
+      timestamp: new Date().toISOString(),
+      type: 'file_read',
+      tool: 'filesystem',
+      input_summary: '/tmp/data.txt',
+      output_summary: '1024 bytes',
+      duration_ms: 1500,
+      success: true,
+    }
+    render(<EventCard event={event} />)
+    expect(screen.getByText('1.5s')).toBeInTheDocument()
+    expect(screen.queryByText('1500ms')).not.toBeInTheDocument()
+  })
+
+  it('RD2: EventCard hides duration when null', () => {
+    const event: AgentEvent = {
+      id: 'rd2',
+      timestamp: new Date().toISOString(),
+      type: 'command_start',
+      tool: 'shell',
+      input_summary: 'echo hello',
+      output_summary: null,
+      duration_ms: null,
+      success: null,
+    }
+    render(<EventCard event={event} />)
+    // duration_ms is null → no duration display at all
+    const card = screen.getByTestId('event-card')
+    expect(card.textContent).not.toContain('0ms')
+    expect(card.textContent).not.toContain('nullms')
+  })
+})
+
+describe('Activity Timing Clarity — group span rendering', () => {
+  function setupSSEAndSendEvents(events: AgentEvent[]) {
+    let capturedOnMessage: ((msg: MessageEvent) => void) | null = null
+    vi.stubGlobal('EventSource', vi.fn(() => {
+      const instance = {
+        onmessage: null as any,
+        addEventListener: vi.fn(),
+        close: vi.fn(),
+      }
+      setTimeout(() => { capturedOnMessage = instance.onmessage }, 0)
+      return instance
+    }))
+
+    render(<EventTimeline agentId="uuid-1" agentStatus="running" />)
+
+    return waitFor(() => expect(capturedOnMessage).toBeTruthy()).then(() => {
+      for (const e of events) {
+        capturedOnMessage!(new MessageEvent('message', { data: JSON.stringify(e) }))
+      }
+      return capturedOnMessage!
+    })
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    Element.prototype.scrollIntoView = vi.fn()
+  })
+  afterEach(() => cleanup())
+
+  it('RD3: group badge shows span ("Completed · 0ms")', async () => {
+    // Back-to-back timestamps → span = 0ms
+    await setupSSEAndSendEvents([inf('a', 0), wr('b', 0, 'W1'), wc('c', 0, 'W1')])
+    await waitFor(() => {
+      expect(screen.getAllByTestId('event-card')).toHaveLength(3)
+    })
+    const badge = screen.getByTestId('group-status-badge')
+    expect(badge).toHaveTextContent('Completed')
+    expect(badge).toHaveTextContent('·')
+    expect(badge).toHaveTextContent('0ms')
+  })
+
+  it('RD4: no span separator on ungrouped event', async () => {
+    await setupSSEAndSendEvents([
+      makeEvent({ id: 'solo', tool: 'shell', type: 'command_start', input_summary: 'ls' }, 0),
+    ])
+    await waitFor(() => {
+      expect(screen.getAllByTestId('event-card')).toHaveLength(1)
+    })
+    expect(screen.queryByTestId('group-status-badge')).not.toBeInTheDocument()
+    expect(screen.queryByText('·')).not.toBeInTheDocument()
   })
 })

--- a/services/ui/src/app/agents/[id]/EventCard.tsx
+++ b/services/ui/src/app/agents/[id]/EventCard.tsx
@@ -40,6 +40,22 @@ export function getLifecycleInfo(event: AgentEvent): LifecycleInfo | null {
   return null
 }
 
+export function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`
+  if (ms < 60_000) {
+    const val = ms / 1000
+    return val % 1 === 0 ? `${val}s` : `${val.toFixed(1)}s`
+  }
+  if (ms < 3_600_000) {
+    const mins = Math.floor(ms / 60_000)
+    const secs = Math.floor((ms % 60_000) / 1000)
+    return `${mins}m ${secs}s`
+  }
+  const hrs = Math.floor(ms / 3_600_000)
+  const mins = Math.floor((ms % 3_600_000) / 60_000)
+  return `${hrs}h ${mins}m`
+}
+
 const TOOL_ICONS: Record<string, typeof Terminal> = {
   shell: Terminal,
   filesystem: FolderOpen,
@@ -108,7 +124,7 @@ export default function EventCard({ event }: { event: AgentEvent }) {
           )
         })()}
         {event.duration_ms !== null && (
-          <span className="text-mountain-500 text-xs">{event.duration_ms}ms</span>
+          <span className="text-mountain-500 text-xs">{formatDuration(event.duration_ms)}</span>
         )}
         <span className="text-mountain-500 text-xs whitespace-nowrap">{relativeTime(event.timestamp)}</span>
         {expanded ? (

--- a/services/ui/src/app/agents/[id]/EventTimeline.tsx
+++ b/services/ui/src/app/agents/[id]/EventTimeline.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useRef, useCallback, useMemo } from 'react'
 import { Terminal, FolderOpen, Cog, User, HeartPulse, Sparkles } from 'lucide-react'
-import EventCard, { type AgentEvent } from './EventCard'
+import EventCard, { type AgentEvent, formatDuration } from './EventCard'
 
 const MAX_EVENTS = 500
 const MAX_STEP_GAP_MS = 3000
@@ -163,6 +163,18 @@ export function deriveGroupStatus(groupEvents: AgentEvent[]): GroupStatus | null
   return 'in_progress'
 }
 
+export function computeGroupSpan(groupEvents: AgentEvent[]): number | null {
+  if (groupEvents.length < 2) return null
+  let minTs = Infinity
+  let maxTs = -Infinity
+  for (const event of groupEvents) {
+    const t = new Date(event.timestamp).getTime()
+    if (t < minTs) minTs = t
+    if (t > maxTs) maxTs = t
+  }
+  return Math.max(0, maxTs - minTs)
+}
+
 // Local icon map — duplicated from EventCard to avoid coupling
 const BANNER_ICONS: Record<string, typeof Terminal> = {
   shell: Terminal,
@@ -312,6 +324,11 @@ export default function EventTimeline({
                         <span className="h-1.5 w-1.5 rounded-full bg-mountain-400 animate-pulse" />
                       )}
                       {cfg.label}
+                      {(() => {
+                        const span = computeGroupSpan(seg.events)
+                        if (span === null) return null
+                        return <span> · {formatDuration(span)}</span>
+                      })()}
                     </div>
                   )
                 })()}


### PR DESCRIPTION
## Summary
- Add `formatDuration(ms)` to EventCard — converts raw milliseconds to human-readable strings (`450ms`, `1.5s`, `2m 3s`, `1h 5m`)
- Add `computeGroupSpan(events)` to EventTimeline — order-agnostic elapsed time via min/max timestamp scan, clamped to 0
- Group status badges now show span: `Completed · 0ms` (today's stub runtime produces back-to-back timestamps)
- EventCard duration display uses `formatDuration()` instead of raw `{duration_ms}ms`

## Changes
| File | Lines | Change |
|------|-------|--------|
| `EventCard.tsx` | +18 -2 | `formatDuration()` function, wired into duration display |
| `EventTimeline.tsx` | +19 -2 | `computeGroupSpan()` function, import `formatDuration`, span in badge |
| `EventTimeline.test.tsx` | +195 -0 | 21 new tests: FD1-FD11, GS1-GS6, RD1-RD4 |

3 files, 228 insertions, 4 deletions. No new files. No backend changes. No new dependencies.

## Test plan
- [x] FD1-FD11: `formatDuration` pure function (sub-second, boundaries, seconds, minutes, hours, no trailing .0)
- [x] GS1-GS6: `computeGroupSpan` pure function (1500ms apart, back-to-back, single event, empty, 3 events, out-of-order timestamps)
- [x] RD1: EventCard shows "1.5s" not "1500ms"
- [x] RD2: EventCard hides duration when null (regression guard)
- [x] RD3: Group badge shows "Completed · 0ms"
- [x] RD4: No span separator on ungrouped events
- [x] REG1: All 388 existing tests pass (34 test files)
- [x] Type check: no new errors (pre-existing only)
- [ ] V1-V6: VPS runtime verification (post-CI)

## Validation evidence
- **Local tests**: 388/388 pass (105 in EventTimeline = 84 existing + 21 new)
- **Type check**: Pre-existing errors only, zero new
- **Plan**: `~/.claude/plans/activity-timing-clarity.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)