### PR TITLE
feat: agent identity model — principal types, owner claims, audit attribution

### DIFF
--- a/docs/architecture/agent-identity-model.md
+++ b/docs/architecture/agent-identity-model.md
@@ -1,0 +1,142 @@
+# Agent Identity Model
+
+> Canonical reference for Hill90's three principal types, token formats, auth boundaries, and anti-patterns.
+>
+> **Source files**: `services/api/src/middleware/auth.ts`, `services/api/src/services/akm-token.ts`, `services/api/src/services/model-router-token.ts`, `services/ai/app/auth.py`, `services/knowledge/app/middleware/agent_auth.py`. If these files are refactored, this document should be reviewed for drift.
+
+## 1. Principal Types
+
+Hill90 has three distinct principal types. Each uses a structurally incompatible authentication mechanism, preventing cross-boundary impersonation.
+
+### Human Users
+
+Human operators authenticated via Keycloak OpenID Connect.
+
+- **Token format**: RS256 JWT, signed by Keycloak JWKS
+- **Required header**: `kid` (Key ID) — used to resolve the signing key from JWKS endpoint
+- **Issuer**: `https://auth.hill90.com/realms/hill90`
+- **Key claims**: `sub` (user UUID), `realm_roles` (array), `exp`, `iat`
+- **Verification**: `services/api/src/middleware/auth.ts` — `createRequireAuth()` validates RS256 algorithm + issuer + kid resolution
+- **Authorization**: `services/api/src/middleware/role.ts` — reads `realm_roles` array for RBAC
+
+### Agent Workload Principals
+
+Autonomous agent containers authenticated via Ed25519 JWTs issued by the API service.
+
+- **Token format**: EdDSA JWT (Ed25519), signed by API service private key
+- **Issuer**: `hill90-api`
+- **Audiences**: `hill90-akm` (Knowledge service) or `hill90-model-router` (AI service)
+- **Key claims**: `sub` (agent_id slug), `owner` (creating user's UUID), `jti` (for revocation), `exp`, `iat`
+- **Lifecycle**: Issued at agent start, revoked at agent stop (JTI blacklisted)
+- **Verification**:
+  - Knowledge service: `services/knowledge/app/middleware/agent_auth.py` — EdDSA + issuer + audience
+  - AI service: `services/ai/app/auth.py` — EdDSA + issuer + audience
+
+### Service Principals
+
+Internal service-to-service communication authenticated via shared secret bearer tokens.
+
+- **Token format**: Opaque UUID strings, compared timing-safe
+- **Verification**: Per-endpoint middleware with `timingSafeEqual`
+- **No JWT claims**: Service tokens carry no identity beyond "authenticated service"
+- **Scope**: Each token authorizes a specific source → target path (see Service Account Inventory below)
+
+## 2. Token Format Reference
+
+| Principal Type | Algorithm | Issuer | Audience | Key Claims | Verification Location |
+|---------------|-----------|--------|----------|------------|----------------------|
+| Human User | RS256 | Keycloak realm | N/A | `sub`, `realm_roles` | `middleware/auth.ts` |
+| Agent (AKM) | EdDSA | `hill90-api` | `hill90-akm` | `sub`, `owner`, `scopes`, `jti` | `knowledge/agent_auth.py` |
+| Agent (Model Router) | EdDSA | `hill90-api` | `hill90-model-router` | `sub`, `owner`, `jti` | `ai/auth.py` |
+| Agent (Delegation) | EdDSA | `hill90-api` | `hill90-model-router` | `sub`, `owner`, `delegation_id`, `parent_jti`, `jti` | `ai/auth.py` |
+| Service | N/A (opaque) | N/A | N/A | None | Per-endpoint handler |
+
+## 3. Auth Boundaries
+
+The structural separation between principal types is enforced by incompatible cryptographic algorithms and claim requirements:
+
+```
+Human (RS256 + kid)  ──►  API Service requireAuth()
+                              │
+                              ├── Requires RS256 algorithm
+                              ├── Requires kid header for JWKS lookup
+                              └── Validates Keycloak issuer
+
+Agent (EdDSA)        ──►  AI Service / Knowledge Service
+                              │
+                              ├── Requires EdDSA algorithm
+                              ├── No kid header expected
+                              ├── Validates 'hill90-api' issuer
+                              └── Validates service-specific audience
+
+Service (opaque)     ──►  /internal/* endpoints
+                              │
+                              ├── Registered BEFORE requireAuth middleware
+                              ├── Timing-safe string comparison
+                              └── Per-endpoint token matching
+```
+
+**Why cross-auth is impossible**:
+- An agent EdDSA token presented to `requireAuth()` fails because: (1) wrong algorithm (EdDSA vs RS256), (2) no `kid` header, (3) wrong issuer
+- A Keycloak RS256 token presented to `verify_model_router_token()` fails because: (1) wrong algorithm (RS256 vs EdDSA), (2) wrong issuer
+- Service tokens are routed to separate middleware before `requireAuth()` runs — no overlap
+
+These boundaries are verified by tests in `auth-boundary.test.ts` (AB-1/2/3) and `test_auth.py` (AB-4).
+
+## 4. Owner Attribution Chain
+
+Every agent action traces back to the human who created it:
+
+```
+Human User (sub: user-uuid)
+    │
+    ├── Creates agent (agents.created_by = user-uuid)
+    │
+    ├── Starts agent → API issues tokens:
+    │       ├── AKM token: owner = agent.created_by
+    │       └── Model-router token: owner = agent.created_by
+    │
+    └── Agent runs → tokens carry owner claim:
+            ├── Knowledge service: scoped queries via owner claim
+            ├── AI service: AgentClaims.owner for attribution
+            └── Audit logs: user_sub + principal_type trace the chain
+```
+
+**Known limitation**: Delegation tokens (child agents created via `POST /v1/delegate`) do not currently carry the `owner` claim from the parent. The AI service resolves ownership via DB lookup from the parent's delegation record. This is documented as future hardening — not a security gap, as delegation enforcement is handled server-side.
+
+## 5. Service Account Inventory
+
+| Token | Env Var | Source Service | Target Service | Target Path | Rotation |
+|-------|---------|---------------|----------------|-------------|----------|
+| AKM internal service token | `AKM_INTERNAL_SERVICE_TOKEN` | API | Knowledge | `/internal/*` | Via vault seed |
+| Model-router internal service token | `MODEL_ROUTER_INTERNAL_SERVICE_TOKEN` | API, AI | AI | `/internal/*` | Via vault seed |
+| Chat callback token | `CHAT_CALLBACK_TOKEN` | Agentbox | API | `/internal/chat/callback` | Via vault seed |
+| AKM signing private key | `AKM_SIGNING_PRIVATE_KEY` | API (signer) | Knowledge (verifier via public key) | JWT payload | Key rotation via vault |
+| Model-router signing private key | `MODEL_ROUTER_SIGNING_PRIVATE_KEY` | API (signer) | AI (verifier via public key) | JWT payload | Key rotation via vault |
+
+All secrets are stored in OpenBao vault and injected at deploy time. SOPS serves as bootstrap/DR backup. See [Secrets Architecture](./secrets-model.md).
+
+## 6. Anti-Patterns
+
+### Agent-as-Human-User (Structurally Prevented)
+
+**Anti-pattern**: Giving an agent container a Keycloak credential (client_id/secret or user password) so it can call API routes directly as a "user."
+
+**Why it's prevented**:
+1. Agent tokens use EdDSA — they cannot pass `requireAuth()` which requires RS256 + kid
+2. API routes read `realm_roles` from Keycloak JWT — agent tokens have no roles
+3. Agent containers receive only explicitly injected env vars (AKM token, model-router token, work token, chat callback token) — no Keycloak credentials are ever injected
+
+**Correct pattern**: Agents interact with platform services via their Ed25519 JWTs (Knowledge, AI services). The API service acts on behalf of agents only through internal service endpoints.
+
+### Service-Token-as-Identity (Avoid)
+
+Service tokens authenticate the calling service, not a specific user or agent. When a service-initiated action needs attribution (e.g., `elevated_agent_response` audit log), the code must pass the relevant agent/user ID explicitly — the service token itself carries no identity.
+
+The `auditLog()` function enforces this by requiring a `principalType` parameter (`'human' | 'agent' | 'service'`) alongside the `userSub`, preventing conflation of service identity with user identity.
+
+## 7. Cross-References
+
+- [Security Architecture](./security.md) — network segmentation, container isolation, service token table
+- [Secrets Architecture](./secrets-model.md) — vault paths, SOPS backup, rotation procedures
+- [Architecture Overview](./overview.md) — system topology and service interactions

--- a/docs/architecture/security.md
+++ b/docs/architecture/security.md
@@ -101,9 +101,12 @@ Internal service endpoints use bearer tokens (shared secrets) distinct from agen
 |-------|---------|---------|-----------------|
 | AKM internal service token | `AKM_INTERNAL_SERVICE_TOKEN` | API service | Knowledge service `/internal/*` endpoints |
 | Model-router internal service token | `MODEL_ROUTER_INTERNAL_SERVICE_TOKEN` | API service, AI service | AI service `/internal/*` endpoints |
+| Chat callback token | `CHAT_CALLBACK_TOKEN` | Agentbox | API service `/internal/chat/callback` |
 | Delegation token signing | `MODEL_ROUTER_SIGNING_PRIVATE_KEY` | API service | Signs child delegation JWTs (private key never leaves API service) |
 
 Both AKM and model-router signing private keys are held exclusively by the API service. The AI and Knowledge services only hold the corresponding public keys for JWT verification.
+
+For a comprehensive view of the three principal types (human, agent, service) and their auth boundaries, see [Agent Identity Model](./agent-identity-model.md).
 
 ## Network Segmentation
 

--- a/services/ai/app/auth.py
+++ b/services/ai/app/auth.py
@@ -28,6 +28,7 @@ class AgentClaims:
     exp: int
     iat: int
     jti: str
+    owner: str | None = None
     delegation_id: str | None = None
     parent_jti: str | None = None
 
@@ -91,6 +92,7 @@ def verify_model_router_token(
         exp=payload["exp"],
         iat=payload["iat"],
         jti=jti,
+        owner=payload.get("owner"),
         delegation_id=delegation_id,
         parent_jti=parent_jti,
     )

--- a/services/ai/tests/conftest.py
+++ b/services/ai/tests/conftest.py
@@ -35,6 +35,7 @@ def make_jwt(ed25519_keypair):
         exp: int | None = None,
         iat: int | None = None,
         jti: str = "test-jti-001",
+        owner: str | None = None,
     ) -> str:
         now = int(time.time())
         payload = {
@@ -44,6 +45,7 @@ def make_jwt(ed25519_keypair):
             "exp": exp if exp is not None else now + 3600,
             "iat": iat if iat is not None else now,
             "jti": jti,
+            **({"owner": owner} if owner else {}),
         }
         return pyjwt.encode(payload, private_pem, algorithm="EdDSA")
 

