### PR TITLE
fix: tasks API returning empty — missing PATCH proxy + error feedback (AI-165)

### DIFF
--- a/services/ui/src/app/api/tasks/[...path]/route.ts
+++ b/services/ui/src/app/api/tasks/[...path]/route.ts
@@ -8,4 +8,5 @@ async function proxyRequest(req: NextRequest, { params }: { params: Promise<{ pa
 
 export const GET = proxyRequest
 export const PUT = proxyRequest
+export const PATCH = proxyRequest
 export const DELETE = proxyRequest

--- a/services/ui/src/app/tasks/TaskBoardClient.tsx
+++ b/services/ui/src/app/tasks/TaskBoardClient.tsx
@@ -54,6 +54,7 @@ interface NewTaskForm {
 export default function TaskBoardClient() {
   const [tasks, setTasks] = useState<Task[]>([])
   const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
   const [agents, setAgents] = useState<Array<{ agent_id: string; name: string }>>([])
   const [selectedTask, setSelectedTask] = useState<Task | null>(null)
   const [transitioning, setTransitioning] = useState<string | null>(null)
@@ -63,13 +64,17 @@ export default function TaskBoardClient() {
 
   const fetchTasks = useCallback(async () => {
     try {
+      setError(null)
       const res = await fetch('/api/tasks')
       if (res.ok) {
         const data = await res.json()
         setTasks(Array.isArray(data) ? data : [])
+      } else {
+        const body = await res.json().catch(() => ({}))
+        setError(body.error || `Failed to load tasks (${res.status})`)
       }
     } catch {
-      // Non-fatal
+      setError('Unable to reach tasks API')
     } finally {
       setLoading(false)
     }
@@ -274,6 +279,19 @@ export default function TaskBoardClient() {
             </button>
           </div>
         </form>
+      )}
+
+      {/* Error banner */}
+      {error && (
+        <div className="rounded-lg border border-red-700/50 bg-red-900/20 px-4 py-3 mb-6 flex items-center justify-between" data-testid="tasks-error">
+          <span className="text-sm text-red-400">{error}</span>
+          <button
+            onClick={() => { setLoading(true); fetchTasks() }}
+            className="text-xs text-red-300 hover:text-white transition-colors cursor-pointer"
+          >
+            Retry
+          </button>
+        </div>
       )}
 
       {/* Board */}


### PR DESCRIPTION
## Summary
- Added missing `PATCH` export to `services/ui/src/app/api/tasks/[...path]/route.ts` — task status transitions were returning 405 from Next.js because the proxy didn't forward PATCH requests
- Added error state + retry button to `TaskBoardClient.tsx` — API errors (503 service not configured, 502 knowledge service down) were silently swallowed, showing an empty board with no feedback

## Root cause
Two independent bugs combined to make the task board appear broken:
1. **PATCH not proxied**: The `[...path]` catch-all route only exported GET/PUT/DELETE, not PATCH. The `/:id/transition` endpoint uses PATCH, so transitions silently failed.
2. **Silent error swallowing**: `fetchTasks()` caught all errors and non-ok responses without surfacing them. Users saw an empty board with no indication of what went wrong.

## Test plan
- [x] Existing 6 TaskBoardClient tests pass
- [ ] Task board loads and shows tasks when knowledge service is healthy
- [ ] Error banner with retry appears when API returns non-200
- [ ] PATCH `/api/tasks/:id/transition` proxies correctly (no more 405)
- [ ] Retry button re-fetches tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)