### PR TITLE
feat: secrets vault UI — read-only inventory (AI-147)

### DIFF
--- a/docs/site/openapi.yaml
+++ b/docs/site/openapi.yaml
@@ -3838,3 +3838,94 @@ paths:
           description: Transitioned task
         "404":
           description: Task not found
+  # ── Admin: Secrets Vault Inventory (AI-147) ──
+
+  /admin/secrets:
+    get:
+      summary: List vault secrets inventory
+      description: >
+        Returns secrets schema grouped by vault path with key names and consumer
+        service mappings. Admin only. NEVER returns secret values.
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Grouped secrets inventory
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  paths:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        path:
+                          type: string
+                          example: secret/shared/database
+                        keys:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              key:
+                                type: string
+                                example: DB_PASSWORD
+                              consumers:
+                                type: array
+                                items:
+                                  type: string
+                                example: ["db", "api", "ai"]
+                        keyCount:
+                          type: integer
+                          example: 3
+                  totalPaths:
+                    type: integer
+                  totalKeys:
+                    type: integer
+                  approleServices:
+                    type: array
+                    items:
+                      type: string
+        "401":
+          description: Not authenticated
+        "403":
+          description: Requires admin role
+        "503":
+          description: Failed to load secrets schema
+
+  /admin/secrets/status:
+    get:
+      summary: Vault seal status
+      description: >
+        Returns vault health status. Degrades gracefully if vault is unreachable.
+        Admin only.
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Vault status
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  available:
+                    type: boolean
+                  sealed:
+                    type: boolean
+                    nullable: true
+                  initialized:
+                    type: boolean
+                    nullable: true
+                  version:
+                    type: string
+                    nullable: true
+                  cluster_name:
+                    type: string
+                    nullable: true
+        "401":
+          description: Not authenticated
+        "403":
+          description: Requires admin role

--- a/services/api/src/__tests__/docs.test.ts
+++ b/services/api/src/__tests__/docs.test.ts
@@ -192,6 +192,8 @@ const EXPECTED_PATHS = [
   '/tasks',
   '/tasks/{id}',
   '/tasks/{id}/transition',
+  '/admin/secrets',
+  '/admin/secrets/status',
 ];
 
 const INFRA_PATHS = ['/docs', '/openapi.json', '/internal/delegation-token', '/internal/chat/callback', '/internal/model-router/refresh-token'];

