### PR TITLE
fix: test coverage for ChatView, ThreadList, EventCard, shared-knowledge routes (AI-140, AI-141)

### DIFF
--- a/services/api/src/__tests__/routes-shared-knowledge.test.ts
+++ b/services/api/src/__tests__/routes-shared-knowledge.test.ts
@@ -1,0 +1,371 @@
+import request from 'supertest';
+import * as crypto from 'crypto';
+import * as jwt from 'jsonwebtoken';
+import { createApp } from '../app';
+
+// Generate RSA keypair for test signing
+const { privateKey, publicKey } = crypto.generateKeyPairSync('rsa', {
+  modulusLength: 2048,
+  publicKeyEncoding: { type: 'spki', format: 'pem' },
+  privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+});
+
+const TEST_ISSUER = 'https://auth.hill90.com/realms/hill90';
+
+// Mock pg pool
+const mockQuery = jest.fn();
+jest.mock('../db/pool', () => ({
+  getPool: () => ({ query: mockQuery }),
+}));
+
+// Mock docker service (needed because agents.ts is imported transitively)
+jest.mock('../services/docker', () => ({
+  createAndStartContainer: jest.fn(),
+  stopAndRemoveContainer: jest.fn(),
+  inspectContainer: jest.fn(),
+  getContainerLogs: jest.fn(),
+  removeAgentVolumes: jest.fn(),
+  reconcileAgentStatuses: jest.fn(),
+  execInContainer: jest.fn(),
+}));
+
+jest.mock('../services/agent-files', () => ({
+  writeAgentFiles: jest.fn(),
+  removeAgentFiles: jest.fn(),
+}));
+
+jest.mock('../services/tool-installer', () => ({
+  ensureRequiredToolsInstalled: jest.fn(),
+  reconcileToolInstalls: jest.fn(),
+}));
+
+// Mock shared-knowledge proxy
+jest.mock('../services/shared-knowledge-proxy', () => ({
+  getStats: jest.fn(),
+  listCollections: jest.fn(),
+  getCollection: jest.fn(),
+  createCollection: jest.fn(),
+  updateCollection: jest.fn(),
+  deleteCollection: jest.fn(),
+  listSources: jest.fn(),
+  getSource: jest.fn(),
+  createSource: jest.fn(),
+  deleteSource: jest.fn(),
+  searchShared: jest.fn(),
+}));
+
+import * as skProxy from '../services/shared-knowledge-proxy';
+const mockGetStats = skProxy.getStats as jest.Mock;
+const mockListCollections = skProxy.listCollections as jest.Mock;
+const mockGetCollection = skProxy.getCollection as jest.Mock;
+const mockCreateCollection = skProxy.createCollection as jest.Mock;
+const mockUpdateCollection = skProxy.updateCollection as jest.Mock;
+const mockDeleteCollection = skProxy.deleteCollection as jest.Mock;
+const mockListSources = skProxy.listSources as jest.Mock;
+const mockGetSource = skProxy.getSource as jest.Mock;
+const mockCreateSource = skProxy.createSource as jest.Mock;
+const mockDeleteSource = skProxy.deleteSource as jest.Mock;
+const mockSearchShared = skProxy.searchShared as jest.Mock;
+
+const app = createApp({
+  issuer: TEST_ISSUER,
+  getSigningKey: async () => publicKey,
+});
+
+function makeToken(sub: string, roles: string[]) {
+  return jwt.sign(
+    { sub, realm_roles: roles },
+    privateKey,
+    { algorithm: 'RS256', issuer: TEST_ISSUER, expiresIn: '5m' }
+  );
+}
+
+const adminToken = makeToken('admin-user', ['admin', 'user']);
+const userToken = makeToken('regular-user', ['user']);
+
+describe('Shared Knowledge routes', () => {
+  beforeEach(() => {
+    mockQuery.mockReset();
+    mockGetStats.mockReset();
+    mockListCollections.mockReset();
+    mockGetCollection.mockReset();
+    mockCreateCollection.mockReset();
+    mockUpdateCollection.mockReset();
+    mockDeleteCollection.mockReset();
+    mockListSources.mockReset();
+    mockGetSource.mockReset();
+    mockCreateSource.mockReset();
+    mockDeleteSource.mockReset();
+    mockSearchShared.mockReset();
+  });
+
+  // ── Stats ──
+
+  it('GET /shared-knowledge/stats returns stats', async () => {
+    mockGetStats.mockResolvedValue({ status: 200, data: { search: {}, ingest: {} } });
+
+    const res = await request(app)
+      .get('/shared-knowledge/stats')
+      .set('Authorization', `Bearer ${adminToken}`);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ search: {}, ingest: {} });
+    expect(mockGetStats).toHaveBeenCalledWith(undefined);
+  });
+
+  it('GET /shared-knowledge/stats passes since param', async () => {
+    mockGetStats.mockResolvedValue({ status: 200, data: {} });
+
+    await request(app)
+      .get('/shared-knowledge/stats?since=24h')
+      .set('Authorization', `Bearer ${userToken}`);
+    expect(mockGetStats).toHaveBeenCalledWith('24h');
+  });
+
+  it('GET /shared-knowledge/stats requires auth', async () => {
+    const res = await request(app).get('/shared-knowledge/stats');
+    expect(res.status).toBe(401);
+  });
+
+  // ── Collections ──
+
+  it('GET /shared-knowledge/collections returns collection list', async () => {
+    mockListCollections.mockResolvedValue({
+      status: 200,
+      data: [{ id: 'col-1', name: 'Test Collection' }],
+    });
+
+    const res = await request(app)
+      .get('/shared-knowledge/collections')
+      .set('Authorization', `Bearer ${userToken}`);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([{ id: 'col-1', name: 'Test Collection' }]);
+    expect(mockListCollections).toHaveBeenCalledWith('regular-user');
+  });
+
+  it('POST /shared-knowledge/collections creates collection', async () => {
+    mockCreateCollection.mockResolvedValue({
+      status: 201,
+      data: { id: 'col-new', name: 'New', visibility: 'shared' },
+    });
+
+    const res = await request(app)
+      .post('/shared-knowledge/collections')
+      .set('Authorization', `Bearer ${userToken}`)
+      .send({ name: 'New', visibility: 'shared' });
+    expect(res.status).toBe(201);
+    expect(mockCreateCollection).toHaveBeenCalledWith({
+      name: 'New',
+      description: '',
+      visibility: 'shared',
+      created_by: 'regular-user',
+    });
+  });
+
+  it('POST /shared-knowledge/collections requires name (passes through to proxy)', async () => {
+    mockCreateCollection.mockResolvedValue({
+      status: 400,
+      data: { error: 'name is required' },
+    });
+
+    const res = await request(app)
+      .post('/shared-knowledge/collections')
+      .set('Authorization', `Bearer ${userToken}`)
+      .send({});
+    expect(mockCreateCollection).toHaveBeenCalled();
+  });
+
+  it('GET /shared-knowledge/collections/:id returns single collection', async () => {
+    mockGetCollection.mockResolvedValue({
+      status: 200,
+      data: { id: 'col-1', name: 'Test', created_by: 'regular-user', visibility: 'private' },
+    });
+
+    const res = await request(app)
+      .get('/shared-knowledge/collections/col-1')
+      .set('Authorization', `Bearer ${userToken}`);
+    expect(res.status).toBe(200);
+    expect(res.body.id).toBe('col-1');
+  });
+
+  it('GET /shared-knowledge/collections/:id returns 404 for non-owner private collection', async () => {
+    mockGetCollection.mockResolvedValue({
+      status: 200,
+      data: { id: 'col-1', name: 'Secret', created_by: 'other-user', visibility: 'private' },
+    });
+
+    const res = await request(app)
+      .get('/shared-knowledge/collections/col-1')
+      .set('Authorization', `Bearer ${userToken}`);
+    expect(res.status).toBe(404);
+  });
+
+  it('PUT /shared-knowledge/collections/:id updates collection', async () => {
+    mockGetCollection.mockResolvedValue({
+      status: 200,
+      data: { id: 'col-1', name: 'Old', created_by: 'admin-user', visibility: 'private' },
+    });
+    mockUpdateCollection.mockResolvedValue({
+      status: 200,
+      data: { id: 'col-1', name: 'Updated' },
+    });
+
+    const res = await request(app)
+      .put('/shared-knowledge/collections/col-1')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ name: 'Updated' });
+    expect(res.status).toBe(200);
+    expect(mockUpdateCollection).toHaveBeenCalledWith('col-1', {
+      name: 'Updated',
+      description: undefined,
+      visibility: undefined,
+    });
+  });
+
+  it('PUT /shared-knowledge/collections/:id returns 403 for non-owner', async () => {
+    mockGetCollection.mockResolvedValue({
+      status: 200,
+      data: { id: 'col-1', name: 'Other', created_by: 'other-user', visibility: 'private' },
+    });
+
+    const res = await request(app)
+      .put('/shared-knowledge/collections/col-1')
+      .set('Authorization', `Bearer ${userToken}`)
+      .send({ name: 'Hijack' });
+    expect(res.status).toBe(403);
+  });
+
+  it('DELETE /shared-knowledge/collections/:id deletes collection', async () => {
+    mockGetCollection.mockResolvedValue({
+      status: 200,
+      data: { id: 'col-1', name: 'Doomed', created_by: 'admin-user', visibility: 'private' },
+    });
+    mockDeleteCollection.mockResolvedValue({
+      status: 200,
+      data: { deleted: true },
+    });
+
+    const res = await request(app)
+      .delete('/shared-knowledge/collections/col-1')
+      .set('Authorization', `Bearer ${adminToken}`);
+    expect(res.status).toBe(200);
+    expect(mockDeleteCollection).toHaveBeenCalledWith('col-1');
+  });
+
+  it('DELETE /shared-knowledge/collections/:id returns 403 for non-owner', async () => {
+    mockGetCollection.mockResolvedValue({
+      status: 200,
+      data: { id: 'col-1', name: 'Protected', created_by: 'other-user', visibility: 'private' },
+    });
+
+    const res = await request(app)
+      .delete('/shared-knowledge/collections/col-1')
+      .set('Authorization', `Bearer ${userToken}`);
+    expect(res.status).toBe(403);
+  });
+
+  // ── Sources ──
+
+  it('GET /shared-knowledge/sources requires collection_id', async () => {
+    const res = await request(app)
+      .get('/shared-knowledge/sources')
+      .set('Authorization', `Bearer ${userToken}`);
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/collection_id/);
+  });
+
+  it('GET /shared-knowledge/sources returns sources for collection', async () => {
+    mockGetCollection.mockResolvedValue({
+      status: 200,
+      data: { id: 'col-1', created_by: 'regular-user', visibility: 'private' },
+    });
+    mockListSources.mockResolvedValue({
+      status: 200,
+      data: [{ id: 'src-1', title: 'Source 1' }],
+    });
+
+    const res = await request(app)
+      .get('/shared-knowledge/sources?collection_id=col-1')
+      .set('Authorization', `Bearer ${userToken}`);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([{ id: 'src-1', title: 'Source 1' }]);
+    expect(mockListSources).toHaveBeenCalledWith('col-1');
+  });
+
+  it('POST /shared-knowledge/sources creates source', async () => {
+    mockGetCollection.mockResolvedValue({
+      status: 200,
+      data: { id: 'col-1', created_by: 'regular-user', visibility: 'private' },
+    });
+    mockCreateSource.mockResolvedValue({
+      status: 201,
+      data: { id: 'src-new', title: 'New Source' },
+    });
+
+    const res = await request(app)
+      .post('/shared-knowledge/sources')
+      .set('Authorization', `Bearer ${userToken}`)
+      .send({
+        collection_id: 'col-1',
+        title: 'New Source',
+        source_type: 'text',
+        raw_content: 'Hello world',
+      });
+    expect(res.status).toBe(201);
+    expect(mockCreateSource).toHaveBeenCalledWith({
+      collection_id: 'col-1',
+      title: 'New Source',
+      source_type: 'text',
+      raw_content: 'Hello world',
+      source_url: undefined,
+      created_by: 'regular-user',
+    });
+  });
+
+  it('DELETE /shared-knowledge/sources/:id deletes source', async () => {
+    mockGetSource.mockResolvedValue({
+      status: 200,
+      data: { id: 'src-1', created_by: 'regular-user', collection_id: 'col-1' },
+    });
+    mockDeleteSource.mockResolvedValue({
+      status: 200,
+      data: { deleted: true },
+    });
+
+    const res = await request(app)
+      .delete('/shared-knowledge/sources/src-1')
+      .set('Authorization', `Bearer ${userToken}`);
+    expect(res.status).toBe(200);
+    expect(mockDeleteSource).toHaveBeenCalledWith('src-1');
+  });
+
+  // ── Search ──
+
+  it('GET /shared-knowledge/search requires q param', async () => {
+    const res = await request(app)
+      .get('/shared-knowledge/search')
+      .set('Authorization', `Bearer ${userToken}`);
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/q/);
+  });
+
+  it('GET /shared-knowledge/search returns results', async () => {
+    mockSearchShared.mockResolvedValue({
+      status: 200,
+      data: { results: [{ id: 'chunk-1', snippet: 'match' }] },
+    });
+
+    const res = await request(app)
+      .get('/shared-knowledge/search?q=test+query')
+      .set('Authorization', `Bearer ${userToken}`);
+    expect(res.status).toBe(200);
+    expect(res.body.results).toHaveLength(1);
+    expect(mockSearchShared).toHaveBeenCalledWith({
+      q: 'test query',
+      collection_id: undefined,
+      owner: 'regular-user',
+      requester_id: 'regular-user',
+      requester_type: 'user',
+      limit: undefined,
+    });
+  });
+});

