### PR TITLE
feat: Chat Phase 1B — @mention autocomplete + participant management (AI-139)

### DIFF
--- a/.claude/plans/ai-139-chat-phase-1b.md
+++ b/.claude/plans/ai-139-chat-phase-1b.md
@@ -1,0 +1,214 @@
+# AI-139: Chat Phase 1B — Group Thread UI Completion
+
+**Linear:** AI-139 | **Status:** Planning | **Date:** 2026-04-04
+
+## Context
+
+Phase 1 (PR #245) shipped direct threads, message persistence, SSE streaming, and callback-based agent responses. Phase 1B was defined as "group threads, multi-agent dispatch, Live Session pane" — but architectural research reveals the API and most UI are **already complete** from incremental work across PRs #245–#271.
+
+**What already works:**
+- API: all 9 chat endpoints fully support group threads (creation with `agent_ids[]`, multi-agent dispatch, @mention routing, participant add/remove, per-agent concurrency guard, event stream filtering, a2a orchestration)
+- UI: group creation (NewThreadDialog multi-select), group display (agent color badges, agent name attribution), session pane (events from all thread agents), cancel button, thread list (group indicator + agent names), chain provenance annotations
+
+**What's missing (2 gaps):**
+1. **@-mention input UX** — placeholder text says "@name to target one" but input has no autocomplete, highlighting, or feedback. API accepts raw @mentions, but users get no guidance.
+2. **Participant management UI** — API endpoint `PUT /threads/:id/participants` exists and works. No UI to call it. Users cannot add/remove agents from existing group threads.
+
+---
+
+## 1. Goal / Signal
+
+After this lands:
+- Users can type `@` in the chat input and see an autocomplete dropdown of thread participant agents
+- Selecting an autocomplete suggestion inserts `@agent-slug ` into the input
+- Users can open a "Manage Participants" panel from the group thread header to add/remove agents
+- Adding an agent calls `PUT /threads/:id/participants` with `{add: [uuid]}`
+- Removing an agent calls `PUT /threads/:id/participants` with `{remove: [uuid]}` and shows confirmation
+- All existing group thread functionality (creation, dispatch, SSE, badges, chain provenance) is unchanged
+
+---
+
+## 2. Scope
+
+**In scope:**
+- `MentionInput` component: `@`-triggered autocomplete dropdown in chat input, inserts `@slug ` on selection
+- `ParticipantPanel` component: slide-out or modal panel to add/remove agents from group thread
+- Integration into `ChatView.tsx`: replace plain textarea with MentionInput, add participant button to header
+- Agent picker within ParticipantPanel: reuse pattern from NewThreadDialog (fetch `/api/agents`, checkbox list)
+- 8 vitest tests for MentionInput + ParticipantPanel
+- 3 API tests for participant management edge cases (optional — API is already well-tested)
+
+**Out of scope:**
+- API changes (all endpoints complete)
+- Backend @mention parsing changes (parseMentions in chat.ts is unchanged)
+- Agentbox changes (agentbox processes one work item per placeholder, unchanged)
+- Changes to NewThreadDialog (already supports multi-select)
+- Changes to ChatMessage rendering (already shows agent badges + chain provenance)
+- Changes to SessionPane (already shows all thread events)
+- Agent-to-agent @mention orchestration (AI-138, already merged)
+- Real-time participant presence indicators (future)
+- @mention in agent responses displayed as links (future)
+
+---
+
+## 3. TDD Matrix
+
+| # | Requirement | Test Name | Type | File |
+|---|---|---|---|---|
+| T1 | `@` triggers autocomplete dropdown | `MentionInput shows autocomplete on @ trigger` | vitest | MentionInput.test.tsx |
+| T2 | Selecting agent inserts @slug into input | `MentionInput inserts @slug on selection` | vitest | MentionInput.test.tsx |
+| T3 | Autocomplete filters by typed prefix | `MentionInput filters agents by prefix after @` | vitest | MentionInput.test.tsx |
+| T4 | Escape closes autocomplete | `MentionInput closes autocomplete on Escape` | vitest | MentionInput.test.tsx |
+| T5 | Submit sends full text including @mention | `MentionInput submits message with @mention intact` | vitest | MentionInput.test.tsx |
+| T6 | ParticipantPanel renders current participants | `ParticipantPanel shows current thread agents` | vitest | ParticipantPanel.test.tsx |
+| T7 | ParticipantPanel add agent calls API | `ParticipantPanel add agent calls PUT /participants` | vitest | ParticipantPanel.test.tsx |
+| T8 | ParticipantPanel remove agent with confirmation | `ParticipantPanel remove agent requires confirmation` | vitest | ParticipantPanel.test.tsx |
+
+---
+
+## 4. Implementation Steps
+
+### Phase A: MentionInput component
+
+1. Create `services/ui/src/app/chat/MentionInput.tsx`:
+   - Props: `agents: ChatAgent[]`, `value: string`, `onChange: (value: string) => void`, `onSubmit: () => void`, `disabled: boolean`, `placeholder: string`
+   - State: `showAutocomplete: boolean`, `autocompleteIndex: number`, `filterText: string`
+   - On `@` typed: set `showAutocomplete = true`, track cursor position
+   - On typing after `@`: filter agents by `agent_id` prefix match
+   - On ArrowDown/ArrowUp: navigate autocomplete list
+   - On Enter in autocomplete: insert `@{agent_id} ` at cursor, close autocomplete
+   - On Escape: close autocomplete
+   - On Enter without autocomplete: call `onSubmit()`
+   - Render: `<textarea>` with absolute-positioned dropdown below cursor
+
+2. Update `ChatView.tsx`:
+   - Replace the plain `<textarea>` (lines ~235-250) with `<MentionInput>`
+   - Pass `agents` prop from thread participants
+   - Keep same `handleSend` logic — message text already includes `@slug` which API parses
+
+### Phase B: ParticipantPanel component
+
+3. Create `services/ui/src/app/chat/ParticipantPanel.tsx`:
+   - Props: `threadId: string`, `currentAgents: ChatAgent[]`, `onUpdated: () => void`, `onClose: () => void`
+   - State: `availableAgents: Agent[]` (fetched from `/api/agents`), `loading: boolean`, `adding: string | null`
+   - Current participants section: list with name + status badge + "Remove" button
+   - Remove flow: `confirm()` → `PUT /api/chat/{threadId}/participants` with `{remove: [uuid]}`
+   - Add section: agent picker (filtered to exclude current participants, exclude stopped agents)
+   - Add flow: click agent → `PUT /api/chat/{threadId}/participants` with `{add: [uuid]}`
+   - Max 8 enforcement: disable add button when at limit
+   - On success: call `onUpdated()` to refresh thread data
+
+4. Update `ChatView.tsx`:
+   - Add "Manage" button (Users icon) to group thread header, next to SessionPane toggle
+   - State: `participantPanelOpen: boolean`
+   - Render `<ParticipantPanel>` when open, passing current agents + threadId
+   - On `onUpdated`: re-fetch thread data (call `onThreadUpdated()`)
+
+### Phase C: Tests
+
+5. Create `services/ui/src/__tests__/MentionInput.test.tsx` with T1-T5.
+6. Create `services/ui/src/__tests__/ParticipantPanel.test.tsx` with T6-T8.
+
+---
+
+## 5. Verification Matrix
+
+| ID | Check | Command | Expected |
+|---|---|---|---|
+| V1 | MentionInput tests pass | `cd services/ui && npx vitest run MentionInput` | 5 tests green |
+| V2 | ParticipantPanel tests pass | `cd services/ui && npx vitest run ParticipantPanel` | 3 tests green |
+| V3 | Existing chat UI tests pass | `cd services/ui && npx vitest run ChatMessage ChatView ThreadList` | All pass |
+| V4 | Full UI suite | `cd services/ui && npx vitest run` | All 560+ pass |
+| V5 | API chat tests unchanged | `cd services/api && npm test -- --testPathPattern routes-chat` | All 75+ pass |
+
+---
+
+## 6. CI / Drift Gates
+
+- **Existing gates preserved:** Vitest (UI), Jest (API), OpenAPI drift, compose validation
+- **No new CI job:** existing vitest suite covers 8 new tests
+- **No API changes:** zero drift risk on backend
+- **Drift risk:** If `ChatAgent` interface changes, MentionInput and ParticipantPanel must be updated. The vitest tests catch this via type-checking at compile time.
+
+---
+
+## 7. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| @mention autocomplete position misaligned on mobile | Medium | Low | Absolute positioning relative to textarea, not viewport. Test at sm breakpoint. |
+| Autocomplete flickers on rapid typing | Low | Low | Debounce filter by 100ms. Close immediately on non-@ character. |
+| Participant removal mid-conversation loses context | Low | Medium | API already marks pending messages as error on removal (chat.ts lines 711-718). UI shows confirmation dialog. |
+| Max 8 agent limit not enforced in add flow | Low | High | Check `currentAgents.length >= 8` before enabling add button. API enforces server-side as backup. |
+| Elevated scope agent added by non-admin | Low | High | API returns 403 for elevated agents. UI shows error toast. No client-side bypass possible. |
+
+---
+
+## 8. Definition of Done
+
+- [ ] `@` in chat input shows autocomplete dropdown with thread agents (T1)
+- [ ] Selecting agent inserts `@slug ` into input text (T2)
+- [ ] Autocomplete filters by prefix (T3)
+- [ ] Escape closes autocomplete (T4)
+- [ ] Message with @mention sends correctly (T5)
+- [ ] Group thread header shows "Manage" button (participants icon)
+- [ ] ParticipantPanel lists current agents with remove option (T6)
+- [ ] Add agent flow calls API and refreshes thread (T7)
+- [ ] Remove agent requires confirmation (T8)
+- [ ] 8 new vitest tests pass (V1, V2)
+- [ ] No existing test regressions (V3, V4, V5)
+- [ ] No API changes
+- [ ] No agentbox changes
+
+---
+
+## 9. Stop Conditions
+
+**Stop if:**
+- MentionInput requires a rich text editor library (should be achievable with plain textarea + absolute dropdown)
+- Participant add/remove causes SSE stream disconnection (shouldn't — SSE cursor is sequence-based, not participant-based)
+- Any elevated scope agent becomes addable by non-admin through the UI (security boundary violation — API guards this, but verify)
+
+**Out of scope (future work):**
+- @mention syntax highlighting in input (colored @slug text — requires contenteditable or rich editor)
+- Real-time participant presence (online/typing indicators)
+- @mention rendering as links in message bubbles
+- Drag-and-drop agent reordering in participant panel
+- Thread-level notification preferences per agent
+- Cross-thread @mentions
+
+---
+
+## Plan Checklist
+
+- [x] Goal / Signal
+- [x] Scope
+- [x] TDD Matrix
+- [x] Implementation Steps
+- [x] Verification Matrix
+- [x] CI / Drift Gates
+- [x] Risks & Mitigations
+- [x] Definition of Done
+- [x] Stop Conditions
+
+---
+
+## Critical Files
+
+| File | Change |
+|---|---|
+| `services/ui/src/app/chat/MentionInput.tsx` | NEW — @-triggered autocomplete input |
+| `services/ui/src/app/chat/ParticipantPanel.tsx` | NEW — add/remove agents panel |
+| `services/ui/src/app/chat/ChatView.tsx` | Replace textarea with MentionInput, add participant button |
+| `services/ui/src/__tests__/MentionInput.test.tsx` | NEW — 5 tests (T1-T5) |
+| `services/ui/src/__tests__/ParticipantPanel.test.tsx` | NEW — 3 tests (T6-T8) |
+
+## Reusable Existing Code
+
+| What | Where |
+|---|---|
+| `ChatAgent` interface | `ChatLayout.tsx:10` — id, agent_id, name, status |
+| Agent picker pattern | `NewThreadDialog.tsx:113-155` — checkbox list with status badges |
+| `parseMentions(content)` | `chat.ts:124` — API-side @mention parser (unchanged) |
+| `PUT /threads/:id/participants` | `chat.ts:660-744` — add/remove with all guards |
+| Agent fetch | `/api/agents` proxy → API GET /agents (user-scoped) |

--- a/services/ui/src/__tests__/MentionInput.test.tsx
+++ b/services/ui/src/__tests__/MentionInput.test.tsx
@@ -1,0 +1,108 @@
+import React, { useState } from 'react'
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+
+import MentionInput from '@/app/chat/MentionInput'
+import type { ChatAgent } from '@/app/chat/ChatLayout'
+
+const MOCK_AGENTS: ChatAgent[] = [
+  { id: 'a1', agent_id: 'research-bot', name: 'ResearchBot', status: 'running' },
+  { id: 'a2', agent_id: 'writer-bot', name: 'WriterBot', status: 'running' },
+  { id: 'a3', agent_id: 'review-bot', name: 'ReviewBot', status: 'stopped' },
+]
+
+// Stateful wrapper that mirrors real usage (controlled input)
+function MentionWrapper({
+  agents = MOCK_AGENTS,
+  onSubmit = vi.fn(),
+  initialValue = '',
+}: {
+  agents?: ChatAgent[]
+  onSubmit?: () => void
+  initialValue?: string
+}) {
+  const [value, setValue] = useState(initialValue)
+  return (
+    <MentionInput
+      agents={agents}
+      value={value}
+      onChange={setValue}
+      onSubmit={onSubmit}
+      disabled={false}
+      placeholder="Message..."
+    />
+  )
+}
+
+// Helper: type into the mention input by setting value + selectionStart on the textarea ref
+function typeInto(textarea: HTMLTextAreaElement, text: string) {
+  // Set selectionStart before firing change so the ref reads it
+  Object.defineProperty(textarea, 'selectionStart', { value: text.length, writable: true, configurable: true })
+  fireEvent.change(textarea, { target: { value: text } })
+}
+
+describe('MentionInput', () => {
+  afterEach(() => cleanup())
+
+  it('T1: shows autocomplete on @ trigger', () => {
+    render(<MentionWrapper />)
+
+    const textarea = screen.getByTestId('mention-input') as HTMLTextAreaElement
+    typeInto(textarea, '@')
+
+    expect(screen.getByTestId('mention-autocomplete')).toBeInTheDocument()
+    expect(screen.getAllByTestId('mention-option')).toHaveLength(3)
+  })
+
+  it('T2: inserts @slug on selection', () => {
+    render(<MentionWrapper />)
+
+    const textarea = screen.getByTestId('mention-input') as HTMLTextAreaElement
+    typeInto(textarea, 'Hello @')
+
+    const options = screen.getAllByTestId('mention-option')
+    fireEvent.click(options[0])
+
+    // After clicking research-bot, the input should contain @research-bot
+    expect(textarea.value).toContain('@research-bot')
+    // Autocomplete should close
+    expect(screen.queryByTestId('mention-autocomplete')).not.toBeInTheDocument()
+  })
+
+  it('T3: filters agents by prefix after @', () => {
+    render(<MentionWrapper />)
+
+    const textarea = screen.getByTestId('mention-input') as HTMLTextAreaElement
+    typeInto(textarea, '@wr')
+
+    // Only writer-bot matches "wr" prefix
+    const options = screen.getAllByTestId('mention-option')
+    expect(options).toHaveLength(1)
+    expect(options[0]).toHaveTextContent('@writer-bot')
+  })
+
+  it('T4: closes autocomplete on Escape', () => {
+    render(<MentionWrapper />)
+
+    const textarea = screen.getByTestId('mention-input') as HTMLTextAreaElement
+    typeInto(textarea, '@')
+
+    expect(screen.getByTestId('mention-autocomplete')).toBeInTheDocument()
+
+    fireEvent.keyDown(textarea, { key: 'Escape' })
+
+    expect(screen.queryByTestId('mention-autocomplete')).not.toBeInTheDocument()
+  })
+
+  it('T5: submits message with @mention intact', () => {
+    const onSubmit = vi.fn()
+    render(<MentionWrapper onSubmit={onSubmit} initialValue="@research-bot what is TypeScript?" />)
+
+    const textarea = screen.getByTestId('mention-input')
+    // Enter without autocomplete open should submit
+    fireEvent.keyDown(textarea, { key: 'Enter' })
+
+    expect(onSubmit).toHaveBeenCalledTimes(1)
+  })
+})

--- a/services/ui/src/__tests__/ParticipantPanel.test.tsx
+++ b/services/ui/src/__tests__/ParticipantPanel.test.tsx
@@ -1,0 +1,134 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+
+// Mock lucide-react
+vi.mock('lucide-react', () => ({
+  X: (props: any) => <span data-testid="icon-x" {...props} />,
+  Plus: (props: any) => <span data-testid="icon-plus" {...props} />,
+  UserMinus: (props: any) => <span data-testid="icon-user-minus" {...props} />,
+}))
+
+import ParticipantPanel from '@/app/chat/ParticipantPanel'
+import type { ChatAgent } from '@/app/chat/ChatLayout'
+
+const CURRENT_AGENTS: ChatAgent[] = [
+  { id: 'a1', agent_id: 'research-bot', name: 'ResearchBot', status: 'running' },
+  { id: 'a2', agent_id: 'writer-bot', name: 'WriterBot', status: 'running' },
+]
+
+const ALL_AGENTS = [
+  ...CURRENT_AGENTS,
+  { id: 'a3', agent_id: 'review-bot', name: 'ReviewBot', status: 'running' },
+  { id: 'a4', agent_id: 'stopped-bot', name: 'StoppedBot', status: 'stopped' },
+]
+
+const mockFetch = vi.fn()
+vi.stubGlobal('fetch', mockFetch)
+
+describe('ParticipantPanel', () => {
+  beforeEach(() => {
+    mockFetch.mockReset()
+    // Default: GET /api/agents returns all agents
+    mockFetch.mockImplementation(async (url: string, opts?: any) => {
+      if (url === '/api/agents' && (!opts || !opts.method || opts.method === 'GET')) {
+        return { ok: true, json: async () => ALL_AGENTS }
+      }
+      if (typeof url === 'string' && url.includes('/participants') && opts?.method === 'PUT') {
+        return { ok: true, json: async () => ({ participants: [] }) }
+      }
+      return { ok: false, json: async () => ({ error: 'Not found' }) }
+    })
+  })
+
+  afterEach(() => cleanup())
+
+  it('T6: shows current thread agents', async () => {
+    render(
+      <ParticipantPanel
+        threadId="thread-1"
+        currentAgents={CURRENT_AGENTS}
+        onUpdated={vi.fn()}
+        onClose={vi.fn()}
+      />
+    )
+
+    expect(screen.getByTestId('participant-panel')).toBeInTheDocument()
+
+    await waitFor(() => {
+      const participants = screen.getAllByTestId('current-participant')
+      expect(participants).toHaveLength(2)
+    })
+
+    expect(screen.getByText('ResearchBot')).toBeInTheDocument()
+    expect(screen.getByText('WriterBot')).toBeInTheDocument()
+  })
+
+  it('T7: add agent calls PUT /participants', async () => {
+    const onUpdated = vi.fn()
+    render(
+      <ParticipantPanel
+        threadId="thread-1"
+        currentAgents={CURRENT_AGENTS}
+        onUpdated={onUpdated}
+        onClose={vi.fn()}
+      />
+    )
+
+    // Wait for agents to load
+    await waitFor(() => {
+      expect(screen.getByText('ReviewBot')).toBeInTheDocument()
+    })
+
+    // Click add button for ReviewBot
+    const addButtons = screen.getAllByTestId('add-agent-button')
+    fireEvent.click(addButtons[0])
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        '/api/chat/thread-1/participants',
+        expect.objectContaining({
+          method: 'PUT',
+          body: expect.stringContaining('"add"'),
+        })
+      )
+      expect(onUpdated).toHaveBeenCalled()
+    })
+  })
+
+  it('T8: remove agent requires confirmation', async () => {
+    render(
+      <ParticipantPanel
+        threadId="thread-1"
+        currentAgents={CURRENT_AGENTS}
+        onUpdated={vi.fn()}
+        onClose={vi.fn()}
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('current-participant')).toHaveLength(2)
+    })
+
+    // Click remove icon on first agent
+    const removeButtons = screen.getAllByTestId('remove-button')
+    fireEvent.click(removeButtons[0])
+
+    // Should show confirmation, not immediately remove
+    expect(screen.getByTestId('confirm-remove')).toBeInTheDocument()
+
+    // Click confirm
+    fireEvent.click(screen.getByTestId('confirm-remove'))
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        '/api/chat/thread-1/participants',
+        expect.objectContaining({
+          method: 'PUT',
+          body: expect.stringContaining('"remove"'),
+        })
+      )
+    })
+  })
+})

