### PR TITLE
feat: group thread parallel dispatch + batch completion (AI-146)

### DIFF
--- a/services/agentbox/app/chat.py
+++ b/services/agentbox/app/chat.py
@@ -89,6 +89,22 @@ def handle_chat(
     if rules:
         system_content = f"{system_content}\n\n{rules}" if system_content else rules
 
+    # Append group context if this is a group thread
+    thread_type = payload.get("thread_type")
+    participants = payload.get("participants")
+    if thread_type == "group" and participants and isinstance(participants, list):
+        agent_lines = "\n".join(
+            f"- @{p['agent_id']}" for p in participants if isinstance(p, dict) and "agent_id" in p
+        )
+        if agent_lines:
+            group_block = (
+                "\n\n## Group Thread\n"
+                "You are in a group conversation with these agents:\n"
+                f"{agent_lines}\n"
+                "Address other agents with @slug if you need their input."
+            )
+            system_content = f"{system_content}{group_block}" if system_content else group_block
+
     # Build final messages: system prompt + API-provided history
     final_messages = []
     if system_content:

--- a/services/agentbox/tests/test_chat.py
+++ b/services/agentbox/tests/test_chat.py
@@ -270,3 +270,82 @@ class TestSystemPromptAssembly:
         ai_body = mock_post.call_args_list[0][1]["json"]
         # No system message when both soul and rules are empty
         assert ai_body["messages"][0]["role"] == "user"
+
+
+class TestGroupChatContext:
+    """AI-146: Group thread context in system prompt."""
+
+    @patch("app.chat.requests.post")
+    def test_group_chat_includes_participants(self, mock_post, emitter, monkeypatch):
+        """T8: Group payload injects participant names into system prompt."""
+        em, _ = emitter
+        monkeypatch.setenv("CHAT_CALLBACK_TOKEN", "cb-token")
+        monkeypatch.setenv("MODEL_ROUTER_TOKEN", "mr-token")
+
+        ai_response = MagicMock(
+            status_code=200,
+            json=lambda: {"choices": [{"message": {"content": "ok"}}], "usage": {}, "model": "m"},
+        )
+        mock_post.side_effect = [ai_response, MagicMock(status_code=200)]
+
+        handle_chat(
+            {
+                "thread_id": "t1", "message_id": "m1",
+                "messages": [{"role": "user", "content": "Hi all"}],
+                "model": "gpt-4o-mini",
+                "callback_url": "http://api:3000/cb",
+                "thread_type": "group",
+                "participants": [
+                    {"agent_id": "alpha", "name": "Alpha"},
+                    {"agent_id": "beta", "name": "Beta"},
+                ],
+            },
+            soul="I am TestBot",
+            rules="Rule 1: Be nice",
+            work_id="w1",
+            emitter=em,
+        )
+
+        ai_body = mock_post.call_args_list[0][1]["json"]
+        system_msg = ai_body["messages"][0]
+        assert system_msg["role"] == "system"
+        assert "Group Thread" in system_msg["content"]
+        assert "@alpha" in system_msg["content"]
+        assert "@beta" in system_msg["content"]
+        assert "@slug" in system_msg["content"]
+        # Original soul + rules still present
+        assert "I am TestBot" in system_msg["content"]
+        assert "Rule 1: Be nice" in system_msg["content"]
+
+    @patch("app.chat.requests.post")
+    def test_direct_chat_no_participant_context(self, mock_post, emitter, monkeypatch):
+        """T9: Direct payload does not alter system prompt."""
+        em, _ = emitter
+        monkeypatch.setenv("CHAT_CALLBACK_TOKEN", "cb-token")
+        monkeypatch.setenv("MODEL_ROUTER_TOKEN", "mr-token")
+
+        ai_response = MagicMock(
+            status_code=200,
+            json=lambda: {"choices": [{"message": {"content": "ok"}}], "usage": {}, "model": "m"},
+        )
+        mock_post.side_effect = [ai_response, MagicMock(status_code=200)]
+
+        handle_chat(
+            {
+                "thread_id": "t1", "message_id": "m1",
+                "messages": [{"role": "user", "content": "Hi"}],
+                "model": "gpt-4o-mini",
+                "callback_url": "http://api:3000/cb",
+                # No thread_type or participants — direct thread
+            },
+            soul="I am TestBot",
+            rules="Rule 1: Be nice",
+            work_id="w1",
+            emitter=em,
+        )
+
+        ai_body = mock_post.call_args_list[0][1]["json"]
+        system_msg = ai_body["messages"][0]
+        assert system_msg["role"] == "system"
+        assert "Group Thread" not in system_msg["content"]
+        assert "I am TestBot" in system_msg["content"]

--- a/services/api/src/__tests__/routes-chat.test.ts
+++ b/services/api/src/__tests__/routes-chat.test.ts
@@ -868,7 +868,8 @@ describe('Chat callback', () => {
   it('POST /internal/chat/callback accepts valid token and updates message', async () => {
     mockQuery
       .mockResolvedValueOnce({ rowCount: 1 })  // guarded UPDATE
-      .mockResolvedValueOnce({ rows: [] });     // UPDATE thread timestamp
+      .mockResolvedValueOnce({ rows: [] })      // UPDATE thread timestamp
+      .mockResolvedValueOnce({ rows: [{ reply_to: null, thread_type: 'direct' }] });  // batch completion: direct, skip
 
     const res = await request(app)
       .post('/internal/chat/callback')
@@ -955,7 +956,8 @@ describe('Chat callback', () => {
   it('POST /internal/chat/callback handles error status', async () => {
     mockQuery
       .mockResolvedValueOnce({ rowCount: 1 })
-      .mockResolvedValueOnce({ rows: [] });
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ reply_to: null, thread_type: 'direct' }] });  // batch completion: direct, skip
 
     const res = await request(app)
       .post('/internal/chat/callback')
@@ -979,6 +981,7 @@ describe('Chat callback', () => {
       mockQuery
         .mockResolvedValueOnce({ rowCount: 1 })  // guarded UPDATE
         .mockResolvedValueOnce({ rows: [] })       // UPDATE thread timestamp
+        .mockResolvedValueOnce({ rows: [{ reply_to: null, thread_type: 'direct' }] })  // batch completion: direct, skip
         .mockResolvedValueOnce({ rows: [{ author_id: 'agent-uuid-1' }] }) // SELECT author_id
         .mockResolvedValueOnce({ rows: [{ scope: 'host_docker' }] }); // getAgentElevatedScope
 
@@ -1132,6 +1135,7 @@ describe('Agent-to-agent @mention orchestration', () => {
     mockQuery
       .mockResolvedValueOnce({ rowCount: 1 })  // guarded UPDATE
       .mockResolvedValueOnce({ rows: [] })       // UPDATE thread timestamp
+      .mockResolvedValueOnce({ rows: [{ reply_to: null, thread_type: 'direct' }] })  // batch completion: direct, skip
       .mockResolvedValueOnce({ rows: [{ author_id: 'agent-a-uuid' }] }) // elevated tagging query
       .mockResolvedValueOnce({ rows: [] })       // getAgentElevatedScope (not elevated)
       // Agent-to-agent orchestration:
@@ -1143,6 +1147,7 @@ describe('Agent-to-agent @mention orchestration', () => {
       .mockResolvedValueOnce({ rows: [] })       // getAgentElevatedScope for target
       .mockResolvedValueOnce({ rows: [{ id: 'agent-b-uuid', agent_id: 'agent-b', name: 'Agent B', status: 'running', work_token: 'wt-b', models: ['gpt-4o-mini'] }] }) // getAgentForDispatch
       .mockResolvedValueOnce({ rows: [] })       // concurrency guard
+      .mockResolvedValueOnce({ rows: [{ type: 'direct' }] })  // chain thread type for group context
       .mockResolvedValueOnce({ rows: [{ role: 'user', content: 'Hello' }] }) // message history
       .mockResolvedValueOnce({ rows: [{ id: 'chain-placeholder' }] }); // INSERT placeholder
 
@@ -1169,6 +1174,7 @@ describe('Agent-to-agent @mention orchestration', () => {
     mockQuery
       .mockResolvedValueOnce({ rowCount: 1 })  // guarded UPDATE
       .mockResolvedValueOnce({ rows: [] })       // UPDATE thread timestamp
+      .mockResolvedValueOnce({ rows: [{ reply_to: null, thread_type: 'direct' }] })  // batch completion: direct, skip
       .mockResolvedValueOnce({ rows: [{ author_id: 'agent-a-uuid' }] }) // elevated tagging
       .mockResolvedValueOnce({ rows: [] })       // not elevated
       // Orchestration:
@@ -1195,6 +1201,7 @@ describe('Agent-to-agent @mention orchestration', () => {
     mockQuery
       .mockResolvedValueOnce({ rowCount: 1 })  // guarded UPDATE
       .mockResolvedValueOnce({ rows: [] })       // UPDATE thread timestamp
+      .mockResolvedValueOnce({ rows: [{ reply_to: null, thread_type: 'direct' }] })  // batch completion: direct, skip
       .mockResolvedValueOnce({ rows: [{ author_id: 'agent-a-uuid' }] }) // elevated tagging
       .mockResolvedValueOnce({ rows: [] })       // not elevated
       // Orchestration:
@@ -1221,6 +1228,7 @@ describe('Agent-to-agent @mention orchestration', () => {
     mockQuery
       .mockResolvedValueOnce({ rowCount: 1 })  // guarded UPDATE
       .mockResolvedValueOnce({ rows: [] })       // UPDATE thread timestamp
+      .mockResolvedValueOnce({ rows: [{ reply_to: null, thread_type: 'direct' }] })  // batch completion: direct, skip
       .mockResolvedValueOnce({ rows: [{ author_id: 'agent-a-uuid' }] }) // elevated tagging
       .mockResolvedValueOnce({ rows: [] })       // not elevated
       // Orchestration:
@@ -1245,6 +1253,7 @@ describe('Agent-to-agent @mention orchestration', () => {
     mockQuery
       .mockResolvedValueOnce({ rowCount: 1 })  // guarded UPDATE
       .mockResolvedValueOnce({ rows: [] })       // UPDATE thread timestamp
+      .mockResolvedValueOnce({ rows: [{ reply_to: null, thread_type: 'direct' }] })  // batch completion: direct, skip
       .mockResolvedValueOnce({ rows: [{ author_id: 'agent-a-uuid' }] }) // elevated tagging
       .mockResolvedValueOnce({ rows: [] })       // not elevated
       // Orchestration:
@@ -1271,6 +1280,7 @@ describe('Agent-to-agent @mention orchestration', () => {
     mockQuery
       .mockResolvedValueOnce({ rowCount: 1 })  // guarded UPDATE
       .mockResolvedValueOnce({ rows: [] })       // UPDATE thread timestamp
+      .mockResolvedValueOnce({ rows: [{ reply_to: null, thread_type: 'direct' }] })  // batch completion: direct, skip
       .mockResolvedValueOnce({ rows: [{ author_id: 'agent-a-uuid' }] }) // elevated tagging
       .mockResolvedValueOnce({ rows: [] })       // not elevated (author)
       // Orchestration:
@@ -1303,6 +1313,7 @@ describe('Agent-to-agent @mention orchestration', () => {
     mockQuery
       .mockResolvedValueOnce({ rowCount: 1 })
       .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ reply_to: null, thread_type: 'direct' }] })  // batch completion: direct, skip
       .mockResolvedValueOnce({ rows: [{ author_id: 'agent-a-uuid' }] })
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [{ thread_id: 'thread-1', author_id: 'agent-a-uuid', chain_id: 'shared-chain-id', chain_hop: 1 }] })
@@ -1312,6 +1323,7 @@ describe('Agent-to-agent @mention orchestration', () => {
       .mockResolvedValueOnce({ rows: [] }) // not elevated
       .mockResolvedValueOnce({ rows: [{ id: 'agent-c-uuid', agent_id: 'agent-c', name: 'Agent C', status: 'running', work_token: 'wt-c', models: ['gpt-4o-mini'] }] })
       .mockResolvedValueOnce({ rows: [] }) // concurrency
+      .mockResolvedValueOnce({ rows: [{ type: 'direct' }] })  // chain thread type
       .mockResolvedValueOnce({ rows: [{ role: 'user', content: 'Hello' }] })
       .mockResolvedValueOnce({ rows: [{ id: 'chain-ph-2' }] }); // placeholder
 
@@ -1333,6 +1345,7 @@ describe('Agent-to-agent @mention orchestration', () => {
     mockQuery
       .mockResolvedValueOnce({ rowCount: 1 })
       .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ reply_to: null, thread_type: 'direct' }] })  // batch completion: direct, skip
       .mockResolvedValueOnce({ rows: [{ author_id: 'agent-a-uuid' }] })
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [{ thread_id: 'thread-1', author_id: 'agent-a-uuid', chain_id: 'chain-inc', chain_hop: 2 }] })
@@ -1342,6 +1355,7 @@ describe('Agent-to-agent @mention orchestration', () => {
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [{ id: 'agent-d-uuid', agent_id: 'agent-d', name: 'Agent D', status: 'running', work_token: 'wt-d', models: ['gpt-4o-mini'] }] })
       .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ type: 'direct' }] })  // chain thread type
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [{ id: 'chain-ph-3' }] });
 
@@ -1363,6 +1377,7 @@ describe('Agent-to-agent @mention orchestration', () => {
     mockQuery
       .mockResolvedValueOnce({ rowCount: 1 })
       .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ reply_to: null, thread_type: 'direct' }] })  // batch completion: direct, skip
       .mockResolvedValueOnce({ rows: [{ author_id: 'agent-a-uuid' }] })
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [{ thread_id: 'thread-1', author_id: 'agent-a-uuid', chain_id: null, chain_hop: null }] })
@@ -1373,6 +1388,7 @@ describe('Agent-to-agent @mention orchestration', () => {
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [{ id: 'agent-e-uuid', agent_id: 'agent-e', name: 'Agent E', status: 'running', work_token: 'wt-e', models: ['gpt-4o-mini'] }] })
       .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ type: 'direct' }] })  // chain thread type
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [{ id: 'chain-ph-tb' }] });
 
