### PR TITLE
feat: agent CLI execution — real command loop (AI-150)

### DIFF
--- a/services/agentbox/app/chat.py
+++ b/services/agentbox/app/chat.py
@@ -1,19 +1,28 @@
-"""Chat work handler — inference call + callback delivery.
+"""Chat work handler — inference call + tool-calling loop + callback delivery.
 
 Agentbox is the sole owner of system prompt assembly (§7.5).
 API sends only structured data: messages array, model, callback info.
 Agentbox reads identity from mounted files (SOUL.md + RULES.md with
 baked-in skill instructions) and prepends the system prompt.
+
+When tools are enabled, the handler runs an iterative loop: call LLM,
+execute any requested tool calls, feed results back, repeat until the
+LLM produces a final text response or the iteration limit is reached.
 """
 
 from __future__ import annotations
 
+import asyncio
+import json
 import logging
 import os
 import time
 from typing import TYPE_CHECKING
 
 import requests
+
+from app.config import ToolLoopConfig, ToolsConfig
+from app.tools import build_tool_definitions, execute_tool_call
 
 if TYPE_CHECKING:
     from app.events import EventEmitter
@@ -28,17 +37,10 @@ def handle_chat(
     rules: str,
     work_id: str,
     emitter: EventEmitter,
+    tools_config: ToolsConfig | None = None,
+    tool_loop_config: ToolLoopConfig | None = None,
 ) -> None:
-    """Handle a chat work item: build prompt, call AI, deliver callback.
-
-    Args:
-        payload: Work payload from API containing messages, model, callback_url,
-                 thread_id, message_id.
-        soul: Agent SOUL.md content.
-        rules: Agent RULES.md content (includes skill instructions).
-        work_id: Unique work execution ID for event correlation.
-        emitter: Event emitter for observability.
-    """
+    """Handle a chat work item: build prompt, run tool loop, deliver callback."""
     thread_id = payload.get("thread_id", "unknown")
     message_id = payload.get("message_id", "unknown")
     model = payload.get("model", "gpt-4o-mini")
@@ -106,104 +108,269 @@ def handle_chat(
             system_content = f"{system_content}{group_block}" if system_content else group_block
 
     # Build final messages: system prompt + API-provided history
-    final_messages = []
+    final_messages: list[dict] = []
     if system_content:
         final_messages.append({"role": "system", "content": system_content})
     final_messages.extend(api_messages)
 
-    emitter.emit(
-        type="chat_inference_start",
-        tool="chat",
-        input_summary=f"thread={thread_id} model={model} messages={len(final_messages)}",
-        output_summary=None,
-        duration_ms=None,
-        success=None,
-        metadata={"work_id": work_id, "message_id": message_id},
+    # Build tool definitions from config
+    tool_defs = build_tool_definitions(tools_config) if tools_config else []
+    loop_config = tool_loop_config or ToolLoopConfig()
+
+    # Run the tool-calling loop
+    _run_tool_loop(
+        messages=final_messages,
+        tool_definitions=tool_defs,
+        loop_config=loop_config,
+        model=model,
+        ai_service_url=ai_service_url,
+        model_router_token=model_router_token,
+        callback_url=callback_url,
+        chat_callback_token=chat_callback_token,
+        message_id=message_id,
+        thread_id=thread_id,
+        work_id=work_id,
+        emitter=emitter,
     )
 
-    # Call AI service
-    start_time = time.monotonic()
-    try:
-        inference_url = f"{ai_service_url}/v1/chat/completions"
-        resp = requests.post(
-            inference_url,
-            json={
-                "model": model,
-                "messages": final_messages,
-            },
-            headers={
-                "Authorization": f"Bearer {model_router_token}",
-                "Content-Type": "application/json",
-            },
-            timeout=120,
-        )
 
-        duration_ms = int((time.monotonic() - start_time) * 1000)
+def _run_tool_loop(
+    *,
+    messages: list[dict],
+    tool_definitions: list[dict],
+    loop_config: ToolLoopConfig,
+    model: str,
+    ai_service_url: str,
+    model_router_token: str,
+    callback_url: str,
+    chat_callback_token: str,
+    message_id: str,
+    thread_id: str,
+    work_id: str,
+    emitter: EventEmitter,
+) -> None:
+    """Iterative tool-calling loop. Calls LLM, executes tools, repeats."""
+    inference_url = f"{ai_service_url}/v1/chat/completions"
+    total_input_tokens = 0
+    total_output_tokens = 0
+    loop_start = time.monotonic()
+    response_model = model
+    content = ""
 
-        if resp.status_code != 200:
-            error_detail = resp.text[:200] if resp.text else f"HTTP {resp.status_code}"
-            logger.error(
-                "Chat inference failed: %s %s", resp.status_code, error_detail
-            )
+    for iteration in range(loop_config.max_iterations):
+        # Check total timeout
+        elapsed = time.monotonic() - loop_start
+        if elapsed > loop_config.iteration_timeout:
+            logger.warning("Tool loop timeout after %.1fs", elapsed)
             _deliver_callback(
                 callback_url, chat_callback_token, message_id,
                 status="error",
-                error_message=f"Inference failed: {error_detail}",
+                error_message=f"Tool loop timed out after {int(elapsed)}s",
+                input_tokens=total_input_tokens,
+                output_tokens=total_output_tokens,
+                duration_ms=int(elapsed * 1000),
+                emitter=emitter, work_id=work_id,
+            )
+            return
+
+        emitter.emit(
+            type="chat_inference_start",
+            tool="chat",
+            input_summary=f"thread={thread_id} model={model} iteration={iteration} messages={len(messages)}",
+            output_summary=None,
+            duration_ms=None,
+            success=None,
+            metadata={"work_id": work_id, "message_id": message_id},
+        )
+
+        # Build request body
+        request_body: dict = {
+            "model": model,
+            "messages": messages,
+        }
+        if tool_definitions:
+            request_body["tools"] = tool_definitions
+
+        # Call LLM
+        call_start = time.monotonic()
+        try:
+            resp = requests.post(
+                inference_url,
+                json=request_body,
+                headers={
+                    "Authorization": f"Bearer {model_router_token}",
+                    "Content-Type": "application/json",
+                },
+                timeout=120,
+            )
+        except requests.Timeout:
+            duration_ms = int((time.monotonic() - loop_start) * 1000)
+            logger.error("Chat inference timed out on iteration %d", iteration)
+            _deliver_callback(
+                callback_url, chat_callback_token, message_id,
+                status="error",
+                error_message="Inference timed out",
+                input_tokens=total_input_tokens,
+                output_tokens=total_output_tokens,
+                duration_ms=duration_ms,
+                emitter=emitter, work_id=work_id,
+            )
+            return
+        except Exception as exc:
+            duration_ms = int((time.monotonic() - loop_start) * 1000)
+            logger.error("Chat inference error on iteration %d: %s", iteration, exc, exc_info=True)
+            _deliver_callback(
+                callback_url, chat_callback_token, message_id,
+                status="error",
+                error_message=f"Inference error: {str(exc)[:200]}",
+                input_tokens=total_input_tokens,
+                output_tokens=total_output_tokens,
                 duration_ms=duration_ms,
                 emitter=emitter, work_id=work_id,
             )
             return
 
+        call_duration = int((time.monotonic() - call_start) * 1000)
+
+        if resp.status_code != 200:
+            error_detail = resp.text[:200] if resp.text else f"HTTP {resp.status_code}"
+            logger.error("Chat inference failed: %s %s", resp.status_code, error_detail)
+            _deliver_callback(
+                callback_url, chat_callback_token, message_id,
+                status="error",
+                error_message=f"Inference failed: {error_detail}",
+                input_tokens=total_input_tokens,
+                output_tokens=total_output_tokens,
+                duration_ms=int((time.monotonic() - loop_start) * 1000),
+                emitter=emitter, work_id=work_id,
+            )
+            return
+
         result = resp.json()
-        content = result.get("choices", [{}])[0].get("message", {}).get("content", "")
-        usage = result.get("usage", {})
-        input_tokens = usage.get("prompt_tokens")
-        output_tokens = usage.get("completion_tokens")
+        choice = result.get("choices", [{}])[0]
+        message = choice.get("message", {})
+        content = message.get("content", "") or ""
+        tool_calls = message.get("tool_calls")
+        finish_reason = choice.get("finish_reason", "stop")
         response_model = result.get("model", model)
+
+        # Accumulate tokens
+        usage = result.get("usage", {})
+        total_input_tokens += usage.get("prompt_tokens", 0)
+        total_output_tokens += usage.get("completion_tokens", 0)
 
         emitter.emit(
             type="chat_inference_complete",
             tool="chat",
-            input_summary=f"thread={thread_id} model={response_model}",
-            output_summary=f"tokens_in={input_tokens} tokens_out={output_tokens}",
-            duration_ms=duration_ms,
+            input_summary=f"thread={thread_id} model={response_model} iteration={iteration}",
+            output_summary=f"tokens_in={usage.get('prompt_tokens')} tokens_out={usage.get('completion_tokens')} finish={finish_reason}",
+            duration_ms=call_duration,
             success=True,
             metadata={"work_id": work_id, "message_id": message_id},
         )
 
-        # Deliver callback with successful response
+        # If no tool calls, this is the final response
+        if not tool_calls or finish_reason != "tool_calls":
+            total_duration = int((time.monotonic() - loop_start) * 1000)
+            _deliver_callback(
+                callback_url, chat_callback_token, message_id,
+                status="complete",
+                content=content,
+                model=response_model,
+                input_tokens=total_input_tokens,
+                output_tokens=total_output_tokens,
+                duration_ms=total_duration,
+                emitter=emitter, work_id=work_id,
+            )
+            return
+
+        # Append the assistant message with tool_calls to the conversation
+        assistant_msg: dict = {"role": "assistant"}
+        if content:
+            assistant_msg["content"] = content
+        assistant_msg["tool_calls"] = tool_calls
+        messages.append(assistant_msg)
+
+        # Execute each tool call and append results
+        for tc in tool_calls:
+            tc_id = tc.get("id", "")
+            func = tc.get("function", {})
+            func_name = func.get("name", "")
+            func_args_raw = func.get("arguments", "{}")
+
+            # Parse arguments
+            try:
+                func_args = json.loads(func_args_raw) if isinstance(func_args_raw, str) else func_args_raw
+            except json.JSONDecodeError:
+                func_args = {}
+                logger.warning("Failed to parse tool call arguments for %s: %s", func_name, func_args_raw[:200])
+
+            emitter.emit(
+                type="tool_call_start",
+                tool="chat",
+                input_summary=f"tool={func_name} args={str(func_args)[:150]}",
+                output_summary=None,
+                duration_ms=None,
+                success=None,
+                metadata={"work_id": work_id, "tool_call_id": tc_id},
+            )
+
+            tool_start = time.monotonic()
+            try:
+                tool_result = asyncio.run(
+                    execute_tool_call(func_name, func_args, work_id=work_id, emitter=emitter)
+                )
+            except Exception as exc:
+                tool_result = json.dumps({"success": False, "error": str(exc)[:500]})
+                logger.error("Tool call %s failed: %s", func_name, exc, exc_info=True)
+
+            tool_duration = int((time.monotonic() - tool_start) * 1000)
+
+            emitter.emit(
+                type="tool_call_complete",
+                tool="chat",
+                input_summary=f"tool={func_name}",
+                output_summary=f"duration={tool_duration}ms result_len={len(tool_result)}",
+                duration_ms=tool_duration,
+                success=True,
+                metadata={"work_id": work_id, "tool_call_id": tc_id},
+            )
+
+            # Append tool result message
+            messages.append({
+                "role": "tool",
+                "tool_call_id": tc_id,
+                "content": tool_result,
+            })
+
+        # Send thinking progress callback
+        tools_summary = ", ".join(
+            tc.get("function", {}).get("name", "?") for tc in tool_calls
+        )
         _deliver_callback(
             callback_url, chat_callback_token, message_id,
-            status="complete",
-            content=content,
+            status="thinking",
+            content=f"Executed: {tools_summary}",
             model=response_model,
-            input_tokens=input_tokens,
-            output_tokens=output_tokens,
-            duration_ms=duration_ms,
+            input_tokens=total_input_tokens,
+            output_tokens=total_output_tokens,
+            duration_ms=int((time.monotonic() - loop_start) * 1000),
             emitter=emitter, work_id=work_id,
         )
 
-    except requests.Timeout:
-        duration_ms = int((time.monotonic() - start_time) * 1000)
-        logger.error("Chat inference timed out after %dms", duration_ms)
-        _deliver_callback(
-            callback_url, chat_callback_token, message_id,
-            status="error",
-            error_message="Inference timed out",
-            duration_ms=duration_ms,
-            emitter=emitter, work_id=work_id,
-        )
-
-    except Exception as exc:
-        duration_ms = int((time.monotonic() - start_time) * 1000)
-        logger.error("Chat inference error: %s", exc, exc_info=True)
-        _deliver_callback(
-            callback_url, chat_callback_token, message_id,
-            status="error",
-            error_message=f"Inference error: {str(exc)[:200]}",
-            duration_ms=duration_ms,
-            emitter=emitter, work_id=work_id,
-        )
+    # Exhausted iterations — deliver whatever content we have
+    logger.warning("Tool loop exhausted %d iterations", loop_config.max_iterations)
+    total_duration = int((time.monotonic() - loop_start) * 1000)
+    _deliver_callback(
+        callback_url, chat_callback_token, message_id,
+        status="complete",
+        content=content or "I reached my tool execution limit. Here's what I found so far.",
+        model=response_model,
+        input_tokens=total_input_tokens,
+        output_tokens=total_output_tokens,
+        duration_ms=total_duration,
+        emitter=emitter, work_id=work_id,
+    )
 
 
 def _deliver_callback(

--- a/services/agentbox/app/config.py
+++ b/services/agentbox/app/config.py
@@ -30,6 +30,11 @@ class HealthConfig(BaseModel):
     enabled: bool = True
 
 
+class ToolLoopConfig(BaseModel):
+    max_iterations: int = 15
+    iteration_timeout: int = 600
+
+
 class ToolsConfig(BaseModel):
     shell: ShellConfig = Field(default_factory=ShellConfig)
     filesystem: FilesystemConfig = Field(default_factory=FilesystemConfig)
@@ -56,6 +61,7 @@ class AgentConfig(BaseModel):
     soul_path: str = "SOUL.md"
     rules_path: str = "RULES.md"
     tools: ToolsConfig = Field(default_factory=ToolsConfig)
+    tool_loop: ToolLoopConfig = Field(default_factory=ToolLoopConfig)
     resources: ResourcesConfig = Field(default_factory=ResourcesConfig)
     state: StateConfig = Field(default_factory=StateConfig)
 

--- a/services/agentbox/app/runtime.py
+++ b/services/agentbox/app/runtime.py
@@ -229,6 +229,8 @@ class AgentRuntime:
                 rules=self.rules,
                 work_id=work_id,
                 emitter=self._emitter,
+                tools_config=self._config.tools,
+                tool_loop_config=self._config.tool_loop,
             )
             self._emitter.emit(
                 type="work_completed",

--- a/services/agentbox/app/server.py
+++ b/services/agentbox/app/server.py
@@ -13,7 +13,7 @@ from starlette.applications import Starlette
 from starlette.responses import JSONResponse
 from starlette.routing import Route
 
-from app import shell
+from app import filesystem, shell
 from app.config import AgentConfig
 from app.events import EventEmitter
 from app.runtime import AgentRuntime
@@ -40,6 +40,9 @@ def create_app(
 
     if config.tools.shell.enabled:
         shell.configure(config.tools.shell, emitter)
+
+    if config.tools.filesystem.enabled:
+        filesystem.configure(config.tools.filesystem, emitter)
 
     async def health_endpoint(request):
         return JSONResponse({"status": "healthy", "agent": config.id})

--- a/services/agentbox/app/tools.py
+++ b/services/agentbox/app/tools.py
@@ -1,0 +1,149 @@
+"""Tool definitions and dispatcher for LLM function calling.
+
+Builds OpenAI-compatible tool definitions from agent config and routes
+tool calls to the existing shell/filesystem modules.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import TYPE_CHECKING
+
+from app import filesystem, shell
+from app.config import ToolsConfig
+
+if TYPE_CHECKING:
+    from app.events import EventEmitter
+
+logger = logging.getLogger(__name__)
+
+SHELL_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "execute_command",
+        "description": "Execute a shell command in the agent workspace. Commands are validated against the agent's binary allowlist and deny patterns.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "command": {
+                    "type": "string",
+                    "description": "The shell command to run (e.g. 'git status', 'ls -la /workspace')",
+                },
+                "timeout": {
+                    "type": "integer",
+                    "description": "Timeout in seconds (default 30, clamped to policy max)",
+                    "default": 30,
+                },
+            },
+            "required": ["command"],
+        },
+    },
+}
+
+READ_FILE_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "read_file",
+        "description": "Read file contents from the workspace. Returns up to 1MB.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Absolute path to the file to read",
+                },
+            },
+            "required": ["path"],
+        },
+    },
+}
+
+WRITE_FILE_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "write_file",
+        "description": "Write content to a file in the workspace. Creates parent directories as needed.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Absolute path to the file to write",
+                },
+                "content": {
+                    "type": "string",
+                    "description": "Content to write to the file",
+                },
+            },
+            "required": ["path", "content"],
+        },
+    },
+}
+
+LIST_DIR_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "list_directory",
+        "description": "List directory contents with file names, types, and sizes.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Absolute path to the directory to list",
+                },
+            },
+            "required": ["path"],
+        },
+    },
+}
+
+
+def build_tool_definitions(tools_config: ToolsConfig) -> list[dict]:
+    """Build the tools array for the LLM request based on agent config."""
+    definitions: list[dict] = []
+    if tools_config.shell.enabled:
+        definitions.append(SHELL_TOOL)
+    if tools_config.filesystem.enabled:
+        definitions.append(READ_FILE_TOOL)
+        if not tools_config.filesystem.read_only:
+            definitions.append(WRITE_FILE_TOOL)
+        definitions.append(LIST_DIR_TOOL)
+    return definitions
+
+
+async def execute_tool_call(
+    name: str,
+    arguments: dict,
+    *,
+    work_id: str | None = None,
+    emitter: EventEmitter | None = None,
+) -> str:
+    """Dispatch a tool call to the appropriate module. Returns JSON string."""
+    if name == "execute_command":
+        command = arguments.get("command", "")
+        timeout = arguments.get("timeout", 30)
+        if not isinstance(timeout, int):
+            try:
+                timeout = int(timeout)
+            except (TypeError, ValueError):
+                timeout = 30
+        return await shell.execute_command(
+            command, timeout=timeout, work_id=work_id,
+        )
+
+    if name == "read_file":
+        path = arguments.get("path", "")
+        return await filesystem.read_file(path)
+
+    if name == "write_file":
+        path = arguments.get("path", "")
+        content = arguments.get("content", "")
+        return await filesystem.write_file(path, content)
+
+    if name == "list_directory":
+        path = arguments.get("path", "")
+        return await filesystem.list_directory(path)
+
+    return json.dumps({"success": False, "error": f"Unknown tool: {name}"})