--- a/services/ui/src/app/chat/ChatView.tsx
+++ b/services/ui/src/app/chat/ChatView.tsx
@@ -2,13 +2,15 @@
 
 import { useState, useEffect, useRef, useCallback } from 'react'
 import { useRouter } from 'next/navigation'
-import { ArrowLeft, Send, Terminal } from 'lucide-react'
+import { ArrowLeft, Send, Terminal, Users } from 'lucide-react'
 import type { Session } from 'next-auth'
 import type { ChatThread } from './ChatLayout'
 import ChatMessage from './ChatMessage'
 import AgentStatusBar from './AgentStatusBar'
 import CancelButton from './CancelButton'
 import SessionPane from './SessionPane'
+import MentionInput from './MentionInput'
+import ParticipantPanel from './ParticipantPanel'
 
 export interface Message {
   id: string
@@ -45,6 +47,7 @@ export default function ChatView({ threadId, session, thread, onBack, onThreadUp
   const [sending, setSending] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [sessionPaneOpen, setSessionPaneOpen] = useState(false)
+  const [participantPanelOpen, setParticipantPanelOpen] = useState(false)
   const messagesEndRef = useRef<HTMLDivElement>(null)
   const eventSourceRef = useRef<EventSource | null>(null)
 
@@ -127,13 +130,6 @@ export default function ChatView({ threadId, session, thread, onBack, onThreadUp
     }
   }
 
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter' && !e.shiftKey) {
-      e.preventDefault()
-      handleSend()
-    }
-  }
-
   const hasPending = messages.some(m => m.status === 'pending')
   const anyAgentRunning = agents.some(a => a.status === 'running')
   const agentName = thread?.agent?.name || 'Agent'
@@ -190,6 +186,20 @@ export default function ChatView({ threadId, session, thread, onBack, onThreadUp
               hasPending={hasPending}
               onCancelled={onThreadUpdated}
             />
+            {isGroup && (
+              <button
+                onClick={() => setParticipantPanelOpen(prev => !prev)}
+                className={`p-1.5 rounded transition-colors ${
+                  participantPanelOpen
+                    ? 'bg-brand-600/20 text-brand-400'
+                    : 'text-mountain-400 hover:text-gray-200 hover:bg-navy-700'
+                }`}
+                title="Manage Participants"
+                data-testid="participants-toggle"
+              >
+                <Users size={18} />
+              </button>
+            )}
             <button
               onClick={() => setSessionPaneOpen(prev => !prev)}
               className={`p-1.5 rounded transition-colors ${
@@ -245,14 +255,13 @@ export default function ChatView({ threadId, session, thread, onBack, onThreadUp
         {/* Input */}
         <div className="px-4 py-3 border-t border-navy-700 bg-navy-900/50">
           <div className="flex gap-2 items-end">
-            <textarea
+            <MentionInput
+              agents={agents}
               value={input}
-              onChange={e => setInput(e.target.value)}
-              onKeyDown={handleKeyDown}
-              placeholder={getPlaceholder()}
+              onChange={setInput}
+              onSubmit={handleSend}
               disabled={sending || !anyAgentRunning}
-              rows={1}
-              className="flex-1 bg-navy-800 border border-navy-700 rounded-lg px-3 py-2 text-sm text-gray-200 placeholder-mountain-500 focus:outline-none focus:ring-1 focus:ring-brand-500 resize-none disabled:opacity-50"
+              placeholder={getPlaceholder()}
             />
             <button
               onClick={handleSend}
@@ -264,6 +273,18 @@ export default function ChatView({ threadId, session, thread, onBack, onThreadUp
           </div>
         </div>
       </div>
+
+      {/* Participant panel (collapsible, group threads only) */}
+      {participantPanelOpen && isGroup && (
+        <div className="hidden xl:flex w-[300px] flex-shrink-0 border-l border-navy-700 bg-navy-900">
+          <ParticipantPanel
+            threadId={threadId}
+            currentAgents={agents}
+            onUpdated={onThreadUpdated}
+            onClose={() => setParticipantPanelOpen(false)}
+          />
+        </div>
+      )}
 
       {/* Session pane (collapsible) */}
       {sessionPaneOpen && (

--- a/services/ui/src/app/chat/MentionInput.tsx
+++ b/services/ui/src/app/chat/MentionInput.tsx
@@ -1,0 +1,148 @@
+'use client'
+
+import { useState, useRef, useEffect, useCallback } from 'react'
+import type { ChatAgent } from './ChatLayout'
+
+interface Props {
+  agents: ChatAgent[]
+  value: string
+  onChange: (value: string) => void
+  onSubmit: () => void
+  disabled: boolean
+  placeholder: string
+}
+
+export default function MentionInput({ agents, value, onChange, onSubmit, disabled, placeholder }: Props) {
+  const [showAutocomplete, setShowAutocomplete] = useState(false)
+  const [selectedIndex, setSelectedIndex] = useState(0)
+  const [filterText, setFilterText] = useState('')
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+
+  const filtered = agents.filter(a =>
+    a.agent_id.toLowerCase().startsWith(filterText.toLowerCase())
+  )
+
+  // Reset selection when filter changes
+  useEffect(() => {
+    setSelectedIndex(0)
+  }, [filterText])
+
+  const insertMention = useCallback((agent: ChatAgent) => {
+    const textarea = textareaRef.current
+    if (!textarea) return
+
+    // Find the @ that triggered autocomplete and replace @prefix with @slug
+    const beforeCursor = value.slice(0, textarea.selectionStart)
+    const atIndex = beforeCursor.lastIndexOf('@')
+    if (atIndex === -1) return
+
+    const before = value.slice(0, atIndex)
+    const after = value.slice(textarea.selectionStart)
+    const newValue = `${before}@${agent.agent_id} ${after}`
+    onChange(newValue)
+    setShowAutocomplete(false)
+    setFilterText('')
+
+    // Focus back and set cursor after inserted mention
+    requestAnimationFrame(() => {
+      if (textareaRef.current) {
+        const pos = before.length + agent.agent_id.length + 2 // @slug + space
+        textareaRef.current.focus()
+        textareaRef.current.setSelectionRange(pos, pos)
+      }
+    })
+  }, [value, onChange])
+
+  const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const newValue = e.target.value
+    onChange(newValue)
+
+    // Check if we should show autocomplete — use ref for cursor position (more reliable in tests)
+    const cursorPos = textareaRef.current?.selectionStart ?? newValue.length
+    const textBeforeCursor = newValue.slice(0, cursorPos)
+    const atMatch = textBeforeCursor.match(/@([a-z0-9-]*)$/)
+
+    if (atMatch) {
+      setShowAutocomplete(true)
+      setFilterText(atMatch[1])
+    } else {
+      setShowAutocomplete(false)
+      setFilterText('')
+    }
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (showAutocomplete && filtered.length > 0) {
+      if (e.key === 'ArrowDown') {
+        e.preventDefault()
+        setSelectedIndex(prev => (prev + 1) % filtered.length)
+        return
+      }
+      if (e.key === 'ArrowUp') {
+        e.preventDefault()
+        setSelectedIndex(prev => (prev - 1 + filtered.length) % filtered.length)
+        return
+      }
+      if (e.key === 'Enter' || e.key === 'Tab') {
+        e.preventDefault()
+        insertMention(filtered[selectedIndex])
+        return
+      }
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        setShowAutocomplete(false)
+        return
+      }
+    }
+
+    // Normal Enter (no autocomplete): submit
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault()
+      onSubmit()
+    }
+  }
+
+  return (
+    <div className="relative flex-1">
+      <textarea
+        ref={textareaRef}
+        value={value}
+        onChange={handleChange}
+        onKeyDown={handleKeyDown}
+        placeholder={placeholder}
+        disabled={disabled}
+        rows={1}
+        data-testid="mention-input"
+        className="w-full bg-navy-800 border border-navy-700 rounded-lg px-3 py-2 text-sm text-gray-200 placeholder-mountain-500 focus:outline-none focus:ring-1 focus:ring-brand-500 resize-none disabled:opacity-50"
+      />
+
+      {showAutocomplete && filtered.length > 0 && (
+        <div
+          className="absolute bottom-full left-0 mb-1 w-64 bg-navy-800 border border-navy-700 rounded-lg shadow-lg overflow-hidden z-50"
+          data-testid="mention-autocomplete"
+        >
+          {filtered.map((agent, i) => (
+            <button
+              key={agent.id}
+              onClick={() => insertMention(agent)}
+              className={`w-full text-left px-3 py-2 text-sm flex items-center gap-2 ${
+                i === selectedIndex
+                  ? 'bg-brand-600/20 text-white'
+                  : 'text-mountain-300 hover:bg-navy-700'
+              }`}
+              data-testid="mention-option"
+            >
+              <span
+                className={`w-1.5 h-1.5 rounded-full ${
+                  agent.status === 'running' ? 'bg-brand-400' : 'bg-mountain-500'
+                }`}
+              />
+              <span className="font-medium">@{agent.agent_id}</span>
+              <span className="text-mountain-500 text-xs truncate">{agent.name}</span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/services/ui/src/app/chat/ParticipantPanel.tsx
+++ b/services/ui/src/app/chat/ParticipantPanel.tsx
@@ -1,0 +1,210 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { X, Plus, UserMinus } from 'lucide-react'
+import type { ChatAgent } from './ChatLayout'
+
+interface Agent {
+  id: string
+  agent_id: string
+  name: string
+  status: string
+}
+
+interface Props {
+  threadId: string
+  currentAgents: ChatAgent[]
+  onUpdated: () => void
+  onClose: () => void
+}
+
+const MAX_AGENTS = 8
+
+export default function ParticipantPanel({ threadId, currentAgents, onUpdated, onClose }: Props) {
+  const [availableAgents, setAvailableAgents] = useState<Agent[]>([])
+  const [loading, setLoading] = useState(true)
+  const [actionLoading, setActionLoading] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [confirmRemoveId, setConfirmRemoveId] = useState<string | null>(null)
+
+  const currentIds = new Set(currentAgents.map(a => a.id))
+  const addableAgents = availableAgents.filter(
+    a => !currentIds.has(a.id) && a.status === 'running'
+  )
+  const atLimit = currentAgents.length >= MAX_AGENTS
+
+  useEffect(() => {
+    async function fetchAgents() {
+      try {
+        const res = await fetch('/api/agents')
+        if (res.ok) {
+          const data = await res.json()
+          setAvailableAgents(data)
+        }
+      } catch {
+        // Non-fatal
+      } finally {
+        setLoading(false)
+      }
+    }
+    fetchAgents()
+  }, [])
+
+  const handleAdd = async (agentId: string) => {
+    setActionLoading(agentId)
+    setError(null)
+    try {
+      const res = await fetch(`/api/chat/${threadId}/participants`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ add: [agentId] }),
+      })
+      if (res.ok) {
+        onUpdated()
+      } else {
+        const data = await res.json()
+        setError(data.error || 'Failed to add agent')
+      }
+    } catch {
+      setError('Failed to add agent')
+    } finally {
+      setActionLoading(null)
+    }
+  }
+
+  const handleRemove = async (agentId: string) => {
+    setConfirmRemoveId(null)
+    setActionLoading(agentId)
+    setError(null)
+    try {
+      const res = await fetch(`/api/chat/${threadId}/participants`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ remove: [agentId] }),
+      })
+      if (res.ok) {
+        onUpdated()
+      } else {
+        const data = await res.json()
+        setError(data.error || 'Failed to remove agent')
+      }
+    } catch {
+      setError('Failed to remove agent')
+    } finally {
+      setActionLoading(null)
+    }
+  }
+
+  return (
+    <div className="flex flex-col h-full" data-testid="participant-panel">
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 py-3 border-b border-navy-700">
+        <h3 className="text-sm font-semibold text-white">Participants</h3>
+        <button
+          onClick={onClose}
+          className="text-mountain-400 hover:text-white transition-colors"
+          aria-label="Close participants"
+        >
+          <X size={18} />
+        </button>
+      </div>
+
+      <div className="flex-1 overflow-y-auto px-4 py-3 space-y-4">
+        {error && (
+          <div className="text-xs text-red-400 bg-red-900/20 rounded px-2 py-1">
+            {error}
+          </div>
+        )}
+
+        {/* Current participants */}
+        <div>
+          <h4 className="text-xs font-medium text-mountain-400 uppercase tracking-wider mb-2">
+            Current ({currentAgents.length}/{MAX_AGENTS})
+          </h4>
+          <div className="space-y-1">
+            {currentAgents.map(agent => (
+              <div
+                key={agent.id}
+                className="flex items-center justify-between px-2 py-1.5 rounded bg-navy-800"
+                data-testid="current-participant"
+              >
+                <div className="flex items-center gap-2 min-w-0">
+                  <span
+                    className={`w-1.5 h-1.5 rounded-full flex-shrink-0 ${
+                      agent.status === 'running' ? 'bg-brand-400' : 'bg-mountain-500'
+                    }`}
+                  />
+                  <span className="text-sm text-gray-200 truncate">{agent.name}</span>
+                  <span className="text-xs text-mountain-500">@{agent.agent_id}</span>
+                </div>
+                {confirmRemoveId === agent.id ? (
+                  <div className="flex items-center gap-1">
+                    <button
+                      onClick={() => handleRemove(agent.id)}
+                      disabled={actionLoading === agent.id}
+                      className="text-xs text-red-400 hover:text-red-300 px-1"
+                      data-testid="confirm-remove"
+                    >
+                      Remove
+                    </button>
+                    <button
+                      onClick={() => setConfirmRemoveId(null)}
+                      className="text-xs text-mountain-400 hover:text-white px-1"
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                ) : (
+                  <button
+                    onClick={() => setConfirmRemoveId(agent.id)}
+                    className="text-mountain-500 hover:text-red-400 transition-colors p-0.5"
+                    title="Remove agent"
+                    data-testid="remove-button"
+                  >
+                    <UserMinus size={14} />
+                  </button>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Add agents */}
+        {!atLimit && (
+          <div>
+            <h4 className="text-xs font-medium text-mountain-400 uppercase tracking-wider mb-2">
+              Add Agent
+            </h4>
+            {loading ? (
+              <p className="text-xs text-mountain-500">Loading agents...</p>
+            ) : addableAgents.length === 0 ? (
+              <p className="text-xs text-mountain-500">No available agents to add</p>
+            ) : (
+              <div className="space-y-1">
+                {addableAgents.map(agent => (
+                  <button
+                    key={agent.id}
+                    onClick={() => handleAdd(agent.id)}
+                    disabled={actionLoading === agent.id}
+                    className="w-full flex items-center gap-2 px-2 py-1.5 rounded bg-navy-800 hover:bg-navy-700 transition-colors disabled:opacity-50 text-left"
+                    data-testid="add-agent-button"
+                  >
+                    <Plus size={14} className="text-brand-400 flex-shrink-0" />
+                    <span className="text-sm text-gray-200 truncate">{agent.name}</span>
+                    <span className="text-xs text-mountain-500">@{agent.agent_id}</span>
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+
+        {atLimit && (
+          <p className="text-xs text-mountain-500">
+            Maximum {MAX_AGENTS} agents per group reached
+          </p>
+        )}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

Completes the group thread UI experience. The API was already 100% done — this PR closes the 2 remaining UI gaps.

- **MentionInput**: `@`-triggered autocomplete dropdown in chat textarea. Filters agents by slug prefix, inserts `@agent-id ` on selection. Keyboard navigation (ArrowUp/Down, Enter/Tab to select, Escape to close). Replaces the plain textarea in ChatView.
- **ParticipantPanel**: Slide-out panel to add/remove agents from existing group threads. Shows current participants with remove button (confirmation required), and available running agents to add. Max 8 enforcement. Calls existing `PUT /threads/:id/participants` API.
- **ChatView integration**: "Manage" button (Users icon) in group thread header toggles ParticipantPanel. MentionInput replaces textarea for all threads.

## Plan

Closed-loop plan: `.claude/plans/ai-139-chat-phase-1b.md` (all 9 sections)

## Risks

| Risk | Mitigation |
|------|-----------|
| Autocomplete position on mobile | Absolute-positioned above input, bounded to input width |
| Participant removal mid-conversation | API marks pending messages as error, UI shows confirmation |
| Max 8 agent limit bypass | Checked client-side + API enforces server-side |
| Elevated scope agent added by non-admin | API returns 403, UI shows error |

## Rollback

UI-only change. Revert commit reverts to plain textarea + no participant panel. API unchanged.

## Validation Evidence

- [x] MentionInput tests pass (5/5): autocomplete trigger, slug insertion, prefix filter, Escape close, submit
- [x] ParticipantPanel tests pass (3/3): current agents display, add calls API, remove requires confirmation
- [x] Full UI suite green (568/568)
- [ ] V1: Type `@` in group chat input → autocomplete appears
- [ ] V2: Select agent → `@slug ` inserted in input
- [ ] V3: Click "Manage" button → participant panel opens
- [ ] V4: Add agent via panel → agent appears in thread
- [ ] V5: Remove agent with confirmation → agent removed

**Linear:** AI-139
**Plan:** `.claude/plans/ai-139-chat-phase-1b.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)