@@ -1393,6 +1409,7 @@ describe('Agent-to-agent @mention orchestration', () => {
     mockQuery
       .mockResolvedValueOnce({ rowCount: 1 })
       .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ reply_to: null, thread_type: 'direct' }] })  // batch completion: direct, skip
       .mockResolvedValueOnce({ rows: [{ author_id: 'agent-a-uuid' }] })
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [{ thread_id: 'thread-1', author_id: 'agent-a-uuid', chain_id: null, chain_hop: null }] })
@@ -1412,6 +1429,7 @@ describe('Agent-to-agent @mention orchestration', () => {
     mockQuery
       .mockResolvedValueOnce({ rowCount: 1 })
       .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ reply_to: null, thread_type: 'direct' }] })  // batch completion: direct, skip
       .mockResolvedValueOnce({ rows: [{ author_id: 'agent-a-uuid' }] })
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [{ thread_id: 'thread-1', author_id: 'agent-a-uuid', chain_id: null, chain_hop: null }] })
@@ -1422,6 +1440,7 @@ describe('Agent-to-agent @mention orchestration', () => {
       .mockResolvedValueOnce({ rows: [] }) // not elevated
       .mockResolvedValueOnce({ rows: [{ id: 'agent-f-uuid', agent_id: 'agent-f', name: 'Agent F', status: 'running', work_token: 'wt-f', models: ['gpt-4o-mini'] }] })
       .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ type: 'direct' }] })  // chain thread type
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [{ id: 'chain-ph-audit' }] });
 