--- a/services/api/src/__tests__/routes-secrets.test.ts
+++ b/services/api/src/__tests__/routes-secrets.test.ts
@@ -1,0 +1,161 @@
+import request from 'supertest';
+import * as crypto from 'crypto';
+import * as jwt from 'jsonwebtoken';
+import { createApp } from '../app';
+
+const { privateKey, publicKey } = crypto.generateKeyPairSync('rsa', {
+  modulusLength: 2048,
+  publicKeyEncoding: { type: 'spki', format: 'pem' },
+  privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+});
+
+const TEST_ISSUER = 'https://auth.hill90.com/realms/hill90';
+
+const mockQuery = jest.fn();
+jest.mock('../db/pool', () => ({
+  getPool: () => ({ query: mockQuery }),
+}));
+
+jest.mock('../services/docker', () => ({
+  createAndStartContainer: jest.fn(),
+  stopAndRemoveContainer: jest.fn(),
+  inspectContainer: jest.fn(),
+  getContainerLogs: jest.fn(),
+  removeAgentVolumes: jest.fn(),
+  reconcileAgentStatuses: jest.fn(),
+  execInContainer: jest.fn(),
+}));
+
+jest.mock('../services/agent-files', () => ({
+  writeAgentFiles: jest.fn(),
+  removeAgentFiles: jest.fn(),
+}));
+
+jest.mock('../services/tool-installer', () => ({
+  ensureRequiredToolsInstalled: jest.fn(),
+  reconcileToolInstalls: jest.fn(),
+}));
+
+jest.mock('../services/chat-dispatch', () => ({
+  dispatchChatWork: jest.fn().mockResolvedValue({ accepted: true, work_id: 'work-123' }),
+}));
+
+const app = createApp({
+  issuer: TEST_ISSUER,
+  getSigningKey: async () => publicKey,
+});
+
+function makeToken(sub: string, roles: string[]) {
+  return jwt.sign(
+    { sub, realm_roles: roles },
+    privateKey,
+    { algorithm: 'RS256', issuer: TEST_ISSUER, expiresIn: '5m' }
+  );
+}
+
+const adminToken = makeToken('admin-user', ['admin', 'user']);
+const userToken = makeToken('regular-user', ['user']);
+
+describe('Secrets vault inventory', () => {
+  beforeEach(() => {
+    mockQuery.mockReset();
+    process.env.DATABASE_URL = 'postgresql://test:test@localhost:5432/test';
+  });
+
+  afterEach(() => {
+    delete process.env.DATABASE_URL;
+  });
+
+  it('GET /admin/secrets returns grouped inventory (T1)', async () => {
+    const res = await request(app)
+      .get('/admin/secrets')
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.paths).toBeDefined();
+    expect(Array.isArray(res.body.paths)).toBe(true);
+    expect(res.body.totalPaths).toBeGreaterThan(0);
+    expect(res.body.totalKeys).toBeGreaterThan(0);
+    expect(res.body.approleServices).toBeDefined();
+
+    // Verify structure of first path
+    const first = res.body.paths[0];
+    expect(first.path).toBeDefined();
+    expect(first.keys).toBeDefined();
+    expect(first.keyCount).toBeGreaterThan(0);
+    expect(first.keys[0].key).toBeDefined();
+    expect(first.keys[0].consumers).toBeDefined();
+
+    // Verify known paths from schema
+    const paths = res.body.paths.map((p: any) => p.path);
+    expect(paths).toContain('secret/shared/database');
+    expect(paths).toContain('secret/auth/config');
+    expect(paths).toContain('secret/ai/config');
+  });
+
+  it('GET /admin/secrets rejects non-admin (T2)', async () => {
+    const res = await request(app)
+      .get('/admin/secrets')
+      .set('Authorization', `Bearer ${userToken}`);
+
+    expect(res.status).toBe(403);
+  });
+
+  it('GET /admin/secrets requires auth', async () => {
+    const res = await request(app)
+      .get('/admin/secrets');
+
+    expect(res.status).toBe(401);
+  });
+
+  it('GET /admin/secrets/status returns vault status (T3)', async () => {
+    const res = await request(app)
+      .get('/admin/secrets/status')
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(res.status).toBe(200);
+    // In test env, vault is not running so expect degraded response
+    expect(res.body).toHaveProperty('available');
+    expect(res.body).toHaveProperty('sealed');
+    expect(res.body).toHaveProperty('version');
+  });
+
+  it('GET /admin/secrets/status rejects non-admin', async () => {
+    const res = await request(app)
+      .get('/admin/secrets/status')
+      .set('Authorization', `Bearer ${userToken}`);
+
+    expect(res.status).toBe(403);
+  });
+
+  it('GET /admin/secrets includes consumer service names', async () => {
+    const res = await request(app)
+      .get('/admin/secrets')
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(res.status).toBe(200);
+
+    // DB_PASSWORD should list db, auth, api, ai, knowledge as consumers
+    const dbPath = res.body.paths.find((p: any) => p.path === 'secret/shared/database');
+    expect(dbPath).toBeDefined();
+    const dbPasswordKey = dbPath.keys.find((k: any) => k.key === 'DB_PASSWORD');
+    expect(dbPasswordKey).toBeDefined();
+    expect(dbPasswordKey.consumers).toContain('db');
+    expect(dbPasswordKey.consumers).toContain('api');
+  });
+
+  it('GET /admin/secrets groups keys by vault path', async () => {
+    const res = await request(app)
+      .get('/admin/secrets')
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    // Paths should be unique
+    const paths = res.body.paths.map((p: any) => p.path);
+    expect(new Set(paths).size).toBe(paths.length);
+
+    // Each path should have correct keyCount
+    for (const p of res.body.paths) {
+      expect(p.keyCount).toBe(p.keys.length);
+    }
+  });
+});

--- a/services/api/src/app.ts
+++ b/services/api/src/app.ts
@@ -16,6 +16,7 @@ import profileRouter from './routes/profile';
 import usageRouter from './routes/usage';
 import { requireRole } from './middleware/role';
 import { docsRouter, specRouter } from './routes/docs';