--- a/services/ui/src/__tests__/ChatView.test.tsx
+++ b/services/ui/src/__tests__/ChatView.test.tsx
@@ -1,0 +1,156 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+
+const mockRouter = { push: vi.fn(), back: vi.fn(), refresh: vi.fn() }
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => mockRouter,
+}))
+
+vi.mock('next/link', () => ({
+  default: ({ children, href, ...props }: any) => <a href={href} {...props}>{children}</a>,
+}))
+
+vi.mock('lucide-react', () => ({
+  ArrowLeft: (props: any) => <span data-testid="icon-arrow-left" {...props} />,
+  Send: (props: any) => <span data-testid="icon-send" {...props} />,
+  Terminal: (props: any) => <span data-testid="icon-terminal" {...props} />,
+}))
+
+vi.mock('@/app/chat/ChatMessage', () => ({
+  default: ({ message }: any) => <div data-testid="chat-message">{message.content}</div>,
+}))
+
+vi.mock('@/app/chat/AgentStatusBar', () => ({
+  default: () => <div data-testid="agent-status-bar" />,
+}))
+
+vi.mock('@/app/chat/CancelButton', () => ({
+  default: () => <div data-testid="cancel-button" />,
+}))
+
+vi.mock('@/app/chat/SessionPane', () => ({
+  default: () => <div data-testid="session-pane" />,
+}))
+
+import ChatView from '@/app/chat/ChatView'
+import type { ChatThread } from '@/app/chat/ChatLayout'
+
+const mockSession = {
+  user: { id: 'user-1', name: 'Test', roles: ['user'] },
+  expires: '2026-12-31',
+}
+
+const mockThread: ChatThread = {
+  id: 'thread-1',
+  type: 'direct',
+  title: 'Test Chat',
+  created_by: 'user-1',
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+  agent: { id: 'agent-1', agent_id: 'bot-1', name: 'TestBot', status: 'running' },
+}
+
+// Mock EventSource
+class MockEventSource {
+  url: string
+  onmessage: ((e: any) => void) | null = null
+  onerror: ((e: any) => void) | null = null
+  listeners: Record<string, ((e: any) => void)[]> = {}
+  static instances: MockEventSource[] = []
+  constructor(url: string) {
+    this.url = url
+    MockEventSource.instances.push(this)
+  }
+  addEventListener(type: string, cb: (e: any) => void) {
+    if (!this.listeners[type]) this.listeners[type] = []
+    this.listeners[type].push(cb)
+  }
+  removeEventListener() {}
+  close() {}
+}
+
+describe('ChatView', () => {
+  let originalFetch: typeof globalThis.fetch
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    MockEventSource.instances = []
+    ;(globalThis as any).EventSource = MockEventSource
+    originalFetch = globalThis.fetch
+  })
+
+  afterEach(() => {
+    cleanup()
+    globalThis.fetch = originalFetch
+    delete (globalThis as any).EventSource
+  })
+
+  const defaultProps = {
+    threadId: 'thread-1',
+    session: mockSession as any,
+    thread: mockThread,
+    onBack: vi.fn(),
+    onThreadUpdated: vi.fn(),
+  }
+
+  it('renders message input', () => {
+    render(<ChatView {...defaultProps} />)
+    expect(screen.getByPlaceholderText('Type a message...')).toBeInTheDocument()
+    expect(screen.getByTestId('icon-send')).toBeInTheDocument()
+  })
+
+  it('renders back button', () => {
+    render(<ChatView {...defaultProps} />)
+    expect(screen.getByTestId('icon-arrow-left')).toBeInTheDocument()
+  })
+
+  it('sends message on form submit', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({}),
+    })
+    globalThis.fetch = mockFetch
+
+    render(<ChatView {...defaultProps} />)
+    const input = screen.getByPlaceholderText('Type a message...')
+    fireEvent.change(input, { target: { value: 'Hello agent' } })
+    fireEvent.keyDown(input, { key: 'Enter', shiftKey: false })
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        '/api/chat/thread-1/messages',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ message: 'Hello agent' }),
+        })
+      )
+    })
+  })
+
+  it('shows error when send fails', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: () => Promise.resolve({ error: 'Server error' }),
+    })
+    globalThis.fetch = mockFetch
+
+    render(<ChatView {...defaultProps} />)
+    const input = screen.getByPlaceholderText('Type a message...')
+    fireEvent.change(input, { target: { value: 'Hello' } })
+    fireEvent.keyDown(input, { key: 'Enter', shiftKey: false })
+
+    await waitFor(() => {
+      expect(screen.getByText('Server error')).toBeInTheDocument()
+    })
+  })
+
+  it('connects to SSE stream on mount', () => {
+    render(<ChatView {...defaultProps} />)
+    expect(MockEventSource.instances.length).toBe(1)
+    expect(MockEventSource.instances[0].url).toBe('/api/chat/thread-1/stream')
+  })
+})