@@ -1441,7 +1460,8 @@ describe('Agent-to-agent @mention orchestration', () => {
   it('error status callback skips mention parsing', async () => {
     mockQuery
       .mockResolvedValueOnce({ rowCount: 1 })
-      .mockResolvedValueOnce({ rows: [] });
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ reply_to: null, thread_type: 'direct' }] });  // batch completion: direct, skip
 
     const res = await request(app)
       .post('/internal/chat/callback')
@@ -1462,6 +1482,7 @@ describe('Agent-to-agent @mention orchestration', () => {
     mockQuery
       .mockResolvedValueOnce({ rowCount: 1 })
       .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ reply_to: null, thread_type: 'direct' }] })  // batch completion: direct, skip
       .mockResolvedValueOnce({ rows: [{ author_id: 'agent-a-uuid' }] })
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [{ thread_id: 'thread-1', author_id: 'agent-a-uuid', chain_id: null, chain_hop: null }] })
@@ -1486,6 +1507,7 @@ describe('Agent-to-agent @mention orchestration', () => {
     mockQuery
       .mockResolvedValueOnce({ rowCount: 1 })
       .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ reply_to: null, thread_type: 'direct' }] })  // batch completion: direct, skip
       .mockResolvedValueOnce({ rows: [{ author_id: 'agent-a-uuid' }] })
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [{ thread_id: 'thread-1', author_id: 'agent-a-uuid', chain_id: null, chain_hop: null }] })
@@ -1696,6 +1718,251 @@ describe('parseMentions', () => {
 });
 
 // ── Thread events ──