--- a/services/agentbox/tests/test_chat.py
+++ b/services/agentbox/tests/test_chat.py
@@ -1,4 +1,4 @@
-"""Tests for app.chat — chat work handler (inference + callback)."""
+"""Tests for app.chat — chat work handler (inference + callback + tool loop)."""
 
 import json
 import os
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from app.chat import handle_chat, _deliver_callback
+from app.config import FilesystemConfig, ShellConfig, ToolLoopConfig, ToolsConfig
 from app.events import EventEmitter
 
 
@@ -349,3 +350,226 @@ class TestGroupChatContext:
         assert system_msg["role"] == "system"
         assert "Group Thread" not in system_msg["content"]
         assert "I am TestBot" in system_msg["content"]
+
+
+class TestToolLoop:
+    """AI-150: Tool-calling loop tests."""
+
+    @patch("app.chat.requests.post")
+    def test_single_shot_no_tools(self, mock_post, emitter, monkeypatch):
+        """When no tools are enabled, behavior is identical to pre-tool-loop."""
+        em, log_path = emitter
+        monkeypatch.setenv("CHAT_CALLBACK_TOKEN", "cb-token")
+        monkeypatch.setenv("MODEL_ROUTER_TOKEN", "mr-token")
+
+        ai_response = MagicMock(
+            status_code=200,
+            json=lambda: {
+                "choices": [{"message": {"content": "Hello!"}, "finish_reason": "stop"}],
+                "usage": {"prompt_tokens": 10, "completion_tokens": 5},
+                "model": "gpt-4o-mini",
+            },
+        )
+        mock_post.side_effect = [ai_response, MagicMock(status_code=200)]
+
+        handle_chat(
+            {
+                "thread_id": "t1", "message_id": "m1",
+                "messages": [{"role": "user", "content": "Hi"}],
+                "model": "gpt-4o-mini",
+                "callback_url": "http://api:3000/cb",
+            },
+            soul="", rules="", work_id="w1", emitter=em,
+            tools_config=ToolsConfig(),  # all disabled
+        )
+
+        # AI call should NOT include tools
+        ai_body = mock_post.call_args_list[0][1]["json"]
+        assert "tools" not in ai_body
+
+        cb_body = mock_post.call_args_list[1][1]["json"]
+        assert cb_body["status"] == "complete"
+        assert cb_body["content"] == "Hello!"
+
+    @patch("app.chat.execute_tool_call")
+    @patch("app.chat.requests.post")
+    def test_tool_loop_single_iteration(self, mock_post, mock_tool, emitter, monkeypatch):
+        """LLM calls one tool, gets result, then responds with text."""
+        em, log_path = emitter
+        monkeypatch.setenv("CHAT_CALLBACK_TOKEN", "cb-token")
+        monkeypatch.setenv("MODEL_ROUTER_TOKEN", "mr-token")
+
+        # First LLM call: returns a tool call
+        tool_call_response = MagicMock(
+            status_code=200,
+            json=lambda: {
+                "choices": [{
+                    "message": {
+                        "content": "",
+                        "tool_calls": [{
+                            "id": "tc-1",
+                            "type": "function",
+                            "function": {
+                                "name": "execute_command",
+                                "arguments": '{"command": "ls /workspace"}',
+                            },
+                        }],
+                    },
+                    "finish_reason": "tool_calls",
+                }],
+                "usage": {"prompt_tokens": 20, "completion_tokens": 10},
+                "model": "gpt-4o-mini",
+            },
+        )
+
+        # Second LLM call: final text response
+        final_response = MagicMock(
+            status_code=200,
+            json=lambda: {
+                "choices": [{"message": {"content": "I see files."}, "finish_reason": "stop"}],
+                "usage": {"prompt_tokens": 50, "completion_tokens": 15},
+                "model": "gpt-4o-mini",
+            },
+        )
+
+        # Callback responses (thinking + final)
+        cb_ok = MagicMock(status_code=200, text="ok")
+        mock_post.side_effect = [tool_call_response, cb_ok, final_response, cb_ok]
+
+        # Mock tool execution — return a coroutine each time called
+        async def _fake_tool(*args, **kwargs):
+            return json.dumps({"success": True, "exit_code": 0, "stdout": "file1.txt\n", "stderr": ""})
+        mock_tool.side_effect = _fake_tool
+
+        handle_chat(
+            {
+                "thread_id": "t1", "message_id": "m1",
+                "messages": [{"role": "user", "content": "List files"}],
+                "model": "gpt-4o-mini",
+                "callback_url": "http://api:3000/cb",
+            },
+            soul="", rules="", work_id="w1", emitter=em,
+            tools_config=ToolsConfig(shell=ShellConfig(enabled=True)),
+        )
+
+        # Should have: AI call (tool) + thinking callback + AI call (final) + complete callback = 4 posts
+        assert mock_post.call_count == 4
+
+        # First AI call should include tools
+        ai_body_1 = mock_post.call_args_list[0][1]["json"]
+        assert "tools" in ai_body_1
+        assert any(t["function"]["name"] == "execute_command" for t in ai_body_1["tools"])
+
+        # Thinking callback
+        thinking_body = mock_post.call_args_list[1][1]["json"]
+        assert thinking_body["status"] == "thinking"
+        assert "execute_command" in thinking_body["content"]
+
+        # Final callback
+        final_body = mock_post.call_args_list[3][1]["json"]
+        assert final_body["status"] == "complete"
+        assert final_body["content"] == "I see files."
+        # Cumulative tokens
+        assert final_body["input_tokens"] == 70  # 20 + 50
+        assert final_body["output_tokens"] == 25  # 10 + 15
+
+    @patch("app.chat.execute_tool_call")
+    @patch("app.chat.requests.post")
+    def test_tool_loop_max_iterations(self, mock_post, mock_tool, emitter, monkeypatch):
+        """Loop stops at max_iterations even if LLM keeps requesting tools."""
+        em, log_path = emitter
+        monkeypatch.setenv("CHAT_CALLBACK_TOKEN", "cb-token")
+        monkeypatch.setenv("MODEL_ROUTER_TOKEN", "mr-token")
+
+        # Always return tool calls
+        def make_tool_response():
+            return MagicMock(
+                status_code=200,
+                json=lambda: {
+                    "choices": [{
+                        "message": {
+                            "content": "",
+                            "tool_calls": [{
+                                "id": "tc-x",
+                                "type": "function",
+                                "function": {"name": "execute_command", "arguments": '{"command": "echo loop"}'},
+                            }],
+                        },
+                        "finish_reason": "tool_calls",
+                    }],
+                    "usage": {"prompt_tokens": 10, "completion_tokens": 5},
+                    "model": "gpt-4o-mini",
+                },
+            )
+
+        cb_ok = MagicMock(status_code=200, text="ok")
+        # 3 iterations × (1 AI call + 1 thinking callback) + 1 final callback = 7
+        mock_post.side_effect = [
+            make_tool_response(), cb_ok,
+            make_tool_response(), cb_ok,
+            make_tool_response(), cb_ok,
+            cb_ok,  # final complete callback
+        ]
+
+        async def _fake_tool(*args, **kwargs):
+            return json.dumps({"success": True})
+        mock_tool.side_effect = _fake_tool
+
+        handle_chat(
+            {
+                "thread_id": "t1", "message_id": "m1",
+                "messages": [{"role": "user", "content": "Loop test"}],
+                "model": "gpt-4o-mini",
+                "callback_url": "http://api:3000/cb",
+            },
+            soul="", rules="", work_id="w1", emitter=em,
+            tools_config=ToolsConfig(shell=ShellConfig(enabled=True)),
+            tool_loop_config=ToolLoopConfig(max_iterations=3),
+        )
+
+        # Last callback should be complete (not error)
+        last_cb = None
+        for call in mock_post.call_args_list:
+            body = call[1].get("json", {})
+            if body.get("status") in ("complete", "error"):
+                last_cb = body
+        assert last_cb is not None
+        assert last_cb["status"] == "complete"
+
+    @patch("app.chat.requests.post")
+    def test_tools_included_when_enabled(self, mock_post, emitter, monkeypatch):
+        """Tool definitions are included in LLM request when shell/filesystem enabled."""
+        em, _ = emitter
+        monkeypatch.setenv("CHAT_CALLBACK_TOKEN", "cb-token")
+        monkeypatch.setenv("MODEL_ROUTER_TOKEN", "mr-token")
+
+        ai_response = MagicMock(
+            status_code=200,
+            json=lambda: {
+                "choices": [{"message": {"content": "ok"}, "finish_reason": "stop"}],
+                "usage": {}, "model": "m",
+            },
+        )
+        mock_post.side_effect = [ai_response, MagicMock(status_code=200)]
+
+        handle_chat(
+            {
+                "thread_id": "t1", "message_id": "m1",
+                "messages": [{"role": "user", "content": "Hi"}],
+                "model": "gpt-4o-mini",
+                "callback_url": "http://api:3000/cb",
+            },
+            soul="", rules="", work_id="w1", emitter=em,
+            tools_config=ToolsConfig(
+                shell=ShellConfig(enabled=True),
+                filesystem=FilesystemConfig(enabled=True),
+            ),
+        )
+
+        ai_body = mock_post.call_args_list[0][1]["json"]
+        assert "tools" in ai_body
+        tool_names = [t["function"]["name"] for t in ai_body["tools"]]
+        assert "execute_command" in tool_names
+        assert "read_file" in tool_names
+        assert "write_file" in tool_names
+        assert "list_directory" in tool_names