--- a/services/ui/src/__tests__/EventCard.test.tsx
+++ b/services/ui/src/__tests__/EventCard.test.tsx
@@ -1,0 +1,135 @@
+import React from 'react'
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, cleanup, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+
+vi.mock('lucide-react', () => ({
+  Terminal: (props: any) => <span data-testid="icon-terminal" {...props} />,
+  FolderOpen: (props: any) => <span data-testid="icon-folder" {...props} />,
+  Cog: (props: any) => <span data-testid="icon-cog" {...props} />,
+  User: (props: any) => <span data-testid="icon-user" {...props} />,
+  HeartPulse: (props: any) => <span data-testid="icon-heart" {...props} />,
+  Sparkles: (props: any) => <span data-testid="icon-sparkles" {...props} />,
+  ChevronDown: (props: any) => <span data-testid="icon-chevron-down" {...props} />,
+  ChevronRight: (props: any) => <span data-testid="icon-chevron-right" {...props} />,
+}))
+
+import EventCard, { parseExitCode, getLifecycleInfo, formatDuration } from '@/app/agents/[id]/EventCard'
+import type { AgentEvent } from '@/app/agents/[id]/EventCard'
+
+function makeEvent(overrides: Partial<AgentEvent> = {}): AgentEvent {
+  return {
+    id: 'evt-1',
+    timestamp: new Date().toISOString(),
+    type: 'file_read',
+    tool: 'filesystem',
+    input_summary: '/workspace/data.txt',
+    output_summary: '1024 bytes',
+    duration_ms: null,
+    success: null,
+    ...overrides,
+  }
+}
+
+describe('EventCard', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('renders tool name and input summary', () => {
+    render(<EventCard event={makeEvent({ tool: 'shell', input_summary: 'echo hello' })} />)
+    expect(screen.getByText('shell')).toBeInTheDocument()
+    expect(screen.getByText('echo hello')).toBeInTheDocument()
+  })
+
+  it('shows OK indicator for successful non-lifecycle event', () => {
+    render(<EventCard event={makeEvent({ tool: 'filesystem', type: 'file_read', success: true })} />)
+    expect(screen.getByText('OK')).toBeInTheDocument()
+  })
+
+  it('shows FAIL indicator for failed non-lifecycle event', () => {
+    render(<EventCard event={makeEvent({ tool: 'filesystem', type: 'file_read', success: false })} />)
+    expect(screen.getByText('FAIL')).toBeInTheDocument()
+  })
+
+  it('shows Running lifecycle label for command_start', () => {
+    render(<EventCard event={makeEvent({ tool: 'shell', type: 'command_start', success: null })} />)
+    expect(screen.getByText('Running')).toBeInTheDocument()
+  })
+
+  it('shows Completed lifecycle label for command_complete', () => {
+    render(<EventCard event={makeEvent({ tool: 'shell', type: 'command_complete', success: true, output_summary: 'exit 0, 6 bytes' })} />)
+    expect(screen.getByText('Completed')).toBeInTheDocument()
+  })
+
+  it('shows Failed lifecycle label for work_failed', () => {
+    render(<EventCard event={makeEvent({ tool: 'runtime', type: 'work_failed', success: false })} />)
+    expect(screen.getByText('Failed')).toBeInTheDocument()
+  })
+
+  it('shows exit code on command_complete', () => {
+    render(<EventCard event={makeEvent({ tool: 'shell', type: 'command_complete', success: true, output_summary: 'exit 0, 6 bytes' })} />)
+    expect(screen.getByText('exit 0')).toBeInTheDocument()
+  })
+
+  it('shows duration when present', () => {
+    render(<EventCard event={makeEvent({ duration_ms: 1500 })} />)
+    expect(screen.getByText('1.5s')).toBeInTheDocument()
+  })
+
+  it('expands on click to show details', () => {
+    render(<EventCard event={makeEvent()} />)
+    expect(screen.queryByTestId('event-details')).not.toBeInTheDocument()
+    fireEvent.click(screen.getByTestId('event-card'))
+    expect(screen.getByTestId('event-details')).toBeInTheDocument()
+  })
+
+  it('shows inference metadata in structured grid on expand', () => {
+    render(
+      <EventCard
+        event={makeEvent({
+          tool: 'inference',
+          type: 'inference_complete',
+          success: true,
+          metadata: {
+            model_name: 'gpt-4o-mini',
+            request_type: 'chat',
+            input_tokens: 100,
+            output_tokens: 200,
+            cost_usd: 0.0015,
+            status: 'success',
+          },
+        })}
+      />
+    )
+    fireEvent.click(screen.getByTestId('event-card'))
+    expect(screen.getByTestId('event-details')).toBeInTheDocument()
+    expect(screen.getByText('Model:')).toBeInTheDocument()
+    expect(screen.getByText('Cost:')).toBeInTheDocument()
+    expect(screen.getByText('Status:')).toBeInTheDocument()
+  })
+})
+
+describe('parseExitCode', () => {
+  it('returns null for null input', () => {
+    expect(parseExitCode(null)).toBeNull()
+  })
+
+  it('extracts code from exit string', () => {
+    expect(parseExitCode('exit 127, 0 bytes')).toBe(127)
+  })
+})
+
+describe('formatDuration', () => {
+  it('formats milliseconds', () => {
+    expect(formatDuration(500)).toBe('500ms')
+  })
+
+  it('formats seconds', () => {
+    expect(formatDuration(1500)).toBe('1.5s')
+  })
+
+  it('formats minutes', () => {
+    expect(formatDuration(90000)).toBe('1m 30s')
+  })
+})