--- a/services/ai/tests/test_auth.py
+++ b/services/ai/tests/test_auth.py
@@ -77,3 +77,51 @@ class TestVerifyModelRouterToken:
         token = pyjwt.encode(payload, private_pem, algorithm="EdDSA")
         with pytest.raises(AuthError):
             verify_model_router_token(token, public_pem)
+
+    def test_valid_token_with_owner_populates_claims(self, ed25519_keypair, make_jwt):
+        """AI-1: Valid token with owner claim populates AgentClaims.owner."""
+        _, public_pem = ed25519_keypair
+        token = make_jwt(owner="user-uuid-123")
+        claims = verify_model_router_token(token, public_pem)
+        assert claims.owner == "user-uuid-123"
+
+    def test_token_without_owner_sets_none(self, ed25519_keypair, make_jwt):
+        """AI-2: Token without owner claim sets AgentClaims.owner to None."""
+        _, public_pem = ed25519_keypair
+        token = make_jwt()
+        claims = verify_model_router_token(token, public_pem)
+        assert claims.owner is None
+
+    def test_rs256_keycloak_token_rejected(self, ed25519_keypair):
+        """AB-4: RS256 Keycloak token rejected by model-router verifier."""
+        import jwt as pyjwt
+        from cryptography.hazmat.primitives.asymmetric import rsa
+        from cryptography.hazmat.primitives.serialization import (
+            Encoding,
+            NoEncryption,
+            PrivateFormat,
+        )
+
+        _, public_pem = ed25519_keypair
+
+        # Generate an RSA key to simulate a Keycloak token
+        rsa_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        rsa_private_pem = rsa_key.private_bytes(
+            Encoding.PEM, PrivateFormat.PKCS8, NoEncryption()
+        )
+
+        payload = {
+            "sub": "human-user-id",
+            "iss": "https://auth.hill90.com/realms/hill90",
+            "aud": "hill90-model-router",
+            "exp": int(time.time()) + 3600,
+            "iat": int(time.time()),
+            "jti": "keycloak-jti-001",
+            "realm_roles": ["user", "admin"],
+        }
+        token = pyjwt.encode(
+            payload, rsa_private_pem, algorithm="RS256", headers={"kid": "keycloak-kid-1"}
+        )
+
+        with pytest.raises(AuthError):
+            verify_model_router_token(token, public_pem)

