### PR TITLE
feat: terminal polish — read-only observer, zsh/tmux/Node.js (AI-158/159/160/162)

### DIFF
--- a/services/agentbox/Dockerfile
+++ b/services/agentbox/Dockerfile
@@ -30,6 +30,8 @@ WORKDIR /app
 # Install runtime tools for agents
 RUN apt-get update && apt-get install -y --no-install-recommends \
     bash \
+    zsh \
+    tmux \
     git \
     curl \
     wget \
@@ -38,7 +40,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     rsync \
     vim \
     make \
+    ca-certificates \
+    gnupg \
     && rm -rf /var/lib/apt/lists/*
+
+# Install Node.js 20 LTS via NodeSource
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
+    apt-get install -y --no-install-recommends nodejs && \
+    rm -rf /var/lib/apt/lists/*
 
 # Copy Python packages from builder (only site-packages, not builder tools)
 COPY --from=builder /usr/local/lib/python3.12/site-packages /usr/local/lib/python3.12/site-packages
@@ -46,8 +55,12 @@ COPY --from=builder /usr/local/lib/python3.12/site-packages /usr/local/lib/pytho
 # Copy AKM CLI binary from knowledge service image
 COPY --from=akm-source /usr/local/bin/akm /usr/local/bin/akm
 
-# Create non-root user
-RUN useradd -m -u 1000 agentuser
+# Create non-root user with zsh as default shell
+RUN useradd -m -u 1000 -s /usr/bin/zsh agentuser
+
+# Install oh-my-zsh for agentuser (non-interactive)
+RUN su - agentuser -c 'sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended' && \
+    sed -i 's/ZSH_THEME="robbyrussell"/ZSH_THEME="agnoster"/' /home/agentuser/.zshrc
 
 # Create required directories
 RUN mkdir -p /etc/agentbox /workspace /var/log/agentbox /data && \

--- a/services/agentbox/app/ws_terminal.py
+++ b/services/agentbox/app/ws_terminal.py
@@ -1,7 +1,8 @@
 """WebSocket terminal — bidirectional PTY relay over WebSocket.
 
-Spawns a shell (bash) in a PTY and relays stdin/stdout between the
-WebSocket and the PTY master fd. Supports terminal resize via JSON
+Spawns a tmux session (with zsh) in a PTY and relays stdin/stdout
+between the WebSocket and the PTY master fd. If tmux is not available,
+falls back to zsh, then bash. Supports terminal resize via JSON
 control messages.
 
 Wire format:
@@ -19,6 +20,7 @@ import logging
 import os
 import pty
 import select
+import shutil
 import signal
 import struct
 import termios
@@ -30,7 +32,29 @@ logger = logging.getLogger(__name__)
 TERM_COLS = 120
 TERM_ROWS = 40
 READ_SIZE = 4096
-SHELL = "/bin/bash"
+TMUX_SESSION = "agent"
+
+
+def _resolve_shell() -> tuple[list[str], str]:
+    """Resolve the best available shell command.
+
+    Prefers: tmux new-session (zsh) > zsh > bash.
+    Returns (argv, shell_path) for execvpe.
+    """
+    tmux = shutil.which("tmux")
+    zsh = shutil.which("zsh")
+    bash = shutil.which("bash") or "/bin/bash"
+
+    if tmux and zsh:
+        # tmux with zsh as default-shell, attach or create session
+        return (
+            [tmux, "new-session", "-A", "-s", TMUX_SESSION,
+             "-x", str(TERM_COLS), "-y", str(TERM_ROWS)],
+            tmux,
+        )
+    if zsh:
+        return ([zsh, "--login"], zsh)
+    return ([bash, "--login"], bash)
 
 
 async def ws_terminal_handler(websocket: WebSocket, work_token: str | None) -> None:
@@ -72,16 +96,18 @@ async def ws_terminal_handler(websocket: WebSocket, work_token: str | None) -> N
             except OSError:
                 pass
 
+            argv, shell_bin = _resolve_shell()
+
             env = {
                 "PATH": "/usr/local/bin:/usr/bin:/bin",
-                "HOME": "/workspace",
+                "HOME": "/home/agentuser",
                 "LANG": "C.UTF-8",
                 "TERM": "xterm-256color",
-                "SHELL": SHELL,
+                "SHELL": shutil.which("zsh") or shutil.which("bash") or "/bin/bash",
             }
 
             try:
-                os.execvpe(SHELL, [SHELL, "--login"], env)
+                os.execvpe(shell_bin, argv, env)
             except OSError as e:
                 os.write(2, f"exec failed: {e}\n".encode())
                 os._exit(127)

--- a/services/ui/src/app/chat/XTerminal.tsx
+++ b/services/ui/src/app/chat/XTerminal.tsx
@@ -23,7 +23,8 @@ export default function XTerminal({ threadId }: Props) {
     const { WebLinksAddon } = await import('@xterm/addon-web-links')
 
     const term = new Terminal({
-      cursorBlink: true,
+      cursorBlink: false,
+      disableStdin: true,
       fontSize: 13,
       fontFamily: "'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace",
       theme: {
@@ -97,13 +98,6 @@ export default function XTerminal({ threadId }: Props) {
       term.write('\r\n\x1b[31m Connection error \x1b[0m\r\n')
     }
 
-    // Terminal input → WebSocket
-    term.onData((data) => {
-      if (ws.readyState === WebSocket.OPEN) {
-        ws.send(new TextEncoder().encode(data))
-      }
-    })
-
     // Handle resize
     const handleResize = () => {
       fitAddon.fit()
@@ -141,7 +135,7 @@ export default function XTerminal({ threadId }: Props) {
         <h3 className="text-sm font-semibold text-gray-200">Terminal</h3>
         <div className="flex items-center gap-2">
           <span className="w-2 h-2 rounded-full bg-green-500 animate-pulse" />
-          <span className="text-xs text-mountain-400">Live</span>
+          <span className="text-xs text-mountain-400">Observer</span>
         </div>
       </div>
       <div


### PR DESCRIPTION
## Summary

- **AI-158 — Read-only terminal**: Disable stdin (`disableStdin: true`), remove keyboard handler, turn off cursor blink. Terminal is view-only observer mode.
- **AI-159 — zsh + oh-my-zsh**: Install zsh, set as default shell for agentuser, install oh-my-zsh with agnoster theme.
- **AI-160 — tmux**: Install tmux. WebSocket terminal spawns `tmux new-session -A -s agent` for session persistence. Falls back to zsh > bash.
- **AI-162 — Node.js**: Install Node.js 20 LTS via NodeSource. Python 3.12 and Git already present from base image.

## Changes

| File | Change |
|------|--------|
| `services/ui/src/app/chat/XTerminal.tsx` | `disableStdin: true`, `cursorBlink: false`, remove `onData` handler, label "Observer" |
| `services/agentbox/Dockerfile` | Add zsh, tmux, ca-certificates, gnupg, Node.js 20 LTS. Create agentuser with `-s /usr/bin/zsh`. Install oh-my-zsh (agnoster). |
| `services/agentbox/app/ws_terminal.py` | `_resolve_shell()` prefers tmux+zsh > zsh > bash. Set HOME=/home/agentuser for oh-my-zsh config. |

## Test plan

- [x] Agentbox: 167 tests pass
- [ ] V1: Terminal renders without cursor, no keyboard input accepted
- [ ] V2: Container builds with zsh, tmux, node, python3, git
- [ ] V3: WebSocket terminal shows tmux session with oh-my-zsh prompt

Linear: AI-158, AI-159, AI-160, AI-162

🤖 Generated with [Claude Code](https://claude.com/claude-code)