--- a/services/ui/src/__tests__/ThreadList.test.tsx
+++ b/services/ui/src/__tests__/ThreadList.test.tsx
@@ -1,0 +1,85 @@
+import React from 'react'
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, cleanup, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+
+vi.mock('next/link', () => ({
+  default: ({ children, href, ...props }: any) => <a href={href} {...props}>{children}</a>,
+}))
+
+vi.mock('lucide-react', () => ({
+  Users: (props: any) => <span data-testid="icon-users" {...props} />,
+  Trash2: (props: any) => <span data-testid="icon-trash" {...props} />,
+}))
+
+import ThreadList from '@/app/chat/ThreadList'
+import type { ChatThread } from '@/app/chat/ChatLayout'
+
+function makeThread(overrides: Partial<ChatThread> = {}): ChatThread {
+  return {
+    id: 'thread-1',
+    type: 'direct',
+    title: 'Test Thread',
+    created_by: 'user-1',
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    last_message: 'Hello there',
+    last_author_type: 'human',
+    agent: { id: 'agent-1', agent_id: 'bot-1', name: 'TestBot', status: 'running' },
+    ...overrides,
+  }
+}
+
+describe('ThreadList', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('shows loading state', () => {
+    render(<ThreadList threads={[]} loading={true} onDelete={vi.fn()} />)
+    expect(screen.getByText('Loading...')).toBeInTheDocument()
+  })
+
+  it('shows empty state', () => {
+    render(<ThreadList threads={[]} loading={false} onDelete={vi.fn()} />)
+    expect(screen.getByText(/No conversations yet/)).toBeInTheDocument()
+  })
+
+  it('renders thread list', () => {
+    const threads = [
+      makeThread({ id: 'thread-1', title: 'First Chat' }),
+      makeThread({ id: 'thread-2', title: 'Second Chat' }),
+    ]
+    render(<ThreadList threads={threads} loading={false} onDelete={vi.fn()} />)
+    expect(screen.getByText('First Chat')).toBeInTheDocument()
+    expect(screen.getByText('Second Chat')).toBeInTheDocument()
+  })
+
+  it('highlights active thread', () => {
+    const threads = [makeThread({ id: 'thread-1', title: 'Active Thread' })]
+    const { container } = render(
+      <ThreadList threads={threads} loading={false} activeThreadId="thread-1" onDelete={vi.fn()} />
+    )
+    const link = container.querySelector('a[href="/chat/thread-1"]')
+    expect(link?.className).toContain('bg-navy-800')
+    expect(link?.className).toContain('border-l-brand-500')
+  })
+
+  it('shows group thread indicator', () => {
+    const threads = [
+      makeThread({ id: 'thread-g', type: 'group', title: null, agent_count: 3 }),
+    ]
+    render(<ThreadList threads={threads} loading={false} onDelete={vi.fn()} />)
+    expect(screen.getByText('Group (3 agents)')).toBeInTheDocument()
+    expect(screen.getByTestId('group-icon')).toBeInTheDocument()
+  })
+
+  it('calls onDelete when delete confirmed', () => {
+    const onDelete = vi.fn()
+    const threads = [makeThread({ id: 'thread-1', title: 'Delete Me' })]
+    render(<ThreadList threads={threads} loading={false} onDelete={onDelete} />)
+    fireEvent.click(screen.getByTestId('delete-thread-thread-1'))
+    fireEvent.click(screen.getByTestId('confirm-yes-thread-1'))
+    expect(onDelete).toHaveBeenCalledWith('thread-1')
+  })
+})