--- a/services/api/src/__tests__/audit.test.ts
+++ b/services/api/src/__tests__/audit.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Tests for structured audit log helper.
+ * Verifies principal_type field is emitted in every log entry.
+ */
+
+import { auditLog } from '../helpers/audit';
+
+describe('auditLog', () => {
+  let consoleSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+  });
+
+  it('AU-1: emits principal_type field for human', () => {
+    auditLog('test_action', 'agent-1', 'user-uuid-123', 'human');
+    expect(consoleSpy).toHaveBeenCalledTimes(1);
+    const logged = JSON.parse(consoleSpy.mock.calls[0][0]);
+    expect(logged.principal_type).toBe('human');
+  });
+
+  it('AU-2: emits principal_type field for service', () => {
+    auditLog('test_action', 'agent-1', 'service', 'service');
+    expect(consoleSpy).toHaveBeenCalledTimes(1);
+    const logged = JSON.parse(consoleSpy.mock.calls[0][0]);
+    expect(logged.principal_type).toBe('service');
+  });
+
+  it('AU-3: output includes all required fields', () => {
+    auditLog('test_action', 'agent-1', 'user-uuid-123', 'human', { custom_key: 'value' });
+    expect(consoleSpy).toHaveBeenCalledTimes(1);
+    const logged = JSON.parse(consoleSpy.mock.calls[0][0]);
+    expect(logged).toEqual(expect.objectContaining({
+      type: 'audit',
+      action: 'test_action',
+      agent_id: 'agent-1',
+      user_sub: 'user-uuid-123',
+      principal_type: 'human',
+      custom_key: 'value',
+    }));
+    expect(logged.timestamp).toBeDefined();
+  });
+});

