### PR TITLE
feat: agent task board (Kanban) MVP (AI-148)

### DIFF
--- a/docs/site/openapi.yaml
+++ b/docs/site/openapi.yaml
@@ -26,6 +26,39 @@ components:
       bearerFormat: JWT
 
   schemas:
+    AgentTask:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        agent_id:
+          type: string
+        title:
+          type: string
+        description:
+          type: string
+        status:
+          type: string
+          enum: [backlog, todo, in_progress, review, done, cancelled]
+        priority:
+          type: integer
+          minimum: 1
+          maximum: 4
+        sort_order:
+          type: integer
+        tags:
+          type: array
+          items:
+            type: string
+        created_by:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
     Agent:
       type: object
       properties:
@@ -3631,3 +3664,177 @@ paths:
           description: Thread not found or not a participant
         "409":
           description: No running agents in thread
+
+  # Task management
+  /tasks:
+    get:
+      summary: List tasks
+      tags: [Tasks]
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: agent_id
+          in: query
+          schema:
+            type: string
+          description: Optional agent ID filter
+        - name: status
+          in: query
+          schema:
+            type: string
+            enum: [backlog, todo, in_progress, review, done, cancelled]
+          description: Optional status filter
+      responses:
+        "200":
+          description: Task list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/AgentTask'
+    post:
+      summary: Create task
+      tags: [Tasks]
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [agent_id, title]
+              properties:
+                agent_id:
+                  type: string
+                title:
+                  type: string
+                description:
+                  type: string
+                status:
+                  type: string
+                  enum: [backlog, todo, in_progress, review, done, cancelled]
+                priority:
+                  type: integer
+                  minimum: 1
+                  maximum: 4
+                tags:
+                  type: array
+                  items:
+                    type: string
+      responses:
+        "200":
+          description: Created task
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentTask'
+
+  /tasks/{id}:
+    get:
+      summary: Get task
+      tags: [Tasks]
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Task detail
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentTask'
+        "404":
+          description: Task not found
+    put:
+      summary: Update task
+      tags: [Tasks]
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                title:
+                  type: string
+                description:
+                  type: string
+                status:
+                  type: string
+                  enum: [backlog, todo, in_progress, review, done, cancelled]
+                priority:
+                  type: integer
+                  minimum: 1
+                  maximum: 4
+                tags:
+                  type: array
+                  items:
+                    type: string
+      responses:
+        "200":
+          description: Updated task
+        "404":
+          description: Task not found
+    delete:
+      summary: Cancel task
+      tags: [Tasks]
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Cancelled task
+        "404":
+          description: Task not found
+
+  /tasks/{id}/transition:
+    patch:
+      summary: Transition task status
+      tags: [Tasks]
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [status]
+              properties:
+                status:
+                  type: string
+                  enum: [backlog, todo, in_progress, review, done, cancelled]
+      responses:
+        "200":
+          description: Transitioned task
+        "404":
+          description: Task not found

--- a/services/api/src/__tests__/docs.test.ts
+++ b/services/api/src/__tests__/docs.test.ts
@@ -189,6 +189,9 @@ const EXPECTED_PATHS = [
   '/chat/threads/{id}/cancel',
   '/chat/threads/{id}/stream',
   '/chat/threads/{id}/events',
+  '/tasks',
+  '/tasks/{id}',
+  '/tasks/{id}/transition',
 ];
 
 const INFRA_PATHS = ['/docs', '/openapi.json', '/internal/delegation-token', '/internal/chat/callback', '/internal/model-router/refresh-token'];

--- a/services/api/src/app.ts
+++ b/services/api/src/app.ts
@@ -18,6 +18,7 @@ import { requireRole } from './middleware/role';
 import { docsRouter, specRouter } from './routes/docs';
 import { delegationTokenHandler } from './services/model-router-delegation';
 import chatRouter, { chatCallbackHandler, startStaleSweeper } from './routes/chat';
