### PR TITLE
feat: connection health monitoring dashboard (AI-152)

### DIFF
--- a/docs/site/openapi.yaml
+++ b/docs/site/openapi.yaml
@@ -2037,6 +2037,16 @@ paths:
                     is_valid:
                       type: boolean
                       nullable: true
+                    last_validated_at:
+                      type: string
+                      format: date-time
+                      nullable: true
+                    last_validation_error:
+                      type: string
+                      nullable: true
+                    validation_latency_ms:
+                      type: integer
+                      nullable: true
                     created_at:
                       type: string
                       format: date-time
@@ -2180,6 +2190,9 @@ paths:
                     format: uuid
                   is_valid:
                     type: boolean
+                  validation_latency_ms:
+                    type: integer
+                    description: Round-trip validation time in milliseconds
                   error:
                     type: string
                     description: Error message if validation failed
@@ -2189,6 +2202,94 @@ paths:
           description: Requires user role
         "404":
           description: Connection not found
+
+  /provider-connections/health:
+    get:
+      summary: Connection health stats
+      description: >
+        Returns aggregate health statistics for the authenticated user's provider connections,
+        including overall counts and per-provider breakdown with average latency.
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Health statistics
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  total:
+                    type: integer
+                  valid:
+                    type: integer
+                  invalid:
+                    type: integer
+                  untested:
+                    type: integer
+                  avg_latency_ms:
+                    type: integer
+                    nullable: true
+                  by_provider:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        provider:
+                          type: string
+                        total:
+                          type: integer
+                        valid:
+                          type: integer
+                        invalid:
+                          type: integer
+                        untested:
+                          type: integer
+                        avg_latency_ms:
+                          type: integer
+                          nullable: true
+        "401":
+          description: Not authenticated
+        "403":
+          description: Requires user role
+
+  /provider-connections/validate-all:
+    post:
+      summary: Validate all connections
+      description: >
+        Validates all provider connections owned by the authenticated user sequentially.
+        Returns per-connection results with latency and error details.
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Validation results
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  results:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                          format: uuid
+                        name:
+                          type: string
+                        is_valid:
+                          type: boolean
+                        validation_latency_ms:
+                          type: integer
+                        error:
+                          type: string
+                          description: Error message if validation failed
+        "401":
+          description: Not authenticated
+        "403":
+          description: Requires user role
 
   /provider-connections/{id}/models:
     parameters:

--- a/services/api/src/__tests__/docs.test.ts
+++ b/services/api/src/__tests__/docs.test.ts
@@ -154,6 +154,8 @@ const EXPECTED_PATHS = [
   '/model-policies',
   '/model-policies/{id}',
   '/provider-connections',
+  '/provider-connections/health',
+  '/provider-connections/validate-all',
   '/provider-connections/{id}',
   '/provider-connections/{id}/validate',
   '/provider-connections/{id}/models',

--- a/services/api/src/__tests__/routes-provider-connections.test.ts
+++ b/services/api/src/__tests__/routes-provider-connections.test.ts
@@ -145,6 +145,29 @@ describe('Provider Connections CRUD', () => {
     expect(call[1]).toEqual(['regular-user']);
   });
 
+  it('list includes health columns', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{
+        id: 'uuid-1', name: 'My OpenAI', provider: 'openai',
+        api_base_url: null, is_valid: true,
+        last_validated_at: '2026-04-01T12:00:00Z',
+        last_validation_error: null,
+        validation_latency_ms: 245,
+        created_at: '2026-01-01', updated_at: '2026-04-01',
+      }],
+    });
+
+    const res = await request(app)
+      .get('/provider-connections')
+      .set('Authorization', `Bearer ${userToken}`);
+
+    expect(res.status).toBe(200);
+    const call = mockQuery.mock.calls[0];
+    expect(call[0]).toContain('last_validated_at');
+    expect(call[0]).toContain('last_validation_error');
+    expect(call[0]).toContain('validation_latency_ms');
+  });
+
   it('delete cascades to user_models', async () => {
     // The CASCADE is DB-level via FK constraint; here we verify the delete query
     mockClientQuery.mockResolvedValueOnce({}); // BEGIN
@@ -165,7 +188,7 @@ describe('Provider Connections CRUD', () => {
     expect(call[1]).toEqual(['uuid-1', 'regular-user']);
   });
 
-  it('validate connection success — delegates to AI service', async () => {
+  it('validate connection success — records latency and clears error', async () => {
     // First query: fetch encrypted key
     mockQuery.mockResolvedValueOnce({
       rows: [{
@@ -175,7 +198,7 @@ describe('Provider Connections CRUD', () => {
         api_base_url: null,
       }],
     });
-    // Second query: update is_valid
+    // Second query: update health columns
     mockQuery.mockResolvedValueOnce({ rows: [] });
 
     mockAxiosPost.mockResolvedValueOnce({ data: { valid: true } });
@@ -186,6 +209,7 @@ describe('Provider Connections CRUD', () => {
 
     expect(res.status).toBe(200);
     expect(res.body.is_valid).toBe(true);
+    expect(typeof res.body.validation_latency_ms).toBe('number');
 
     // Verify AI service was called
     expect(mockAxiosPost).toHaveBeenCalledTimes(1);
@@ -193,9 +217,15 @@ describe('Provider Connections CRUD', () => {
     expect(url).toBe('http://ai:8000/internal/validate-provider');
     expect(body.provider).toBe('openai');
     expect(opts.headers.Authorization).toBe('Bearer test-service-token');
+
+    // Verify update query includes health columns
+    const updateCall = mockQuery.mock.calls[1];
+    expect(updateCall[0]).toContain('last_validated_at = NOW()');
+    expect(updateCall[0]).toContain('validation_latency_ms');
+    expect(updateCall[0]).toContain('last_validation_error = NULL');
   });
 
-  it('validate connection invalid key — AI returns error', async () => {
+  it('validate connection invalid key — records error and latency', async () => {
     mockQuery.mockResolvedValueOnce({
       rows: [{
         id: 'uuid-1', provider: 'openai',
@@ -217,6 +247,12 @@ describe('Provider Connections CRUD', () => {
     expect(res.status).toBe(200);
     expect(res.body.is_valid).toBe(false);
     expect(res.body.error).toBe('Invalid API key');
+    expect(typeof res.body.validation_latency_ms).toBe('number');
+
+    // Verify update query includes error
+    const updateCall = mockQuery.mock.calls[1];
+    expect(updateCall[0]).toContain('last_validation_error');
+    expect(updateCall[0]).toContain('last_validated_at = NOW()');
   });
 
   it('update re-encrypts key', async () => {
@@ -273,5 +309,104 @@ describe('Provider Connections CRUD', () => {
       .delete('/provider-connections/uuid-nonexistent')
       .set('Authorization', `Bearer ${userToken}`);
     expect(res.status).toBe(404);
+  });
+});
+
+describe('Provider Connections Health', () => {
+  beforeEach(() => {
+    mockQuery.mockReset();
+    mockAxiosPost.mockReset();
+    process.env.DATABASE_URL = 'postgresql://test:test@localhost:5432/test';
+    process.env.PROVIDER_KEY_ENCRYPTION_KEY = TEST_ENCRYPTION_KEY;
+    process.env.MODEL_ROUTER_INTERNAL_SERVICE_TOKEN = 'test-service-token';
+    process.env.AI_SERVICE_URL = 'http://ai:8000';
+  });
+
+  afterEach(() => {
+    delete process.env.DATABASE_URL;
+    delete process.env.PROVIDER_KEY_ENCRYPTION_KEY;
+    delete process.env.MODEL_ROUTER_INTERNAL_SERVICE_TOKEN;
+    delete process.env.AI_SERVICE_URL;
+  });
+
+  it('GET /provider-connections/health returns aggregate stats', async () => {
+    // Overall query
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ total: 3, valid: 2, invalid: 1, untested: 0, avg_latency_ms: 320 }],
+    });
+    // By provider query
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        { provider: 'anthropic', total: 1, valid: 1, invalid: 0, untested: 0, avg_latency_ms: 250 },
+        { provider: 'openai', total: 2, valid: 1, invalid: 1, untested: 0, avg_latency_ms: 355 },
+      ],
+    });
+
+    const res = await request(app)
+      .get('/provider-connections/health')
+      .set('Authorization', `Bearer ${userToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.total).toBe(3);
+    expect(res.body.valid).toBe(2);
+    expect(res.body.invalid).toBe(1);
+    expect(res.body.untested).toBe(0);
+    expect(res.body.avg_latency_ms).toBe(320);
+    expect(res.body.by_provider).toHaveLength(2);
+    expect(res.body.by_provider[0].provider).toBe('anthropic');
+  });
+
+  it('health stats are owner-scoped', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ total: 0, valid: 0, invalid: 0, untested: 0, avg_latency_ms: null }],
+    });
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    await request(app)
+      .get('/provider-connections/health')
+      .set('Authorization', `Bearer ${userToken}`);
+
+    // Both queries should scope to owner
+    expect(mockQuery.mock.calls[0][1]).toEqual(['regular-user']);
+    expect(mockQuery.mock.calls[1][1]).toEqual(['regular-user']);
+  });
+
+  it('POST /provider-connections/validate-all validates all connections', async () => {
+    // Fetch all connections
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        {
+          id: 'conn-1', name: 'OpenAI', provider: 'openai',
+          api_key_encrypted: Buffer.from('enc1'),
+          api_key_nonce: Buffer.from('nonce1'),
+          api_base_url: null,
+        },
+        {
+          id: 'conn-2', name: 'Anthropic', provider: 'anthropic',
+          api_key_encrypted: Buffer.from('enc2'),
+          api_key_nonce: Buffer.from('nonce2'),
+          api_base_url: null,
+        },
+      ],
+    });
+    // Update queries for each connection
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    mockAxiosPost
+      .mockResolvedValueOnce({ data: { valid: true } })
+      .mockResolvedValueOnce({ data: { valid: false } });
+
+    const res = await request(app)
+      .post('/provider-connections/validate-all')
+      .set('Authorization', `Bearer ${userToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.results).toHaveLength(2);
+    expect(res.body.results[0].is_valid).toBe(true);
+    expect(res.body.results[0].name).toBe('OpenAI');
+    expect(typeof res.body.results[0].validation_latency_ms).toBe('number');
+    expect(res.body.results[1].is_valid).toBe(false);
+    expect(mockAxiosPost).toHaveBeenCalledTimes(2);
   });
 });

--- a/services/api/src/db/migrations/043_add_connection_health_columns.sql
+++ b/services/api/src/db/migrations/043_add_connection_health_columns.sql
@@ -1,0 +1,4 @@
+-- Add health monitoring columns to provider_connections
+ALTER TABLE provider_connections ADD COLUMN last_validated_at TIMESTAMPTZ DEFAULT NULL;
+ALTER TABLE provider_connections ADD COLUMN last_validation_error TEXT DEFAULT NULL;
+ALTER TABLE provider_connections ADD COLUMN validation_latency_ms INTEGER DEFAULT NULL;

--- a/services/api/src/openapi/openapi.yaml
+++ b/services/api/src/openapi/openapi.yaml
@@ -2037,6 +2037,16 @@ paths:
                     is_valid:
                       type: boolean
                       nullable: true
+                    last_validated_at:
+                      type: string
+                      format: date-time
+                      nullable: true
+                    last_validation_error:
+                      type: string
+                      nullable: true
+                    validation_latency_ms:
+                      type: integer
+                      nullable: true
                     created_at:
                       type: string
                       format: date-time
@@ -2180,6 +2190,9 @@ paths:
                     format: uuid
                   is_valid:
                     type: boolean
+                  validation_latency_ms:
+                    type: integer
+                    description: Round-trip validation time in milliseconds
                   error:
                     type: string
                     description: Error message if validation failed
@@ -2189,6 +2202,94 @@ paths:
           description: Requires user role
         "404":
           description: Connection not found
+
+  /provider-connections/health:
+    get:
+      summary: Connection health stats
+      description: >
+        Returns aggregate health statistics for the authenticated user's provider connections,
+        including overall counts and per-provider breakdown with average latency.
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Health statistics
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  total:
+                    type: integer
+                  valid:
+                    type: integer
+                  invalid:
+                    type: integer
+                  untested:
+                    type: integer
+                  avg_latency_ms:
+                    type: integer
+                    nullable: true
+                  by_provider:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        provider:
+                          type: string
+                        total:
+                          type: integer
+                        valid:
+                          type: integer
+                        invalid:
+                          type: integer
+                        untested:
+                          type: integer
+                        avg_latency_ms:
+                          type: integer
+                          nullable: true
+        "401":
+          description: Not authenticated
+        "403":
+          description: Requires user role
+
+  /provider-connections/validate-all:
+    post:
+      summary: Validate all connections
+      description: >
+        Validates all provider connections owned by the authenticated user sequentially.
+        Returns per-connection results with latency and error details.
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Validation results
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  results:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                          format: uuid
+                        name:
+                          type: string
+                        is_valid:
+                          type: boolean
+                        validation_latency_ms:
+                          type: integer
+                        error:
+                          type: string
+                          description: Error message if validation failed
+        "401":
+          description: Not authenticated
+        "403":
+          description: Requires user role
 
   /provider-connections/{id}/models:
     parameters:

--- a/services/api/src/routes/provider-connections.ts
+++ b/services/api/src/routes/provider-connections.ts
@@ -31,13 +31,58 @@ router.get('/', async (req: Request, res: Response) => {
 
   const user = (req as any).user;
   const result = await pool.query(
-    `SELECT id, name, provider, api_base_url, is_valid, created_at, updated_at
+    `SELECT id, name, provider, api_base_url, is_valid,
+            last_validated_at, last_validation_error, validation_latency_ms,
+            created_at, updated_at
      FROM provider_connections
      WHERE created_by = $1
      ORDER BY created_at DESC`,
     [user.sub]
   );
   res.json(result.rows);
+});
+
+// GET /provider-connections/health — aggregate health stats for own connections
+router.get('/health', async (req: Request, res: Response) => {
+  const pool = getPool();
+  if (!process.env.DATABASE_URL) {
+    res.status(503).json({ error: 'Database not configured' });
+    return;
+  }
+
+  const user = (req as any).user;
+
+  const overall = await pool.query(
+    `SELECT
+       COUNT(*)::int AS total,
+       COUNT(*) FILTER (WHERE is_valid = true)::int AS valid,
+       COUNT(*) FILTER (WHERE is_valid = false)::int AS invalid,
+       COUNT(*) FILTER (WHERE is_valid IS NULL)::int AS untested,
+       ROUND(AVG(validation_latency_ms) FILTER (WHERE validation_latency_ms IS NOT NULL))::int AS avg_latency_ms
+     FROM provider_connections
+     WHERE created_by = $1`,
+    [user.sub]
+  );
+
+  const byProvider = await pool.query(
+    `SELECT
+       provider,
+       COUNT(*)::int AS total,
+       COUNT(*) FILTER (WHERE is_valid = true)::int AS valid,
+       COUNT(*) FILTER (WHERE is_valid = false)::int AS invalid,
+       COUNT(*) FILTER (WHERE is_valid IS NULL)::int AS untested,
+       ROUND(AVG(validation_latency_ms) FILTER (WHERE validation_latency_ms IS NOT NULL))::int AS avg_latency_ms
+     FROM provider_connections
+     WHERE created_by = $1
+     GROUP BY provider
+     ORDER BY provider`,
+    [user.sub]
+  );
+
+  res.json({
+    ...overall.rows[0],
+    by_provider: byProvider.rows,
+  });
 });
 
 // POST /provider-connections — create connection with encrypted key
@@ -82,6 +127,80 @@ router.post('/', async (req: Request, res: Response) => {
     }
     throw err;
   }
+});
+
+// POST /provider-connections/validate-all — bulk validate all own connections
+router.post('/validate-all', async (req: Request, res: Response) => {
+  const pool = getPool();
+  if (!process.env.DATABASE_URL) {
+    res.status(503).json({ error: 'Database not configured' });
+    return;
+  }
+
+  const user = (req as any).user;
+  const aiServiceUrl = process.env.AI_SERVICE_URL || process.env.MODEL_ROUTER_URL || 'http://ai:8000';
+  const serviceToken = process.env.MODEL_ROUTER_INTERNAL_SERVICE_TOKEN;
+
+  if (!serviceToken) {
+    res.status(503).json({ error: 'Internal service token not configured' });
+    return;
+  }
+
+  const conns = await pool.query(
+    `SELECT id, name, provider, api_key_encrypted, api_key_nonce, api_base_url
+     FROM provider_connections
+     WHERE created_by = $1
+     ORDER BY created_at DESC`,
+    [user.sub]
+  );
+
+  const results: any[] = [];
+
+  for (const row of conns.rows) {
+    const startTime = Date.now();
+    try {
+      const response = await axios.post(
+        `${aiServiceUrl}/internal/validate-provider`,
+        {
+          provider: row.provider,
+          api_key_encrypted: Buffer.from(row.api_key_encrypted).toString('hex'),
+          api_key_nonce: Buffer.from(row.api_key_nonce).toString('hex'),
+          api_base_url: row.api_base_url,
+        },
+        {
+          headers: {
+            Authorization: `Bearer ${serviceToken}`,
+            'Content-Type': 'application/json',
+          },
+          timeout: 15000,
+        }
+      );
+
+      const latencyMs = Date.now() - startTime;
+      const isValid = response.data?.valid === true;
+      await pool.query(
+        `UPDATE provider_connections
+         SET is_valid = $1, last_validated_at = NOW(), validation_latency_ms = $2,
+             last_validation_error = NULL, updated_at = NOW()
+         WHERE id = $3`,
+        [isValid, latencyMs, row.id]
+      );
+      results.push({ id: row.id, name: row.name, is_valid: isValid, validation_latency_ms: latencyMs });
+    } catch (err: any) {
+      const latencyMs = Date.now() - startTime;
+      const errorMsg = (err.response?.data?.error || err.message || '').slice(0, 500);
+      await pool.query(
+        `UPDATE provider_connections
+         SET is_valid = false, last_validated_at = NOW(), validation_latency_ms = $1,
+             last_validation_error = $2, updated_at = NOW()
+         WHERE id = $3`,
+        [latencyMs, errorMsg, row.id]
+      );
+      results.push({ id: row.id, name: row.name, is_valid: false, validation_latency_ms: latencyMs, error: errorMsg });
+    }
+  }
+
+  res.json({ results });
 });
 
 // PUT /provider-connections/:id — update own connection
@@ -360,6 +479,7 @@ router.post('/:id/validate', async (req: Request, res: Response) => {
     return;
   }
 
+  const startTime = Date.now();
   try {
     const response = await axios.post(
       `${aiServiceUrl}/internal/validate-provider`,
@@ -378,20 +498,27 @@ router.post('/:id/validate', async (req: Request, res: Response) => {
       }
     );
 
+    const latencyMs = Date.now() - startTime;
     const isValid = response.data?.valid === true;
     await pool.query(
-      'UPDATE provider_connections SET is_valid = $1, updated_at = NOW() WHERE id = $2',
-      [isValid, id]
+      `UPDATE provider_connections
+       SET is_valid = $1, last_validated_at = NOW(), validation_latency_ms = $2,
+           last_validation_error = NULL, updated_at = NOW()
+       WHERE id = $3`,
+      [isValid, latencyMs, id]
     );
-    res.json({ id, is_valid: isValid });
+    res.json({ id, is_valid: isValid, validation_latency_ms: latencyMs });
   } catch (err: any) {
-    // AI service returned an error or was unreachable
-    const errorMsg = err.response?.data?.error || err.message;
+    const latencyMs = Date.now() - startTime;
+    const errorMsg = (err.response?.data?.error || err.message || '').slice(0, 500);
     await pool.query(
-      'UPDATE provider_connections SET is_valid = false, updated_at = NOW() WHERE id = $1',
-      [id]
+      `UPDATE provider_connections
+       SET is_valid = false, last_validated_at = NOW(), validation_latency_ms = $1,
+           last_validation_error = $2, updated_at = NOW()
+       WHERE id = $3`,
+      [latencyMs, errorMsg, id]
     );
-    res.json({ id, is_valid: false, error: errorMsg });
+    res.json({ id, is_valid: false, validation_latency_ms: latencyMs, error: errorMsg });
   }
 });
 

--- a/services/ui/src/__tests__/ConnectionsClient.test.tsx
+++ b/services/ui/src/__tests__/ConnectionsClient.test.tsx
@@ -23,19 +23,49 @@ const MOCK_CONNECTIONS = [
     provider: 'openai',
     api_base_url: null,
     is_valid: true,
+    last_validated_at: '2026-04-01T12:00:00Z',
+    last_validation_error: null,
+    validation_latency_ms: 245,
     created_at: '2026-01-15T00:00:00Z',
-    updated_at: '2026-01-15T00:00:00Z',
+    updated_at: '2026-04-01T12:00:00Z',
   },
   {
     id: 'conn-2',
     name: 'Anthropic Prod',
     provider: 'anthropic',
     api_base_url: 'https://custom.api.com',
-    is_valid: null,
+    is_valid: false,
+    last_validated_at: '2026-03-30T08:00:00Z',
+    last_validation_error: 'Invalid API key',
+    validation_latency_ms: 180,
     created_at: '2026-02-01T00:00:00Z',
-    updated_at: '2026-02-01T00:00:00Z',
+    updated_at: '2026-03-30T08:00:00Z',
+  },
+  {
+    id: 'conn-3',
+    name: 'Untested Key',
+    provider: 'openai',
+    api_base_url: null,
+    is_valid: null,
+    last_validated_at: null,
+    last_validation_error: null,
+    validation_latency_ms: null,
+    created_at: '2026-03-01T00:00:00Z',
+    updated_at: '2026-03-01T00:00:00Z',
   },
 ]
+
+const MOCK_HEALTH = {
+  total: 3,
+  valid: 1,
+  invalid: 1,
+  untested: 1,
+  avg_latency_ms: 213,
+  by_provider: [
+    { provider: 'anthropic', total: 1, valid: 0, invalid: 1, untested: 0, avg_latency_ms: 180 },
+    { provider: 'openai', total: 2, valid: 1, invalid: 0, untested: 1, avg_latency_ms: 245 },
+  ],
+}
 
 describe('ConnectionsClient', () => {
   const session = { user: { name: 'Test', roles: ['user'] }, accessToken: 'jwt' } as any
@@ -61,7 +91,7 @@ describe('ConnectionsClient', () => {
       expect(screen.getByText('Anthropic Prod')).toBeInTheDocument()
     })
 
-    expect(screen.getByText('2 connections')).toBeInTheDocument()
+    expect(screen.getByText('3 connections')).toBeInTheDocument()
   })
 
   it('shows validity badges', async () => {
@@ -174,8 +204,167 @@ describe('ConnectionsClient', () => {
     render(<ConnectionsClient session={session} />)
 
     await waitFor(() => {
-      expect(screen.getByText('openai')).toBeInTheDocument()
+      expect(screen.getAllByText('openai').length).toBeGreaterThanOrEqual(1)
       expect(screen.getByText('anthropic')).toBeInTheDocument()
+    })
+  })
+
+  it('shows Check All button when connections exist', async () => {
+    render(<ConnectionsClient session={session} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Check All')).toBeInTheDocument()
+    })
+  })
+
+  it('Check All triggers validate-all endpoint', async () => {
+    mockFetch
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(MOCK_CONNECTIONS) }) // initial
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ results: [] }) }) // validate-all
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(MOCK_CONNECTIONS) }) // refetch
+
+    render(<ConnectionsClient session={session} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Check All')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByText('Check All'))
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith('/api/provider-connections/validate-all', expect.objectContaining({
+        method: 'POST',
+      }))
+    })
+  })
+
+  it('shows tabs for Connections and Health', async () => {
+    render(<ConnectionsClient session={session} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Connections')).toBeInTheDocument()
+      expect(screen.getByText('Health')).toBeInTheDocument()
+    })
+  })
+
+  it('shows validation latency on connection cards', async () => {
+    render(<ConnectionsClient session={session} />)
+
+    await waitFor(() => {
+      expect(screen.getByText(/245ms/)).toBeInTheDocument()
+    })
+  })
+
+  it('shows last validation error on connection cards', async () => {
+    render(<ConnectionsClient session={session} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Invalid API key')).toBeInTheDocument()
+    })
+  })
+})
+
+describe('ConnectionsClient Health Tab', () => {
+  const session = { user: { name: 'Test', roles: ['user'] }, accessToken: 'jwt' } as any
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSession = { user: { roles: ['user'] } }
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('renders health summary cards', async () => {
+    mockFetch.mockImplementation((...args: any[]) => {
+      const url = typeof args[0] === 'string' ? args[0] : args[0]?.url || ''
+      if (url.includes('/health')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_HEALTH) })
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_CONNECTIONS) })
+    })
+
+    render(<ConnectionsClient session={session} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('My OpenAI Key')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByText('Health'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Connection Details')).toBeInTheDocument()
+      expect(screen.getByText('By Provider')).toBeInTheDocument()
+      expect(screen.getByText('213ms')).toBeInTheDocument()
+    })
+  })
+
+  it('renders per-connection health table', async () => {
+    mockFetch.mockImplementation((...args: any[]) => {
+      const url = typeof args[0] === 'string' ? args[0] : args[0]?.url || ''
+      if (url.includes('/health')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_HEALTH) })
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_CONNECTIONS) })
+    })
+
+    render(<ConnectionsClient session={session} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('My OpenAI Key')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByText('Health'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Connection Details')).toBeInTheDocument()
+      expect(screen.getByText('By Provider')).toBeInTheDocument()
+    })
+  })
+
+  it('displays latency for validated connections', async () => {
+    mockFetch.mockImplementation((...args: any[]) => {
+      const url = typeof args[0] === 'string' ? args[0] : args[0]?.url || ''
+      if (url.includes('/health')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_HEALTH) })
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_CONNECTIONS) })
+    })
+
+    render(<ConnectionsClient session={session} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('My OpenAI Key')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByText('Health'))
+
+    await waitFor(() => {
+      expect(screen.getByText('213ms')).toBeInTheDocument() // avg latency
+    })
+  })
+
+  it('shows empty state when no connections', async () => {
+    const emptyHealth = { total: 0, valid: 0, invalid: 0, untested: 0, avg_latency_ms: null, by_provider: [] }
+    mockFetch.mockImplementation((...args: any[]) => {
+      const url = typeof args[0] === 'string' ? args[0] : args[0]?.url || ''
+      if (url.includes('/health')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(emptyHealth) })
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve([]) })
+    })
+
+    render(<ConnectionsClient session={session} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('No provider connections yet')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByText('Health'))
+
+    await waitFor(() => {
+      expect(screen.getByText('No connections to monitor')).toBeInTheDocument()
     })
   })
 })

--- a/services/ui/src/app/harness/connections/ConnectionsClient.tsx
+++ b/services/ui/src/app/harness/connections/ConnectionsClient.tsx
@@ -9,8 +9,29 @@ interface ProviderConnection {
   provider: string
   api_base_url: string | null
   is_valid: boolean | null
+  last_validated_at: string | null
+  last_validation_error: string | null
+  validation_latency_ms: number | null
   created_at: string
   updated_at: string
+}
+
+interface HealthStats {
+  total: number
+  valid: number
+  invalid: number
+  untested: number
+  avg_latency_ms: number | null
+  by_provider: ProviderHealthRow[]
+}
+
+interface ProviderHealthRow {
+  provider: string
+  total: number
+  valid: number
+  invalid: number
+  untested: number
+  avg_latency_ms: number | null
 }
 
 const PROVIDERS = ['openai', 'anthropic', 'google', 'mistral', 'cohere', 'azure']
@@ -23,6 +44,10 @@ export default function ConnectionsClient({ session }: { session: Session }) {
   const [actionLoading, setActionLoading] = useState<string | null>(null)
   const [formData, setFormData] = useState({ name: '', provider: 'openai', api_key: '', api_base_url: '' })
   const [formError, setFormError] = useState('')
+  const [activeTab, setActiveTab] = useState<'connections' | 'health'>('connections')
+  const [healthStats, setHealthStats] = useState<HealthStats | null>(null)
+  const [healthLoading, setHealthLoading] = useState(false)
+  const [checkAllLoading, setCheckAllLoading] = useState(false)
 
   const fetchConnections = useCallback(async () => {
     try {
@@ -37,9 +62,29 @@ export default function ConnectionsClient({ session }: { session: Session }) {
     }
   }, [])
 
+  const fetchHealth = useCallback(async () => {
+    setHealthLoading(true)
+    try {
+      const res = await fetch('/api/provider-connections/health')
+      if (res.ok) {
+        setHealthStats(await res.json())
+      }
+    } catch (err) {
+      console.error('Failed to fetch health stats:', err)
+    } finally {
+      setHealthLoading(false)
+    }
+  }, [])
+
   useEffect(() => {
     fetchConnections()
   }, [fetchConnections])
+
+  useEffect(() => {
+    if (activeTab === 'health') {
+      fetchHealth()
+    }
+  }, [activeTab, fetchHealth])
 
   const resetForm = () => {
     setFormData({ name: '', provider: 'openai', api_key: '', api_base_url: '' })
@@ -140,6 +185,23 @@ export default function ConnectionsClient({ session }: { session: Session }) {
     }
   }
 
+  const handleCheckAll = async () => {
+    setCheckAllLoading(true)
+    try {
+      const res = await fetch('/api/provider-connections/validate-all', { method: 'POST' })
+      if (res.ok) {
+        await fetchConnections()
+        if (activeTab === 'health') {
+          await fetchHealth()
+        }
+      }
+    } catch {
+      alert('Failed to validate connections')
+    } finally {
+      setCheckAllLoading(false)
+    }
+  }
+
   if (loading) {
     return (
       <div className="flex items-center justify-center py-24">
@@ -150,156 +212,341 @@ export default function ConnectionsClient({ session }: { session: Session }) {
 
   return (
     <>
-      <div className="flex items-center justify-between mb-8">
+      <div className="flex items-center justify-between mb-6">
         <div>
           <h1 className="text-2xl font-bold">Provider Connections</h1>
           <p className="text-sm text-mountain-400 mt-1">
             {connections.length} connection{connections.length !== 1 ? 's' : ''}
           </p>
         </div>
+        <div className="flex items-center gap-2">
+          {connections.length > 0 && (
+            <button
+              onClick={handleCheckAll}
+              disabled={checkAllLoading}
+              className="px-4 py-2 text-sm font-medium rounded-lg border border-navy-600 text-mountain-400 hover:text-white hover:border-navy-500 transition-colors disabled:opacity-50 cursor-pointer disabled:cursor-not-allowed"
+            >
+              {checkAllLoading ? 'Checking...' : 'Check All'}
+            </button>
+          )}
+          <button
+            onClick={() => { resetForm(); setShowCreate(true); setActiveTab('connections') }}
+            className="px-4 py-2 text-sm font-medium rounded-lg bg-brand-600 hover:bg-brand-500 text-white transition-colors cursor-pointer"
+          >
+            Add Connection
+          </button>
+        </div>
+      </div>
+
+      {/* Tabs */}
+      <div className="flex gap-1 mb-6 border-b border-navy-700">
         <button
-          onClick={() => { resetForm(); setShowCreate(true) }}
-          className="px-4 py-2 text-sm font-medium rounded-lg bg-brand-600 hover:bg-brand-500 text-white transition-colors cursor-pointer"
+          onClick={() => setActiveTab('connections')}
+          className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors cursor-pointer ${
+            activeTab === 'connections'
+              ? 'border-brand-500 text-white'
+              : 'border-transparent text-mountain-400 hover:text-white'
+          }`}
         >
-          Add Connection
+          Connections
+        </button>
+        <button
+          onClick={() => setActiveTab('health')}
+          className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors cursor-pointer ${
+            activeTab === 'health'
+              ? 'border-brand-500 text-white'
+              : 'border-transparent text-mountain-400 hover:text-white'
+          }`}
+        >
+          Health
         </button>
       </div>
 
-      {/* Create/Edit form */}
-      {showCreate && (
-        <div className="rounded-lg border border-navy-700 bg-navy-800 p-5 mb-6">
-          <h2 className="text-lg font-semibold text-white mb-4">
-            {editingId ? 'Edit Connection' : 'New Connection'}
-          </h2>
-          <form onSubmit={handleSubmit} className="space-y-4">
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-              <div>
-                <label className="block text-sm text-mountain-400 mb-1">Name</label>
-                <input
-                  type="text"
-                  value={formData.name}
-                  onChange={(e) => setFormData({ ...formData, name: e.target.value })}
-                  className="w-full rounded-md border border-navy-600 bg-navy-900 px-3 py-2 text-sm text-white placeholder-mountain-500 focus:border-brand-500 focus:outline-none"
-                  placeholder="My OpenAI Key"
-                />
-              </div>
-              <div>
-                <label className="block text-sm text-mountain-400 mb-1">Provider</label>
-                <select
-                  value={formData.provider}
-                  onChange={(e) => setFormData({ ...formData, provider: e.target.value })}
-                  className="w-full rounded-md border border-navy-600 bg-navy-900 px-3 py-2 text-sm text-white focus:border-brand-500 focus:outline-none"
+      {activeTab === 'connections' && (
+        <>
+          {/* Create/Edit form */}
+          {showCreate && (
+            <div className="rounded-lg border border-navy-700 bg-navy-800 p-5 mb-6">
+              <h2 className="text-lg font-semibold text-white mb-4">
+                {editingId ? 'Edit Connection' : 'New Connection'}
+              </h2>
+              <form onSubmit={handleSubmit} className="space-y-4">
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                  <div>
+                    <label className="block text-sm text-mountain-400 mb-1">Name</label>
+                    <input
+                      type="text"
+                      value={formData.name}
+                      onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+                      className="w-full rounded-md border border-navy-600 bg-navy-900 px-3 py-2 text-sm text-white placeholder-mountain-500 focus:border-brand-500 focus:outline-none"
+                      placeholder="My OpenAI Key"
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-sm text-mountain-400 mb-1">Provider</label>
+                    <select
+                      value={formData.provider}
+                      onChange={(e) => setFormData({ ...formData, provider: e.target.value })}
+                      className="w-full rounded-md border border-navy-600 bg-navy-900 px-3 py-2 text-sm text-white focus:border-brand-500 focus:outline-none"
+                    >
+                      {PROVIDERS.map((p) => (
+                        <option key={p} value={p}>{p}</option>
+                      ))}
+                    </select>
+                  </div>
+                </div>
+                <div>
+                  <label className="block text-sm text-mountain-400 mb-1">
+                    API Key {editingId && <span className="text-mountain-500">(leave blank to keep current)</span>}
+                  </label>
+                  <input
+                    type="password"
+                    value={formData.api_key}
+                    onChange={(e) => setFormData({ ...formData, api_key: e.target.value })}
+                    className="w-full rounded-md border border-navy-600 bg-navy-900 px-3 py-2 text-sm text-white placeholder-mountain-500 focus:border-brand-500 focus:outline-none"
+                    placeholder={editingId ? 'Enter new key to update' : 'sk-...'}
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm text-mountain-400 mb-1">
+                    Custom Base URL <span className="text-mountain-500">(optional)</span>
+                  </label>
+                  <input
+                    type="text"
+                    value={formData.api_base_url}
+                    onChange={(e) => setFormData({ ...formData, api_base_url: e.target.value })}
+                    className="w-full rounded-md border border-navy-600 bg-navy-900 px-3 py-2 text-sm text-white placeholder-mountain-500 focus:border-brand-500 focus:outline-none"
+                    placeholder="https://api.example.com/v1"
+                  />
+                </div>
+                {formError && (
+                  <p className="text-sm text-red-400">{formError}</p>
+                )}
+                <div className="flex items-center gap-2">
+                  <button
+                    type="submit"
+                    className="px-4 py-2 text-sm font-medium rounded-lg bg-brand-600 hover:bg-brand-500 text-white transition-colors cursor-pointer"
+                  >
+                    {editingId ? 'Update' : 'Create'}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={resetForm}
+                    className="px-4 py-2 text-sm font-medium rounded-lg border border-navy-600 text-mountain-400 hover:text-white hover:border-navy-500 transition-colors cursor-pointer"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </form>
+            </div>
+          )}
+
+          {/* Connection list */}
+          {connections.length === 0 ? (
+            <div className="rounded-lg border border-navy-700 bg-navy-800 p-12 text-center">
+              <p className="text-mountain-400 mb-4">No provider connections yet</p>
+              <button
+                onClick={() => { resetForm(); setShowCreate(true) }}
+                className="text-brand-400 hover:text-brand-300 text-sm font-medium cursor-pointer"
+              >
+                Add your first API key to get started
+              </button>
+            </div>
+          ) : (
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+              {connections.map((conn) => (
+                <div
+                  key={conn.id}
+                  className="rounded-lg border border-navy-700 bg-navy-800 p-5 flex flex-col"
                 >
-                  {PROVIDERS.map((p) => (
-                    <option key={p} value={p}>{p}</option>
-                  ))}
-                </select>
-              </div>
+                  <div className="flex items-center justify-between mb-2">
+                    <h3 className="font-semibold text-white truncate">{conn.name}</h3>
+                    <ValidityBadge isValid={conn.is_valid} />
+                  </div>
+
+                  <p className="text-sm text-mountain-400 mb-1">{conn.provider}</p>
+                  {conn.api_base_url && (
+                    <p className="text-xs text-mountain-500 mb-1 truncate">{conn.api_base_url}</p>
+                  )}
+                  <p className="text-xs text-mountain-500 mb-1">
+                    Added {new Date(conn.created_at).toLocaleDateString()}
+                  </p>
+                  {conn.last_validated_at && (
+                    <p className="text-xs text-mountain-500 mb-1">
+                      Checked {formatRelativeTime(conn.last_validated_at)}
+                      {conn.validation_latency_ms != null && ` (${conn.validation_latency_ms}ms)`}
+                    </p>
+                  )}
+                  {conn.last_validation_error && (
+                    <p className="text-xs text-red-400 mb-1 truncate" title={conn.last_validation_error}>
+                      {conn.last_validation_error}
+                    </p>
+                  )}
+
+                  <div className="flex items-center gap-2 mt-auto pt-2">
+                    <button
+                      onClick={() => handleValidate(conn)}
+                      disabled={actionLoading === conn.id}
+                      className="px-3 py-1.5 text-xs font-medium rounded-md bg-brand-600 hover:bg-brand-500 text-white transition-colors disabled:opacity-50 cursor-pointer disabled:cursor-not-allowed"
+                    >
+                      {actionLoading === conn.id ? 'Testing...' : 'Test'}
+                    </button>
+                    <button
+                      onClick={() => handleEdit(conn)}
+                      className="px-3 py-1.5 text-xs font-medium rounded-md border border-navy-600 text-mountain-400 hover:text-white hover:border-navy-500 transition-colors cursor-pointer"
+                    >
+                      Edit
+                    </button>
+                    <button
+                      onClick={() => handleDelete(conn)}
+                      disabled={actionLoading === conn.id}
+                      className="px-3 py-1.5 text-xs font-medium rounded-md border border-red-700 text-red-400 hover:bg-red-900/30 transition-colors disabled:opacity-50 cursor-pointer disabled:cursor-not-allowed"
+                    >
+                      Delete
+                    </button>
+                  </div>
+                </div>
+              ))}
             </div>
-            <div>
-              <label className="block text-sm text-mountain-400 mb-1">
-                API Key {editingId && <span className="text-mountain-500">(leave blank to keep current)</span>}
-              </label>
-              <input
-                type="password"
-                value={formData.api_key}
-                onChange={(e) => setFormData({ ...formData, api_key: e.target.value })}
-                className="w-full rounded-md border border-navy-600 bg-navy-900 px-3 py-2 text-sm text-white placeholder-mountain-500 focus:border-brand-500 focus:outline-none"
-                placeholder={editingId ? 'Enter new key to update' : 'sk-...'}
-              />
-            </div>
-            <div>
-              <label className="block text-sm text-mountain-400 mb-1">
-                Custom Base URL <span className="text-mountain-500">(optional)</span>
-              </label>
-              <input
-                type="text"
-                value={formData.api_base_url}
-                onChange={(e) => setFormData({ ...formData, api_base_url: e.target.value })}
-                className="w-full rounded-md border border-navy-600 bg-navy-900 px-3 py-2 text-sm text-white placeholder-mountain-500 focus:border-brand-500 focus:outline-none"
-                placeholder="https://api.example.com/v1"
-              />
-            </div>
-            {formError && (
-              <p className="text-sm text-red-400">{formError}</p>
-            )}
-            <div className="flex items-center gap-2">
-              <button
-                type="submit"
-                className="px-4 py-2 text-sm font-medium rounded-lg bg-brand-600 hover:bg-brand-500 text-white transition-colors cursor-pointer"
-              >
-                {editingId ? 'Update' : 'Create'}
-              </button>
-              <button
-                type="button"
-                onClick={resetForm}
-                className="px-4 py-2 text-sm font-medium rounded-lg border border-navy-600 text-mountain-400 hover:text-white hover:border-navy-500 transition-colors cursor-pointer"
-              >
-                Cancel
-              </button>
-            </div>
-          </form>
-        </div>
+          )}
+        </>
       )}
 
-      {/* Connection list */}
-      {connections.length === 0 ? (
-        <div className="rounded-lg border border-navy-700 bg-navy-800 p-12 text-center">
-          <p className="text-mountain-400 mb-4">No provider connections yet</p>
-          <button
-            onClick={() => { resetForm(); setShowCreate(true) }}
-            className="text-brand-400 hover:text-brand-300 text-sm font-medium cursor-pointer"
-          >
-            Add your first API key to get started
-          </button>
-        </div>
-      ) : (
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-          {connections.map((conn) => (
-            <div
-              key={conn.id}
-              className="rounded-lg border border-navy-700 bg-navy-800 p-5 flex flex-col"
-            >
-              <div className="flex items-center justify-between mb-2">
-                <h3 className="font-semibold text-white truncate">{conn.name}</h3>
-                <ValidityBadge isValid={conn.is_valid} />
-              </div>
-
-              <p className="text-sm text-mountain-400 mb-1">{conn.provider}</p>
-              {conn.api_base_url && (
-                <p className="text-xs text-mountain-500 mb-1 truncate">{conn.api_base_url}</p>
-              )}
-              <p className="text-xs text-mountain-500 mb-4">
-                Added {new Date(conn.created_at).toLocaleDateString()}
-              </p>
-
-              <div className="flex items-center gap-2 mt-auto">
-                <button
-                  onClick={() => handleValidate(conn)}
-                  disabled={actionLoading === conn.id}
-                  className="px-3 py-1.5 text-xs font-medium rounded-md bg-brand-600 hover:bg-brand-500 text-white transition-colors disabled:opacity-50 cursor-pointer disabled:cursor-not-allowed"
-                >
-                  {actionLoading === conn.id ? 'Testing...' : 'Test'}
-                </button>
-                <button
-                  onClick={() => handleEdit(conn)}
-                  className="px-3 py-1.5 text-xs font-medium rounded-md border border-navy-600 text-mountain-400 hover:text-white hover:border-navy-500 transition-colors cursor-pointer"
-                >
-                  Edit
-                </button>
-                <button
-                  onClick={() => handleDelete(conn)}
-                  disabled={actionLoading === conn.id}
-                  className="px-3 py-1.5 text-xs font-medium rounded-md border border-red-700 text-red-400 hover:bg-red-900/30 transition-colors disabled:opacity-50 cursor-pointer disabled:cursor-not-allowed"
-                >
-                  Delete
-                </button>
-              </div>
-            </div>
-          ))}
-        </div>
+      {activeTab === 'health' && (
+        <HealthTab
+          stats={healthStats}
+          loading={healthLoading}
+          connections={connections}
+        />
       )}
     </>
+  )
+}
+
+function HealthTab({
+  stats,
+  loading,
+  connections,
+}: {
+  stats: HealthStats | null
+  loading: boolean
+  connections: ProviderConnection[]
+}) {
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <div className="h-6 w-6 rounded-full border-2 border-brand-500 border-t-transparent animate-spin" />
+      </div>
+    )
+  }
+
+  if (!stats || stats.total === 0) {
+    return (
+      <div className="rounded-lg border border-navy-700 bg-navy-800 p-12 text-center">
+        <p className="text-mountain-400">No connections to monitor</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Summary cards */}
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+        <StatCard label="Total" value={stats.total} color="text-white" />
+        <StatCard label="Valid" value={stats.valid} color="text-brand-400" />
+        <StatCard label="Invalid" value={stats.invalid} color="text-red-400" />
+        <StatCard label="Untested" value={stats.untested} color="text-mountain-400" />
+      </div>
+
+      {stats.avg_latency_ms != null && (
+        <div className="rounded-lg border border-navy-700 bg-navy-800 p-4">
+          <p className="text-sm text-mountain-400">
+            Average validation latency: <span className="text-white font-medium">{stats.avg_latency_ms}ms</span>
+          </p>
+        </div>
+      )}
+
+      {/* Per-provider breakdown */}
+      {stats.by_provider.length > 0 && (
+        <div className="rounded-lg border border-navy-700 bg-navy-800 overflow-hidden">
+          <div className="px-4 py-3 border-b border-navy-700">
+            <h3 className="text-sm font-semibold text-white">By Provider</h3>
+          </div>
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-mountain-400 text-left">
+                <th className="px-4 py-2 font-medium">Provider</th>
+                <th className="px-4 py-2 font-medium">Total</th>
+                <th className="px-4 py-2 font-medium">Valid</th>
+                <th className="px-4 py-2 font-medium">Invalid</th>
+                <th className="px-4 py-2 font-medium">Avg Latency</th>
+              </tr>
+            </thead>
+            <tbody>
+              {stats.by_provider.map((row) => (
+                <tr key={row.provider} className="border-t border-navy-700">
+                  <td className="px-4 py-2 text-white">{row.provider}</td>
+                  <td className="px-4 py-2 text-mountain-400">{row.total}</td>
+                  <td className="px-4 py-2 text-brand-400">{row.valid}</td>
+                  <td className="px-4 py-2 text-red-400">{row.invalid}</td>
+                  <td className="px-4 py-2 text-mountain-400">
+                    {row.avg_latency_ms != null ? `${row.avg_latency_ms}ms` : '—'}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {/* Per-connection health table */}
+      <div className="rounded-lg border border-navy-700 bg-navy-800 overflow-hidden">
+        <div className="px-4 py-3 border-b border-navy-700">
+          <h3 className="text-sm font-semibold text-white">Connection Details</h3>
+        </div>
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="text-mountain-400 text-left">
+              <th className="px-4 py-2 font-medium">Name</th>
+              <th className="px-4 py-2 font-medium">Provider</th>
+              <th className="px-4 py-2 font-medium">Status</th>
+              <th className="px-4 py-2 font-medium">Latency</th>
+              <th className="px-4 py-2 font-medium">Last Checked</th>
+              <th className="px-4 py-2 font-medium">Error</th>
+            </tr>
+          </thead>
+          <tbody>
+            {connections.map((conn) => (
+              <tr key={conn.id} className="border-t border-navy-700">
+                <td className="px-4 py-2 text-white">{conn.name}</td>
+                <td className="px-4 py-2 text-mountain-400">{conn.provider}</td>
+                <td className="px-4 py-2">
+                  <ValidityBadge isValid={conn.is_valid} />
+                </td>
+                <td className="px-4 py-2 text-mountain-400">
+                  {conn.validation_latency_ms != null ? `${conn.validation_latency_ms}ms` : '—'}
+                </td>
+                <td className="px-4 py-2 text-mountain-400">
+                  {conn.last_validated_at ? formatRelativeTime(conn.last_validated_at) : 'Never'}
+                </td>
+                <td className="px-4 py-2 text-red-400 max-w-xs truncate" title={conn.last_validation_error || ''}>
+                  {conn.last_validation_error || '—'}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}
+
+function StatCard({ label, value, color }: { label: string; value: number; color: string }) {
+  return (
+    <div className="rounded-lg border border-navy-700 bg-navy-800 p-4">
+      <p className="text-xs text-mountain-400 mb-1">{label}</p>
+      <p className={`text-2xl font-bold ${color}`}>{value}</p>
+    </div>
   )
 }
 
@@ -326,4 +573,22 @@ function ValidityBadge({ isValid }: { isValid: boolean | null }) {
       Untested
     </span>
   )
+}
+
+function formatRelativeTime(iso: string): string {
+  const now = Date.now()
+  const then = new Date(iso).getTime()
+  const diffMs = now - then
+
+  const seconds = Math.floor(diffMs / 1000)
+  if (seconds < 60) return 'just now'
+
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60) return `${minutes}m ago`
+
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours}h ago`
+
+  const days = Math.floor(hours / 24)
+  return `${days}d ago`
 }


### PR DESCRIPTION
## Summary
- **Migration 043**: adds `last_validated_at`, `last_validation_error`, `validation_latency_ms` columns to `provider_connections`
- **Enhanced validate endpoint**: records round-trip latency, error message, and timestamp on every validation
- **New `GET /provider-connections/health`**: aggregate stats (total/valid/invalid/untested + per-provider breakdown with avg latency)
- **New `POST /provider-connections/validate-all`**: bulk validates all user connections sequentially, returns per-connection results
- **UI Health tab**: summary cards (Total, Valid, Invalid, Untested), avg latency, per-provider table, per-connection details table with latency/last-checked/error
- **Check All button**: triggers bulk validation from the header, refreshes both tabs on completion
- **Connection cards**: now show last-checked time, latency, and error message inline

## Test Plan
- [x] API tests pass — 23 tests (Jest): `npx jest routes-provider-connections --verbose`
- [x] UI tests pass — 17 tests (Vitest): `npx vitest run src/__tests__/ConnectionsClient.test.tsx`
- [x] TypeScript compiles clean (no new errors)
- [x] OpenAPI spec updated with new endpoints and response fields

## Validation Evidence
- `GET /health` returns `{ total, valid, invalid, untested, avg_latency_ms, by_provider }` — owner-scoped
- `POST /validate-all` returns `{ results: [{ id, name, is_valid, validation_latency_ms, error? }] }`
- Validate endpoint now returns `validation_latency_ms` in response
- List endpoint now includes `last_validated_at`, `last_validation_error`, `validation_latency_ms`

## Risks
- `validate-all` is sequential (15s timeout per connection) — acceptable for current user count; Phase 2 can add concurrency
- All new columns are nullable with DEFAULT NULL — safe migration on existing data

Linear: AI-152

🤖 Generated with [Claude Code](https://claude.com/claude-code)