--- a/services/agentbox/tests/test_tools.py
+++ b/services/agentbox/tests/test_tools.py
@@ -1,0 +1,118 @@
+"""Tests for app.tools — tool definitions and dispatcher."""
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.config import FilesystemConfig, ShellConfig, ToolsConfig
+from app.tools import build_tool_definitions, execute_tool_call
+
+
+class TestBuildToolDefinitions:
+    def test_no_tools_when_disabled(self):
+        config = ToolsConfig()
+        assert build_tool_definitions(config) == []
+
+    def test_shell_only(self):
+        config = ToolsConfig(shell=ShellConfig(enabled=True))
+        defs = build_tool_definitions(config)
+        names = [d["function"]["name"] for d in defs]
+        assert names == ["execute_command"]
+
+    def test_filesystem_only(self):
+        config = ToolsConfig(filesystem=FilesystemConfig(enabled=True))
+        defs = build_tool_definitions(config)
+        names = [d["function"]["name"] for d in defs]
+        assert "read_file" in names
+        assert "write_file" in names
+        assert "list_directory" in names
+        assert "execute_command" not in names
+
+    def test_filesystem_read_only(self):
+        config = ToolsConfig(filesystem=FilesystemConfig(enabled=True, read_only=True))
+        defs = build_tool_definitions(config)
+        names = [d["function"]["name"] for d in defs]
+        assert "read_file" in names
+        assert "write_file" not in names
+        assert "list_directory" in names
+
+    def test_all_tools(self):
+        config = ToolsConfig(
+            shell=ShellConfig(enabled=True),
+            filesystem=FilesystemConfig(enabled=True),
+        )
+        defs = build_tool_definitions(config)
+        names = [d["function"]["name"] for d in defs]
+        assert len(names) == 4
+        assert "execute_command" in names
+        assert "read_file" in names
+        assert "write_file" in names
+        assert "list_directory" in names
+
+    def test_tool_definitions_are_valid_openai_format(self):
+        config = ToolsConfig(
+            shell=ShellConfig(enabled=True),
+            filesystem=FilesystemConfig(enabled=True),
+        )
+        defs = build_tool_definitions(config)
+        for d in defs:
+            assert d["type"] == "function"
+            func = d["function"]
+            assert "name" in func
+            assert "description" in func
+            assert "parameters" in func
+            assert func["parameters"]["type"] == "object"
+            assert "required" in func["parameters"]
+
+
+class TestExecuteToolCall:
+    @pytest.mark.asyncio
+    @patch("app.tools.shell.execute_command", new_callable=AsyncMock)
+    async def test_execute_command(self, mock_exec):
+        mock_exec.return_value = json.dumps({"success": True, "exit_code": 0, "stdout": "hello\n", "stderr": ""})
+        result = await execute_tool_call("execute_command", {"command": "echo hello", "timeout": 10})
+        parsed = json.loads(result)
+        assert parsed["success"] is True
+        mock_exec.assert_called_once_with("echo hello", timeout=10, work_id=None)
+
+    @pytest.mark.asyncio
+    @patch("app.tools.filesystem.read_file", new_callable=AsyncMock)
+    async def test_read_file(self, mock_read):
+        mock_read.return_value = json.dumps({"success": True, "content": "data", "path": "/workspace/f.txt"})
+        result = await execute_tool_call("read_file", {"path": "/workspace/f.txt"})
+        parsed = json.loads(result)
+        assert parsed["success"] is True
+        mock_read.assert_called_once_with("/workspace/f.txt")
+
+    @pytest.mark.asyncio
+    @patch("app.tools.filesystem.write_file", new_callable=AsyncMock)
+    async def test_write_file(self, mock_write):
+        mock_write.return_value = json.dumps({"success": True, "path": "/workspace/f.txt", "bytes_written": 4})
+        result = await execute_tool_call("write_file", {"path": "/workspace/f.txt", "content": "data"})
+        parsed = json.loads(result)
+        assert parsed["success"] is True
+        mock_write.assert_called_once_with("/workspace/f.txt", "data")
+
+    @pytest.mark.asyncio
+    @patch("app.tools.filesystem.list_directory", new_callable=AsyncMock)
+    async def test_list_directory(self, mock_list):
+        mock_list.return_value = json.dumps({"success": True, "path": "/workspace", "entries": []})
+        result = await execute_tool_call("list_directory", {"path": "/workspace"})
+        parsed = json.loads(result)
+        assert parsed["success"] is True
+        mock_list.assert_called_once_with("/workspace")
+
+    @pytest.mark.asyncio
+    async def test_unknown_tool(self):
+        result = await execute_tool_call("unknown_tool", {})
+        parsed = json.loads(result)
+        assert parsed["success"] is False
+        assert "Unknown tool" in parsed["error"]
+
+    @pytest.mark.asyncio
+    @patch("app.tools.shell.execute_command", new_callable=AsyncMock)
+    async def test_bad_timeout_defaults_to_30(self, mock_exec):
+        mock_exec.return_value = json.dumps({"success": True})
+        await execute_tool_call("execute_command", {"command": "ls", "timeout": "invalid"})
+        mock_exec.assert_called_once_with("ls", timeout=30, work_id=None)