+import secretsRouter from './routes/secrets';
 import { delegationTokenHandler } from './services/model-router-delegation';
 import chatRouter, { chatCallbackHandler, startStaleSweeper } from './routes/chat';
 import tasksRouter from './routes/tasks';
@@ -96,6 +97,9 @@ export function createApp(opts: AppOptions = {}): Application {
 
   // User profile routes
   app.use('/profile', requireAuth, profileRouter);
+
+  // Secrets vault inventory (admin-only, AI-147)
+  app.use('/admin/secrets', requireAuth, requireRole('admin'), secretsRouter);
 
   // API documentation (admin-only)
   app.use('/docs', requireAuth, requireRole('admin'), docsRouter);

--- a/services/api/src/openapi/openapi.yaml
+++ b/services/api/src/openapi/openapi.yaml
@@ -3838,3 +3838,94 @@ paths:
           description: Transitioned task
         "404":
           description: Task not found
+  # ── Admin: Secrets Vault Inventory (AI-147) ──
+
+  /admin/secrets:
+    get:
+      summary: List vault secrets inventory
+      description: >
+        Returns secrets schema grouped by vault path with key names and consumer
+        service mappings. Admin only. NEVER returns secret values.
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Grouped secrets inventory
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  paths:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        path:
+                          type: string
+                          example: secret/shared/database
+                        keys:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              key:
+                                type: string
+                                example: DB_PASSWORD
+                              consumers:
+                                type: array
+                                items:
+                                  type: string
+                                example: ["db", "api", "ai"]
+                        keyCount:
+                          type: integer
+                          example: 3
+                  totalPaths:
+                    type: integer
+                  totalKeys:
+                    type: integer
+                  approleServices:
+                    type: array
+                    items:
+                      type: string
+        "401":
+          description: Not authenticated
+        "403":
+          description: Requires admin role
+        "503":
+          description: Failed to load secrets schema
+
+  /admin/secrets/status:
+    get:
+      summary: Vault seal status
+      description: >
+        Returns vault health status. Degrades gracefully if vault is unreachable.
+        Admin only.
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Vault status
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  available:
+                    type: boolean
+                  sealed:
+                    type: boolean
+                    nullable: true
+                  initialized:
+                    type: boolean
+                    nullable: true
+                  version:
+                    type: string
+                    nullable: true
+                  cluster_name:
+                    type: string
+                    nullable: true
+        "401":
+          description: Not authenticated
+        "403":
+          description: Requires admin role

--- a/services/api/src/routes/secrets.ts
+++ b/services/api/src/routes/secrets.ts
@@ -1,0 +1,142 @@
+/**
+ * Secrets Vault UI — read-only inventory surface (Phase 1, AI-147).
+ *
+ * Parses platform/vault/secrets-schema.yaml to produce a grouped
+ * inventory of vault paths, key names, and consumer services.
+ * NEVER exposes secret values — metadata only.
+ *
+ * Endpoints:
+ *   GET /admin/secrets        — grouped inventory from schema
+ *   GET /admin/secrets/status — vault seal status (degrades gracefully)
+ */
+
+import { Router, Request, Response } from 'express';
+import fs from 'fs';
+import path from 'path';
+import yaml from 'js-yaml';
+
+const router = Router();
+
+// ───────────────────────────────────────────────────────────────────
+// Schema loading
+// ───────────────────────────────────────────────────────────────────
+
+interface SchemaEntry {
+  key: string;
+  vault_path: string;
+  compose_refs: string[];
+  dedup?: string[];
+}
+
+interface SecretsSchema {
+  runtime_secrets: SchemaEntry[];
+  bootstrap_secrets?: string[];
+  vault_management_secrets?: string[];
+  vault_approle_services?: string[];
+}
+
+interface VaultPathGroup {
+  path: string;
+  keys: { key: string; consumers: string[] }[];
+  keyCount: number;
+}
+
+let cachedSchema: SecretsSchema | null = null;
+
+function loadSchema(): SecretsSchema {
+  if (cachedSchema) return cachedSchema;
+
+  const schemaPath = process.env.SECRETS_SCHEMA_PATH
+    || path.resolve(__dirname, '../../../../platform/vault/secrets-schema.yaml');
+
+  const raw = fs.readFileSync(schemaPath, 'utf8');
+  cachedSchema = yaml.load(raw) as SecretsSchema;
+  return cachedSchema;
+}
+
+/** Extract service name from compose filename (e.g., docker-compose.api.yml → api). */
+function extractService(composeRef: string): string {
+  const match = composeRef.match(/docker-compose\.(.+)\.yml/);
+  return match ? match[1] : composeRef;
+}
+
+/** Group schema entries by vault_path. */
+function groupByPath(schema: SecretsSchema): VaultPathGroup[] {
+  const grouped = new Map<string, { key: string; consumers: string[] }[]>();
+
+  for (const entry of schema.runtime_secrets) {
+    if (!grouped.has(entry.vault_path)) {
+      grouped.set(entry.vault_path, []);
+    }
+    const consumers = [...new Set(entry.compose_refs.map(extractService))];
+    grouped.get(entry.vault_path)!.push({ key: entry.key, consumers });
+  }
+
+  return Array.from(grouped.entries())
+    .map(([vaultPath, keys]) => ({
+      path: vaultPath,
+      keys,
+      keyCount: keys.length,
+    }))
+    .sort((a, b) => a.path.localeCompare(b.path));
+}
+
+// ───────────────────────────────────────────────────────────────────
+// GET /admin/secrets — inventory
+// ───────────────────────────────────────────────────────────────────
+
+router.get('/', async (_req: Request, res: Response) => {
+  try {
+    const schema = loadSchema();
+    const inventory = groupByPath(schema);
+    res.json({
+      paths: inventory,
+      totalPaths: inventory.length,
+      totalKeys: schema.runtime_secrets.length,
+      approleServices: schema.vault_approle_services || [],
+    });
+  } catch (err) {
+    console.error('[secrets] Failed to load schema:', err);
+    res.status(503).json({ error: 'Failed to load secrets schema' });
+  }
+});
+
+// ───────────────────────────────────────────────────────────────────
+// GET /admin/secrets/status — vault health
+// ───────────────────────────────────────────────────────────────────
+
+router.get('/status', async (_req: Request, res: Response) => {
+  const vaultAddr = process.env.VAULT_ADDR || process.env.BAO_ADDR || 'http://127.0.0.1:8200';
+
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 3000);
+
+    const response = await fetch(`${vaultAddr}/v1/sys/health`, {
+      signal: controller.signal,
+    });
+    clearTimeout(timeout);
+
+    const body = await response.json() as Record<string, unknown>;
+    res.json({
+      available: true,
+      sealed: body.sealed ?? null,
+      initialized: body.initialized ?? null,
+      version: body.version ?? null,
+      cluster_name: body.cluster_name ?? null,
+    });
+  } catch {
+    res.json({
+      available: false,
+      sealed: null,
+      initialized: null,
+      version: null,
+      cluster_name: null,
+    });
+  }
+});
+
+export default router;
+
+// For testing
+export { loadSchema, groupByPath, extractService };