--- a/services/api/src/__tests__/auth-boundary.test.ts
+++ b/services/api/src/__tests__/auth-boundary.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Cross-auth boundary tests.
+ *
+ * Proves that the structural separation between human (Keycloak RS256),
+ * agent (Ed25519), and service (shared secret) auth paths holds.
+ */
+
+import request from 'supertest';
+import * as crypto from 'crypto';
+import * as jwt from 'jsonwebtoken';
+import { createApp } from '../app';
+
+// Generate a throwaway RSA keypair for Keycloak-style tokens
+const { privateKey: rsaPrivateKey, publicKey: rsaPublicKey } = crypto.generateKeyPairSync('rsa', {
+  modulusLength: 2048,
+  publicKeyEncoding: { type: 'spki', format: 'pem' },
+  privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+});
+
+// Generate Ed25519 keypair for agent tokens
+const { privateKey: ed25519PrivateKey } = crypto.generateKeyPairSync('ed25519');
+
+const TEST_ISSUER = 'https://auth.hill90.com/realms/hill90';
+
+const app = createApp({
+  issuer: TEST_ISSUER,
+  getSigningKey: async () => rsaPublicKey,
+});
+
+function base64url(input: string | Buffer): string {
+  const buf = typeof input === 'string' ? Buffer.from(input) : input;
+  return buf.toString('base64url');
+}
+
+function makeAgentToken(agentId: string): string {
+  const header = base64url(JSON.stringify({ alg: 'EdDSA', typ: 'JWT' }));
+  const now = Math.floor(Date.now() / 1000);
+  const payload = base64url(JSON.stringify({
+    sub: agentId,
+    iss: 'hill90-api',
+    aud: 'hill90-model-router',
+    exp: now + 3600,
+    iat: now,
+    jti: crypto.randomUUID(),
+  }));
+  const signingInput = `${header}.${payload}`;
+  const signature = crypto.sign(null, Buffer.from(signingInput), ed25519PrivateKey);
+  return `${signingInput}.${signature.toString('base64url')}`;
+}
+
+describe('Cross-auth boundary', () => {
+  it('AB-1: Ed25519 agent token rejected by requireAuth', async () => {
+    const agentToken = makeAgentToken('test-agent-1');
+    const res = await request(app)
+      .get('/me')
+      .set('Authorization', `Bearer ${agentToken}`);
+    expect(res.status).toBe(401);
+  });
+
+  it('AB-2: Agent token without kid header rejected by requireAuth', async () => {
+    // Ed25519 tokens never have a kid header — this proves they fail
+    const agentToken = makeAgentToken('test-agent-2');
+    const res = await request(app)
+      .get('/me')
+      .set('Authorization', `Bearer ${agentToken}`);
+    expect(res.status).toBe(401);
+  });
+
+  it('AB-3: Random bearer string rejected by requireAuth', async () => {
+    const res = await request(app)
+      .get('/me')
+      .set('Authorization', 'Bearer totally-not-a-jwt');
+    expect(res.status).toBe(401);
+  });
+});

