### PR TITLE
feat: add admin CRUD + audit for container profiles

### DIFF
--- a/docs/site/openapi.yaml
+++ b/docs/site/openapi.yaml
@@ -149,6 +149,43 @@ components:
           type: string
           format: date-time
 
+    ContainerProfileCreate:
+      type: object
+      required:
+        - name
+        - docker_image
+      properties:
+        name:
+          type: string
+          description: Unique profile name
+        description:
+          type: string
+        docker_image:
+          type: string
+          description: Docker image for agent containers
+        default_cpus:
+          type: string
+        default_mem_limit:
+          type: string
+        default_pids_limit:
+          type: integer
+
+    ContainerProfileUpdate:
+      type: object
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        docker_image:
+          type: string
+        default_cpus:
+          type: string
+        default_mem_limit:
+          type: string
+        default_pids_limit:
+          type: integer
+
     AgentStatus:
       type: object
       properties:
@@ -2623,6 +2660,112 @@ paths:
           description: Not authenticated
         "403":
           description: Requires user role
+
+    post:
+      summary: Create container profile
+      description: Creates a new container profile. Admin only. API-created profiles always have is_platform=false.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ContainerProfileCreate"
+      responses:
+        "201":
+          description: Container profile created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ContainerProfile"
+        "400":
+          description: Missing required fields (name or docker_image)
+        "401":
+          description: Not authenticated
+        "403":
+          description: Requires admin role
+        "409":
+          description: Duplicate profile name
+
+  /container-profiles/{id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+
+    get:
+      summary: Get container profile
+      description: Returns a single container profile by ID.
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Container profile detail
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ContainerProfile"
+        "401":
+          description: Not authenticated
+        "403":
+          description: Requires user role
+        "404":
+          description: Container profile not found
+
+    put:
+      summary: Update container profile
+      description: Updates a container profile. Admin only. is_platform cannot be changed via API.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ContainerProfileUpdate"
+      responses:
+        "200":
+          description: Container profile updated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ContainerProfile"
+        "401":
+          description: Not authenticated
+        "403":
+          description: Requires admin role
+        "404":
+          description: Container profile not found
+        "409":
+          description: Duplicate profile name
+
+    delete:
+      summary: Delete container profile
+      description: Deletes a container profile. Admin only. Platform profiles cannot be deleted. Profiles assigned to agents cannot be deleted.
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Container profile deleted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  deleted:
+                    type: boolean
+        "401":
+          description: Not authenticated
+        "403":
+          description: Requires admin role or platform profile is undeletable
+        "404":
+          description: Container profile not found
+        "409":
+          description: Profile is assigned to agents
 
   /tools:
     get:

--- a/services/api/src/__tests__/docs.test.ts
+++ b/services/api/src/__tests__/docs.test.ts
@@ -160,6 +160,7 @@ const EXPECTED_PATHS = [
   '/user-models/{id}',
   '/usage',
   '/container-profiles',
+  '/container-profiles/{id}',
   '/knowledge/agents',
   '/knowledge/entries',
   '/knowledge/entries/{agentId}/{path}',

--- a/services/api/src/__tests__/routes-container-profiles.test.ts
+++ b/services/api/src/__tests__/routes-container-profiles.test.ts
@@ -51,6 +51,35 @@ function makeToken(sub: string, roles: string[]) {
 }
 
 const userToken = makeToken('regular-user', ['user']);
+const adminToken = makeToken('admin-user', ['admin', 'user']);
+
+const PROFILE_UUID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+
+const standardProfile = {
+  id: 'profile-uuid-1',
+  name: 'standard',
+  description: 'Standard agentbox runtime',
+  docker_image: 'hill90/agentbox:latest',
+  default_cpus: '1.0',
+  default_mem_limit: '1g',
+  default_pids_limit: 200,
+  is_platform: true,
+  created_at: '2026-03-14T00:00:00Z',
+  updated_at: '2026-03-14T00:00:00Z',
+};
+
+const customProfile = {
+  id: PROFILE_UUID,
+  name: 'gpu-enabled',
+  description: 'GPU-enabled runtime',
+  docker_image: 'hill90/agentbox-gpu:latest',
+  default_cpus: '2.0',
+  default_mem_limit: '4g',
+  default_pids_limit: 400,
+  is_platform: false,
+  created_at: '2026-03-14T00:00:00Z',
+  updated_at: '2026-03-14T00:00:00Z',
+};
 
 describe('Container Profiles routes', () => {
   beforeEach(() => {
@@ -64,18 +93,6 @@ describe('Container Profiles routes', () => {
 
   // CP-1: GET /container-profiles returns seeded standard profile
   it('GET /container-profiles returns profile list for authenticated user', async () => {
-    const standardProfile = {
-      id: 'profile-uuid-1',
-      name: 'standard',
-      description: 'Standard agentbox runtime',
-      docker_image: 'hill90/agentbox:latest',
-      default_cpus: '1.0',
-      default_mem_limit: '1g',
-      default_pids_limit: 200,
-      is_platform: true,
-      created_at: '2026-03-14T00:00:00Z',
-      updated_at: '2026-03-14T00:00:00Z',
-    };
     mockQuery.mockResolvedValueOnce({ rows: [standardProfile] });
 
     const res = await request(app)
@@ -93,5 +110,392 @@ describe('Container Profiles routes', () => {
   it('GET /container-profiles returns 401 without auth', async () => {
     const res = await request(app).get('/container-profiles');
     expect(res.status).toBe(401);
+  });
+
+  // ---------------------------------------------------------------------------
+  // GET /:id — single profile
+  // ---------------------------------------------------------------------------
+
+  // CP-4: GET /container-profiles/:id returns single profile
+  it('GET /container-profiles/:id returns single profile (200)', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [customProfile] });
+
+    const res = await request(app)
+      .get(`/container-profiles/${PROFILE_UUID}`)
+      .set('Authorization', `Bearer ${userToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.id).toBe(PROFILE_UUID);
+    expect(res.body.name).toBe('gpu-enabled');
+    expect(res.body.docker_image).toBe('hill90/agentbox-gpu:latest');
+  });
+
+  // CP-14: GET /container-profiles/:id nonexistent returns 404
+  it('GET /container-profiles/:id nonexistent returns 404', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    const res = await request(app)
+      .get(`/container-profiles/${PROFILE_UUID}`)
+      .set('Authorization', `Bearer ${userToken}`);
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toMatch(/not found/i);
+  });
+
+  // ---------------------------------------------------------------------------
+  // POST / — create profile
+  // ---------------------------------------------------------------------------
+
+  // CP-3: POST /container-profiles admin creates profile (201)
+  it('POST /container-profiles admin creates profile (201)', async () => {
+    const newProfile = { ...customProfile, is_platform: false };
+    mockQuery.mockResolvedValueOnce({ rows: [newProfile] });
+
+    const res = await request(app)
+      .post('/container-profiles')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ name: 'gpu-enabled', docker_image: 'hill90/agentbox-gpu:latest', description: 'GPU-enabled runtime' });
+
+    expect(res.status).toBe(201);
+    expect(res.body.name).toBe('gpu-enabled');
+    expect(res.body.is_platform).toBe(false);
+  });
+
+  // CP-7: POST /container-profiles missing name returns 400
+  it('POST /container-profiles missing name returns 400', async () => {
+    const res = await request(app)
+      .post('/container-profiles')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ docker_image: 'hill90/agentbox-gpu:latest' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/name/i);
+  });
+
+  // CP-8: POST /container-profiles missing docker_image returns 400
+  it('POST /container-profiles missing docker_image returns 400', async () => {
+    const res = await request(app)
+      .post('/container-profiles')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ name: 'gpu-enabled' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/docker_image/i);
+  });
+
+  // CP-9: POST /container-profiles duplicate name returns 409
+  it('POST /container-profiles duplicate name returns 409', async () => {
+    const err: any = new Error('duplicate');
+    err.code = '23505';
+    mockQuery.mockRejectedValueOnce(err);
+
+    const res = await request(app)
+      .post('/container-profiles')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ name: 'standard', docker_image: 'hill90/agentbox:latest' });
+
+    expect(res.status).toBe(409);
+    expect(res.body.error).toMatch(/already exists/i);
+  });
+
+  // CP-15: POST /container-profiles non-admin returns 403
+  it('POST /container-profiles non-admin returns 403', async () => {
+    const res = await request(app)
+      .post('/container-profiles')
+      .set('Authorization', `Bearer ${userToken}`)
+      .send({ name: 'gpu-enabled', docker_image: 'hill90/agentbox-gpu:latest' });
+
+    expect(res.status).toBe(403);
+  });
+
+  // ---------------------------------------------------------------------------
+  // PUT /:id — update profile
+  // ---------------------------------------------------------------------------
+
+  // CP-5: PUT /container-profiles/:id admin updates profile (200)
+  it('PUT /container-profiles/:id admin updates profile (200)', async () => {
+    const updated = { ...customProfile, docker_image: 'hill90/agentbox-gpu:v2' };
+    mockQuery
+      .mockResolvedValueOnce({ rows: [customProfile] }) // SELECT existing
+      .mockResolvedValueOnce({ rows: [updated] }); // UPDATE RETURNING
+
+    const res = await request(app)
+      .put(`/container-profiles/${PROFILE_UUID}`)
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ docker_image: 'hill90/agentbox-gpu:v2' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.docker_image).toBe('hill90/agentbox-gpu:v2');
+  });
+
+  // CP-10: PUT /container-profiles/:id nonexistent returns 404
+  it('PUT /container-profiles/:id nonexistent returns 404', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    const res = await request(app)
+      .put(`/container-profiles/${PROFILE_UUID}`)
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ docker_image: 'hill90/agentbox-gpu:v2' });
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toMatch(/not found/i);
+  });
+
+  // CP-16: PUT /container-profiles/:id non-admin returns 403
+  it('PUT /container-profiles/:id non-admin returns 403', async () => {
+    const res = await request(app)
+      .put(`/container-profiles/${PROFILE_UUID}`)
+      .set('Authorization', `Bearer ${userToken}`)
+      .send({ docker_image: 'hill90/agentbox-gpu:v2' });
+
+    expect(res.status).toBe(403);
+  });
+
+  // ---------------------------------------------------------------------------
+  // DELETE /:id — delete profile
+  // ---------------------------------------------------------------------------
+
+  // CP-6: DELETE /container-profiles/:id admin deletes unassigned non-platform profile (200)
+  it('DELETE /container-profiles/:id admin deletes non-platform unassigned profile (200)', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [customProfile] }) // SELECT existing
+      .mockResolvedValueOnce({ rows: [] }) // SELECT agents referencing
+      .mockResolvedValueOnce({ rows: [] }); // DELETE
+
+    const res = await request(app)
+      .delete(`/container-profiles/${PROFILE_UUID}`)
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.deleted).toBe(true);
+  });
+
+  // CP-11: DELETE /container-profiles/:id platform profile returns 403
+  it('DELETE /container-profiles/:id platform profile returns 403', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [standardProfile] }); // SELECT existing (is_platform=true)
+
+    const res = await request(app)
+      .delete(`/container-profiles/profile-uuid-1`)
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toMatch(/platform profile/i);
+  });
+
+  // CP-12: DELETE /container-profiles/:id profile in use by agents returns 409
+  it('DELETE /container-profiles/:id profile in use by agents returns 409', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [customProfile] }) // SELECT existing
+      .mockResolvedValueOnce({ rows: [{ id: 'agent-uuid', agent_id: 'my-agent' }] }); // agents referencing
+
+    const res = await request(app)
+      .delete(`/container-profiles/${PROFILE_UUID}`)
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(res.status).toBe(409);
+    expect(res.body.error).toMatch(/agents are assigned/i);
+    expect(res.body.agent_id).toBe('my-agent');
+  });
+
+  // CP-13: DELETE /container-profiles/:id nonexistent returns 404
+  it('DELETE /container-profiles/:id nonexistent returns 404', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    const res = await request(app)
+      .delete(`/container-profiles/${PROFILE_UUID}`)
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toMatch(/not found/i);
+  });
+
+  // CP-17: DELETE /container-profiles/:id non-admin returns 403
+  it('DELETE /container-profiles/:id non-admin returns 403', async () => {
+    const res = await request(app)
+      .delete(`/container-profiles/${PROFILE_UUID}`)
+      .set('Authorization', `Bearer ${userToken}`);
+
+    expect(res.status).toBe(403);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Audit emission tests
+  // ---------------------------------------------------------------------------
+
+  describe('audit emissions', () => {
+    let consoleSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      consoleSpy.mockRestore();
+    });
+
+    function getAuditCalls(): any[] {
+      return consoleSpy.mock.calls
+        .map((c: any[]) => { try { return JSON.parse(c[0]); } catch { return null; } })
+        .filter((obj: any) => obj?.type === 'audit');
+    }
+
+    // CP-18: POST emits container_profile_create audit
+    it('POST /container-profiles emits container_profile_create audit', async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [customProfile] });
+
+      await request(app)
+        .post('/container-profiles')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ name: 'gpu-enabled', docker_image: 'hill90/agentbox-gpu:latest' });
+
+      const audits = getAuditCalls();
+      expect(audits).toHaveLength(1);
+      expect(audits[0].action).toBe('container_profile_create');
+      expect(audits[0].agent_id).toBe(PROFILE_UUID);
+      expect(audits[0].principal_type).toBe('human');
+      expect(audits[0].profile_name).toBe('gpu-enabled');
+    });
+
+    // CP-19: PUT emits container_profile_update audit
+    it('PUT /container-profiles/:id emits container_profile_update audit', async () => {
+      const updated = { ...customProfile, docker_image: 'hill90/agentbox-gpu:v2' };
+      mockQuery
+        .mockResolvedValueOnce({ rows: [customProfile] })
+        .mockResolvedValueOnce({ rows: [updated] });
+
+      await request(app)
+        .put(`/container-profiles/${PROFILE_UUID}`)
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ docker_image: 'hill90/agentbox-gpu:v2' });
+
+      const audits = getAuditCalls();
+      expect(audits).toHaveLength(1);
+      expect(audits[0].action).toBe('container_profile_update');
+      expect(audits[0].agent_id).toBe(PROFILE_UUID);
+      expect(audits[0].principal_type).toBe('human');
+      expect(audits[0].profile_name).toBe('gpu-enabled');
+    });
+
+    // CP-20: DELETE emits container_profile_delete audit
+    it('DELETE /container-profiles/:id emits container_profile_delete audit', async () => {
+      mockQuery
+        .mockResolvedValueOnce({ rows: [customProfile] })
+        .mockResolvedValueOnce({ rows: [] }) // no agents referencing
+        .mockResolvedValueOnce({ rows: [] }); // DELETE
+
+      await request(app)
+        .delete(`/container-profiles/${PROFILE_UUID}`)
+        .set('Authorization', `Bearer ${adminToken}`);
+
+      const audits = getAuditCalls();
+      expect(audits).toHaveLength(1);
+      expect(audits[0].action).toBe('container_profile_delete');
+      expect(audits[0].agent_id).toBe(PROFILE_UUID);
+      expect(audits[0].principal_type).toBe('human');
+      expect(audits[0].profile_name).toBe('gpu-enabled');
+    });
+
+    // CP-21: DELETE blocked by platform guard does NOT emit audit
+    it('DELETE blocked by platform guard does NOT emit audit', async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [standardProfile] });
+
+      await request(app)
+        .delete(`/container-profiles/profile-uuid-1`)
+        .set('Authorization', `Bearer ${adminToken}`);
+
+      const audits = getAuditCalls();
+      expect(audits).toHaveLength(0);
+    });
+
+    // CP-22: DELETE blocked by agent reference does NOT emit audit
+    it('DELETE blocked by agent reference does NOT emit audit', async () => {
+      mockQuery
+        .mockResolvedValueOnce({ rows: [customProfile] })
+        .mockResolvedValueOnce({ rows: [{ id: 'agent-uuid', agent_id: 'my-agent' }] });
+
+      await request(app)
+        .delete(`/container-profiles/${PROFILE_UUID}`)
+        .set('Authorization', `Bearer ${adminToken}`);
+
+      const audits = getAuditCalls();
+      expect(audits).toHaveLength(0);
+    });
+
+    // CP-23: POST duplicate name (409) does NOT emit audit
+    it('POST duplicate name (409) does NOT emit audit', async () => {
+      const err: any = new Error('duplicate');
+      err.code = '23505';
+      mockQuery.mockRejectedValueOnce(err);
+
+      await request(app)
+        .post('/container-profiles')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ name: 'standard', docker_image: 'hill90/agentbox:latest' });
+
+      const audits = getAuditCalls();
+      expect(audits).toHaveLength(0);
+    });
+
+    // CP-24: PUT nonexistent (404) does NOT emit audit
+    it('PUT nonexistent (404) does NOT emit audit', async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [] });
+
+      await request(app)
+        .put(`/container-profiles/${PROFILE_UUID}`)
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ docker_image: 'hill90/agentbox-gpu:v2' });
+
+      const audits = getAuditCalls();
+      expect(audits).toHaveLength(0);
+    });
+
+    // CP-25: PUT duplicate name (409) does NOT emit audit
+    it('PUT duplicate name (409) does NOT emit audit', async () => {
+      const err: any = new Error('duplicate');
+      err.code = '23505';
+      mockQuery
+        .mockResolvedValueOnce({ rows: [customProfile] }) // SELECT existing
+        .mockRejectedValueOnce(err); // UPDATE fails with duplicate
+
+      await request(app)
+        .put(`/container-profiles/${PROFILE_UUID}`)
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ name: 'standard' });
+
+      const audits = getAuditCalls();
+      expect(audits).toHaveLength(0);
+    });
+
+    // CP-15 audit: POST non-admin does NOT emit audit
+    it('POST non-admin does NOT emit audit', async () => {
+      await request(app)
+        .post('/container-profiles')
+        .set('Authorization', `Bearer ${userToken}`)
+        .send({ name: 'gpu-enabled', docker_image: 'hill90/agentbox-gpu:latest' });
+
+      const audits = getAuditCalls();
+      expect(audits).toHaveLength(0);
+    });
+
+    // CP-16 audit: PUT non-admin does NOT emit audit
+    it('PUT non-admin does NOT emit audit', async () => {
+      await request(app)
+        .put(`/container-profiles/${PROFILE_UUID}`)
+        .set('Authorization', `Bearer ${userToken}`)
+        .send({ docker_image: 'hill90/agentbox-gpu:v2' });
+
+      const audits = getAuditCalls();
+      expect(audits).toHaveLength(0);
+    });
+
+    // CP-17 audit: DELETE non-admin does NOT emit audit
+    it('DELETE non-admin does NOT emit audit', async () => {
+      await request(app)
+        .delete(`/container-profiles/${PROFILE_UUID}`)
+        .set('Authorization', `Bearer ${userToken}`);
+
+      const audits = getAuditCalls();
+      expect(audits).toHaveLength(0);
+    });
   });
 });

--- a/services/api/src/openapi/openapi.yaml
+++ b/services/api/src/openapi/openapi.yaml
@@ -149,6 +149,43 @@ components:
           type: string
           format: date-time
 
+    ContainerProfileCreate:
+      type: object
+      required:
+        - name
+        - docker_image
+      properties:
+        name:
+          type: string
+          description: Unique profile name
+        description:
+          type: string
+        docker_image:
+          type: string
+          description: Docker image for agent containers
+        default_cpus:
+          type: string
+        default_mem_limit:
+          type: string
+        default_pids_limit:
+          type: integer
+
+    ContainerProfileUpdate:
+      type: object
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        docker_image:
+          type: string
+        default_cpus:
+          type: string
+        default_mem_limit:
+          type: string
+        default_pids_limit:
+          type: integer
+
     AgentStatus:
       type: object
       properties:
@@ -2623,6 +2660,112 @@ paths:
           description: Not authenticated
         "403":
           description: Requires user role
+
+    post:
+      summary: Create container profile
+      description: Creates a new container profile. Admin only. API-created profiles always have is_platform=false.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ContainerProfileCreate"
+      responses:
+        "201":
+          description: Container profile created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ContainerProfile"
+        "400":
+          description: Missing required fields (name or docker_image)
+        "401":
+          description: Not authenticated
+        "403":
+          description: Requires admin role
+        "409":
+          description: Duplicate profile name
+
+  /container-profiles/{id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+
+    get:
+      summary: Get container profile
+      description: Returns a single container profile by ID.
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Container profile detail
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ContainerProfile"
+        "401":
+          description: Not authenticated
+        "403":
+          description: Requires user role
+        "404":
+          description: Container profile not found
+
+    put:
+      summary: Update container profile
+      description: Updates a container profile. Admin only. is_platform cannot be changed via API.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ContainerProfileUpdate"
+      responses:
+        "200":
+          description: Container profile updated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ContainerProfile"
+        "401":
+          description: Not authenticated
+        "403":
+          description: Requires admin role
+        "404":
+          description: Container profile not found
+        "409":
+          description: Duplicate profile name
+
+    delete:
+      summary: Delete container profile
+      description: Deletes a container profile. Admin only. Platform profiles cannot be deleted. Profiles assigned to agents cannot be deleted.
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Container profile deleted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  deleted:
+                    type: boolean
+        "401":
+          description: Not authenticated
+        "403":
+          description: Requires admin role or platform profile is undeletable
+        "404":
+          description: Container profile not found
+        "409":
+          description: Profile is assigned to agents
 
   /tools:
     get:

--- a/services/api/src/routes/container-profiles.ts
+++ b/services/api/src/routes/container-profiles.ts
@@ -1,6 +1,7 @@
 import { Router, Request, Response } from 'express';
 import { getPool } from '../db/pool';
 import { requireRole } from '../middleware/role';
+import { auditLog } from '../helpers/audit';
 
 const router = Router();
 
@@ -27,6 +28,146 @@ router.get('/', requireRole('user'), async (_req: Request, res: Response) => {
   } catch (err) {
     console.error('[container-profiles] List error:', err);
     res.status(500).json({ error: 'Failed to list container profiles' });
+  }
+});
+
+// Get single container profile
+router.get('/:id', requireRole('user'), async (req: Request, res: Response) => {
+  try {
+    const { rows } = await getPool().query(
+      `SELECT id, name, description, docker_image, default_cpus, default_mem_limit,
+              default_pids_limit, is_platform, created_at, updated_at
+       FROM container_profiles WHERE id = $1`,
+      [req.params.id]
+    );
+    if (rows.length === 0) {
+      res.status(404).json({ error: 'Container profile not found' });
+      return;
+    }
+    res.json(rows[0]);
+  } catch (err) {
+    console.error('[container-profiles] Get error:', err);
+    res.status(500).json({ error: 'Failed to get container profile' });
+  }
+});
+
+// Create container profile — admin only
+router.post('/', requireRole('admin'), async (req: Request, res: Response) => {
+  try {
+    const { name, description, docker_image, default_cpus, default_mem_limit, default_pids_limit } = req.body;
+
+    if (!name) {
+      res.status(400).json({ error: 'name is required' });
+      return;
+    }
+    if (!docker_image) {
+      res.status(400).json({ error: 'docker_image is required' });
+      return;
+    }
+
+    const { rows } = await getPool().query(
+      `INSERT INTO container_profiles (name, description, docker_image, default_cpus, default_mem_limit, default_pids_limit, is_platform)
+       VALUES ($1, $2, $3, $4, $5, $6, false)
+       RETURNING *`,
+      [name, description || '', docker_image, default_cpus || '1.0', default_mem_limit || '1g', default_pids_limit || 200]
+    );
+
+    const profile = rows[0];
+    const user = (req as any).user;
+    auditLog('container_profile_create', profile.id, user.sub, 'human', { profile_name: profile.name });
+
+    res.status(201).json(profile);
+  } catch (err: any) {
+    if (err.code === '23505') {
+      res.status(409).json({ error: 'A container profile with this name already exists' });
+      return;
+    }
+    console.error('[container-profiles] Create error:', err);
+    res.status(500).json({ error: 'Failed to create container profile' });
+  }
+});
+
+// Update container profile — admin only, is_platform immutable
+router.put('/:id', requireRole('admin'), async (req: Request, res: Response) => {
+  try {
+    const { rows: existing } = await getPool().query(
+      'SELECT id, name FROM container_profiles WHERE id = $1',
+      [req.params.id]
+    );
+    if (existing.length === 0) {
+      res.status(404).json({ error: 'Container profile not found' });
+      return;
+    }
+
+    const { name, description, docker_image, default_cpus, default_mem_limit, default_pids_limit } = req.body;
+
+    const { rows } = await getPool().query(
+      `UPDATE container_profiles SET
+         name = COALESCE($2, name),
+         description = COALESCE($3, description),
+         docker_image = COALESCE($4, docker_image),
+         default_cpus = COALESCE($5, default_cpus),
+         default_mem_limit = COALESCE($6, default_mem_limit),
+         default_pids_limit = COALESCE($7, default_pids_limit),
+         updated_at = NOW()
+       WHERE id = $1
+       RETURNING *`,
+      [req.params.id, name, description, docker_image, default_cpus, default_mem_limit, default_pids_limit]
+    );
+
+    const profile = rows[0];
+    const user = (req as any).user;
+    auditLog('container_profile_update', profile.id, user.sub, 'human', { profile_name: profile.name });
+
+    res.json(profile);
+  } catch (err: any) {
+    if (err.code === '23505') {
+      res.status(409).json({ error: 'A container profile with this name already exists' });
+      return;
+    }
+    console.error('[container-profiles] Update error:', err);
+    res.status(500).json({ error: 'Failed to update container profile' });
+  }
+});
+
+// Delete container profile — admin only, platform guard + agent-reference guard
+router.delete('/:id', requireRole('admin'), async (req: Request, res: Response) => {
+  try {
+    const { rows: existing } = await getPool().query(
+      'SELECT id, name, is_platform FROM container_profiles WHERE id = $1',
+      [req.params.id]
+    );
+    if (existing.length === 0) {
+      res.status(404).json({ error: 'Container profile not found' });
+      return;
+    }
+
+    if (existing[0].is_platform) {
+      res.status(403).json({ error: 'Cannot delete a platform profile' });
+      return;
+    }
+
+    const { rows: agents } = await getPool().query(
+      `SELECT a.id, a.agent_id FROM agents a WHERE a.container_profile_id = $1 LIMIT 1`,
+      [req.params.id]
+    );
+    if (agents.length > 0) {
+      res.status(409).json({
+        error: 'Cannot delete profile while agents are assigned to it',
+        agent_id: agents[0].agent_id,
+      });
+      return;
+    }
+
+    await getPool().query('DELETE FROM container_profiles WHERE id = $1', [req.params.id]);
+
+    const user = (req as any).user;
+    auditLog('container_profile_delete', existing[0].id, user.sub, 'human', { profile_name: existing[0].name });
+
+    res.json({ deleted: true });
+  } catch (err) {
+    console.error('[container-profiles] Delete error:', err);
+    res.status(500).json({ error: 'Failed to delete container profile' });
   }
 });
 


### PR DESCRIPTION
## Summary
- Add POST, GET/:id, PUT, DELETE endpoints for container profiles (admin-only mutations)
- Platform profiles (`is_platform=true`) cannot be deleted (403)
- Profiles referenced by agents cannot be deleted (409 with agent context)
- All mutations emit structured audit logs (`container_profile_create/update/delete`) with `principalType: 'human'`
- Blocked operations (403/404/409) do NOT emit audit entries
- OpenAPI spec documents all 5 container-profiles endpoints
- `is_platform` is immutable via API — only migration/seed can set it

**Linear**: AI-122 (sub-issue of AI-91)
**Plan**: `.claude/plans/admin-container-profiles.md` (approved)

## Test plan
- [x] CP-3: POST creates profile (201)
- [x] CP-4: GET /:id returns single profile (200)
- [x] CP-5: PUT /:id updates profile (200)
- [x] CP-6: DELETE /:id deletes non-platform unassigned profile (200)
- [x] CP-7: POST missing name → 400
- [x] CP-8: POST missing docker_image → 400
- [x] CP-9: POST duplicate name → 409
- [x] CP-10: PUT nonexistent → 404
- [x] CP-11: DELETE platform profile → 403
- [x] CP-12: DELETE profile in use → 409 with agent_id
- [x] CP-13: DELETE nonexistent → 404
- [x] CP-14: GET /:id nonexistent → 404
- [x] CP-15: POST non-admin → 403, no audit
- [x] CP-16: PUT non-admin → 403, no audit
- [x] CP-17: DELETE non-admin → 403, no audit
- [x] CP-18: POST audit emits `container_profile_create`
- [x] CP-19: PUT audit emits `container_profile_update`
- [x] CP-20: DELETE audit emits `container_profile_delete`
- [x] CP-21: DELETE blocked by platform → no audit
- [x] CP-22: DELETE blocked by agent ref → no audit
- [x] CP-23: POST duplicate → no audit
- [x] CP-24: PUT nonexistent → no audit
- [x] CP-25: PUT duplicate name → no audit
- [x] All 507 API tests pass (28 container-profiles + 479 existing)
- [x] TypeScript compiles cleanly
- [x] docs.test.ts drift enforcement passes
- [x] OpenAPI spec synced to docs/site

## Validation evidence
- `npx jest routes-container-profiles --verbose` → 28/28 pass
- `npx jest docs --verbose` → 13/13 pass
- `npm test` → 507/507 pass (34 suites)
- `npx tsc --noEmit` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)