--- a/services/api/src/__tests__/routes-chat.test.ts
+++ b/services/api/src/__tests__/routes-chat.test.ts
@@ -889,7 +889,7 @@ describe('Chat callback', () => {
     // Verify guarded UPDATE uses nextval
     const sql = mockQuery.mock.calls[0][0];
     expect(sql).toContain('nextval');
-    expect(sql).toContain("status = 'pending'");
+    expect(sql).toContain("status IN ('pending', 'thinking')");
   });
 
   it('POST /internal/chat/callback rejects invalid token (401)', async () => {

--- a/services/api/src/db/migrations/043_add_thinking_status.sql
+++ b/services/api/src/db/migrations/043_add_thinking_status.sql
@@ -1,0 +1,10 @@
+-- Migration 043: Add 'thinking' status for tool-loop progress callbacks
+--
+-- The agentbox tool-calling loop sends intermediate 'thinking' callbacks
+-- while executing tool calls. These update the message content and advance
+-- the SSE sequence so the UI can show progress, but don't transition to
+-- a terminal state.
+
+ALTER TABLE chat_messages DROP CONSTRAINT IF EXISTS chat_messages_status_check;
+ALTER TABLE chat_messages ADD CONSTRAINT chat_messages_status_check
+  CHECK (status IN ('pending', 'thinking', 'complete', 'error'));

--- a/services/api/src/routes/chat.ts
+++ b/services/api/src/routes/chat.ts
@@ -1253,18 +1253,56 @@ export async function chatCallbackHandler(req: Request, res: Response): Promise<
     return;
   }
 
-  const finalStatus = status === 'error' ? 'error' : 'complete';
-
   const pool = getPool();
 
-  // Guarded UPDATE: only pending → terminal (§7.5 idempotency rules)
+  // Thinking callbacks are intermediate progress updates during tool loops.
+  // They update content + advance seq (so SSE picks up) but stay non-terminal.
+  if (status === 'thinking') {
+    const { rowCount } = await pool.query(
+      `UPDATE chat_messages
+       SET content = $2, status = 'thinking', model = $3,
+           input_tokens = $4, output_tokens = $5, duration_ms = $6,
+           seq = nextval('chat_messages_seq')
+       WHERE id = $1 AND status IN ('pending', 'thinking')`,
+      [message_id, content || '', model || null,
+       input_tokens || null, output_tokens || null, duration_ms || null]
+    );
+
+    if (rowCount === 0) {
+      const { rows } = await pool.query(
+        `SELECT status FROM chat_messages WHERE id = $1`,
+        [message_id]
+      );
+      if (rows.length === 0) {
+        res.status(404).json({ error: 'unknown_message' });
+        return;
+      }
+      // Already terminal — ignore thinking update
+      res.json({ updated: false });
+      return;
+    }
+
+    console.info(`[chat-callback] Thinking update for message ${message_id}`);
+    // Update thread timestamp for thinking updates too
+    await pool.query(
+      `UPDATE chat_threads SET updated_at = NOW()
+       WHERE id = (SELECT thread_id FROM chat_messages WHERE id = $1)`,
+      [message_id]
+    );
+    res.json({ updated: true });
+    return;
+  }
+
+  const finalStatus = status === 'error' ? 'error' : 'complete';
+
+  // Guarded UPDATE: only non-terminal → terminal (§7.5 idempotency rules)
   // Advances seq so SSE cursor picks up the state transition
   const { rowCount } = await pool.query(
     `UPDATE chat_messages
      SET content = $2, status = $3, model = $4,
          input_tokens = $5, output_tokens = $6, duration_ms = $7,
          error_message = $8, seq = nextval('chat_messages_seq')
-     WHERE id = $1 AND status = 'pending'`,
+     WHERE id = $1 AND status IN ('pending', 'thinking')`,
     [message_id, content || '', finalStatus, model || null,
      input_tokens || null, output_tokens || null, duration_ms || null,
      error_message || null]

--- a/services/api/src/services/agent-files.ts
+++ b/services/api/src/services/agent-files.ts
@@ -29,6 +29,10 @@ export function writeAgentFiles(agent: AgentRow, skillInstructions?: string): st
     soul_path: 'SOUL.md',
     rules_path: 'RULES.md',
     tools: agent.tools_config,
+    tool_loop: {
+      max_iterations: 15,
+      iteration_timeout: 600,
+    },
     resources: {
       cpus: agent.cpus,
       mem_limit: agent.mem_limit,


### PR DESCRIPTION
## Summary

- **Tool-calling loop in agentbox**: `chat.py` now iterates — calls LLM with tool definitions, executes requested tool calls (shell commands, file I/O), feeds results back, repeats until final text response or iteration limit
- **Tool definitions + dispatcher** (`tools.py`): OpenAI function-calling format, routes to existing policy-gated `shell.py` and `filesystem.py` modules
- **Thinking status**: New `thinking` callback status for intermediate progress during tool loops — UI can show activity while agent works
- **Backward compatible**: No tools enabled = identical single-shot behavior as before

## Changes

| File | Change |
|------|--------|
| `services/agentbox/app/chat.py` | Refactored from single-shot to iterative tool loop with cumulative token tracking |
| `services/agentbox/app/tools.py` | **New** — tool definitions (execute_command, read_file, write_file, list_directory) + dispatcher |
| `services/agentbox/app/config.py` | Added `ToolLoopConfig` (max_iterations=15, iteration_timeout=600s) |
| `services/agentbox/app/server.py` | Configure filesystem module at startup |
| `services/agentbox/app/runtime.py` | Pass tools_config + tool_loop_config to chat handler |
| `services/api/src/db/migrations/043_add_thinking_status.sql` | **New** — add `thinking` to chat_messages status CHECK |
| `services/api/src/routes/chat.ts` | Callback handler accepts `thinking` status for progress updates |
| `services/api/src/services/agent-files.ts` | Write tool_loop config to agent.yml |

## Safety

- Tools only included when enabled in agent config (shell.enabled / filesystem.enabled)
- All tool execution goes through existing policy enforcement (CommandPolicy, PathPolicy)
- Max iterations ceiling (default 15) + total timeout (default 600s) prevent runaway loops
- `thinking` → `thinking` updates are safe (UPDATE WHERE status IN pending/thinking)
- Final callback does `pending/thinking` → `complete/error` (terminal)

## Test plan

- [x] Agentbox tests: 152 passed (includes 16 new tool loop + tool definition tests)
- [x] API tests: 673 passed across 50 suites (callback handler updated)
- [ ] V3: Agent with no tools → same single-shot behavior
- [ ] V4: Agent with shell → LLM calls execute_command, sees output, responds
- [ ] V7: Thinking status visible in SSE stream during tool loop

Linear: AI-150

🤖 Generated with [Claude Code](https://claude.com/claude-code)