--- a/services/api/src/__tests__/model-router-token.test.ts
+++ b/services/api/src/__tests__/model-router-token.test.ts
@@ -36,14 +36,14 @@ function verifyEd25519Jwt(token: string, publicKey: crypto.KeyObject): boolean {
 
 describe('generateAgentModelRouterToken', () => {
   it('generates a valid Ed25519 JWT', async () => {
-    const result = await generateAgentModelRouterToken('test-agent-1');
+    const result = await generateAgentModelRouterToken('test-agent-1', 'test-owner');
     expect(result.token).toBeTruthy();
     expect(result.jti).toBeTruthy();
     expect(result.expiresAt).toBeGreaterThan(Math.floor(Date.now() / 1000));
   });
 
   it('uses hill90-model-router audience (not hill90-akm)', async () => {
-    const result = await generateAgentModelRouterToken('test-agent-1');
+    const result = await generateAgentModelRouterToken('test-agent-1', 'test-owner');
     const { payload } = decodeJwt(result.token);
     expect(payload.aud).toBe('hill90-model-router');
     expect(payload.iss).toBe('hill90-api');
@@ -51,7 +51,7 @@ describe('generateAgentModelRouterToken', () => {
   });
 
   it('JWT carries identity only — no model scopes in claims', async () => {
-    const result = await generateAgentModelRouterToken('test-agent-1');
+    const result = await generateAgentModelRouterToken('test-agent-1', 'test-owner');
     const { payload } = decodeJwt(result.token);
     expect(payload.scopes).toBeUndefined();
     expect(payload.models).toBeUndefined();
@@ -59,7 +59,7 @@ describe('generateAgentModelRouterToken', () => {
   });
 
   it('includes jti for revocation tracking', async () => {
-    const result = await generateAgentModelRouterToken('test-agent-1');
+    const result = await generateAgentModelRouterToken('test-agent-1', 'test-owner');
     const { payload } = decodeJwt(result.token);
     expect(payload.jti).toBe(result.jti);
     // JTI should be a UUID
@@ -69,14 +69,14 @@ describe('generateAgentModelRouterToken', () => {
   });
 
   it('signature verifies with the public key', async () => {
-    const result = await generateAgentModelRouterToken('test-agent-1');
+    const result = await generateAgentModelRouterToken('test-agent-1', 'test-owner');
     const valid = verifyEd25519Jwt(result.token, testPublicKey);
     expect(valid).toBe(true);
   });
 
   it('has 1-hour expiry', async () => {
     const before = Math.floor(Date.now() / 1000);
-    const result = await generateAgentModelRouterToken('test-agent-1');
+    const result = await generateAgentModelRouterToken('test-agent-1', 'test-owner');
     const { payload } = decodeJwt(result.token);
     // exp should be ~1h from now (allow 2s tolerance)
     expect(payload.exp).toBeGreaterThanOrEqual(before + 3600 - 2);
@@ -86,7 +86,7 @@ describe('generateAgentModelRouterToken', () => {
 
 describe('getModelRouterEnvVars', () => {
   it('returns MODEL_ROUTER_TOKEN and MODEL_ROUTER_URL', async () => {
-    const result = await generateAgentModelRouterToken('test-agent-1');
+    const result = await generateAgentModelRouterToken('test-agent-1', 'test-owner');
     const envVars = getModelRouterEnvVars(result);
     expect(envVars).toContainEqual(expect.stringMatching(/^MODEL_ROUTER_TOKEN=/));
     expect(envVars).toContainEqual(expect.stringMatching(/^MODEL_ROUTER_URL=/));
@@ -96,5 +96,21 @@ describe('getModelRouterEnvVars', () => {
 describe('isModelRouterConfigured', () => {
   it('returns true when private key is set', () => {
     expect(isModelRouterConfigured()).toBe(true);
+  });
+});
+
+describe('model-router token owner claim', () => {
+  it('MRT-1: includes owner claim in JWT payload', async () => {
+    const result = await generateAgentModelRouterToken('test-agent-1', 'owner-uuid-123');
+    const { payload } = decodeJwt(result.token);
+    expect(payload.owner).toBe('owner-uuid-123');
+  });
+
+  it('MRT-2: owner claim survives Ed25519 round-trip', async () => {
+    const result = await generateAgentModelRouterToken('test-agent-1', 'owner-uuid-456');
+    const valid = verifyEd25519Jwt(result.token, testPublicKey);
+    expect(valid).toBe(true);
+    const { payload } = decodeJwt(result.token);
+    expect(payload.owner).toBe('owner-uuid-456');
   });
 });

--- a/services/api/src/helpers/audit.ts
+++ b/services/api/src/helpers/audit.ts
@@ -2,12 +2,19 @@
  * Structured audit log helper.
  * Emits JSON to stdout for Promtail → Loki collection.
  */
-export function auditLog(action: string, agentId: string, userSub: string, extra?: Record<string, unknown>): void {
+export function auditLog(
+  action: string,
+  agentId: string,
+  userSub: string,
+  principalType: 'human' | 'agent' | 'service',
+  extra?: Record<string, unknown>,
+): void {
   console.log(JSON.stringify({
     type: 'audit',
     action,
     agent_id: agentId,
     user_sub: userSub,
+    principal_type: principalType,
     timestamp: new Date().toISOString(),
     ...extra,
   }));

--- a/services/api/src/routes/agents.ts
+++ b/services/api/src/routes/agents.ts
@@ -235,7 +235,7 @@ router.post('/', requireRole('user'), async (req: Request, res: Response) => {
       }
       if (skillRows.some((s: any) => ELEVATED_SCOPES.includes(s.scope)) && !isAdmin(req)) {
         const elevatedScope = skillRows.find((s: any) => ELEVATED_SCOPES.includes(s.scope))!.scope;
-        auditLog('skill_assign_denied', agent_id, user.sub, { skill_scope: elevatedScope, endpoint: 'POST /agents' });
+        auditLog('skill_assign_denied', agent_id, user.sub, 'human', { skill_scope: elevatedScope, endpoint: 'POST /agents' });
         res.status(403).json({ error: `Assigning ${elevatedScope} skills requires admin role` });
         return;
       }
@@ -486,7 +486,7 @@ router.put('/:id', requireRole('user'), async (req: Request, res: Response) => {
         }
         if (skillRows.some((s: any) => ELEVATED_SCOPES.includes(s.scope)) && !isAdmin(req)) {
           const elevatedScope = skillRows.find((s: any) => ELEVATED_SCOPES.includes(s.scope))!.scope;
-          auditLog('skill_assign_denied', existing[0].agent_id, user.sub, { skill_scope: elevatedScope, endpoint: 'PUT /agents/:id' });
+          auditLog('skill_assign_denied', existing[0].agent_id, user.sub, 'human', { skill_scope: elevatedScope, endpoint: 'PUT /agents/:id' });
           res.status(403).json({ error: `Assigning ${elevatedScope} skills requires admin role` });
           return;
         }
@@ -506,7 +506,7 @@ router.put('/:id', requireRole('user'), async (req: Request, res: Response) => {
           .filter((cs: any) => !skill_ids.includes(cs.skill_id))
           .filter((cs: any) => ELEVATED_SCOPES.includes(cs.scope));
         if (removedIds.length > 0) {
-          auditLog('skill_remove_denied', existing[0].agent_id, user.sub, { skill_scope: removedIds[0].scope, endpoint: 'PUT /agents/:id' });
+          auditLog('skill_remove_denied', existing[0].agent_id, user.sub, 'human', { skill_scope: removedIds[0].scope, endpoint: 'PUT /agents/:id' });
           res.status(403).json({ error: `Cannot remove ${removedIds[0].scope} skills without admin role` });
           return;
         }
@@ -603,7 +603,7 @@ router.delete('/:id', requireRole('admin'), async (req: Request, res: Response) 
     // Purge volumes if requested
     if (req.query.purge === 'true') {
       await removeAgentVolumes(agent.agent_id);
-      auditLog('purge_volumes', agent.agent_id, user.sub);
+      auditLog('purge_volumes', agent.agent_id, user.sub, 'human');
     }
 
     // Remove config files
@@ -612,7 +612,7 @@ router.delete('/:id', requireRole('admin'), async (req: Request, res: Response) 
     // Delete from DB
     await getPool().query('DELETE FROM agents WHERE id = $1', [req.params.id]);
 
-    auditLog('delete', agent.agent_id, user.sub);
+    auditLog('delete', agent.agent_id, user.sub, 'human');
     res.json({ deleted: true });
   } catch (err) {
     console.error('[agents] Delete error:', err);
@@ -684,7 +684,7 @@ router.post('/:id/start', requireRole('admin'), async (req: Request, res: Respon
     let modelRouterExp: number | null = null;
     if (isModelRouterConfigured()) {
       try {
-        const mrToken = await generateAgentModelRouterToken(agent.agent_id);
+        const mrToken = await generateAgentModelRouterToken(agent.agent_id, agent.created_by);
         modelRouterEnv = getModelRouterEnvVars(mrToken);
         modelRouterJti = mrToken.jti;
         modelRouterExp = mrToken.expiresAt;
@@ -750,7 +750,7 @@ router.post('/:id/start', requireRole('admin'), async (req: Request, res: Respon
       [containerId, workToken, req.params.id]
     );
 
-    auditLog('start', agent.agent_id, user.sub, { container_id: containerId, network, akm_jti: akmJti, model_router_jti: modelRouterJti });
+    auditLog('start', agent.agent_id, user.sub, 'human', { container_id: containerId, network, akm_jti: akmJti, model_router_jti: modelRouterJti });
     res.json({ status: 'running', container_id: containerId });
   } catch (err: any) {
     console.error('[agents] Start error:', err);
@@ -825,7 +825,7 @@ router.post('/:id/stop', requireRole('admin'), async (req: Request, res: Respons
       [req.params.id]
     );
 
-    auditLog('stop', agent.agent_id, user.sub);
+    auditLog('stop', agent.agent_id, user.sub, 'human');
     res.json({ status: 'stopped' });
   } catch (err: any) {
     console.error('[agents] Stop error:', err);
@@ -912,7 +912,7 @@ router.post('/:id/reconcile-tools', requireRole('admin'), async (req: Request, r
     }
 
     const result = await reconcileToolInstalls(agent.id, agent.agent_id);
-    auditLog('reconcile_tools', agent.agent_id, user.sub, result);
+    auditLog('reconcile_tools', agent.agent_id, user.sub, 'human', result);
     res.json(result);
   } catch (err: any) {
     console.error('[agents] Reconcile tools error:', err);
@@ -1298,7 +1298,7 @@ router.post('/:id/skills', requireRole('user'), async (req: Request, res: Respon
 
     const skillScope = skillRows[0].scope;
     if (ELEVATED_SCOPES.includes(skillScope) && !isAdmin(req)) {
-      auditLog('skill_assign_denied', req.params.id, user.sub, { skill_id, skill_scope: skillScope, endpoint: 'POST /agents/:id/skills' });
+      auditLog('skill_assign_denied', req.params.id, user.sub, 'human', { skill_id, skill_scope: skillScope, endpoint: 'POST /agents/:id/skills' });
       res.status(403).json({ error: `Assigning ${skillScope} skills requires admin role` });
       return;
     }
@@ -1335,7 +1335,7 @@ router.post('/:id/skills', requireRole('user'), async (req: Request, res: Respon
       [JSON.stringify(mergedConfig), req.params.id]
     );
 
-    auditLog('skill_assign', req.params.id, user.sub, { skill_id, skill_scope: skillScope, endpoint: 'POST /agents/:id/skills' });
+    auditLog('skill_assign', req.params.id, user.sub, 'human', { skill_id, skill_scope: skillScope, endpoint: 'POST /agents/:id/skills' });
     res.status(201).json(assignmentRow);
   } catch (err: any) {
     console.error('[agents] Assign skill error:', err);
@@ -1375,7 +1375,7 @@ router.delete('/:id/skills/:skillId', requireRole('user'), async (req: Request, 
     const skillScope = skillRows[0].scope;
     if (ELEVATED_SCOPES.includes(skillScope) && !isAdmin(req)) {
       const user = (req as any).user;
-      auditLog('skill_remove_denied', req.params.id, user.sub, { skill_id: req.params.skillId, skill_scope: skillScope, endpoint: 'DELETE /agents/:id/skills/:skillId' });
+      auditLog('skill_remove_denied', req.params.id, user.sub, 'human', { skill_id: req.params.skillId, skill_scope: skillScope, endpoint: 'DELETE /agents/:id/skills/:skillId' });
       res.status(403).json({ error: `Removing ${skillScope} skills requires admin role` });
       return;
     }
@@ -1407,7 +1407,7 @@ router.delete('/:id/skills/:skillId', requireRole('user'), async (req: Request, 
     );
 
     const user = (req as any).user;
-    auditLog('skill_remove', req.params.id, user.sub, { skill_id: req.params.skillId, skill_scope: skillScope, endpoint: 'DELETE /agents/:id/skills/:skillId' });
+    auditLog('skill_remove', req.params.id, user.sub, 'human', { skill_id: req.params.skillId, skill_scope: skillScope, endpoint: 'DELETE /agents/:id/skills/:skillId' });
     res.json({ removed: true });
   } catch (err) {
     console.error('[agents] Remove skill error:', err);

--- a/services/api/src/routes/chat.ts
+++ b/services/api/src/routes/chat.ts
@@ -293,7 +293,7 @@ router.post('/threads', requireRole('user'), async (req: Request, res: Response)
     for (const agent of agents) {
       const elevatedScope = await getAgentElevatedScope(agent!.id);
       if (elevatedScope && !admin) {
-        auditLog('chat_elevated_denied', agent!.agent_id, user.sub, { skill_scope: elevatedScope, endpoint: 'POST /chat/threads' });
+        auditLog('chat_elevated_denied', agent!.agent_id, user.sub, 'human', { skill_scope: elevatedScope, endpoint: 'POST /chat/threads' });
         res.status(403).json({
           error: `Elevated agent ${agent!.name || agent!.agent_id} (${elevatedScope}) requires admin privileges`,
         });
@@ -608,7 +608,7 @@ router.put('/threads/:id/participants', requireRole('user'), async (req: Request
       for (const agentUuid of add) {
         const elevatedScope = await getAgentElevatedScope(agentUuid);
         if (elevatedScope && !admin) {
-          auditLog('chat_elevated_denied', agentUuid, user.sub, { skill_scope: elevatedScope, endpoint: 'PUT /chat/threads/:id/participants' });
+          auditLog('chat_elevated_denied', agentUuid, user.sub, 'human', { skill_scope: elevatedScope, endpoint: 'PUT /chat/threads/:id/participants' });
           res.status(403).json({
             error: `Elevated agent ${agentUuid} (${elevatedScope}) requires admin privileges`,
           });
@@ -738,7 +738,7 @@ router.post('/threads/:id/messages', requireRole('user'), async (req: Request, r
     for (const agent of targetAgents) {
       const elevatedScope = await getAgentElevatedScope(agent.id);
       if (elevatedScope && !admin) {
-        auditLog('chat_elevated_denied', agent.agent_id, user.sub, { skill_scope: elevatedScope, endpoint: 'POST /chat/threads/:id/messages' });
+        auditLog('chat_elevated_denied', agent.agent_id, user.sub, 'human', { skill_scope: elevatedScope, endpoint: 'POST /chat/threads/:id/messages' });
         res.status(403).json({
           error: `Elevated agent ${agent.name || agent.agent_id} (${elevatedScope}) requires admin privileges`,
         });
@@ -1261,7 +1261,7 @@ export async function chatCallbackHandler(req: Request, res: Response): Promise<
     if (msgRows.length > 0) {
       const elevatedScope = await getAgentElevatedScope(msgRows[0].author_id);
       if (elevatedScope) {
-        auditLog('elevated_agent_response', msgRows[0].author_id, 'service', { message_id, skill_scope: elevatedScope, status: finalStatus });
+        auditLog('elevated_agent_response', msgRows[0].author_id, 'service', 'service', { message_id, skill_scope: elevatedScope, status: finalStatus });
       }
     }
   } catch (tagErr) {

--- a/services/api/src/routes/skills.ts
+++ b/services/api/src/routes/skills.ts
@@ -201,7 +201,7 @@ router.put('/:id', requireRole('admin'), async (req: Request, res: Response) => 
       );
       if (runningAgents.length > 0) {
         const user = (req as any).user;
-        auditLog('skill_scope_change_blocked', req.params.id, user.sub, {
+        auditLog('skill_scope_change_blocked', req.params.id, user.sub, 'human', {
           old_scope: oldScope, new_scope: newScope, reason: 'running_agents',
           running_agents: runningAgents.map((a: any) => a.agent_id),
         });
@@ -220,7 +220,7 @@ router.put('/:id', requireRole('admin'), async (req: Request, res: Response) => 
         );
         if (countRows[0].count > 0) {
           const user = (req as any).user;
-          auditLog('skill_scope_change_blocked', req.params.id, user.sub, {
+          auditLog('skill_scope_change_blocked', req.params.id, user.sub, 'human', {
             old_scope: oldScope, new_scope: newScope, reason: 'escalation_with_assignments',
             assigned_count: countRows[0].count,
           });
@@ -256,7 +256,7 @@ router.put('/:id', requireRole('admin'), async (req: Request, res: Response) => 
     // Audit scope change if scope actually changed
     if (oldScope !== newScope) {
       const user = (req as any).user;
-      auditLog('skill_scope_change', req.params.id, user.sub, { old_scope: oldScope, new_scope: newScope });
+      auditLog('skill_scope_change', req.params.id, user.sub, 'human', { old_scope: oldScope, new_scope: newScope });
     }
 
     // Update skill_tools if provided

--- a/services/api/src/services/akm-token.ts
+++ b/services/api/src/services/akm-token.ts
@@ -40,7 +40,7 @@ export interface AkmTokenResult {
 export async function generateAgentAkmToken(
   agentId: string,
   scopes: string[] = ['akm:read', 'akm:write'],
-  owner?: string,
+  owner: string,
 ): Promise<AkmTokenResult> {
   const privateKey = getPrivateKey();
   const jti = crypto.randomUUID();
@@ -57,7 +57,7 @@ export async function generateAgentAkmToken(
     iat: now,
     jti,
     scopes,
-    ...(owner ? { owner } : {}),
+    owner,
   }));
 
   const signingInput = `${header}.${payload}`;

--- a/services/api/src/services/model-router-token.ts
+++ b/services/api/src/services/model-router-token.ts
@@ -40,6 +40,7 @@ export interface ModelRouterTokenResult {
  */
 export async function generateAgentModelRouterToken(
   agentId: string,
+  owner: string,
 ): Promise<ModelRouterTokenResult> {
   const privateKey = getPrivateKey();
   const jti = crypto.randomUUID();
@@ -54,6 +55,7 @@ export async function generateAgentModelRouterToken(
     exp: expiresAt,
     iat: now,
     jti,
+    owner,
   }));
 
   const signingInput = `${header}.${payload}`;


### PR DESCRIPTION
## Summary
- Make the three principal types (human, agent, service) explicit with architecture documentation
- Add `principal_type` field to all audit log entries (19 call sites updated)
- Add `owner` claim to model-router tokens (matching existing AKM pattern)
- Make AKM token `owner` parameter required (was vestigially optional)
- Add AI service `AgentClaims.owner` field to extract owner from model-router tokens
- Add cross-auth boundary tests proving structural separation (EdDSA vs RS256)
- Add `CHAT_CALLBACK_TOKEN` to service token table in `security.md`

## Linear
- Issue: AI-115

## Validation Evidence
- API (full suite): 470/470 tests pass (33 suites) — includes 10 new tests (AB-1/2/3, AU-1/2/3, MRT-1/2 + existing updated)
- AI (full suite): 130/130 tests pass — includes 3 new tests (AI-1, AI-2, AB-4)
- TypeScript: `tsc --noEmit` clean, no new errors
- Knowledge: 48 unit tests pass (integration tests require live DB — pre-existing, no changes to knowledge service)
- Doc: `docs/architecture/agent-identity-model.md` created with 7 sections
- Security.md: `CHAT_CALLBACK_TOKEN` row added to service token table, cross-ref to identity doc

## Test plan
- [x] `npx jest --verbose` — 470/470 pass (API service)
- [x] `npx jest auth-boundary --verbose` — AB-1/2/3 pass
- [x] `npx jest audit --verbose` — AU-1/2/3 pass
- [x] `npx jest model-router-token --verbose` — 10/10 pass (MRT-1/2 + existing)
- [x] `python3 -m pytest tests/test_auth.py -v` — 11/11 pass (AI-1, AI-2, AB-4 + existing)
- [x] `python3 -m pytest tests/ -v` — 130/130 pass (AI full suite)
- [x] `npx tsc --noEmit` — clean
- [ ] CI checks pass

## Notes
- 3 new files, 11 edited files (14 total)
- All changes are additive and backward compatible — existing tokens without `owner` parse to `None`
- Delegation token `owner` propagation deferred (documented as future hardening in architecture doc)
- VPS runtime verification deferred to post-merge (V1-V6 items in plan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)