### PR DESCRIPTION
## Summary

44 new tests across 4 files closing coverage gaps on core UI components and the shared-knowledge API routes.

**AI-140 — UI component tests (26 tests):**
- `EventCard.test.tsx` (15): Rendering, lifecycle labels (Running/Completed/Failed), exit code display, expand/collapse, inference metadata structured grid, plus unit tests for `parseExitCode` and `formatDuration`
- `ThreadList.test.tsx` (6): Loading state, empty state, thread list rendering, active thread highlight, group thread indicator, delete confirmation flow
- `ChatView.test.tsx` (5): Message input rendering, back button, message send via fetch, error display on send failure, SSE EventSource connection on mount

**AI-141 — Shared knowledge route tests (18 tests):**
- `routes-shared-knowledge.test.ts` (18): Stats (GET + since param + auth), Collections CRUD (list, get, create, update, delete) with ownership boundary tests (404 for non-owner private, 403 for non-owner write), Sources CRUD (list requires collection_id, create, delete), Search (requires q param, passes requester_id)

## Test plan

- [x] EventCard tests pass (15/15)
- [x] ThreadList tests pass (6/6)
- [x] ChatView tests pass (5/5)
- [x] Shared knowledge route tests pass (18/18)
- [x] Full UI suite green (560/560)
- [x] Full API suite green (659/659)

**Linear:** AI-140, AI-141

🤖 Generated with [Claude Code](https://claude.com/claude-code)