### PR TITLE
fix: mark stale token-expired chat errors (AI-167)

### DIFF
--- a/services/api/src/db/migrations/044_mark_stale_token_errors.sql
+++ b/services/api/src/db/migrations/044_mark_stale_token_errors.sql
@@ -1,0 +1,17 @@
+-- Migration 044: Mark stale 'token expired' error messages (AI-167)
+--
+-- Old chat messages with 'token expired' errors are noise — the token was
+-- refreshed and the agent recovered, but the error messages remain visible
+-- in thread history. This migration marks them as stale so the UI can
+-- filter or dim them.
+
+-- Widen status enum to include 'stale'
+ALTER TABLE chat_messages DROP CONSTRAINT IF EXISTS chat_messages_status_check;
+ALTER TABLE chat_messages ADD CONSTRAINT chat_messages_status_check
+  CHECK (status IN ('pending', 'thinking', 'complete', 'error', 'stale'));
+
+-- Mark existing token-expired error messages as stale
+UPDATE chat_messages
+   SET status = 'stale'
+ WHERE status = 'error'
+   AND error_message ILIKE '%token expired%';

--- a/services/ui/src/__tests__/ChatMessage.test.tsx
+++ b/services/ui/src/__tests__/ChatMessage.test.tsx
@@ -240,4 +240,53 @@ describe('ChatMessage', () => {
     const provenance = screen.getByTestId('chain-provenance')
     expect(provenance).toHaveTextContent('Triggered by @WriterBot')
   })
+
+  // AI-167: Stale error messages
+  it('renders stale message dimmed with original error text', () => {
+    render(
+      <ChatMessage
+        message={makeMessage({
+          author_type: 'agent',
+          role: 'assistant',
+          status: 'stale',
+          error_message: 'token expired',
+        })}
+        isOwnMessage={false}
+      />
+    )
+    const stale = screen.getByTestId('stale-message')
+    expect(stale).toBeInTheDocument()
+    expect(stale).toHaveTextContent('token expired')
+  })
+
+  it('renders stale fallback text when no error_message', () => {
+    render(
+      <ChatMessage
+        message={makeMessage({
+          author_type: 'agent',
+          role: 'assistant',
+          status: 'stale',
+          error_message: null,
+        })}
+        isOwnMessage={false}
+      />
+    )
+    expect(screen.getByTestId('stale-message')).toHaveTextContent('Stale error (resolved)')
+  })
+
+  it('stale message does not render red error styling', () => {
+    const { container } = render(
+      <ChatMessage
+        message={makeMessage({
+          author_type: 'agent',
+          role: 'assistant',
+          status: 'stale',
+          error_message: 'token expired',
+        })}
+        isOwnMessage={false}
+      />
+    )
+    // Should not have red error styling
+    expect(container.querySelector('.text-red-400')).not.toBeInTheDocument()
+  })
 })

--- a/services/ui/src/app/chat/ChatMessage.tsx
+++ b/services/ui/src/app/chat/ChatMessage.tsx
@@ -33,6 +33,7 @@ export default function ChatMessage({ message, isOwnMessage, isGroup, agents = [
   const isUser = message.role === 'user'
   const isPending = message.status === 'pending'
   const isError = message.status === 'error'
+  const isStale = message.status === 'stale'
 
   // In group threads, find the agent name for assistant messages
   const agentName = !isUser && isGroup
@@ -61,6 +62,8 @@ export default function ChatMessage({ message, isOwnMessage, isGroup, agents = [
             ? 'bg-brand-600/20 border border-brand-600/30'
             : isError
             ? 'bg-red-900/20 border border-red-800/30'
+            : isStale
+            ? 'bg-navy-800/50 border border-navy-700/50 opacity-50'
             : 'bg-navy-800 border border-navy-700'
         }`}
       >
@@ -100,6 +103,10 @@ export default function ChatMessage({ message, isOwnMessage, isGroup, agents = [
               </p>
             </div>
           </div>
+        ) : isStale ? (
+          <p className="text-xs text-mountain-500 italic" data-testid="stale-message">
+            {message.error_message || 'Stale error (resolved)'}
+          </p>
         ) : (
           <p className="text-sm text-gray-200 whitespace-pre-wrap break-words">
             {message.content}

--- a/services/ui/src/app/chat/ChatView.tsx
+++ b/services/ui/src/app/chat/ChatView.tsx
@@ -20,7 +20,7 @@ export interface Message {
   author_type: 'human' | 'agent'
   role: 'user' | 'assistant'
   content: string
-  status: 'pending' | 'complete' | 'error'
+  status: 'pending' | 'complete' | 'error' | 'stale'
   model: string | null
   input_tokens: number | null
   output_tokens: number | null


### PR DESCRIPTION
## Summary
- **Migration 044**: Adds `stale` to the `chat_messages.status` check constraint and updates existing rows where `error_message ILIKE '%token expired%'` from `error` to `stale`
- **ChatMessage.tsx**: Renders `stale` messages as dimmed italic text instead of red error styling
- **ChatView.tsx**: Adds `stale` to the `Message.status` type union

Closes AI-167

## Test plan
- [x] 3 new vitest tests for stale rendering in `ChatMessage.test.tsx`
  - [x] Stale message shows original error text dimmed
  - [x] Stale fallback text when no `error_message`
  - [x] Stale message does NOT have red error styling
- [x] All 15 ChatMessage tests pass
- [ ] Migration runs cleanly on VPS (post-merge deploy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)