### PR TITLE
feat: multi-step workflow prompt for coding agents (AI-169)

### DIFF
--- a/services/agentbox/app/chat.py
+++ b/services/agentbox/app/chat.py
@@ -119,14 +119,7 @@ def handle_chat(
     # Inject tool-use instruction so the LLM knows to call tools
     if tool_defs:
         tool_names = ", ".join(t["function"]["name"] for t in tool_defs)
-        tool_instruction = (
-            "\n\n## Tools\n"
-            f"You have access to these tools: {tool_names}.\n"
-            "When the user asks you to run a command, read a file, write a file, "
-            "or list a directory, you MUST use the appropriate tool — do not just "
-            "describe what the command would do or output what you think the result is. "
-            "Always use the tool and show the actual output."
-        )
+        tool_instruction = _build_tool_instruction(tool_names, tool_defs)
         if final_messages and final_messages[0].get("role") == "system":
             final_messages[0]["content"] += tool_instruction
         else:
@@ -148,6 +141,55 @@ def handle_chat(
         work_id=work_id,
         emitter=emitter,
     )
+
+
+def _build_tool_instruction(tool_names: str, tool_defs: list[dict]) -> str:
+    """Build the tool-use system prompt section.
+
+    Includes multi-step workflow guidance so the LLM plans before coding,
+    verifies results, and iterates on failures instead of giving up.
+    """
+    has_shell = any(t["function"]["name"] == "execute_command" for t in tool_defs)
+    has_write = any(t["function"]["name"] == "write_file" for t in tool_defs)
+    has_read = any(t["function"]["name"] == "read_file" for t in tool_defs)
+
+    parts = [
+        f"\n\n## Tools\nYou have access to these tools: {tool_names}.",
+        "",
+        "When asked to run a command, read a file, write a file, or list a "
+        "directory, you MUST use the appropriate tool. Do not guess outputs — "
+        "always call the tool and show the real result.",
+    ]
+
+    # Only inject workflow guidance when the agent has coding-capable tools
+    if has_shell and has_write and has_read:
+        parts.append("")
+        parts.append(
+            "## Multi-Step Task Workflow\n"
+            "For coding tasks (new features, bug fixes, refactors), follow this workflow:\n"
+            "\n"
+            "1. **Understand** — Read relevant files and explore the codebase before "
+            "changing anything. Identify which files need edits and how they connect.\n"
+            "2. **Plan** — State your approach in 2-3 sentences before writing code. "
+            "If the task is ambiguous, ask the user to clarify.\n"
+            "3. **Implement** — Make changes one file at a time. Write complete, "
+            "working code — do not leave placeholder comments like `// TODO` or "
+            "`# implement later`.\n"
+            "4. **Verify** — After writing code, run the relevant test or validation "
+            "command (e.g. `npm test`, `pytest`, `go test`, type-checking). If no "
+            "test exists and the change is non-trivial, write one.\n"
+            "5. **Iterate** — If tests fail, read the error output carefully, fix the "
+            "issue, and re-run. Do not give up after one failure — keep going until "
+            "tests pass or you hit a blocker you cannot resolve.\n"
+            "\n"
+            "Key principles:\n"
+            "- Read before you write. Understand existing patterns and follow them.\n"
+            "- Run commands to verify — do not assume your code is correct.\n"
+            "- When a command fails, read the full error output before attempting a fix.\n"
+            "- Keep changes minimal and focused on the task at hand."
+        )
+
+    return "\n".join(parts)
 
 
 def _run_tool_loop(

--- a/services/agentbox/tests/test_chat.py
+++ b/services/agentbox/tests/test_chat.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from app.chat import handle_chat, _deliver_callback
+from app.chat import handle_chat, _build_tool_instruction, _deliver_callback
 from app.config import FilesystemConfig, ShellConfig, ToolLoopConfig, ToolsConfig
 from app.events import EventEmitter
 
@@ -573,3 +573,122 @@ class TestToolLoop:
         assert "read_file" in tool_names
         assert "write_file" in tool_names
         assert "list_directory" in tool_names
+
+
+class TestBuildToolInstruction:
+    """AI-169: Multi-step task workflow in tool instruction."""
+
+    def test_includes_tool_names(self):
+        tool_defs = [
+            {"function": {"name": "execute_command"}},
+            {"function": {"name": "read_file"}},
+        ]
+        result = _build_tool_instruction("execute_command, read_file", tool_defs)
+        assert "execute_command, read_file" in result
+
+    def test_multistep_workflow_with_full_tools(self):
+        """Workflow section appears when shell + read + write are all enabled."""
+        tool_defs = [
+            {"function": {"name": "execute_command"}},
+            {"function": {"name": "read_file"}},
+            {"function": {"name": "write_file"}},
+            {"function": {"name": "list_directory"}},
+        ]
+        result = _build_tool_instruction(
+            "execute_command, read_file, write_file, list_directory", tool_defs,
+        )
+        assert "Multi-Step Task Workflow" in result
+        assert "Understand" in result
+        assert "Plan" in result
+        assert "Implement" in result
+        assert "Verify" in result
+        assert "Iterate" in result
+
+    def test_no_multistep_without_write(self):
+        """Read-only agents should not get the coding workflow."""
+        tool_defs = [
+            {"function": {"name": "execute_command"}},
+            {"function": {"name": "read_file"}},
+            {"function": {"name": "list_directory"}},
+        ]
+        result = _build_tool_instruction(
+            "execute_command, read_file, list_directory", tool_defs,
+        )
+        assert "Multi-Step Task Workflow" not in result
+
+    def test_no_multistep_shell_only(self):
+        """Shell-only agents should not get the coding workflow."""
+        tool_defs = [{"function": {"name": "execute_command"}}]
+        result = _build_tool_instruction("execute_command", tool_defs)
+        assert "Multi-Step Task Workflow" not in result
+
+    @patch("app.chat.requests.post")
+    def test_multistep_prompt_in_system_message(self, mock_post, emitter, monkeypatch):
+        """End-to-end: multi-step workflow appears in the system message sent to LLM."""
+        em, _ = emitter
+        monkeypatch.setenv("CHAT_CALLBACK_TOKEN", "cb-token")
+        monkeypatch.setenv("MODEL_ROUTER_TOKEN", "mr-token")
+
+        ai_response = MagicMock(
+            status_code=200,
+            json=lambda: {
+                "choices": [{"message": {"content": "ok"}, "finish_reason": "stop"}],
+                "usage": {}, "model": "m",
+            },
+        )
+        mock_post.side_effect = [ai_response, MagicMock(status_code=200)]
+
+        handle_chat(
+            {
+                "thread_id": "t1", "message_id": "m1",
+                "messages": [{"role": "user", "content": "Fix the bug"}],
+                "model": "gpt-4o-mini",
+                "callback_url": "http://api:3000/cb",
+            },
+            soul="I am CodeBot", rules="", work_id="w1", emitter=em,
+            tools_config=ToolsConfig(
+                shell=ShellConfig(enabled=True),
+                filesystem=FilesystemConfig(enabled=True),
+            ),
+        )
+
+        ai_body = mock_post.call_args_list[0][1]["json"]
+        system_msg = ai_body["messages"][0]
+        assert system_msg["role"] == "system"
+        assert "I am CodeBot" in system_msg["content"]
+        assert "Multi-Step Task Workflow" in system_msg["content"]
+        assert "Verify" in system_msg["content"]
+
+    @patch("app.chat.requests.post")
+    def test_readonly_no_multistep_in_system(self, mock_post, emitter, monkeypatch):
+        """Read-only filesystem does not inject multi-step workflow."""
+        em, _ = emitter
+        monkeypatch.setenv("CHAT_CALLBACK_TOKEN", "cb-token")
+        monkeypatch.setenv("MODEL_ROUTER_TOKEN", "mr-token")
+
+        ai_response = MagicMock(
+            status_code=200,
+            json=lambda: {
+                "choices": [{"message": {"content": "ok"}, "finish_reason": "stop"}],
+                "usage": {}, "model": "m",
+            },
+        )
+        mock_post.side_effect = [ai_response, MagicMock(status_code=200)]
+
+        handle_chat(
+            {
+                "thread_id": "t1", "message_id": "m1",
+                "messages": [{"role": "user", "content": "What files?"}],
+                "model": "gpt-4o-mini",
+                "callback_url": "http://api:3000/cb",
+            },
+            soul="", rules="", work_id="w1", emitter=em,
+            tools_config=ToolsConfig(
+                shell=ShellConfig(enabled=True),
+                filesystem=FilesystemConfig(enabled=True, read_only=True),
+            ),
+        )
+
+        ai_body = mock_post.call_args_list[0][1]["json"]
+        system_msg = ai_body["messages"][0]
+        assert "Multi-Step Task Workflow" not in system_msg["content"]


### PR DESCRIPTION
## Summary
- Agents with full coding tools (shell + read + write) now receive a **multi-step workflow** section in their system prompt: Understand → Plan → Implement → Verify → Iterate
- Read-only and shell-only agents are **not affected** — the workflow only appears when the agent can actually write code and run tests
- Extracted `_build_tool_instruction()` for clean testability

Closes AI-169

## Test plan
- [x] 6 new unit tests in `test_chat.py::TestBuildToolInstruction`
  - [x] Tool names included in output
  - [x] Full-tools agent gets multi-step workflow
  - [x] Read-only agent does NOT get multi-step workflow
  - [x] Shell-only agent does NOT get multi-step workflow
  - [x] End-to-end: workflow appears in system message sent to LLM
  - [x] End-to-end: read-only filesystem excludes workflow from system message
- [x] All 22 existing + new tests pass (`pytest tests/test_chat.py` — 22 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)