--- a/services/ui/src/__tests__/SecretsClient.test.tsx
+++ b/services/ui/src/__tests__/SecretsClient.test.tsx
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, cleanup, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+import SecretsClient from '../app/harness/secrets/SecretsClient'
+
+let mockSession: any = null
+
+vi.mock('next-auth/react', () => ({
+  useSession: () => ({ data: mockSession, status: mockSession ? 'authenticated' : 'unauthenticated' }),
+  SessionProvider: ({ children }: any) => children,
+}))
+
+vi.mock('next/link', () => ({
+  default: ({ children, href, ...props }: any) => <a href={href} {...props}>{children}</a>,
+}))
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/harness/secrets',
+  useRouter: () => ({ push: vi.fn() }),
+}))
+
+const mockInventory = {
+  paths: [
+    {
+      path: 'secret/shared/database',
+      keys: [
+        { key: 'DB_USER', consumers: ['db', 'api'] },
+        { key: 'DB_PASSWORD', consumers: ['db', 'api', 'ai'] },
+      ],
+      keyCount: 2,
+    },
+    {
+      path: 'secret/auth/config',
+      keys: [
+        { key: 'KC_ADMIN_USERNAME', consumers: ['auth'] },
+        { key: 'KC_ADMIN_PASSWORD', consumers: ['auth'] },
+      ],
+      keyCount: 2,
+    },
+  ],
+  totalPaths: 2,
+  totalKeys: 4,
+  approleServices: ['db', 'api', 'ai', 'auth'],
+}
+
+const mockStatus = {
+  available: true,
+  sealed: false,
+  initialized: true,
+  version: '2.0.0',
+  cluster_name: 'hill90-vault',
+}
+
+describe('SecretsClient', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    global.fetch = vi.fn()
+  })
+
+  afterEach(() => {
+    cleanup()
+    mockSession = null
+  })
+
+  it('shows access denied for non-admin (T5)', () => {
+    mockSession = { user: { name: 'Regular User', roles: ['user'] } }
+    render(<SecretsClient />)
+    expect(screen.getByText('Access Denied')).toBeInTheDocument()
+    expect(screen.getByText(/admin privileges/)).toBeInTheDocument()
+  })
+
+  it('renders secrets inventory table (T4)', async () => {
+    mockSession = { user: { name: 'Admin', roles: ['admin', 'user'] } }
+
+    ;(global.fetch as any)
+      .mockResolvedValueOnce({ ok: true, json: async () => mockInventory })
+      .mockResolvedValueOnce({ ok: true, json: async () => mockStatus })
+
+    render(<SecretsClient />)
+
+    // Wait for data to load
+    expect(await screen.findByText('Secrets')).toBeInTheDocument()
+    expect(screen.getByText('2 vault paths')).toBeInTheDocument()
+    expect(screen.getByText('4 total keys')).toBeInTheDocument()
+
+    // Vault status bar
+    expect(screen.getByText('Vault unsealed')).toBeInTheDocument()
+
+    // Table paths
+    expect(screen.getByText('secret/shared/database')).toBeInTheDocument()
+    expect(screen.getByText('secret/auth/config')).toBeInTheDocument()
+  })
+
+  it('expands row to show key names (T6)', async () => {
+    mockSession = { user: { name: 'Admin', roles: ['admin', 'user'] } }
+
+    ;(global.fetch as any)
+      .mockResolvedValueOnce({ ok: true, json: async () => mockInventory })
+      .mockResolvedValueOnce({ ok: true, json: async () => mockStatus })
+
+    render(<SecretsClient />)
+
+    // Wait for table to render
+    const dbRow = await screen.findByText('secret/shared/database')
+    expect(dbRow).toBeInTheDocument()
+
+    // Keys should not be visible before expanding
+    expect(screen.queryByText('DB_USER')).not.toBeInTheDocument()
+
+    // Click to expand
+    fireEvent.click(dbRow.closest('tr')!)
+
+    // Keys should now be visible
+    expect(screen.getByText('DB_USER')).toBeInTheDocument()
+    expect(screen.getByText('DB_PASSWORD')).toBeInTheDocument()
+  })
+
+  it('shows vault unavailable status', async () => {
+    mockSession = { user: { name: 'Admin', roles: ['admin', 'user'] } }
+
+    const unavailableStatus = { available: false, sealed: null, initialized: null, version: null, cluster_name: null }
+
+    ;(global.fetch as any)
+      .mockResolvedValueOnce({ ok: true, json: async () => mockInventory })
+      .mockResolvedValueOnce({ ok: true, json: async () => unavailableStatus })
+
+    render(<SecretsClient />)
+
+    expect(await screen.findByText('Vault unreachable')).toBeInTheDocument()
+  })
+
+  it('shows vault sealed status', async () => {
+    mockSession = { user: { name: 'Admin', roles: ['admin', 'user'] } }
+
+    const sealedStatus = { available: true, sealed: true, initialized: true, version: '2.0.0', cluster_name: null }
+
+    ;(global.fetch as any)
+      .mockResolvedValueOnce({ ok: true, json: async () => mockInventory })
+      .mockResolvedValueOnce({ ok: true, json: async () => sealedStatus })
+
+    render(<SecretsClient />)
+
+    expect(await screen.findByText('Vault sealed')).toBeInTheDocument()
+  })
+
+  it('shows error state on fetch failure', async () => {
+    mockSession = { user: { name: 'Admin', roles: ['admin', 'user'] } }
+
+    ;(global.fetch as any)
+      .mockResolvedValueOnce({ ok: false, status: 503 })
+      .mockResolvedValueOnce({ ok: true, json: async () => mockStatus })
+
+    render(<SecretsClient />)
+
+    expect(await screen.findByText('Error')).toBeInTheDocument()
+    expect(screen.getByText('Failed to load secrets inventory')).toBeInTheDocument()
+  })
+})

