### PR TITLE
fix: agent progression stats/artifacts 404 for non-admin users (AI-166)

### DIFF
--- a/services/api/src/routes/agents.ts
+++ b/services/api/src/routes/agents.ts
@@ -1632,9 +1632,10 @@ function stripDockerHeader(buf: Buffer): string[] {
 router.get('/:id/stats', requireRole('user'), async (req: Request, res: Response) => {
   try {
     const scope = scopeToOwner(req);
+    const paramOffset = scope.params.length + 1;
     const { rows } = await getPool().query(
-      `SELECT * FROM agents WHERE id = $1${scope.where !== '1=1' ? ` AND ${scope.where}` : ''}`,
-      scope.where === '1=1' ? [req.params.id] : [req.params.id, ...scope.params],
+      `SELECT * FROM agents WHERE id = $${paramOffset}${scope.where !== '1=1' ? ` AND ${scope.where}` : ''}`,
+      [...scope.params, req.params.id],
     );
     if (rows.length === 0) {
       res.status(404).json({ error: 'Agent not found' });
@@ -1720,9 +1721,10 @@ const ARTIFACT_CATALOG = [
 router.get('/:id/artifacts', requireRole('user'), async (req: Request, res: Response) => {
   try {
     const scope = scopeToOwner(req);
+    const paramOffset = scope.params.length + 1;
     const { rows } = await getPool().query(
-      `SELECT * FROM agents WHERE id = $1${scope.where !== '1=1' ? ` AND ${scope.where}` : ''}`,
-      scope.where === '1=1' ? [req.params.id] : [req.params.id, ...scope.params],
+      `SELECT * FROM agents WHERE id = $${paramOffset}${scope.where !== '1=1' ? ` AND ${scope.where}` : ''}`,
+      [...scope.params, req.params.id],
     );
     if (rows.length === 0) {
       res.status(404).json({ error: 'Agent not found' });


### PR DESCRIPTION
## Summary
- Fixed SQL parameter numbering bug in `GET /agents/:id/stats` and `GET /agents/:id/artifacts` that caused 404 for all non-admin users
- Root cause: `scopeToOwner()` returns `created_by = $1` with `[user.sub]`, but the query prepended the agent ID as `$1`, making both `id` and `created_by` reference the same parameter (agent UUID). The `created_by` check compared against the agent UUID instead of the user's Keycloak sub — zero rows returned → 404 "Agent not found"
- Fix: use `paramOffset` pattern (scope params first, agent ID at `$N`) matching the working `GET /:id` handler

## Test plan
- [x] API: 677 tests pass (50 suites)
- [x] UI: 4 AgentProgression tests pass
- [ ] Non-admin user can view agent stats on the agent detail page
- [ ] Non-admin user can view earned/locked artifacts
- [ ] Admin user still sees stats/artifacts (unchanged — scope.where is `1=1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)