+import tasksRouter from './routes/tasks';
 import { modelRouterRefreshHandler } from './services/model-router-refresh';
 
 interface AppOptions {
@@ -86,6 +87,9 @@ export function createApp(opts: AppOptions = {}): Application {
 
   // Shared knowledge proxy routes (user-scoped CRUD)
   app.use('/shared-knowledge', requireAuth, sharedKnowledgeRouter);
+
+  // Task management routes (user-scoped Kanban)
+  app.use('/tasks', requireAuth, tasksRouter);
 
   // Chat routes (user-scoped, participant-enforced in router)
   app.use('/chat', requireAuth, chatRouter);

--- a/services/api/src/openapi/openapi.yaml
+++ b/services/api/src/openapi/openapi.yaml
@@ -26,6 +26,39 @@ components:
       bearerFormat: JWT
 
   schemas:
+    AgentTask:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        agent_id:
+          type: string
+        title:
+          type: string
+        description:
+          type: string
+        status:
+          type: string
+          enum: [backlog, todo, in_progress, review, done, cancelled]
+        priority:
+          type: integer
+          minimum: 1
+          maximum: 4
+        sort_order:
+          type: integer
+        tags:
+          type: array
+          items:
+            type: string
+        created_by:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
     Agent:
       type: object
       properties:
@@ -3631,3 +3664,177 @@ paths:
           description: Thread not found or not a participant
         "409":
           description: No running agents in thread
+
+  # Task management
+  /tasks:
+    get:
+      summary: List tasks
+      tags: [Tasks]
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: agent_id
+          in: query
+          schema:
+            type: string
+          description: Optional agent ID filter
+        - name: status
+          in: query
+          schema:
+            type: string
+            enum: [backlog, todo, in_progress, review, done, cancelled]
+          description: Optional status filter
+      responses:
+        "200":
+          description: Task list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/AgentTask'
+    post:
+      summary: Create task
+      tags: [Tasks]
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [agent_id, title]
+              properties:
+                agent_id:
+                  type: string
+                title:
+                  type: string
+                description:
+                  type: string
+                status:
+                  type: string
+                  enum: [backlog, todo, in_progress, review, done, cancelled]
+                priority:
+                  type: integer
+                  minimum: 1
+                  maximum: 4
+                tags:
+                  type: array
+                  items:
+                    type: string
+      responses:
+        "200":
+          description: Created task
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentTask'
+
+  /tasks/{id}:
+    get:
+      summary: Get task
+      tags: [Tasks]
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Task detail
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentTask'
+        "404":
+          description: Task not found
+    put:
+      summary: Update task
+      tags: [Tasks]
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                title:
+                  type: string
+                description:
+                  type: string
+                status:
+                  type: string
+                  enum: [backlog, todo, in_progress, review, done, cancelled]
+                priority:
+                  type: integer
+                  minimum: 1
+                  maximum: 4
+                tags:
+                  type: array
+                  items:
+                    type: string
+      responses:
+        "200":
+          description: Updated task
+        "404":
+          description: Task not found
+    delete:
+      summary: Cancel task
+      tags: [Tasks]
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Cancelled task
+        "404":
+          description: Task not found
+
+  /tasks/{id}/transition:
+    patch:
+      summary: Transition task status
+      tags: [Tasks]
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [status]
+              properties:
+                status:
+                  type: string
+                  enum: [backlog, todo, in_progress, review, done, cancelled]
+      responses:
+        "200":
+          description: Transitioned task
+        "404":
+          description: Task not found

--- a/services/api/src/routes/tasks.ts
+++ b/services/api/src/routes/tasks.ts
@@ -1,0 +1,192 @@
+/**
+ * Task routes — user-facing Kanban task management.
+ *
+ * Auth: requireAuth at mount (Keycloak JWT) + requireRole('user') per-route.
+ * Ownership: scopeToOwner for admin bypass vs user scoping.
+ */
+
+import { Router, Request, Response } from 'express';
+import { requireRole } from '../middleware/role';
+import { scopeToOwner } from '../helpers/scope';
+import { getPool } from '../db/pool';
+import * as taskProxy from '../services/task-proxy';
+
+const router = Router();
+
+/**
+ * Get allowed agent_ids for the requesting user.
+ * Admins: null (no filter). Users: their owned agent_ids.
+ */
+async function getAllowedAgentIds(req: Request): Promise<string[] | null> {
+  const scope = scopeToOwner(req);
+  if (scope.where === '1=1') return null;
+  const { rows } = await getPool().query(
+    `SELECT agent_id FROM agents WHERE ${scope.where}`,
+    scope.params,
+  );
+  return rows.map((r: { agent_id: string }) => r.agent_id);
+}
+
+// List tasks (optional ?agent_id=, ?status=)
+router.get('/', requireRole('user'), async (req: Request, res: Response) => {
+  try {
+    const agentId = req.query.agent_id as string | undefined;
+    const status = req.query.status as string | undefined;
+
+    const result = await taskProxy.listTasks(agentId, status);
+    if (result.status !== 200) {
+      res.status(result.status).json(result.data);
+      return;
+    }
+
+    // Filter to owned agents
+    const allowed = await getAllowedAgentIds(req);
+    let tasks = result.data as Array<{ agent_id: string }>;
+    if (allowed !== null) {
+      tasks = tasks.filter(t => allowed.includes(t.agent_id));
+    }
+
+    res.json(tasks);
+  } catch (err) {
+    console.error('[tasks] List error:', err);
+    res.status(500).json({ error: 'Failed to list tasks' });
+  }
+});
+
+// Get task detail
+router.get('/:id', requireRole('user'), async (req: Request, res: Response) => {
+  try {
+    const result = await taskProxy.getTask(req.params.id);
+    if (result.status !== 200) {
+      res.status(result.status).json(result.data);
+      return;
+    }
+
+    const task = result.data as { agent_id: string };
+    const allowed = await getAllowedAgentIds(req);
+    if (allowed !== null && !allowed.includes(task.agent_id)) {
+      res.status(403).json({ error: 'Not authorized' });
+      return;
+    }
+
+    res.json(result.data);
+  } catch (err) {
+    console.error('[tasks] Get error:', err);
+    res.status(500).json({ error: 'Failed to get task' });
+  }
+});
+
+// Create task
+router.post('/', requireRole('user'), async (req: Request, res: Response) => {
+  try {
+    const { agent_id, title, description, status, priority, tags } = req.body;
+    if (!agent_id || !title) {
+      res.status(400).json({ error: 'agent_id and title are required' });
+      return;
+    }
+
+    // Verify ownership
+    const allowed = await getAllowedAgentIds(req);
+    if (allowed !== null && !allowed.includes(agent_id)) {
+      res.status(403).json({ error: 'Not authorized to create tasks for this agent' });
+      return;
+    }
+
+    const userSub = (req as any).user?.sub || 'unknown';
+    const result = await taskProxy.createTask({
+      agent_id,
+      title,
+      description,
+      status,
+      priority,
+      tags,
+      created_by: userSub,
+    });
+    res.status(result.status).json(result.data);
+  } catch (err) {
+    console.error('[tasks] Create error:', err);
+    res.status(500).json({ error: 'Failed to create task' });
+  }
+});
+
+// Update task
+router.put('/:id', requireRole('user'), async (req: Request, res: Response) => {
+  try {
+    // Verify ownership first
+    const getResult = await taskProxy.getTask(req.params.id);
+    if (getResult.status !== 200) {
+      res.status(getResult.status).json(getResult.data);
+      return;
+    }
+    const task = getResult.data as { agent_id: string };
+    const allowed = await getAllowedAgentIds(req);
+    if (allowed !== null && !allowed.includes(task.agent_id)) {
+      res.status(403).json({ error: 'Not authorized' });
+      return;
+    }
+
+    const { title, description, status, priority, tags } = req.body;
+    const result = await taskProxy.updateTask(req.params.id, {
+      title, description, status, priority, tags,
+    });
+    res.status(result.status).json(result.data);
+  } catch (err) {
+    console.error('[tasks] Update error:', err);
+    res.status(500).json({ error: 'Failed to update task' });
+  }
+});
+
+// Transition task status
+router.patch('/:id/transition', requireRole('user'), async (req: Request, res: Response) => {
+  try {
+    const { status } = req.body;
+    if (!status) {
+      res.status(400).json({ error: 'status is required' });
+      return;
+    }
+
+    // Verify ownership
+    const getResult = await taskProxy.getTask(req.params.id);
+    if (getResult.status !== 200) {
+      res.status(getResult.status).json(getResult.data);
+      return;
+    }
+    const task = getResult.data as { agent_id: string };
+    const allowed = await getAllowedAgentIds(req);
+    if (allowed !== null && !allowed.includes(task.agent_id)) {
+      res.status(403).json({ error: 'Not authorized' });
+      return;
+    }
+
+    const result = await taskProxy.transitionTask(req.params.id, status);
+    res.status(result.status).json(result.data);
+  } catch (err) {
+    console.error('[tasks] Transition error:', err);
+    res.status(500).json({ error: 'Failed to transition task' });
+  }
+});
+
+// Cancel task (soft delete)
+router.delete('/:id', requireRole('user'), async (req: Request, res: Response) => {
+  try {
+    const getResult = await taskProxy.getTask(req.params.id);
+    if (getResult.status !== 200) {
+      res.status(getResult.status).json(getResult.data);
+      return;
+    }
+    const task = getResult.data as { agent_id: string };
+    const allowed = await getAllowedAgentIds(req);
+    if (allowed !== null && !allowed.includes(task.agent_id)) {
+      res.status(403).json({ error: 'Not authorized' });
+      return;
+    }
+
+    const result = await taskProxy.cancelTask(req.params.id);
+    res.status(result.status).json(result.data);
+  } catch (err) {
+    console.error('[tasks] Cancel error:', err);
+    res.status(500).json({ error: 'Failed to cancel task' });
+  }
+});
+
+export default router;

--- a/services/api/src/services/task-proxy.ts
+++ b/services/api/src/services/task-proxy.ts
@@ -1,0 +1,94 @@
+/**
+ * HTTP client for proxying task requests to the knowledge service's
+ * internal admin task endpoints. Authenticated with AKM_INTERNAL_SERVICE_TOKEN.
+ */
+
+const AKM_SERVICE_URL = process.env.AKM_SERVICE_URL || 'http://knowledge:8002';
+const AKM_INTERNAL_SERVICE_TOKEN = process.env.AKM_INTERNAL_SERVICE_TOKEN;
+
+export interface ProxyResponse {
+  status: number;
+  data: unknown;
+}
+
+async function proxyRequest(
+  method: string,
+  path: string,
+  params?: Record<string, string>,
+  body?: unknown,
+): Promise<ProxyResponse> {
+  if (!AKM_INTERNAL_SERVICE_TOKEN) {
+    return { status: 503, data: { error: 'Knowledge service not configured' } };
+  }
+
+  const url = new URL(`${AKM_SERVICE_URL}${path}`);
+  if (params) {
+    for (const [key, value] of Object.entries(params)) {
+      if (value !== undefined && value !== null && value !== '') {
+        url.searchParams.set(key, value);
+      }
+    }
+  }
+
+  const headers: Record<string, string> = {
+    'Authorization': `Bearer ${AKM_INTERNAL_SERVICE_TOKEN}`,
+  };
+  if (body) {
+    headers['Content-Type'] = 'application/json';
+  }
+
+  let resp: Response;
+  try {
+    resp = await fetch(url.toString(), {
+      method,
+      headers,
+      body: body ? JSON.stringify(body) : undefined,
+    });
+  } catch {
+    return { status: 502, data: { error: 'Knowledge service unavailable' } };
+  }
+
+  const data = await resp.json();
+  return { status: resp.status, data };
+}
+
+export async function listTasks(agentId?: string, status?: string): Promise<ProxyResponse> {
+  const params: Record<string, string> = {};
+  if (agentId) params.agent_id = agentId;
+  if (status) params.status = status;
+  return proxyRequest('GET', '/internal/admin/tasks', params);
+}
+
+export async function getTask(taskId: string): Promise<ProxyResponse> {
+  return proxyRequest('GET', `/internal/admin/tasks/${taskId}`);
+}
+
+export async function createTask(body: {
+  agent_id: string;
+  title: string;
+  description?: string;
+  status?: string;
+  priority?: number;
+  tags?: string[];
+  created_by: string;
+}): Promise<ProxyResponse> {
+  return proxyRequest('POST', '/internal/admin/tasks', undefined, body);
+}
+
+export async function updateTask(taskId: string, body: {
+  title?: string;
+  description?: string;
+  status?: string;
+  priority?: number;
+  tags?: string[];
+}): Promise<ProxyResponse> {
+  return proxyRequest('PUT', `/internal/admin/tasks/${taskId}`, undefined, body);
+}
+
+export async function transitionTask(taskId: string, status: string): Promise<ProxyResponse> {
+  return proxyRequest('PATCH', `/internal/admin/tasks/${taskId}/transition`, undefined, { status });
+}
+
+export async function cancelTask(taskId: string): Promise<ProxyResponse> {
+  return proxyRequest('DELETE', `/internal/admin/tasks/${taskId}`);
+}

--- a/services/knowledge/app/db/migrations/009_create_agent_tasks.sql
+++ b/services/knowledge/app/db/migrations/009_create_agent_tasks.sql
@@ -1,0 +1,19 @@
+-- Agent tasks table — Kanban-style task tracking for agents
+CREATE TABLE IF NOT EXISTS agent_tasks (
+    id          UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    agent_id    TEXT NOT NULL,
+    title       VARCHAR(255) NOT NULL,
+    description TEXT DEFAULT '',
+    status      VARCHAR(20) NOT NULL DEFAULT 'backlog'
+                CHECK (status IN ('backlog', 'todo', 'in_progress', 'review', 'done', 'cancelled')),
+    priority    SMALLINT NOT NULL DEFAULT 3
+                CHECK (priority BETWEEN 1 AND 4),
+    sort_order  INTEGER NOT NULL DEFAULT 0,
+    tags        TEXT[] DEFAULT '{}',
+    created_by  VARCHAR(255) NOT NULL,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_tasks_agent_status ON agent_tasks (agent_id, status);
+CREATE INDEX IF NOT EXISTS idx_agent_tasks_status ON agent_tasks (status) WHERE status NOT IN ('done', 'cancelled');

--- a/services/knowledge/app/main.py
+++ b/services/knowledge/app/main.py
@@ -22,9 +22,11 @@ from app.routes import (
     internal,
     internal_admin,
     internal_admin_shared,
+    internal_admin_tasks,
     journal,
     search,
     shared,
+    tasks,
 )
 from app.services.reconciler import reconcile
 
@@ -149,7 +151,9 @@ def create_app(
     app.include_router(internal.router)
     app.include_router(internal_admin.router)
     app.include_router(internal_admin_shared.router)
+    app.include_router(internal_admin_tasks.router)
     app.include_router(shared.router)
+    app.include_router(tasks.router)
 
     return app
 

--- a/services/knowledge/app/routes/internal_admin_tasks.py
+++ b/services/knowledge/app/routes/internal_admin_tasks.py
@@ -1,0 +1,127 @@
+"""Internal admin task endpoints for the API proxy layer.
+
+Authenticated with AKM_INTERNAL_SERVICE_TOKEN. The API service enforces
+user-level authorization before calling these endpoints.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Query, Request
+from pydantic import BaseModel, Field
+
+from app.services import task_store
+
+router = APIRouter(prefix="/internal/admin/tasks", tags=["internal-admin-tasks"])
+
+
+def _verify_service_token(request: Request) -> None:
+    internal_token = request.app.state.settings.internal_service_token
+    auth_header = request.headers.get("Authorization", "")
+    if auth_header != f"Bearer {internal_token}":
+        raise HTTPException(status_code=401, detail="invalid service token")
+
+
+class CreateTaskBody(BaseModel):
+    agent_id: str
+    title: str = Field(..., min_length=1, max_length=255)
+    description: str = ""
+    status: str = "backlog"
+    priority: int = 3
+    tags: list[str] = []
+    created_by: str = ""
+
+
+class UpdateTaskBody(BaseModel):
+    title: str | None = None
+    description: str | None = None
+    status: str | None = None
+    priority: int | None = None
+    tags: list[str] | None = None
+
+
+class TransitionBody(BaseModel):
+    status: str
+
+
+@router.get("")
+async def list_tasks(
+    request: Request,
+    agent_id: str | None = Query(None),
+    status: str | None = Query(None),
+) -> list[dict[str, Any]]:
+    _verify_service_token(request)
+    pool = request.app.state.pool
+    return await task_store.list_tasks(pool, agent_id=agent_id, status=status)
+
+
+@router.post("")
+async def create_task(body: CreateTaskBody, request: Request) -> dict[str, Any]:
+    _verify_service_token(request)
+    pool = request.app.state.pool
+    try:
+        return await task_store.create_task(
+            pool,
+            agent_id=body.agent_id,
+            title=body.title,
+            description=body.description,
+            status=body.status,
+            priority=body.priority,
+            tags=body.tags,
+            created_by=body.created_by,
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
+@router.get("/{task_id}")
+async def get_task(task_id: str, request: Request) -> dict[str, Any]:
+    _verify_service_token(request)
+    pool = request.app.state.pool
+    task = await task_store.get_task(pool, task_id)
+    if task is None:
+        raise HTTPException(status_code=404, detail="task not found")
+    return task
+
+
+@router.put("/{task_id}")
+async def update_task(
+    task_id: str, body: UpdateTaskBody, request: Request
+) -> dict[str, Any]:
+    _verify_service_token(request)
+    pool = request.app.state.pool
+    try:
+        task = await task_store.update_task(
+            pool, task_id, **body.model_dump(exclude_none=True)
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    if task is None:
+        raise HTTPException(status_code=404, detail="task not found")
+    return task
+
+
+@router.patch("/{task_id}/transition")
+async def transition_task(
+    task_id: str, body: TransitionBody, request: Request
+) -> dict[str, Any]:
+    _verify_service_token(request)
+    pool = request.app.state.pool
+    try:
+        task = await task_store.transition_task(pool, task_id, body.status)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    if task is None:
+        raise HTTPException(status_code=404, detail="task not found")
+    return task
+
+
+@router.delete("/{task_id}")
+async def cancel_task(task_id: str, request: Request) -> dict[str, Any]:
+    _verify_service_token(request)
+    pool = request.app.state.pool
+    task = await task_store.transition_task(pool, task_id, "cancelled")
+    if task is None:
+        raise HTTPException(status_code=404, detail="task not found")
+    return task

--- a/services/knowledge/app/routes/tasks.py
+++ b/services/knowledge/app/routes/tasks.py
@@ -1,0 +1,132 @@
+"""Agent-facing task endpoints (Ed25519 JWT auth)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Query, Request
+from pydantic import BaseModel, Field
+
+from app.services import task_store
+
+router = APIRouter(prefix="/api/v1/tasks", tags=["tasks"])
+
+
+class CreateTaskRequest(BaseModel):
+    title: str = Field(..., min_length=1, max_length=255)
+    description: str = ""
+    status: str = "backlog"
+    priority: int = 3
+    tags: list[str] = []
+
+
+class UpdateTaskRequest(BaseModel):
+    title: str | None = None
+    description: str | None = None
+    status: str | None = None
+    priority: int | None = None
+    tags: list[str] | None = None
+
+
+class TransitionRequest(BaseModel):
+    status: str
+
+
+@router.post("")
+async def create_task(body: CreateTaskRequest, request: Request) -> dict[str, Any]:
+    claims = getattr(request.state, "agent_claims", None)
+    if claims is None:
+        raise HTTPException(status_code=401, detail="authentication required")
+
+    pool = request.app.state.pool
+    try:
+        task = await task_store.create_task(
+            pool,
+            agent_id=claims.sub,
+            title=body.title,
+            description=body.description,
+            status=body.status,
+            priority=body.priority,
+            tags=body.tags,
+            created_by=claims.sub,
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    return task
+
+
+@router.get("")
+async def list_tasks(
+    request: Request,
+    status: str | None = Query(None),
+) -> list[dict[str, Any]]:
+    claims = getattr(request.state, "agent_claims", None)
+    if claims is None:
+        raise HTTPException(status_code=401, detail="authentication required")
+
+    pool = request.app.state.pool
+    return await task_store.list_tasks(pool, agent_id=claims.sub, status=status)
+
+
+@router.get("/{task_id}")
+async def get_task(task_id: str, request: Request) -> dict[str, Any]:
+    claims = getattr(request.state, "agent_claims", None)
+    if claims is None:
+        raise HTTPException(status_code=401, detail="authentication required")
+
+    pool = request.app.state.pool
+    task = await task_store.get_task(pool, task_id)
+    if task is None or task["agent_id"] != claims.sub:
+        raise HTTPException(status_code=404, detail="task not found")
+    return task
+
+
+@router.put("/{task_id}")
+async def update_task(
+    task_id: str, body: UpdateTaskRequest, request: Request
+) -> dict[str, Any]:
+    claims = getattr(request.state, "agent_claims", None)
+    if claims is None:
+        raise HTTPException(status_code=401, detail="authentication required")
+
+    pool = request.app.state.pool
+    existing = await task_store.get_task(pool, task_id)
+    if existing is None or existing["agent_id"] != claims.sub:
+        raise HTTPException(status_code=404, detail="task not found")
+
+    try:
+        task = await task_store.update_task(
+            pool,
+            task_id,
+            **body.model_dump(exclude_none=True),
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    if task is None:
+        raise HTTPException(status_code=404, detail="task not found")
+    return task
+
+
+@router.patch("/{task_id}/transition")
+async def transition_task(
+    task_id: str, body: TransitionRequest, request: Request
+) -> dict[str, Any]:
+    claims = getattr(request.state, "agent_claims", None)
+    if claims is None:
+        raise HTTPException(status_code=401, detail="authentication required")
+
+    pool = request.app.state.pool
+    existing = await task_store.get_task(pool, task_id)
+    if existing is None or existing["agent_id"] != claims.sub:
+        raise HTTPException(status_code=404, detail="task not found")
+
+    try:
+        task = await task_store.transition_task(pool, task_id, body.status)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    if task is None:
+        raise HTTPException(status_code=404, detail="task not found")
+    return task

--- a/services/knowledge/app/services/task_store.py
+++ b/services/knowledge/app/services/task_store.py
@@ -1,0 +1,155 @@
+"""Task store — CRUD and transition logic for agent tasks."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import asyncpg
+import structlog
+
+logger = structlog.get_logger()
+
+VALID_STATUSES = frozenset({"backlog", "todo", "in_progress", "review", "done", "cancelled"})
+
+
+async def create_task(
+    pool: asyncpg.Pool,
+    agent_id: str,
+    title: str,
+    created_by: str,
+    description: str = "",
+    status: str = "backlog",
+    priority: int = 3,
+    tags: list[str] | None = None,
+) -> dict[str, Any]:
+    """Create a new task for an agent."""
+    if status not in VALID_STATUSES:
+        raise ValueError(f"invalid status '{status}'")
+    if not 1 <= priority <= 4:
+        raise ValueError(f"invalid priority {priority}")
+
+    row = await pool.fetchrow(
+        """INSERT INTO agent_tasks (agent_id, title, description, status, priority, tags, created_by)
+           VALUES ($1, $2, $3, $4, $5, $6, $7)
+           RETURNING *""",
+        agent_id,
+        title,
+        description,
+        status,
+        priority,
+        tags or [],
+        created_by,
+    )
+    return _serialize(dict(row))
+
+
+async def list_tasks(
+    pool: asyncpg.Pool,
+    agent_id: str | None = None,
+    status: str | None = None,
+) -> list[dict[str, Any]]:
+    """List tasks, optionally filtered by agent_id and/or status."""
+    conditions = []
+    params: list[Any] = []
+    idx = 1
+
+    if agent_id:
+        conditions.append(f"agent_id = ${idx}")
+        params.append(agent_id)
+        idx += 1
+
+    if status:
+        conditions.append(f"status = ${idx}")
+        params.append(status)
+        idx += 1
+
+    where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
+
+    rows = await pool.fetch(
+        f"""SELECT * FROM agent_tasks {where}
+            ORDER BY sort_order ASC, updated_at DESC""",
+        *params,
+    )
+    return [_serialize(dict(r)) for r in rows]
+
+
+async def get_task(pool: asyncpg.Pool, task_id: str) -> dict[str, Any] | None:
+    """Get a single task by ID."""
+    row = await pool.fetchrow("SELECT * FROM agent_tasks WHERE id = $1", task_id)
+    if row is None:
+        return None
+    return _serialize(dict(row))
+
+
+async def update_task(
+    pool: asyncpg.Pool,
+    task_id: str,
+    **fields: Any,
+) -> dict[str, Any] | None:
+    """Update task fields. Only provided fields are updated."""
+    allowed = {"title", "description", "status", "priority", "tags", "sort_order"}
+    updates = {k: v for k, v in fields.items() if k in allowed and v is not None}
+
+    if not updates:
+        return await get_task(pool, task_id)
+
+    if "status" in updates and updates["status"] not in VALID_STATUSES:
+        raise ValueError(f"invalid status '{updates['status']}'")
+    if "priority" in updates and not 1 <= updates["priority"] <= 4:
+        raise ValueError(f"invalid priority {updates['priority']}")
+
+    set_clauses = []
+    params: list[Any] = []
+    idx = 1
+
+    for key, value in updates.items():
+        set_clauses.append(f"{key} = ${idx}")
+        params.append(value)
+        idx += 1
+
+    set_clauses.append(f"updated_at = NOW()")
+    params.append(task_id)
+
+    row = await pool.fetchrow(
+        f"""UPDATE agent_tasks SET {', '.join(set_clauses)}
+            WHERE id = ${idx}
+            RETURNING *""",
+        *params,
+    )
+    if row is None:
+        return None
+    return _serialize(dict(row))
+
+
+async def transition_task(
+    pool: asyncpg.Pool,
+    task_id: str,
+    new_status: str,
+) -> dict[str, Any] | None:
+    """Transition a task to a new status."""
+    if new_status not in VALID_STATUSES:
+        raise ValueError(f"invalid status '{new_status}'")
+
+    row = await pool.fetchrow(
+        """UPDATE agent_tasks SET status = $1, updated_at = NOW()
+           WHERE id = $2
+           RETURNING *""",
+        new_status,
+        task_id,
+    )
+    if row is None:
+        return None
+    return _serialize(dict(row))
+
+
+def _serialize(row: dict[str, Any]) -> dict[str, Any]:
+    """Serialize DB row for JSON response."""
+    result = {}
+    for key, value in row.items():
+        if hasattr(value, "hex"):  # UUID
+            result[key] = str(value)
+        elif hasattr(value, "isoformat"):  # datetime
+            result[key] = value.isoformat()
+        else:
+            result[key] = value
+    return result

--- a/services/ui/src/__tests__/TaskBoardClient.test.tsx
+++ b/services/ui/src/__tests__/TaskBoardClient.test.tsx
@@ -1,0 +1,152 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+
+import TaskBoardClient from '@/app/tasks/TaskBoardClient'
+
+const MOCK_TASKS = [
+  { id: 't1', agent_id: 'bot-1', title: 'Deploy API', description: 'Deploy the API service', status: 'backlog', priority: 2, sort_order: 0, tags: ['ops'], created_by: 'user-1', created_at: '2026-01-01T00:00:00Z', updated_at: '2026-01-01T00:00:00Z' },
+  { id: 't2', agent_id: 'bot-1', title: 'Fix auth bug', description: '', status: 'in_progress', priority: 1, sort_order: 0, tags: [], created_by: 'user-1', created_at: '2026-01-02T00:00:00Z', updated_at: '2026-01-02T00:00:00Z' },
+  { id: 't3', agent_id: 'bot-2', title: 'Write tests', description: '', status: 'done', priority: 3, sort_order: 0, tags: [], created_by: 'bot-2', created_at: '2026-01-03T00:00:00Z', updated_at: '2026-01-03T00:00:00Z' },
+]
+
+const MOCK_AGENTS = [
+  { agent_id: 'bot-1', name: 'Bot One' },
+  { agent_id: 'bot-2', name: 'Bot Two' },
+]
+
+const mockFetch = vi.fn()
+vi.stubGlobal('fetch', mockFetch)
+
+describe('TaskBoardClient', () => {
+  beforeEach(() => {
+    mockFetch.mockReset()
+    mockFetch.mockImplementation(async (url: string, opts?: RequestInit) => {
+      if (typeof url === 'string' && url === '/api/tasks' && (!opts || opts.method === undefined || opts.method === 'GET')) {
+        return { ok: true, json: async () => MOCK_TASKS }
+      }
+      if (typeof url === 'string' && url === '/api/agents') {
+        return { ok: true, json: async () => MOCK_AGENTS }
+      }
+      if (typeof url === 'string' && url.includes('/transition')) {
+        const body = JSON.parse(opts?.body as string)
+        const taskId = url.split('/tasks/')[1].split('/')[0]
+        const task = MOCK_TASKS.find(t => t.id === taskId)
+        return { ok: true, json: async () => ({ ...task, status: body.status }) }
+      }
+      return { ok: false, json: async () => ({}) }
+    })
+  })
+
+  afterEach(() => cleanup())
+
+  it('T1: renders all 5 board columns', async () => {
+    render(<TaskBoardClient />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('board')).toBeInTheDocument()
+    })
+
+    expect(screen.getByTestId('column-backlog')).toBeInTheDocument()
+    expect(screen.getByTestId('column-todo')).toBeInTheDocument()
+    expect(screen.getByTestId('column-in_progress')).toBeInTheDocument()
+    expect(screen.getByTestId('column-review')).toBeInTheDocument()
+    expect(screen.getByTestId('column-done')).toBeInTheDocument()
+  })
+
+  it('T2: tasks appear in correct columns', async () => {
+    render(<TaskBoardClient />)
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('task-card')).toHaveLength(3)
+    })
+
+    // Deploy API should be in backlog column
+    const backlog = screen.getByTestId('column-backlog')
+    expect(backlog).toHaveTextContent('Deploy API')
+
+    // Fix auth bug should be in in_progress column
+    const inProgress = screen.getByTestId('column-in_progress')
+    expect(inProgress).toHaveTextContent('Fix auth bug')
+
+    // Write tests should be in done column
+    const done = screen.getByTestId('column-done')
+    expect(done).toHaveTextContent('Write tests')
+  })
+
+  it('T3: empty columns show empty state', async () => {
+    mockFetch.mockImplementation(async (url: string) => {
+      if (typeof url === 'string' && url === '/api/tasks') {
+        return { ok: true, json: async () => [] }
+      }
+      if (typeof url === 'string' && url === '/api/agents') {
+        return { ok: true, json: async () => [] }
+      }
+      return { ok: false, json: async () => ({}) }
+    })
+
+    render(<TaskBoardClient />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('board')).toBeInTheDocument()
+    })
+
+    const emptyStates = screen.getAllByTestId('column-empty')
+    expect(emptyStates.length).toBe(5)
+  })
+
+  it('T4: click task shows detail panel', async () => {
+    render(<TaskBoardClient />)
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('task-card')).toHaveLength(3)
+    })
+
+    fireEvent.click(screen.getAllByTestId('task-card')[0])
+
+    await waitFor(() => {
+      expect(screen.getByTestId('task-detail')).toBeInTheDocument()
+    })
+
+    expect(screen.getByText('Deploy API')).toBeInTheDocument()
+    expect(screen.getByTestId('back-to-board')).toBeInTheDocument()
+  })
+
+  it('T5: click-to-transition calls API and updates task', async () => {
+    render(<TaskBoardClient />)
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('task-card')).toHaveLength(3)
+    })
+
+    // Click "Deploy API" (backlog task)
+    fireEvent.click(screen.getAllByTestId('task-card')[0])
+
+    await waitFor(() => {
+      expect(screen.getByTestId('task-detail')).toBeInTheDocument()
+    })
+
+    // Click "To Do" transition button
+    const todoButton = screen.getByTestId('transition-todo')
+    fireEvent.click(todoButton)
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        '/api/tasks/t1/transition',
+        expect.objectContaining({
+          method: 'PATCH',
+          body: JSON.stringify({ status: 'todo' }),
+        }),
+      )
+    })
+  })
+
+  it('T6: shows loading state', () => {
+    mockFetch.mockImplementation(() => new Promise(() => {}))
+
+    render(<TaskBoardClient />)
+
+    expect(screen.getByTestId('loading')).toBeInTheDocument()
+  })
+})

--- a/services/ui/src/app/tasks/TaskBoardClient.tsx
+++ b/services/ui/src/app/tasks/TaskBoardClient.tsx
@@ -1,0 +1,325 @@
+'use client'
+
+import React, { useState, useEffect, useCallback } from 'react'
+
+interface Task {
+  id: string
+  agent_id: string
+  title: string
+  description: string
+  status: string
+  priority: number
+  sort_order: number
+  tags: string[]
+  created_by: string
+  created_at: string
+  updated_at: string
+}
+
+const COLUMNS = [
+  { id: 'backlog', label: 'Backlog' },
+  { id: 'todo', label: 'To Do' },
+  { id: 'in_progress', label: 'In Progress' },
+  { id: 'review', label: 'Review' },
+  { id: 'done', label: 'Done' },
+] as const
+
+type ColumnId = typeof COLUMNS[number]['id']
+
+const PRIORITY_LABELS: Record<number, { label: string; color: string }> = {
+  1: { label: 'Urgent', color: 'bg-red-900/50 text-red-400 border-red-700' },
+  2: { label: 'High', color: 'bg-amber-900/50 text-amber-400 border-amber-700' },
+  3: { label: 'Medium', color: 'bg-navy-700/50 text-mountain-300 border-navy-600' },
+  4: { label: 'Low', color: 'bg-navy-800/50 text-mountain-500 border-navy-700' },
+}
+
+function timeAgo(dateStr: string): string {
+  const seconds = Math.floor((Date.now() - new Date(dateStr).getTime()) / 1000)
+  if (seconds < 60) return 'just now'
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60) return `${minutes}m ago`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours}h ago`
+  const days = Math.floor(hours / 24)
+  return `${days}d ago`
+}
+
+interface NewTaskForm {
+  agent_id: string
+  title: string
+  description: string
+  priority: number
+}
+
+export default function TaskBoardClient() {
+  const [tasks, setTasks] = useState<Task[]>([])
+  const [loading, setLoading] = useState(true)
+  const [agents, setAgents] = useState<Array<{ agent_id: string; name: string }>>([])
+  const [selectedTask, setSelectedTask] = useState<Task | null>(null)
+  const [transitioning, setTransitioning] = useState<string | null>(null)
+  const [showNewForm, setShowNewForm] = useState(false)
+  const [newTask, setNewTask] = useState<NewTaskForm>({ agent_id: '', title: '', description: '', priority: 3 })
+  const [creating, setCreating] = useState(false)
+
+  const fetchTasks = useCallback(async () => {
+    try {
+      const res = await fetch('/api/tasks')
+      if (res.ok) {
+        const data = await res.json()
+        setTasks(Array.isArray(data) ? data : [])
+      }
+    } catch {
+      // Non-fatal
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  const fetchAgents = useCallback(async () => {
+    try {
+      const res = await fetch('/api/agents')
+      if (res.ok) {
+        const data = await res.json()
+        setAgents(Array.isArray(data) ? data : [])
+      }
+    } catch {
+      // Non-fatal
+    }
+  }, [])
+
+  useEffect(() => {
+    fetchTasks()
+    fetchAgents()
+  }, [fetchTasks, fetchAgents])
+
+  const handleTransition = async (taskId: string, newStatus: string) => {
+    setTransitioning(taskId)
+    try {
+      const res = await fetch(`/api/tasks/${taskId}/transition`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: newStatus }),
+      })
+      if (res.ok) {
+        const updated = await res.json()
+        setTasks(prev => prev.map(t => t.id === taskId ? updated : t))
+        if (selectedTask?.id === taskId) setSelectedTask(updated)
+      }
+    } catch {
+      // Non-fatal
+    } finally {
+      setTransitioning(null)
+    }
+  }
+
+  const handleCreate = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!newTask.agent_id || !newTask.title.trim()) return
+    setCreating(true)
+    try {
+      const res = await fetch('/api/tasks', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(newTask),
+      })
+      if (res.ok) {
+        const created = await res.json()
+        setTasks(prev => [...prev, created])
+        setNewTask({ agent_id: '', title: '', description: '', priority: 3 })
+        setShowNewForm(false)
+      }
+    } catch {
+      // Non-fatal
+    } finally {
+      setCreating(false)
+    }
+  }
+
+  const tasksByColumn = (columnId: string) =>
+    tasks.filter(t => t.status === columnId)
+
+  // Task detail panel
+  if (selectedTask) {
+    const nextStatuses = COLUMNS.map(c => c.id).filter(s => s !== selectedTask.status && s !== 'cancelled')
+    return (
+      <div>
+        <div className="mb-4">
+          <button
+            onClick={() => setSelectedTask(null)}
+            className="text-sm text-brand-400 hover:text-brand-300 transition-colors cursor-pointer"
+            data-testid="back-to-board"
+          >
+            Back to board
+          </button>
+        </div>
+        <div className="rounded-lg border border-navy-700 bg-navy-800 p-6" data-testid="task-detail">
+          <h2 className="text-xl font-semibold text-white mb-2">{selectedTask.title}</h2>
+          <div className="flex items-center gap-2 mb-4">
+            <span className={`px-2 py-0.5 text-xs rounded-md border ${PRIORITY_LABELS[selectedTask.priority]?.color || ''}`}>
+              {PRIORITY_LABELS[selectedTask.priority]?.label || `P${selectedTask.priority}`}
+            </span>
+            <span className="text-xs text-mountain-400">{selectedTask.agent_id}</span>
+            <span className="text-xs text-mountain-500">Updated {timeAgo(selectedTask.updated_at)}</span>
+          </div>
+          {selectedTask.description && (
+            <p className="text-sm text-mountain-300 mb-4 whitespace-pre-wrap">{selectedTask.description}</p>
+          )}
+          {selectedTask.tags.length > 0 && (
+            <div className="flex gap-1 mb-4">
+              {selectedTask.tags.map(tag => (
+                <span key={tag} className="px-1.5 py-0.5 text-xs rounded-md border border-navy-600 text-mountain-400">{tag}</span>
+              ))}
+            </div>
+          )}
+          <div className="flex items-center gap-2">
+            <span className="text-xs text-mountain-500">Move to:</span>
+            {nextStatuses.map(s => (
+              <button
+                key={s}
+                onClick={() => handleTransition(selectedTask.id, s)}
+                disabled={transitioning === selectedTask.id}
+                className="px-3 py-1 text-xs font-medium rounded-md bg-navy-700 hover:bg-navy-600 text-white transition-colors cursor-pointer disabled:opacity-50"
+                data-testid={`transition-${s}`}
+              >
+                {COLUMNS.find(c => c.id === s)?.label || s}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div>
+      {/* Header */}
+      <div className="flex items-center justify-between mb-6">
+        <h1 className="text-2xl font-bold text-white">Tasks</h1>
+        <button
+          onClick={() => setShowNewForm(!showNewForm)}
+          className="px-4 py-2 text-sm font-medium rounded-lg bg-brand-600 hover:bg-brand-500 text-white transition-colors cursor-pointer"
+          data-testid="new-task-button"
+        >
+          + New Task
+        </button>
+      </div>
+
+      {/* New task form */}
+      {showNewForm && (
+        <form onSubmit={handleCreate} className="rounded-lg border border-navy-700 bg-navy-800 p-5 mb-6" data-testid="new-task-form">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-4">
+            <div>
+              <label className="block text-xs text-mountain-400 mb-1">Agent</label>
+              <select
+                value={newTask.agent_id}
+                onChange={e => setNewTask(prev => ({ ...prev, agent_id: e.target.value }))}
+                className="w-full rounded-md border border-navy-600 bg-navy-900 px-3 py-2 text-sm text-white focus:border-brand-500 focus:outline-none"
+                required
+              >
+                <option value="">Select agent...</option>
+                {agents.map(a => (
+                  <option key={a.agent_id} value={a.agent_id}>{a.name || a.agent_id}</option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <label className="block text-xs text-mountain-400 mb-1">Priority</label>
+              <select
+                value={newTask.priority}
+                onChange={e => setNewTask(prev => ({ ...prev, priority: Number(e.target.value) }))}
+                className="w-full rounded-md border border-navy-600 bg-navy-900 px-3 py-2 text-sm text-white focus:border-brand-500 focus:outline-none"
+              >
+                <option value={1}>Urgent</option>
+                <option value={2}>High</option>
+                <option value={3}>Medium</option>
+                <option value={4}>Low</option>
+              </select>
+            </div>
+          </div>
+          <div className="mb-4">
+            <label className="block text-xs text-mountain-400 mb-1">Title</label>
+            <input
+              type="text"
+              value={newTask.title}
+              onChange={e => setNewTask(prev => ({ ...prev, title: e.target.value }))}
+              className="w-full rounded-md border border-navy-600 bg-navy-900 px-3 py-2 text-sm text-white placeholder-mountain-500 focus:border-brand-500 focus:outline-none"
+              placeholder="Task title..."
+              required
+            />
+          </div>
+          <div className="mb-4">
+            <label className="block text-xs text-mountain-400 mb-1">Description</label>
+            <textarea
+              value={newTask.description}
+              onChange={e => setNewTask(prev => ({ ...prev, description: e.target.value }))}
+              rows={2}
+              className="w-full rounded-md border border-navy-600 bg-navy-900 px-3 py-2 text-sm text-white placeholder-mountain-500 focus:border-brand-500 focus:outline-none resize-y"
+              placeholder="Optional description..."
+            />
+          </div>
+          <div className="flex gap-2">
+            <button
+              type="submit"
+              disabled={creating}
+              className="px-4 py-2 text-sm font-medium rounded-md bg-brand-600 hover:bg-brand-500 text-white transition-colors cursor-pointer disabled:opacity-50"
+            >
+              {creating ? 'Creating...' : 'Create Task'}
+            </button>
+            <button
+              type="button"
+              onClick={() => setShowNewForm(false)}
+              className="px-4 py-2 text-sm font-medium rounded-md text-mountain-400 hover:text-white transition-colors cursor-pointer"
+            >
+              Cancel
+            </button>
+          </div>
+        </form>
+      )}
+
+      {/* Board */}
+      {loading ? (
+        <div className="flex items-center justify-center py-12" data-testid="loading">
+          <div className="h-8 w-8 rounded-full border-2 border-brand-500 border-t-transparent animate-spin" />
+        </div>
+      ) : (
+        <div className="grid grid-cols-5 gap-3" data-testid="board">
+          {COLUMNS.map(col => {
+            const colTasks = tasksByColumn(col.id)
+            return (
+              <div key={col.id} className="min-h-[200px]" data-testid={`column-${col.id}`}>
+                <div className="flex items-center justify-between mb-3 px-1">
+                  <h3 className="text-sm font-medium text-mountain-400">{col.label}</h3>
+                  <span className="text-xs text-mountain-500">{colTasks.length}</span>
+                </div>
+                <div className="space-y-2">
+                  {colTasks.map(task => (
+                    <button
+                      key={task.id}
+                      onClick={() => setSelectedTask(task)}
+                      className="w-full text-left rounded-lg border border-navy-700 bg-navy-900 p-3 hover:border-navy-500 transition-colors cursor-pointer"
+                      data-testid="task-card"
+                    >
+                      <p className="text-sm font-medium text-white line-clamp-2 mb-1">{task.title}</p>
+                      <div className="flex items-center gap-1.5">
+                        <span className={`px-1.5 py-0.5 text-[10px] rounded border ${PRIORITY_LABELS[task.priority]?.color || ''}`}>
+                          {PRIORITY_LABELS[task.priority]?.label || `P${task.priority}`}
+                        </span>
+                        <span className="text-[10px] text-mountain-500 truncate">{task.agent_id}</span>
+                      </div>
+                      <p className="text-[10px] text-mountain-500 mt-1">{timeAgo(task.updated_at)}</p>
+                    </button>
+                  ))}
+                  {colTasks.length === 0 && (
+                    <p className="text-xs text-mountain-500 text-center py-4" data-testid="column-empty">
+                      No tasks
+                    </p>
+                  )}
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/services/ui/src/app/tasks/page.tsx
+++ b/services/ui/src/app/tasks/page.tsx
@@ -1,0 +1,30 @@
+'use client'
+
+import { useSession } from 'next-auth/react'
+import { redirect } from 'next/navigation'
+import AppShell from '@/components/AppShell'
+import TaskBoardClient from './TaskBoardClient'
+
+export default function TasksPage() {
+  const { data: session, status } = useSession()
+
+  if (status === 'loading') {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-navy-900">
+        <div className="h-8 w-8 rounded-full border-2 border-brand-500 border-t-transparent animate-spin" />
+      </div>
+    )
+  }
+
+  if (!session) {
+    redirect('/api/auth/signin')
+  }
+
+  return (
+    <AppShell>
+      <main className="flex-1 px-6 py-12 max-w-7xl mx-auto w-full">
+        <TaskBoardClient />
+      </main>
+    </AppShell>
+  )
+}

--- a/services/ui/src/components/nav-items.ts
+++ b/services/ui/src/components/nav-items.ts
@@ -1,4 +1,4 @@
-import { Home, LayoutDashboard, Bot, FileText, Book, ExternalLink, KeyRound, Cpu, BarChart3, BookOpen, Library, Wrench, Layers, Settings, Server, MessageSquare, Package } from 'lucide-react'
+import { Home, LayoutDashboard, Bot, FileText, Book, ExternalLink, KeyRound, Cpu, BarChart3, BookOpen, Library, Wrench, Layers, Settings, Server, MessageSquare, Package, CheckSquare } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
 
 export interface NavLink {
@@ -27,6 +27,7 @@ export const NAV_ITEMS: NavItem[] = [
   { type: 'link', id: 'dashboard', label: 'Dashboard', href: '/dashboard', icon: LayoutDashboard },
   { type: 'link', id: 'agents', label: 'Agents', href: '/agents', icon: Bot },
   { type: 'link', id: 'chat', label: 'Chat', href: '/chat', icon: MessageSquare },
+  { type: 'link', id: 'tasks', label: 'Tasks', href: '/tasks', icon: CheckSquare },
   { type: 'link', id: 'knowledge', label: 'Knowledge', href: '/harness/knowledge', icon: BookOpen },
   {
     type: 'group',


### PR DESCRIPTION
## Summary
- New `agent_tasks` table (migration 009) with Kanban status flow: backlog → todo → in_progress → review → done (+ cancelled)
- Knowledge service: `task_store.py` CRUD, agent-facing routes (`/api/v1/tasks`), internal admin routes (`/internal/admin/tasks`)
- API service: `task-proxy.ts` HTTP client, `tasks.ts` user-facing routes with ownership scoping via `scopeToOwner`
- UI: top-level `/tasks` page with 5-column Kanban board, task cards with priority badges, click-to-transition, task creation form
- Tasks nav link added to sidebar (CheckSquare icon)
- OpenAPI spec updated with AgentTask schema + 4 task endpoints
- Design doc: `docs/architecture/task-board.md` (AI-112)

## Changes (14 files)
| Service | Files | Description |
|---------|-------|-------------|
| Knowledge | migration 009, task_store.py, tasks.py, internal_admin_tasks.py, main.py | Task table + CRUD + routes |
| API | task-proxy.ts, tasks.ts, app.ts, openapi.yaml | Proxy + user routes + spec |
| UI | TaskBoardClient.tsx, page.tsx, nav-items.ts | Board UI + nav link |
| Docs | docs/site/openapi.yaml | Spec sync |

## Test plan
- [x] T1: Board renders all 5 columns
- [x] T2: Tasks appear in correct columns
- [x] T3: Empty columns show empty state
- [x] T4: Click task shows detail panel
- [x] T5: Click-to-transition calls API
- [x] T6: Loading state renders

Linear: AI-148

🤖 Generated with [Claude Code](https://claude.com/claude-code)