--- a/services/ui/src/app/api/admin/secrets/route.ts
+++ b/services/ui/src/app/api/admin/secrets/route.ts
@@ -1,0 +1,8 @@
+import { NextRequest } from 'next/server'
+import { proxyToApi } from '@/utils/api-proxy'
+
+async function proxyRequest(req: NextRequest) {
+  return proxyToApi(req, '/admin/secrets', { label: 'secrets-proxy' })
+}
+
+export const GET = proxyRequest

--- a/services/ui/src/app/api/admin/secrets/status/route.ts
+++ b/services/ui/src/app/api/admin/secrets/status/route.ts
@@ -1,0 +1,8 @@
+import { NextRequest } from 'next/server'
+import { proxyToApi } from '@/utils/api-proxy'
+
+async function proxyRequest(req: NextRequest) {
+  return proxyToApi(req, '/admin/secrets/status', { label: 'secrets-status-proxy' })
+}
+
+export const GET = proxyRequest

--- a/services/ui/src/app/harness/secrets/SecretsClient.tsx
+++ b/services/ui/src/app/harness/secrets/SecretsClient.tsx
@@ -1,0 +1,248 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+import { useSession } from 'next-auth/react'
+import { ChevronDown, ChevronRight, KeyRound, Shield, ShieldOff, ShieldAlert } from 'lucide-react'
+
+interface KeyEntry {
+  key: string
+  consumers: string[]
+}
+
+interface VaultPathGroup {
+  path: string
+  keys: KeyEntry[]
+  keyCount: number
+}
+
+interface SecretsInventory {
+  paths: VaultPathGroup[]
+  totalPaths: number
+  totalKeys: number
+  approleServices: string[]
+}
+
+interface VaultStatus {
+  available: boolean
+  sealed: boolean | null
+  initialized: boolean | null
+  version: string | null
+  cluster_name: string | null
+}
+
+function consumerBadge(service: string) {
+  const colors: Record<string, string> = {
+    db: 'bg-blue-900/50 text-blue-400 border-blue-700',
+    api: 'bg-brand-900/50 text-brand-400 border-brand-700',
+    ai: 'bg-purple-900/50 text-purple-400 border-purple-700',
+    auth: 'bg-amber-900/50 text-amber-400 border-amber-700',
+    ui: 'bg-cyan-900/50 text-cyan-400 border-cyan-700',
+    knowledge: 'bg-emerald-900/50 text-emerald-400 border-emerald-700',
+    minio: 'bg-orange-900/50 text-orange-400 border-orange-700',
+    infra: 'bg-red-900/50 text-red-400 border-red-700',
+    observability: 'bg-pink-900/50 text-pink-400 border-pink-700',
+  }
+  const classes = colors[service] || 'bg-navy-700/50 text-gray-400 border-navy-600'
+  return (
+    <span key={service} className={`inline-block px-2 py-0.5 text-xs rounded border ${classes}`}>
+      {service}
+    </span>
+  )
+}
+
+function VaultStatusBar({ status }: { status: VaultStatus | null }) {
+  if (!status) {
+    return (
+      <div className="flex items-center gap-3 px-4 py-3 rounded-lg bg-navy-800 border border-navy-700 mb-6">
+        <div className="h-4 w-4 rounded-full bg-navy-600 animate-pulse" />
+        <span className="text-sm text-gray-400">Loading vault status...</span>
+      </div>
+    )
+  }
+
+  if (!status.available) {
+    return (
+      <div className="flex items-center gap-3 px-4 py-3 rounded-lg bg-navy-800 border border-red-800/50 mb-6">
+        <ShieldAlert className="h-4 w-4 text-red-400" />
+        <span className="text-sm text-red-400">Vault unreachable</span>
+        <span className="text-xs text-gray-500 ml-auto">Status endpoint unavailable</span>
+      </div>
+    )
+  }
+
+  if (status.sealed) {
+    return (
+      <div className="flex items-center gap-3 px-4 py-3 rounded-lg bg-navy-800 border border-amber-800/50 mb-6">
+        <ShieldOff className="h-4 w-4 text-amber-400" />
+        <span className="text-sm text-amber-400">Vault sealed</span>
+        {status.version && <span className="text-xs text-gray-500 ml-auto">v{status.version}</span>}
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex items-center gap-3 px-4 py-3 rounded-lg bg-navy-800 border border-brand-800/50 mb-6">
+      <Shield className="h-4 w-4 text-brand-400" />
+      <span className="text-sm text-brand-400">Vault unsealed</span>
+      {status.version && <span className="text-xs text-gray-500">v{status.version}</span>}
+      {status.cluster_name && <span className="text-xs text-gray-500">({status.cluster_name})</span>}
+    </div>
+  )
+}
+
+function PathRow({ group }: { group: VaultPathGroup }) {
+  const [expanded, setExpanded] = useState(false)
+
+  const allConsumers = [...new Set(group.keys.flatMap(k => k.consumers))].sort()
+
+  return (
+    <>
+      <tr
+        className="border-b border-navy-700/50 hover:bg-navy-800/50 cursor-pointer transition-colors"
+        onClick={() => setExpanded(!expanded)}
+      >
+        <td className="px-4 py-3">
+          <div className="flex items-center gap-2">
+            {expanded
+              ? <ChevronDown className="h-4 w-4 text-gray-500 flex-shrink-0" />
+              : <ChevronRight className="h-4 w-4 text-gray-500 flex-shrink-0" />
+            }
+            <code className="text-sm text-mountain-400 font-mono">{group.path}</code>
+          </div>
+        </td>
+        <td className="px-4 py-3">
+          <span className="inline-block px-2 py-0.5 text-xs rounded bg-navy-700 text-gray-300 border border-navy-600">
+            {group.keyCount} {group.keyCount === 1 ? 'key' : 'keys'}
+          </span>
+        </td>
+        <td className="px-4 py-3">
+          <div className="flex flex-wrap gap-1">
+            {allConsumers.map(s => consumerBadge(s))}
+            {allConsumers.length === 0 && <span className="text-xs text-gray-600">none</span>}
+          </div>
+        </td>
+      </tr>
+      {expanded && group.keys.map(k => (
+        <tr key={k.key} className="border-b border-navy-800/30 bg-navy-900/50">
+          <td className="pl-12 pr-4 py-2">
+            <div className="flex items-center gap-2">
+              <KeyRound className="h-3 w-3 text-gray-600" />
+              <code className="text-xs text-gray-400 font-mono">{k.key}</code>
+            </div>
+          </td>
+          <td className="px-4 py-2" />
+          <td className="px-4 py-2">
+            <div className="flex flex-wrap gap-1">
+              {k.consumers.map(s => consumerBadge(s))}
+              {k.consumers.length === 0 && <span className="text-xs text-gray-600">-</span>}
+            </div>
+          </td>
+        </tr>
+      ))}
+    </>
+  )
+}
+
+export default function SecretsClient() {
+  const { data: session } = useSession()
+  const isAdmin = (session?.user as any)?.roles?.includes('admin')
+
+  const [inventory, setInventory] = useState<SecretsInventory | null>(null)
+  const [vaultStatus, setVaultStatus] = useState<VaultStatus | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const fetchData = useCallback(async () => {
+    try {
+      const [invRes, statusRes] = await Promise.all([
+        fetch('/api/admin/secrets'),
+        fetch('/api/admin/secrets/status'),
+      ])
+      if (invRes.ok) {
+        setInventory(await invRes.json())
+      } else {
+        setError('Failed to load secrets inventory')
+      }
+      if (statusRes.ok) {
+        setVaultStatus(await statusRes.json())
+      }
+    } catch (err) {
+      setError('Failed to connect to API')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (isAdmin) fetchData()
+    else setLoading(false)
+  }, [isAdmin, fetchData])
+
+  if (!isAdmin) {
+    return (
+      <div className="text-center py-20">
+        <ShieldOff className="h-12 w-12 text-red-400 mx-auto mb-4" />
+        <h2 className="text-lg font-semibold text-white mb-2">Access Denied</h2>
+        <p className="text-gray-400">Secrets management requires admin privileges.</p>
+      </div>
+    )
+  }
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <div className="h-8 w-8 rounded-full border-2 border-brand-500 border-t-transparent animate-spin" />
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="text-center py-20">
+        <ShieldAlert className="h-12 w-12 text-red-400 mx-auto mb-4" />
+        <h2 className="text-lg font-semibold text-white mb-2">Error</h2>
+        <p className="text-gray-400">{error}</p>
+      </div>
+    )
+  }
+
+  return (
+    <div>
+      <div className="mb-8">
+        <h1 className="text-2xl font-bold text-white">Secrets</h1>
+        <p className="text-sm text-gray-400 mt-1">
+          Vault secrets inventory and metadata. Values are never displayed.
+        </p>
+      </div>
+
+      <VaultStatusBar status={vaultStatus} />
+
+      {inventory && (
+        <>
+          <div className="flex items-center gap-4 mb-4 text-sm text-gray-400">
+            <span>{inventory.totalPaths} vault paths</span>
+            <span>{inventory.totalKeys} total keys</span>
+            <span>{inventory.approleServices.length} AppRole services</span>
+          </div>
+
+          <div className="rounded-lg border border-navy-700 overflow-hidden">
+            <table className="w-full">
+              <thead>
+                <tr className="bg-navy-800 border-b border-navy-700">
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-400 uppercase tracking-wider">Path</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-400 uppercase tracking-wider">Keys</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-400 uppercase tracking-wider">Consumers</th>
+                </tr>
+              </thead>
+              <tbody>
+                {inventory.paths.map(group => (
+                  <PathRow key={group.path} group={group} />
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </>
+      )}
+    </div>
+  )
+}

--- a/services/ui/src/app/harness/secrets/page.tsx
+++ b/services/ui/src/app/harness/secrets/page.tsx
@@ -1,0 +1,30 @@
+'use client'
+
+import { useSession } from 'next-auth/react'
+import { redirect } from 'next/navigation'
+import AppShell from '@/components/AppShell'
+import SecretsClient from './SecretsClient'
+
+export default function SecretsPage() {
+  const { data: session, status } = useSession()
+
+  if (status === 'loading') {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-navy-900">
+        <div className="h-8 w-8 rounded-full border-2 border-brand-500 border-t-transparent animate-spin" />
+      </div>
+    )
+  }
+
+  if (!session) {
+    redirect('/api/auth/signin')
+  }
+
+  return (
+    <AppShell>
+      <main className="flex-1 px-6 py-12 max-w-6xl mx-auto w-full">
+        <SecretsClient />
+      </main>
+    </AppShell>
+  )
+}

--- a/services/ui/src/components/nav-items.ts
+++ b/services/ui/src/components/nav-items.ts
@@ -41,6 +41,7 @@ export const NAV_ITEMS: NavItem[] = [
       { type: 'link', id: 'dependencies', label: 'Dependencies', href: '/harness/tools', icon: Package, adminOnly: true },
       { type: 'link', id: 'usage', label: 'Usage', href: '/harness/usage', icon: BarChart3 },
       { type: 'link', id: 'library', label: 'Library', href: '/harness/shared-knowledge', icon: Library },
+      { type: 'link', id: 'secrets', label: 'Secrets', href: '/harness/secrets', icon: KeyRound, adminOnly: true },
     ],
   },
   {


### PR DESCRIPTION
## Summary

Phase 1 of the Secrets Vault UI (design doc: `docs/architecture/secrets-vault-ui-design.md`).

- **API route** `GET /admin/secrets` — parses `secrets-schema.yaml`, returns grouped inventory (vault paths, key names, consumer service mappings). NEVER returns secret values.
- **API route** `GET /admin/secrets/status` — vault health check (seal status, version). Degrades gracefully if vault unreachable.
- **UI page** `/harness/secrets` — admin-only harness page with vault status bar, expandable inventory table grouped by vault path, consumer service badges per key
- **Nav item** in harness group with `adminOnly: true`
- **OpenAPI spec** updated with both endpoints
- **RBAC** enforced at API (`requireRole('admin')`) and UI (session role check) layers

## Test plan

- [x] T1: GET /admin/secrets returns grouped inventory — 7 API tests
- [x] T2: Non-admin rejected with 403
- [x] T3: Vault status endpoint degrades gracefully
- [x] T4: UI renders inventory table — 6 UI tests
- [x] T5: UI shows access denied for non-admin
- [x] T6: Expandable rows show key names + consumers
- [x] V3: Full API suite — 673/673 pass (50 suites)
- [x] V4: Full UI suite — 579/579 pass (50 suites)
- [x] V5: TypeScript compiles clean
- [x] V6: OpenAPI drift check passes (docs.test.ts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)