### PR TITLE
feat: connect tool-use loop to PTY shell executor (AI-156)

### DIFF
--- a/services/agentbox/app/tools.py
+++ b/services/agentbox/app/tools.py
@@ -2,12 +2,17 @@
 
 Builds OpenAI-compatible tool definitions from agent config and routes
 tool calls to the existing shell/filesystem modules.
+
+Shell commands prefer PTY execution (execute_command_pty) when the terminal
+logger is configured, so output streams to terminal.jsonl for the live
+terminal view. Falls back to plain subprocess (execute_command) otherwise.
 """
 
 from __future__ import annotations
 
 import json
 import logging
+import uuid
 from typing import TYPE_CHECKING
 
 from app import filesystem, shell
@@ -129,8 +134,15 @@ async def execute_tool_call(
                 timeout = int(timeout)
             except (TypeError, ValueError):
                 timeout = 30
+        command_id = str(uuid.uuid4())
+        # Prefer PTY execution when terminal logger is configured —
+        # streams output to terminal.jsonl for the live terminal view.
+        if shell._terminal is not None:
+            return await shell.execute_command_pty(
+                command, timeout=timeout, command_id=command_id, work_id=work_id,
+            )
         return await shell.execute_command(
-            command, timeout=timeout, work_id=work_id,
+            command, timeout=timeout, command_id=command_id, work_id=work_id,
         )
 
     if name == "read_file":

--- a/services/agentbox/tests/test_tools.py
+++ b/services/agentbox/tests/test_tools.py
@@ -1,7 +1,7 @@
 """Tests for app.tools — tool definitions and dispatcher."""
 
 import json
-from unittest.mock import AsyncMock, patch
+from unittest.mock import ANY, AsyncMock, patch
 
 import pytest
 
@@ -74,7 +74,28 @@ class TestExecuteToolCall:
         result = await execute_tool_call("execute_command", {"command": "echo hello", "timeout": 10})
         parsed = json.loads(result)
         assert parsed["success"] is True
-        mock_exec.assert_called_once_with("echo hello", timeout=10, work_id=None)
+        mock_exec.assert_called_once_with("echo hello", timeout=10, command_id=ANY, work_id=None)
+
+    @pytest.mark.asyncio
+    @patch("app.tools.shell.execute_command", new_callable=AsyncMock)
+    async def test_execute_command_generates_command_id(self, mock_exec):
+        mock_exec.return_value = json.dumps({"success": True})
+        await execute_tool_call("execute_command", {"command": "ls"})
+        _, kwargs = mock_exec.call_args
+        # command_id should be a valid UUID string
+        import uuid
+        uuid.UUID(kwargs["command_id"])  # raises if not valid
+
+    @pytest.mark.asyncio
+    @patch("app.tools.shell.execute_command_pty", new_callable=AsyncMock)
+    @patch("app.tools.shell._terminal", new="fake-terminal")
+    async def test_prefers_pty_when_terminal_configured(self, mock_pty):
+        """When terminal logger is configured, execute_command uses PTY path."""
+        mock_pty.return_value = json.dumps({"success": True, "exit_code": 0, "stdout": "", "stderr": ""})
+        result = await execute_tool_call("execute_command", {"command": "git status"})
+        parsed = json.loads(result)
+        assert parsed["success"] is True
+        mock_pty.assert_called_once_with("git status", timeout=30, command_id=ANY, work_id=None)
 
     @pytest.mark.asyncio
     @patch("app.tools.filesystem.read_file", new_callable=AsyncMock)
@@ -115,4 +136,4 @@ class TestExecuteToolCall:
     async def test_bad_timeout_defaults_to_30(self, mock_exec):
         mock_exec.return_value = json.dumps({"success": True})
         await execute_tool_call("execute_command", {"command": "ls", "timeout": "invalid"})
-        mock_exec.assert_called_once_with("ls", timeout=30, work_id=None)
+        mock_exec.assert_called_once_with("ls", timeout=30, command_id=ANY, work_id=None)


### PR DESCRIPTION
## Summary

- **Wire tool loop to PTY executor**: `tools.py` now prefers `shell.execute_command_pty()` over `shell.execute_command()` when the terminal logger is configured
- **Terminal streaming works**: Commands executed by the LLM during chat tool loops now write to `terminal.jsonl`, enabling the live terminal view (AI-151) to show real-time output
- **Generates command_id**: Each tool call gets a UUID `command_id` for terminal log correlation
- **Graceful fallback**: If terminal logger isn't configured (e.g. in tests or minimal profile), falls back to plain subprocess execution

## What was broken

The tool-calling loop (AI-150/PR#297) routed `execute_command` through `shell.execute_command()` (plain subprocess), completely bypassing the PTY executor (PR#296) and terminal logger. LLM-driven commands produced no output in `terminal.jsonl`, so the live terminal view was blind to agent tool execution.

## Changes

| File | Change |
|------|--------|
| `services/agentbox/app/tools.py` | Check `shell._terminal`, prefer `execute_command_pty` when available; generate `command_id` per call |
| `services/agentbox/tests/test_tools.py` | Add PTY preference test, command_id generation test, fix assertions for new `command_id` param |

## Test plan

- [x] 163 agentbox tests pass (0 failures)
- [x] `test_prefers_pty_when_terminal_configured` — verifies PTY path is used when terminal logger exists
- [x] `test_execute_command_generates_command_id` — verifies valid UUID generated
- [x] `test_execute_command` — verifies fallback to subprocess when no terminal logger

Linear: AI-156

🤖 Generated with [Claude Code](https://claude.com/claude-code)