### PR TITLE
feat: agent detail Knowledge tab — in-place search, browse, read (AI-104)

### DIFF
--- a/services/api/src/__tests__/routes-knowledge.test.ts
+++ b/services/api/src/__tests__/routes-knowledge.test.ts
@@ -237,6 +237,84 @@ describe('Knowledge proxy routes — read entry', () => {
   });
 });
 
+describe('Knowledge proxy routes — response-field contracts', () => {
+  beforeEach(() => {
+    mockQuery.mockReset();
+    mockListEntries.mockReset();
+    mockReadEntry.mockReset();
+    mockSearchEntries.mockReset();
+    process.env.DATABASE_URL = 'postgresql://test:test@localhost:5432/test';
+  });
+
+  afterEach(() => {
+    delete process.env.DATABASE_URL;
+  });
+
+  it('entry list response contains path, title, entry_type fields', async () => {
+    mockListEntries.mockResolvedValueOnce({
+      status: 200,
+      data: [
+        { id: '1', agent_id: 'my-agent', path: 'notes/test.md', title: 'Test Note', entry_type: 'note', tags: [], status: 'active', sync_status: 'synced', created_at: '2026-01-01T00:00:00Z', updated_at: '2026-01-01T00:00:00Z' },
+      ],
+    });
+
+    const res = await request(app)
+      .get('/knowledge/entries?agent_id=my-agent')
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body[0]).toHaveProperty('path', 'notes/test.md');
+    expect(res.body[0]).toHaveProperty('title', 'Test Note');
+    expect(res.body[0]).toHaveProperty('entry_type', 'note');
+  });
+
+  it('entry detail response contains content field', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ agent_id: 'my-agent' }] });
+    mockReadEntry.mockResolvedValueOnce({
+      status: 200,
+      data: { id: '1', agent_id: 'my-agent', path: 'notes/test.md', title: 'Test Note', entry_type: 'note', content: '# Test Content', content_hash: 'abc123', tags: [], status: 'active', sync_status: 'synced', created_at: '2026-01-01T00:00:00Z', updated_at: '2026-01-01T00:00:00Z' },
+    });
+
+    const res = await request(app)
+      .get('/knowledge/entries/my-agent/notes/test.md')
+      .set('Authorization', `Bearer ${userToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('content', '# Test Content');
+  });
+
+  it('search response contains score and headline fields', async () => {
+    mockSearchEntries.mockResolvedValueOnce({
+      status: 200,
+      data: { query: 'test', results: [{ id: '1', agent_id: 'a', path: 'notes/test.md', title: 'Test', entry_type: 'note', tags: [], score: 0.85, headline: 'Some **test** content', created_at: '2026-01-01T00:00:00Z', updated_at: '2026-01-01T00:00:00Z' }], count: 1, search_type: 'fts', score_type: 'ts_rank' },
+    });
+
+    const res = await request(app)
+      .get('/knowledge/search?q=test')
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.results[0]).toHaveProperty('score', 0.85);
+    expect(res.body.results[0]).toHaveProperty('headline', 'Some **test** content');
+  });
+
+  it('search response envelope has query, count, search_type', async () => {
+    mockSearchEntries.mockResolvedValueOnce({
+      status: 200,
+      data: { query: 'test', results: [], count: 0, search_type: 'fts', score_type: 'ts_rank' },
+    });
+
+    const res = await request(app)
+      .get('/knowledge/search?q=test')
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('query', 'test');
+    expect(res.body).toHaveProperty('count', 0);
+    expect(res.body).toHaveProperty('search_type', 'fts');
+  });
+});
+
 describe('Knowledge proxy routes — search', () => {
   beforeEach(() => {
     mockQuery.mockReset();

--- a/services/ui/src/__tests__/AgentDetailClient.test.tsx
+++ b/services/ui/src/__tests__/AgentDetailClient.test.tsx
@@ -79,9 +79,19 @@ const MOCK_USAGE = {
 }
 
 const MOCK_KNOWLEDGE_ENTRIES = [
-  { id: '1', agent_id: 'research-bot', content: 'Some knowledge', created_at: '2026-01-10T00:00:00Z' },
-  { id: '2', agent_id: 'research-bot', content: 'More knowledge', created_at: '2026-01-12T00:00:00Z' },
+  { id: '1', agent_id: 'research-bot', path: 'notes/research.md', title: 'Research Notes', entry_type: 'note', tags: [], status: 'active', sync_status: 'synced', created_at: '2026-01-10T00:00:00Z', updated_at: '2026-01-10T00:00:00Z' },
+  { id: '2', agent_id: 'research-bot', path: 'docs/api.md', title: 'API Documentation', entry_type: 'doc', tags: ['api'], status: 'active', sync_status: 'synced', created_at: '2026-01-12T00:00:00Z', updated_at: '2026-01-12T00:00:00Z' },
 ]
+
+const MOCK_KNOWLEDGE_SEARCH_RESULTS = {
+  query: 'test', results: [
+    { id: '1', agent_id: 'research-bot', path: 'notes/research.md', title: 'Research Notes', entry_type: 'note', tags: [], score: 0.85, headline: 'Some **test** content', created_at: '2026-01-10T00:00:00Z', updated_at: '2026-01-10T00:00:00Z' },
+  ], count: 1, search_type: 'fts', score_type: 'ts_rank',
+}
+
+const MOCK_KNOWLEDGE_ENTRY_DETAIL = {
+  id: '1', agent_id: 'research-bot', path: 'notes/research.md', title: 'Research Notes', entry_type: 'note', content: '# Research Notes\n\nFull content here.', content_hash: 'abc123', tags: [], status: 'active', sync_status: 'synced', created_at: '2026-01-10T00:00:00Z', updated_at: '2026-01-10T00:00:00Z',
+}
 
 const ADMIN_SESSION = {
   user: { name: 'Admin', email: 'admin@hill90.com', roles: ['admin'] },
@@ -157,6 +167,12 @@ function mockFetchDefaults(agentOverride?: typeof MOCK_AGENT) {
     }
     if (typeof url === 'string' && url.includes('/api/usage')) {
       return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_USAGE) })
+    }
+    if (typeof url === 'string' && url.includes('/api/knowledge/search')) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_KNOWLEDGE_SEARCH_RESULTS) })
+    }
+    if (typeof url === 'string' && /\/api\/knowledge\/entries\/[^/]+\/.+/.test(url)) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_KNOWLEDGE_ENTRY_DETAIL) })
     }
     if (typeof url === 'string' && url.includes('/api/knowledge/entries')) {
       return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_KNOWLEDGE_ENTRIES) })
@@ -641,6 +657,208 @@ describe('AgentDetailClient', () => {
 
     // Non-admin should NOT see Reconcile button even on running agent
     expect(screen.queryByText('Reconcile')).not.toBeInTheDocument()
+  })
+
+  // U1: Knowledge tab shows entry list with paths
+  it('Knowledge tab shows entry list with paths', async () => {
+    render(<AgentDetailClient agentId="uuid-1" session={ADMIN_SESSION as any} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('ResearchBot')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Knowledge' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('notes/research.md')).toBeInTheDocument()
+    })
+    expect(screen.getByText('docs/api.md')).toBeInTheDocument()
+    expect(screen.getByText('Research Notes')).toBeInTheDocument()
+    expect(screen.getByText('API Documentation')).toBeInTheDocument()
+  })
+
+  // U2: Knowledge search triggers API call
+  it('Knowledge search triggers API call', async () => {
+    render(<AgentDetailClient agentId="uuid-1" session={ADMIN_SESSION as any} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('ResearchBot')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Knowledge' }))
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('Search knowledge entries...')).toBeInTheDocument()
+    })
+
+    fireEvent.change(screen.getByPlaceholderText('Search knowledge entries...'), { target: { value: 'test' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Search' }))
+
+    await waitFor(() => {
+      const searchCalls = mockFetch.mock.calls.filter(
+        (c: any[]) => typeof c[0] === 'string' && c[0].includes('/api/knowledge/search?q=test&agent_id=research-bot')
+      )
+      expect(searchCalls.length).toBeGreaterThan(0)
+    })
+  })
+
+  // U3: Knowledge search results display
+  it('Knowledge search results display with path and headline', async () => {
+    render(<AgentDetailClient agentId="uuid-1" session={ADMIN_SESSION as any} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('ResearchBot')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Knowledge' }))
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('Search knowledge entries...')).toBeInTheDocument()
+    })
+
+    fireEvent.change(screen.getByPlaceholderText('Search knowledge entries...'), { target: { value: 'test' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Search' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('1 results')).toBeInTheDocument()
+    })
+    expect(screen.getByText('notes/research.md')).toBeInTheDocument()
+    expect(screen.getByText('score: 0.85')).toBeInTheDocument()
+  })
+
+  // U4: Knowledge entry click loads full content
+  it('Knowledge entry click loads full content', async () => {
+    render(<AgentDetailClient agentId="uuid-1" session={ADMIN_SESSION as any} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('ResearchBot')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Knowledge' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Research Notes')).toBeInTheDocument()
+    })
+
+    // Click the first entry
+    fireEvent.click(screen.getByText('Research Notes'))
+
+    // Should fetch entry detail
+    await waitFor(() => {
+      const detailCalls = mockFetch.mock.calls.filter(
+        (c: any[]) => typeof c[0] === 'string' && c[0].includes('/api/knowledge/entries/research-bot/notes/research.md')
+      )
+      expect(detailCalls.length).toBeGreaterThan(0)
+    })
+
+    // Should show full content
+    await waitFor(() => {
+      expect(screen.getByText(/# Research Notes/)).toBeInTheDocument()
+      expect(screen.getByText(/Full content here/)).toBeInTheDocument()
+    })
+  })
+
+  // U5: Knowledge back button returns to list
+  it('Knowledge back button returns to list', async () => {
+    render(<AgentDetailClient agentId="uuid-1" session={ADMIN_SESSION as any} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('ResearchBot')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Knowledge' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Research Notes')).toBeInTheDocument()
+    })
+
+    // Click entry to go to detail view
+    fireEvent.click(screen.getByText('Research Notes'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Back to list')).toBeInTheDocument()
+    })
+
+    // Click back
+    fireEvent.click(screen.getByText('Back to list'))
+
+    // Should be back to list view
+    await waitFor(() => {
+      expect(screen.getByText('Knowledge Entries')).toBeInTheDocument()
+    })
+    expect(screen.getByText('notes/research.md')).toBeInTheDocument()
+  })
+
+  // U6: Knowledge empty state
+  it('Knowledge empty state shows message', async () => {
+    mockFetch.mockImplementation((url: string, opts?: any) => {
+      if (url === `/api/agents/uuid-1` && (!opts || !opts.method || opts.method === 'GET')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_AGENT) })
+      }
+      if (url === '/api/skills') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_ALL_SKILLS) })
+      }
+      if (typeof url === 'string' && url.includes('/api/agents/uuid-1/tool-installs')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_TOOL_INSTALLS) })
+      }
+      if (typeof url === 'string' && url.includes('/api/knowledge/entries')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve([]) })
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+    })
+
+    render(<AgentDetailClient agentId="uuid-1" session={ADMIN_SESSION as any} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('ResearchBot')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Knowledge' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('No knowledge entries')).toBeInTheDocument()
+    })
+  })
+
+  // U7: Knowledge search no results
+  it('Knowledge search no results shows message', async () => {
+    mockFetch.mockImplementation((url: string, opts?: any) => {
+      if (url === `/api/agents/uuid-1` && (!opts || !opts.method || opts.method === 'GET')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_AGENT) })
+      }
+      if (url === '/api/skills') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_ALL_SKILLS) })
+      }
+      if (typeof url === 'string' && url.includes('/api/agents/uuid-1/tool-installs')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_TOOL_INSTALLS) })
+      }
+      if (typeof url === 'string' && url.includes('/api/knowledge/search')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ query: 'nothing', results: [], count: 0, search_type: 'fts', score_type: 'ts_rank' }) })
+      }
+      if (typeof url === 'string' && url.includes('/api/knowledge/entries')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_KNOWLEDGE_ENTRIES) })
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+    })
+
+    render(<AgentDetailClient agentId="uuid-1" session={ADMIN_SESSION as any} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('ResearchBot')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Knowledge' }))
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('Search knowledge entries...')).toBeInTheDocument()
+    })
+
+    fireEvent.change(screen.getByPlaceholderText('Search knowledge entries...'), { target: { value: 'nothing' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Search' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('No results found')).toBeInTheDocument()
+    })
   })
 
 })

--- a/services/ui/src/app/agents/[id]/AgentDetailClient.tsx
+++ b/services/ui/src/app/agents/[id]/AgentDetailClient.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect, useCallback, useRef } from 'react'
+import React, { useState, useEffect, useCallback, useRef } from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import type { Session } from 'next-auth'
@@ -83,6 +83,14 @@ export default function AgentDetailClient({
   const [knowledge, setKnowledge] = useState<any[]>([])
   const [knowledgeLoading, setKnowledgeLoading] = useState(false)
   const [knowledgeFetched, setKnowledgeFetched] = useState(false)
+
+  // Knowledge tab sub-views
+  const [knowledgeSearch, setKnowledgeSearch] = useState('')
+  const [knowledgeSearchResults, setKnowledgeSearchResults] = useState<any[] | null>(null)
+  const [knowledgeSearchLoading, setKnowledgeSearchLoading] = useState(false)
+  const [selectedEntry, setSelectedEntry] = useState<any | null>(null)
+  const [selectedEntryContent, setSelectedEntryContent] = useState<string | null>(null)
+  const [selectedEntryLoading, setSelectedEntryLoading] = useState(false)
 
   // Logs
   const [logs, setLogs] = useState('')
@@ -764,46 +772,165 @@ export default function AgentDetailClient({
 
       {activeTab === 'knowledge' && (
         <div className="space-y-6">
-          <div className="rounded-lg border border-navy-700 bg-navy-800 p-5">
-            <div className="flex items-center justify-between mb-3">
-              <h2 className="text-lg font-semibold text-white">Knowledge Entries</h2>
-              <Link
-                href="/harness/knowledge"
-                className="text-sm text-brand-400 hover:text-brand-300 transition-colors"
-              >
-                Browse in Harness
-              </Link>
+          {selectedEntry ? (
+            /* Entry detail view */
+            <div className="rounded-lg border border-navy-700 bg-navy-800 p-5">
+              <div className="mb-3">
+                <button
+                  onClick={() => { setSelectedEntry(null); setSelectedEntryContent(null) }}
+                  className="text-sm text-brand-400 hover:text-brand-300 transition-colors cursor-pointer"
+                >
+                  Back to list
+                </button>
+              </div>
+              <div className="mb-3">
+                <h2 className="text-lg font-semibold text-white">{selectedEntry.title || selectedEntry.path}</h2>
+                <div className="flex items-center gap-2 mt-1">
+                  <span className="text-xs font-mono text-mountain-400">{selectedEntry.path}</span>
+                  <span className="px-1.5 py-0.5 text-xs rounded-md bg-navy-900 text-mountain-300 border border-navy-600">
+                    {selectedEntry.entry_type}
+                  </span>
+                </div>
+              </div>
+              {selectedEntryLoading ? (
+                <div className="flex items-center justify-center py-8">
+                  <div className="h-6 w-6 rounded-full border-2 border-brand-500 border-t-transparent animate-spin" />
+                </div>
+              ) : selectedEntryContent !== null ? (
+                <pre className="text-sm text-mountain-300 whitespace-pre-wrap bg-navy-900 rounded-md p-4 max-h-96 overflow-auto">
+                  {selectedEntryContent}
+                </pre>
+              ) : (
+                <p className="text-sm text-mountain-500">Failed to load entry content</p>
+              )}
             </div>
-            {knowledgeLoading ? (
-              <div className="flex items-center justify-center py-8">
-                <div className="h-6 w-6 rounded-full border-2 border-brand-500 border-t-transparent animate-spin" />
+          ) : (
+            /* List / search view */
+            <div className="rounded-lg border border-navy-700 bg-navy-800 p-5">
+              <div className="mb-3">
+                <h2 className="text-lg font-semibold text-white">Knowledge Entries</h2>
               </div>
-            ) : knowledge.length > 0 ? (
-              <div className="space-y-2">
-                <p className="text-sm text-mountain-400 mb-3">{knowledge.length} entries</p>
-                {knowledge.slice(0, 10).map((entry: any) => (
-                  <div key={entry.id} className="rounded-md border border-navy-700 bg-navy-900 p-3">
-                    <pre className="text-xs text-mountain-300 whitespace-pre-wrap line-clamp-3">
-                      {entry.content}
-                    </pre>
-                    <p className="text-xs text-mountain-500 mt-1">
-                      {new Date(entry.created_at).toLocaleString()}
-                    </p>
-                  </div>
-                ))}
-                {knowledge.length > 10 && (
-                  <p className="text-xs text-mountain-500">
-                    Showing 10 of {knowledge.length} entries.{' '}
-                    <Link href="/harness/knowledge" className="text-brand-400 hover:text-brand-300">
-                      View all
-                    </Link>
-                  </p>
-                )}
-              </div>
-            ) : (
-              <p className="text-sm text-mountain-500">No knowledge entries</p>
-            )}
-          </div>
+
+              {/* Search input */}
+              <form
+                onSubmit={(e) => {
+                  e.preventDefault()
+                  if (!knowledgeSearch.trim() || !agent) return
+                  setKnowledgeSearchLoading(true)
+                  fetch(`/api/knowledge/search?q=${encodeURIComponent(knowledgeSearch.trim())}&agent_id=${agent.agent_id}`)
+                    .then((res) => (res.ok ? res.json() : null))
+                    .then((data) => {
+                      if (data && data.results) setKnowledgeSearchResults(data.results)
+                      else setKnowledgeSearchResults([])
+                    })
+                    .catch(() => setKnowledgeSearchResults([]))
+                    .finally(() => setKnowledgeSearchLoading(false))
+                }}
+                className="flex gap-2 mb-4"
+              >
+                <input
+                  type="text"
+                  value={knowledgeSearch}
+                  onChange={(e) => {
+                    setKnowledgeSearch(e.target.value)
+                    if (!e.target.value.trim()) setKnowledgeSearchResults(null)
+                  }}
+                  placeholder="Search knowledge entries..."
+                  className="flex-1 rounded-md border border-navy-600 bg-navy-900 px-3 py-2 text-sm text-white placeholder-mountain-500 focus:outline-none focus:border-brand-500"
+                />
+                <button
+                  type="submit"
+                  disabled={knowledgeSearchLoading || !knowledgeSearch.trim()}
+                  className="px-4 py-2 text-sm font-medium rounded-md bg-brand-600 hover:bg-brand-500 text-white transition-colors disabled:opacity-50 cursor-pointer disabled:cursor-not-allowed"
+                >
+                  Search
+                </button>
+              </form>
+
+              {knowledgeSearchResults !== null ? (
+                /* Search results view */
+                <div>
+                  {knowledgeSearchLoading ? (
+                    <div className="flex items-center justify-center py-8">
+                      <div className="h-6 w-6 rounded-full border-2 border-brand-500 border-t-transparent animate-spin" />
+                    </div>
+                  ) : knowledgeSearchResults.length > 0 ? (
+                    <div className="space-y-2">
+                      <p className="text-sm text-mountain-400 mb-2">{knowledgeSearchResults.length} results</p>
+                      {knowledgeSearchResults.map((result: any) => (
+                        <button
+                          key={result.id || result.path}
+                          onClick={() => {
+                            setSelectedEntry(result)
+                            setSelectedEntryLoading(true)
+                            fetch(`/api/knowledge/entries/${agent.agent_id}/${result.path}`)
+                              .then((res) => (res.ok ? res.json() : null))
+                              .then((data) => { if (data) setSelectedEntryContent(data.content ?? null) })
+                              .catch(() => setSelectedEntryContent(null))
+                              .finally(() => setSelectedEntryLoading(false))
+                          }}
+                          className="w-full text-left rounded-md border border-navy-700 bg-navy-900 p-3 hover:border-navy-500 transition-colors cursor-pointer"
+                        >
+                          <div className="flex items-center gap-2 mb-1">
+                            <span className="text-sm font-medium text-white">{result.title || result.path}</span>
+                            <span className="px-1.5 py-0.5 text-xs rounded-md bg-navy-800 text-mountain-300 border border-navy-600">
+                              {result.entry_type}
+                            </span>
+                            {result.score != null && (
+                              <span className="text-xs text-mountain-500">score: {Number(result.score).toFixed(2)}</span>
+                            )}
+                          </div>
+                          <p className="text-xs font-mono text-mountain-400 mb-1">{result.path}</p>
+                          {result.headline && (
+                            <p className="text-xs text-mountain-300">{renderHeadline(result.headline)}</p>
+                          )}
+                        </button>
+                      ))}
+                    </div>
+                  ) : (
+                    <p className="text-sm text-mountain-500">No results found</p>
+                  )}
+                </div>
+              ) : knowledgeLoading ? (
+                <div className="flex items-center justify-center py-8">
+                  <div className="h-6 w-6 rounded-full border-2 border-brand-500 border-t-transparent animate-spin" />
+                </div>
+              ) : knowledge.length > 0 ? (
+                /* Entry list */
+                <div className="space-y-2">
+                  <p className="text-sm text-mountain-400 mb-3">{knowledge.length} entries</p>
+                  {knowledge.map((entry: any) => (
+                    <button
+                      key={entry.id}
+                      onClick={() => {
+                        setSelectedEntry(entry)
+                        setSelectedEntryLoading(true)
+                        fetch(`/api/knowledge/entries/${agent.agent_id}/${entry.path}`)
+                          .then((res) => (res.ok ? res.json() : null))
+                          .then((data) => { if (data) setSelectedEntryContent(data.content ?? null) })
+                          .catch(() => setSelectedEntryContent(null))
+                          .finally(() => setSelectedEntryLoading(false))
+                      }}
+                      className="w-full text-left rounded-md border border-navy-700 bg-navy-900 p-3 hover:border-navy-500 transition-colors cursor-pointer"
+                    >
+                      <div className="flex items-center gap-2 mb-1">
+                        <span className="text-sm font-medium text-white">{entry.title || entry.path}</span>
+                        <span className="px-1.5 py-0.5 text-xs rounded-md bg-navy-800 text-mountain-300 border border-navy-600">
+                          {entry.entry_type}
+                        </span>
+                      </div>
+                      <p className="text-xs font-mono text-mountain-400">{entry.path}</p>
+                      <p className="text-xs text-mountain-500 mt-1">
+                        {new Date(entry.created_at).toLocaleString()}
+                      </p>
+                    </button>
+                  ))}
+                </div>
+              ) : (
+                <p className="text-sm text-mountain-500">No knowledge entries</p>
+              )}
+            </div>
+          )}
         </div>
       )}
 
@@ -876,6 +1003,15 @@ export default function AgentDetailClient({
         </div>
       )}
     </>
+  )
+}
+
+function renderHeadline(text: string): React.ReactNode {
+  const parts = text.split('**')
+  return parts.map((part, i) =>
+    i % 2 === 1
+      ? React.createElement('strong', { key: i, className: 'text-white' }, part)
+      : part
   )
 }
 


### PR DESCRIPTION
## Summary
- Enriches the Agent Detail Knowledge tab with in-place list, search, and entry detail views — operators no longer need to navigate to `/harness/knowledge`
- Adds search box querying `/knowledge/search?q=&agent_id=` with safely-rendered headlines (no `dangerouslySetInnerHTML`)
- Adds entry detail view (click → full content → "Back to list")
- Removes "Browse in Harness" links — AI-104 acceptance is "in-place workflow works without requiring navigation"
- Fixes `MOCK_KNOWLEDGE_ENTRIES` shape to match real API response (`path`, `title`, `entry_type` instead of bare `content`)
- Adds 4 API response-field contract tests (A1-A4) and 7 UI interaction tests (U1-U7) = 11 new tests

## Files Changed (3 edited, 0 created, 0 deleted)
| File | Lines | Description |
|------|-------|-------------|
| `services/api/src/__tests__/routes-knowledge.test.ts` | +78 | A1-A4: response-field contract tests for list, detail, search |
| `services/ui/src/__tests__/AgentDetailClient.test.tsx` | +222/-5 | Fix mock shape, add U1-U7 knowledge interaction tests |
| `services/ui/src/app/agents/[id]/AgentDetailClient.tsx` | +214/-36 | Enriched Knowledge tab with search, entry detail, headline renderer |

## Validation Evidence

### Local — Targeted
```
API knowledge tests: 22/22 pass (including A1-A4)
UI agent detail tests: 32/32 pass (including U1-U7)
TypeScript: No new errors (pre-existing only)
```

### Local — Full Regression
```
API full suite: 449/449 pass (30 suites)
UI full suite: 447/447 pass (40 suites)
```

### "Browse in Harness" Link Decision
**Removed.** AI-104 acceptance criterion is "in-place workflow works without requiring navigation." The harness nav item (`/harness/knowledge`) already exists for cross-agent knowledge browsing. Adding a redundant link inside the in-place view contradicts the goal.

## Test Plan
- [ ] CI: API jest tests pass (routes-knowledge.test.ts)
- [ ] CI: UI vitest tests pass (AgentDetailClient.test.tsx)
- [ ] V1: Navigate to agent detail → Knowledge tab → entry list renders with paths, titles, entry_type badges
- [ ] V2: Search knowledge → results render with scores and highlighted headlines
- [ ] V3: Click an entry → full content renders in detail view
- [ ] V4: Click "Back to list" → returns to entry list
- [ ] V5: Agent with no knowledge entries → "No knowledge entries" message

Linear: AI-104

🤖 Generated with [Claude Code](https://claude.com/claude-code)