+
+// ── Group broadcast dispatch (AI-146) ──
+
+describe('Group broadcast dispatch', () => {
+  beforeEach(() => {
+    mockQuery.mockReset();
+    mockDispatchChatWork.mockReset();
+    mockDispatchChatWork.mockResolvedValue({ accepted: true, work_id: 'work-123' });
+    process.env.DATABASE_URL = 'postgresql://test:test@localhost:5432/test';
+  });
+
+  afterEach(() => {
+    delete process.env.DATABASE_URL;
+  });
+
+  it('dispatches to all group agents in parallel (T1)', async () => {
+    // Track dispatch timing to verify parallel execution
+    const dispatchOrder: string[] = [];
+    mockDispatchChatWork.mockImplementation(async (params: any) => {
+      dispatchOrder.push(params.agentId);
+      return { accepted: true, work_id: `work-${params.agentId}` };
+    });
+
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ id: 1 }] })  // isParticipant
+      .mockResolvedValueOnce({ rows: [{ type: 'group' }] })  // getThreadType
+      .mockResolvedValueOnce({  // getThreadAgents
+        rows: [{ participant_id: 'a1' }, { participant_id: 'a2' }, { participant_id: 'a3' }],
+      })
+      .mockResolvedValueOnce({ rows: [{ id: 'a1', agent_id: 'alpha', name: 'Alpha', status: 'running', work_token: 'wt1', models: ['gpt-4o'] }] })
+      .mockResolvedValueOnce({ rows: [{ id: 'a2', agent_id: 'beta', name: 'Beta', status: 'running', work_token: 'wt2', models: ['gpt-4o'] }] })
+      .mockResolvedValueOnce({ rows: [{ id: 'a3', agent_id: 'gamma', name: 'Gamma', status: 'running', work_token: 'wt3', models: ['gpt-4o'] }] })
+      .mockResolvedValueOnce({ rows: [] })  // elevated scope a1
+      .mockResolvedValueOnce({ rows: [] })  // elevated scope a2
+      .mockResolvedValueOnce({ rows: [] })  // elevated scope a3
+      .mockResolvedValueOnce({ rows: [] })  // concurrency guard a1
+      .mockResolvedValueOnce({ rows: [] })  // concurrency guard a2
+      .mockResolvedValueOnce({ rows: [] })  // concurrency guard a3
+      .mockResolvedValueOnce({ rows: [{ id: 'user-msg', seq: 10 }] })  // INSERT user message
+      .mockResolvedValueOnce({ rows: [] })  // UPDATE thread timestamp
+      .mockResolvedValueOnce({ rows: [{ role: 'user', content: 'prev' }] })  // history
+      .mockResolvedValueOnce({ rows: [{ id: 'ph-1' }] })  // placeholder a1
+      .mockResolvedValueOnce({ rows: [{ id: 'ph-2' }] })  // placeholder a2
+      .mockResolvedValueOnce({ rows: [{ id: 'ph-3' }] });  // placeholder a3
+
+    const res = await request(app)
+      .post('/chat/threads/thread-1/messages')
+      .set('Authorization', `Bearer ${userToken}`)
+      .send({ message: 'Hello everyone' });
+
+    expect(res.status).toBe(201);
+    expect(res.body.dispatched).toHaveLength(3);
+    // All 3 dispatches fired (parallel via Promise.allSettled)
+    expect(mockDispatchChatWork).toHaveBeenCalledTimes(3);
+    expect(dispatchOrder).toEqual(['alpha', 'beta', 'gamma']);
+  });
+
+  it('partial dispatch failure marks only failed placeholders as error (T2)', async () => {
+    mockDispatchChatWork
+      .mockResolvedValueOnce({ accepted: true, work_id: 'w1' })
+      .mockRejectedValueOnce(new Error('connection refused'))  // agent 2 fails
+      .mockResolvedValueOnce({ accepted: true, work_id: 'w3' });
+
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ id: 1 }] })  // isParticipant
+      .mockResolvedValueOnce({ rows: [{ type: 'group' }] })  // getThreadType
+      .mockResolvedValueOnce({  // getThreadAgents
+        rows: [{ participant_id: 'a1' }, { participant_id: 'a2' }, { participant_id: 'a3' }],
+      })
+      .mockResolvedValueOnce({ rows: [{ id: 'a1', agent_id: 'alpha', name: 'Alpha', status: 'running', work_token: 'wt1', models: [] }] })
+      .mockResolvedValueOnce({ rows: [{ id: 'a2', agent_id: 'beta', name: 'Beta', status: 'running', work_token: 'wt2', models: [] }] })
+      .mockResolvedValueOnce({ rows: [{ id: 'a3', agent_id: 'gamma', name: 'Gamma', status: 'running', work_token: 'wt3', models: [] }] })
+      .mockResolvedValueOnce({ rows: [] })  // elevated scope a1
+      .mockResolvedValueOnce({ rows: [] })  // elevated scope a2
+      .mockResolvedValueOnce({ rows: [] })  // elevated scope a3
+      .mockResolvedValueOnce({ rows: [] })  // concurrency guard a1
+      .mockResolvedValueOnce({ rows: [] })  // concurrency guard a2
+      .mockResolvedValueOnce({ rows: [] })  // concurrency guard a3
+      .mockResolvedValueOnce({ rows: [{ id: 'user-msg', seq: 10 }] })  // INSERT user message
+      .mockResolvedValueOnce({ rows: [] })  // UPDATE thread timestamp
+      .mockResolvedValueOnce({ rows: [{ role: 'user', content: 'prev' }] })  // history
+      .mockResolvedValueOnce({ rows: [{ id: 'ph-1' }] })  // placeholder a1
+      .mockResolvedValueOnce({ rows: [{ id: 'ph-2' }] })  // placeholder a2
+      .mockResolvedValueOnce({ rows: [{ id: 'ph-3' }] })  // placeholder a3
+      .mockResolvedValueOnce({ rowCount: 1 });  // UPDATE ph-2 status=error
+
+    const res = await request(app)
+      .post('/chat/threads/thread-1/messages')
+      .set('Authorization', `Bearer ${userToken}`)
+      .send({ message: 'Hello everyone' });
+
+    expect(res.status).toBe(201);
+    expect(res.body.dispatched).toHaveLength(2);
+    expect(res.body.failed).toHaveLength(1);
+    expect(res.body.failed[0].agent_id).toBe('a2');
+  });
+
+  it('group dispatch payload includes thread_type and participants (T3)', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ id: 1 }] })  // isParticipant
+      .mockResolvedValueOnce({ rows: [{ type: 'group' }] })  // getThreadType
+      .mockResolvedValueOnce({  // getThreadAgents
+        rows: [{ participant_id: 'a1' }, { participant_id: 'a2' }],
+      })
+      .mockResolvedValueOnce({ rows: [{ id: 'a1', agent_id: 'alpha', name: 'Alpha', status: 'running', work_token: 'wt1', models: [] }] })
+      .mockResolvedValueOnce({ rows: [{ id: 'a2', agent_id: 'beta', name: 'Beta', status: 'running', work_token: 'wt2', models: [] }] })
+      .mockResolvedValueOnce({ rows: [] })  // elevated scope a1
+      .mockResolvedValueOnce({ rows: [] })  // elevated scope a2
+      .mockResolvedValueOnce({ rows: [] })  // concurrency guard a1
+      .mockResolvedValueOnce({ rows: [] })  // concurrency guard a2
+      .mockResolvedValueOnce({ rows: [{ id: 'user-msg', seq: 10 }] })  // INSERT user message
+      .mockResolvedValueOnce({ rows: [] })  // UPDATE thread timestamp
+      .mockResolvedValueOnce({ rows: [{ role: 'user', content: 'prev' }] })  // history
+      .mockResolvedValueOnce({ rows: [{ id: 'ph-1' }] })  // placeholder a1
+      .mockResolvedValueOnce({ rows: [{ id: 'ph-2' }] });  // placeholder a2
+
+    await request(app)
+      .post('/chat/threads/thread-1/messages')
+      .set('Authorization', `Bearer ${userToken}`)
+      .send({ message: 'Hello' });
+
+    expect(mockDispatchChatWork).toHaveBeenCalledTimes(2);
+    const call1 = mockDispatchChatWork.mock.calls[0][0];
+    expect(call1.threadType).toBe('group');
+    expect(call1.participants).toEqual([
+      { agent_id: 'alpha', name: 'Alpha' },
+      { agent_id: 'beta', name: 'Beta' },
+    ]);
+  });
+
+  it('direct dispatch payload has no participants field (T4)', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ id: 1 }] })  // isParticipant
+      .mockResolvedValueOnce({ rows: [{ type: 'direct' }] })  // getThreadType
+      .mockResolvedValueOnce({  // getThreadAgents
+        rows: [{ participant_id: 'a1' }],
+      })
+      .mockResolvedValueOnce({ rows: [{ id: 'a1', agent_id: 'alpha', name: 'Alpha', status: 'running', work_token: 'wt1', models: [] }] })
+      .mockResolvedValueOnce({ rows: [] })  // elevated scope
+      .mockResolvedValueOnce({ rows: [] })  // concurrency guard
+      .mockResolvedValueOnce({ rows: [{ id: 'user-msg', seq: 10 }] })  // INSERT user message
+      .mockResolvedValueOnce({ rows: [] })  // UPDATE thread timestamp
+      .mockResolvedValueOnce({ rows: [{ role: 'user', content: 'prev' }] })  // history
+      .mockResolvedValueOnce({ rows: [{ id: 'ph-1' }] });  // placeholder
+
+    await request(app)
+      .post('/chat/threads/thread-1/messages')
+      .set('Authorization', `Bearer ${userToken}`)
+      .send({ message: 'Hello' });
+
+    const call1 = mockDispatchChatWork.mock.calls[0][0];
+    expect(call1.threadType).toBe('direct');
+    expect(call1.participants).toBeUndefined();
+  });
+});
+
+// ── Batch completion (AI-146) ──
+
+describe('Batch completion', () => {
+  beforeEach(() => {
+    mockQuery.mockReset();
+    process.env.DATABASE_URL = 'postgresql://test:test@localhost:5432/test';
+    process.env.CHAT_CALLBACK_TOKEN = 'test-callback-secret';
+  });
+
+  afterEach(() => {
+    delete process.env.DATABASE_URL;
+    delete process.env.CHAT_CALLBACK_TOKEN;
+  });
+
+  it('batch_complete emitted when all siblings terminal (T5)', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rowCount: 1 })  // guarded UPDATE
+      .mockResolvedValueOnce({ rows: [] })       // UPDATE thread timestamp
+      // batch completion: get reply_to + thread_type
+      .mockResolvedValueOnce({ rows: [{ reply_to: 'user-msg-1', thread_type: 'group' }] })
+      // sibling count: all 3 terminal
+      .mockResolvedValueOnce({ rows: [{ total: 3, terminal: 3 }] })
+      // UPDATE batch_complete = true
+      .mockResolvedValueOnce({ rowCount: 1 })
+      // elevated tagging (no agent match)
+      .mockResolvedValueOnce({ rows: [] });
+
+    const res = await request(app)
+      .post('/internal/chat/callback')
+      .set('Authorization', 'Bearer test-callback-secret')
+      .send({ message_id: 'msg-3', content: 'Last response', status: 'complete' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.updated).toBe(true);
+
+    // Verify batch_complete UPDATE was called
+    const batchUpdateCall = mockQuery.mock.calls[4];
+    expect(batchUpdateCall[0]).toContain('batch_complete = true');
+  });
+
+  it('no batch_complete when siblings still pending (T6)', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rowCount: 1 })  // guarded UPDATE
+      .mockResolvedValueOnce({ rows: [] })       // UPDATE thread timestamp
+      // batch completion: get reply_to + thread_type
+      .mockResolvedValueOnce({ rows: [{ reply_to: 'user-msg-1', thread_type: 'group' }] })
+      // sibling count: only 1 of 3 terminal
+      .mockResolvedValueOnce({ rows: [{ total: 3, terminal: 1 }] })
+      // elevated tagging
+      .mockResolvedValueOnce({ rows: [] });
+
+    const res = await request(app)
+      .post('/internal/chat/callback')
+      .set('Authorization', 'Bearer test-callback-secret')
+      .send({ message_id: 'msg-1', content: 'First response', status: 'complete' });
+
+    expect(res.status).toBe(200);
+    // Should NOT have a batch_complete UPDATE call
+    const batchCalls = mockQuery.mock.calls.filter(
+      (c: any[]) => typeof c[0] === 'string' && c[0].includes('batch_complete')
+    );
+    expect(batchCalls).toHaveLength(0);
+  });
+
+  it('batch_complete emitted even with error siblings (T7)', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rowCount: 1 })  // guarded UPDATE
+      .mockResolvedValueOnce({ rows: [] })       // UPDATE thread timestamp
+      // batch completion: get reply_to + thread_type
+      .mockResolvedValueOnce({ rows: [{ reply_to: 'user-msg-1', thread_type: 'group' }] })
+      // sibling count: 2 complete + 1 error = 3 terminal out of 3 total
+      .mockResolvedValueOnce({ rows: [{ total: 3, terminal: 3 }] })
+      // UPDATE batch_complete = true
+      .mockResolvedValueOnce({ rowCount: 1 })
+      // elevated tagging
+      .mockResolvedValueOnce({ rows: [] });
+
+    const res = await request(app)
+      .post('/internal/chat/callback')
+      .set('Authorization', 'Bearer test-callback-secret')
+      .send({ message_id: 'msg-2', content: 'Second response', status: 'complete' });
+
+    expect(res.status).toBe(200);
+    const batchCalls = mockQuery.mock.calls.filter(
+      (c: any[]) => typeof c[0] === 'string' && c[0].includes('batch_complete')
+    );
+    expect(batchCalls).toHaveLength(1);
+  });
+});
 
 describe('Chat thread events', () => {
   beforeEach(() => {

--- a/services/api/src/db/migrations/041_add_batch_complete.sql
+++ b/services/api/src/db/migrations/041_add_batch_complete.sql
@@ -1,0 +1,5 @@
+-- Add batch_complete flag for group thread dispatch completion tracking.
+-- When the last agent in a dispatch batch completes (or errors), the callback
+-- handler sets batch_complete = true on that message so SSE clients can detect
+-- "all agents responded" without client-side counting.
+ALTER TABLE chat_messages ADD COLUMN IF NOT EXISTS batch_complete BOOLEAN DEFAULT NULL;

--- a/services/api/src/routes/chat.ts
+++ b/services/api/src/routes/chat.ts
@@ -160,7 +160,7 @@ async function resolveAgentSlugs(threadId: string, slugs: string[]): Promise<Map
 
 /**
  * Dispatch chat work to a set of agents. Shared by human-send and agent-to-agent orchestration.
- * Creates assistant placeholder messages and fires dispatch calls.
+ * Creates assistant placeholder messages (sequential), then fires dispatch calls (parallel).
  */
 async function dispatchToAgents(opts: {
   threadId: string;
@@ -170,6 +170,8 @@ async function dispatchToAgents(opts: {
   chainId?: string | null;
   chainHop?: number | null;
   triggeredBy?: string | null;
+  threadType?: string;
+  participants?: { agent_id: string; name: string }[];
 }): Promise<{
   dispatched: { agent_id: string; message_id: string }[];
   failed: { agent_id: string; message_id: string; reason: string }[];
@@ -179,11 +181,12 @@ async function dispatchToAgents(opts: {
   const dispatched: { agent_id: string; message_id: string }[] = [];
   const failed: { agent_id: string; message_id: string; reason: string }[] = [];
 
+  // Phase 1: Create all placeholders sequentially (DB inserts are fast, seq ordering matters)
+  const placeholders: { agent: typeof opts.agents[0]; placeholderId: string; model: string }[] = [];
   for (const agent of opts.agents) {
     const models: string[] = Array.isArray(agent.models) ? agent.models : [];
     const model = models[0] || 'gpt-4o-mini';
 
-    // Build chain columns for the INSERT
     const chainCols = opts.chainId ? ', chain_id, chain_hop, triggered_by' : '';
     const chainPlaceholders = opts.chainId ? ', $4, $5, $6' : '';
     const chainParams = opts.chainId
@@ -197,30 +200,49 @@ async function dispatchToAgents(opts: {
       [opts.threadId, agent.id, opts.replyTo, ...chainParams]
     );
 
-    try {
-      await dispatchChatWork({
+    placeholders.push({ agent, placeholderId: placeholder.id, model });
+  }
+
+  // Phase 2: Dispatch all work items in parallel
+  const results = await Promise.allSettled(
+    placeholders.map(({ agent, placeholderId, model }) =>
+      dispatchChatWork({
         agentId: agent.agent_id,
         workToken: agent.work_token!,
         threadId: opts.threadId,
-        messageId: placeholder.id,
+        messageId: placeholderId,
         messages: opts.historyMessages,
         model,
         callbackUrl,
-      });
-      dispatched.push({ agent_id: agent.id, message_id: placeholder.id });
-    } catch (err) {
-      console.error(`[chat] Dispatch failed for agent=${agent.agent_id}:`, err);
+        threadType: opts.threadType,
+        participants: opts.participants,
+      })
+    )
+  );
+
+  // Phase 3: Map settled results to dispatched/failed
+  for (let i = 0; i < results.length; i++) {
+    const { agent, placeholderId } = placeholders[i];
+    const result = results[i];
+
+    if (result.status === 'fulfilled' && result.value.accepted) {
+      dispatched.push({ agent_id: agent.id, message_id: placeholderId });
+    } else {
+      const reason = result.status === 'rejected'
+        ? String(result.reason)
+        : (result.value.error || 'not accepted');
+      console.error(`[chat] Dispatch failed for agent=${agent.agent_id}: ${reason}`);
       try {
         await pool.query(
           `UPDATE chat_messages SET status = 'error', error_message = 'Dispatch failed',
            seq = nextval('chat_messages_seq')
            WHERE id = $1 AND status = 'pending'`,
-          [placeholder.id]
+          [placeholderId]
         );
       } catch (updateErr) {
         console.error(`[chat] Failed to mark dispatch error:`, updateErr);
       }
-      failed.push({ agent_id: agent.id, message_id: placeholder.id, reason: 'dispatch_failed' });
+      failed.push({ agent_id: agent.id, message_id: placeholderId, reason: 'dispatch_failed' });
     }
   }
 
@@ -413,58 +435,33 @@ router.post('/threads', requireRole('user'), async (req: Request, res: Response)
       [thread.id, user.sub, message.trim(), idempotency_key || null]
     );
 
-    // Dispatch to agents: placeholder-then-dispatch pattern (§7a)
-    const callbackUrl = 'http://api:3000/internal/chat/callback';
-    const messages = [{ role: 'user', content: message.trim() }];
-    const dispatched: { agent_id: string; message_id: string }[] = [];
+    // Classify agents for dispatch
+    const dispatchableAgents: NonNullable<Awaited<ReturnType<typeof getAgentForDispatch>>>[] = [];
     const skipped: { agent_id: string; reason: string }[] = [];
-    const failed: { agent_id: string; message_id: string; reason: string }[] = [];
 
     for (const agent of agents) {
       if (agent!.status !== 'running' || !agent!.work_token) {
         skipped.push({ agent_id: agent!.id, reason: 'not_running' });
-        continue;
-      }
-
-      const models: string[] = Array.isArray(agent!.models) ? agent!.models : [];
-      const model = models[0] || 'gpt-4o-mini';
-
-      // Create assistant placeholder
-      const { rows: [placeholder] } = await pool.query(
-        `INSERT INTO chat_messages (thread_id, author_id, author_type, role, content, status, reply_to)
-         VALUES ($1, $2, 'agent', 'assistant', '', 'pending', $3)
-         RETURNING id`,
-        [thread.id, agent!.id, userMsg.id]
-      );
-
-      // Fire-and-forget dispatch
-      try {
-        await dispatchChatWork({
-          agentId: agent!.agent_id,
-          workToken: agent!.work_token!,
-          threadId: thread.id,
-          messageId: placeholder.id,
-          messages,
-          model,
-          callbackUrl,
-        });
-        dispatched.push({ agent_id: agent!.id, message_id: placeholder.id });
-      } catch (err) {
-        console.error(`[chat] Dispatch failed for agent=${agent!.agent_id}:`, err);
-        // Mark placeholder as error immediately
-        try {
-          await pool.query(
-            `UPDATE chat_messages SET status = 'error', error_message = 'Dispatch failed',
-             seq = nextval('chat_messages_seq')
-             WHERE id = $1 AND status = 'pending'`,
-            [placeholder.id]
-          );
-        } catch (updateErr) {
-          console.error(`[chat] Failed to mark dispatch error:`, updateErr);
-        }
-        failed.push({ agent_id: agent!.id, message_id: placeholder.id, reason: 'dispatch_failed' });
+      } else {
+        dispatchableAgents.push(agent!);
       }
     }
+
+    // Build participant list for group context
+    const participantList = threadType === 'group'
+      ? agents.map(a => ({ agent_id: a!.agent_id, name: a!.name || a!.agent_id }))
+      : undefined;
+
+    // Dispatch via shared helper (parallel dispatch, §7a placeholder-then-dispatch pattern)
+    const historyMessages = [{ role: 'user', content: message.trim() }];
+    const { dispatched, failed } = await dispatchToAgents({
+      threadId: thread.id,
+      agents: dispatchableAgents,
+      replyTo: userMsg.id,
+      historyMessages,
+      threadType: threadType || undefined,
+      participants: participantList,
+    });
 
     // Direct thread backward compat response
     if (threadType === 'direct') {
@@ -889,12 +886,19 @@ router.post('/threads/:id/messages', requireRole('user'), async (req: Request, r
     );
     const historyMessages = history.reverse();
 
+    // Build participant list for group context
+    const participantList = threadType === 'group'
+      ? targetAgents.map(a => ({ agent_id: a.agent_id, name: a.name || a.agent_id }))
+      : undefined;
+
     // Dispatch to each dispatchable agent via shared helper
     const { dispatched, failed: failedArr } = await dispatchToAgents({
       threadId,
       agents: dispatchable,
       replyTo: userMsg.id,
       historyMessages,
+      threadType: threadType || undefined,
+      participants: participantList,
     });
 
     // Direct thread backward compat response
@@ -1294,6 +1298,38 @@ export async function chatCallbackHandler(req: Request, res: Response): Promise<
     [message_id]
   );
 
+  // ── Batch completion detection for group threads ──
+  // Check if all sibling messages (same reply_to) are terminal
+  try {
+    const { rows: batchRows } = await pool.query(
+      `SELECT m.reply_to, t.type AS thread_type
+       FROM chat_messages m
+       JOIN chat_threads t ON t.id = m.thread_id
+       WHERE m.id = $1`,
+      [message_id]
+    );
+    if (batchRows.length > 0 && batchRows[0].thread_type === 'group' && batchRows[0].reply_to) {
+      const replyTo = batchRows[0].reply_to;
+      const { rows: siblingRows } = await pool.query(
+        `SELECT count(*)::int AS total,
+                count(*) FILTER (WHERE status IN ('complete', 'error'))::int AS terminal
+         FROM chat_messages
+         WHERE reply_to = $1 AND author_type = 'agent'`,
+        [replyTo]
+      );
+      if (siblingRows.length > 0 && siblingRows[0].total > 0 && siblingRows[0].terminal === siblingRows[0].total) {
+        await pool.query(
+          `UPDATE chat_messages SET batch_complete = true, seq = nextval('chat_messages_seq')
+           WHERE id = $1`,
+          [message_id]
+        );
+        console.info(`[chat-callback] Batch complete for reply_to=${replyTo} (${siblingRows[0].total} agents)`);
+      }
+    }
+  } catch (batchErr) {
+    console.error('[chat-callback] Batch completion check failed (non-blocking):', batchErr);
+  }
+
   // Elevated-agent response tagging (D6): informational audit only
   try {
     const { rows: msgRows } = await pool.query(
@@ -1408,6 +1444,22 @@ export async function chatCallbackHandler(req: Request, res: Response): Promise<
                       );
                       const historyMessages = history.reverse();
 
+                      // Build participant list for group context in chain dispatch
+                      const { rows: threadInfoRows } = await pool.query(
+                        `SELECT t.type FROM chat_threads t WHERE t.id = $1`, [threadId]
+                      );
+                      const chainThreadType = threadInfoRows[0]?.type;
+                      let chainParticipantsList: { agent_id: string; name: string }[] | undefined;
+                      if (chainThreadType === 'group') {
+                        const { rows: pRows } = await pool.query(
+                          `SELECT a.agent_id, a.name FROM chat_participants cp
+                           JOIN agents a ON a.id = cp.participant_id::uuid
+                           WHERE cp.thread_id = $1 AND cp.participant_type = 'agent' AND cp.left_at IS NULL`,
+                          [threadId]
+                        );
+                        chainParticipantsList = pRows.map((r: any) => ({ agent_id: r.agent_id, name: r.name || r.agent_id }));
+                      }
+
                       const { dispatched: chainDispatched } = await dispatchToAgents({
                         threadId,
                         agents: eligibleAgents,
@@ -1416,6 +1468,8 @@ export async function chatCallbackHandler(req: Request, res: Response): Promise<
                         chainId,
                         chainHop: newHop,
                         triggeredBy: message_id,
+                        threadType: chainThreadType || undefined,
+                        participants: chainParticipantsList,
                       });
 
                       for (const d of chainDispatched) {

--- a/services/api/src/services/chat-dispatch.ts
+++ b/services/api/src/services/chat-dispatch.ts
@@ -13,6 +13,8 @@ interface ChatDispatchParams {
   messages: Array<{ role: string; content: string }>;
   model: string;
   callbackUrl: string;
+  threadType?: string;   // 'direct' | 'group' — omitted for backward compat
+  participants?: Array<{ agent_id: string; name: string }>;  // group thread participant list
 }
 
 interface DispatchResult {
@@ -22,21 +24,25 @@ interface DispatchResult {
 }
 
 export async function dispatchChatWork(params: ChatDispatchParams): Promise<DispatchResult> {
-  const { agentId, workToken, threadId, messageId, messages, model, callbackUrl } = params;
+  const { agentId, workToken, threadId, messageId, messages, model, callbackUrl, threadType, participants } = params;
 
   const url = `http://agentbox-${agentId}:8054/work`;
 
   console.log(`[chat-dispatch] Dispatching to ${agentId}: thread_id=${threadId} message_id=${messageId} model=${model}`);
 
+  const payload: Record<string, unknown> = {
+    thread_id: threadId,
+    message_id: messageId,
+    messages,
+    model,
+    callback_url: callbackUrl,
+  };
+  if (threadType) payload.thread_type = threadType;
+  if (participants && participants.length > 0) payload.participants = participants;
+
   const body = {
     type: 'chat',
-    payload: {
-      thread_id: threadId,
-      message_id: messageId,
-      messages,
-      model,
-      callback_url: callbackUrl,
-    },
+    payload,
     correlation_id: messageId, // §8.5: correlation_id = message_id
   };
 


### PR DESCRIPTION
## Summary

- **Parallel dispatch**: `dispatchToAgents()` now creates all placeholders sequentially (for correct seq ordering), then fires all N dispatch HTTP calls concurrently via `Promise.allSettled`. Partial failures mark only the failed placeholder as error.
- **Group context in dispatch payload**: Group thread dispatches include `thread_type` and `participants` array. Agentbox injects a "Group Thread" section into the system prompt listing peer agents with `@slug` syntax.
- **Batch completion detection**: Callback handler checks if all sibling messages (same `reply_to`) are terminal after each update. When the last agent responds, sets `batch_complete=true` and bumps seq so SSE clients detect completion without client-side counting.
- **Migration 041**: Adds nullable `batch_complete` boolean column to `chat_messages`.

## Test plan

- [x] T1: dispatches to all group agents in parallel
- [x] T2: partial dispatch failure marks only failed placeholders
- [x] T3: group dispatch payload includes thread_type + participants
- [x] T4: direct dispatch payload unchanged (no participants)
- [x] T5: batch_complete emitted when all siblings terminal
- [x] T6: no batch_complete when siblings still pending
- [x] T7: batch_complete emitted even with error siblings
- [x] T8: agentbox group payload injects participant names into system prompt
- [x] T9: agentbox direct payload does not alter system prompt
- [x] V1: API chat tests — 82/82 pass
- [x] V3: Full API suite — 666/666 pass
- [x] V4: Full agentbox suite — 136/136 pass
- [x] V7: TypeScript compiles clean (`tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)