### PR TITLE
fix: connection health validation loses error on HTTP 200 invalid (AI-172)

### DIFF
--- a/services/api/src/__tests__/routes-provider-connections.test.ts
+++ b/services/api/src/__tests__/routes-provider-connections.test.ts
@@ -222,7 +222,9 @@ describe('Provider Connections CRUD', () => {
     const updateCall = mockQuery.mock.calls[1];
     expect(updateCall[0]).toContain('last_validated_at = NOW()');
     expect(updateCall[0]).toContain('validation_latency_ms');
-    expect(updateCall[0]).toContain('last_validation_error = NULL');
+    expect(updateCall[0]).toContain('last_validation_error');
+    // Valid connection should clear the error (null param)
+    expect(updateCall[1][2]).toBeNull(); // last_validation_error param
   });
 
   it('validate connection invalid key — records error and latency', async () => {
@@ -253,6 +255,35 @@ describe('Provider Connections CRUD', () => {
     const updateCall = mockQuery.mock.calls[1];
     expect(updateCall[0]).toContain('last_validation_error');
     expect(updateCall[0]).toContain('last_validated_at = NOW()');
+  });
+
+  it('validate connection invalid via HTTP 200 — preserves error message', async () => {
+    // AI service returns {valid: false, error: "..."} with HTTP 200 (not a throw)
+    mockQuery.mockResolvedValueOnce({
+      rows: [{
+        id: 'uuid-1', provider: 'openai',
+        api_key_encrypted: Buffer.from('encrypted-data'),
+        api_key_nonce: Buffer.from('nonce-data'),
+        api_base_url: null,
+      }],
+    });
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    mockAxiosPost.mockResolvedValueOnce({
+      data: { valid: false, error: 'Incorrect API key provided' },
+    });
+
+    const res = await request(app)
+      .post('/provider-connections/uuid-1/validate')
+      .set('Authorization', `Bearer ${userToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.is_valid).toBe(false);
+    expect(res.body.error).toBe('Incorrect API key provided');
+
+    // Verify DB update includes the error
+    const updateCall = mockQuery.mock.calls[1];
+    expect(updateCall[1][2]).toBe('Incorrect API key provided'); // last_validation_error param
   });
 
   it('update re-encrypts key', async () => {

--- a/services/api/src/routes/provider-connections.ts
+++ b/services/api/src/routes/provider-connections.ts
@@ -178,14 +178,17 @@ router.post('/validate-all', async (req: Request, res: Response) => {
 
       const latencyMs = Date.now() - startTime;
       const isValid = response.data?.valid === true;
+      const validationError = isValid ? null : (response.data?.error || '').slice(0, 500) || null;
       await pool.query(
         `UPDATE provider_connections
          SET is_valid = $1, last_validated_at = NOW(), validation_latency_ms = $2,
-             last_validation_error = NULL, updated_at = NOW()
-         WHERE id = $3`,
-        [isValid, latencyMs, row.id]
+             last_validation_error = $3, updated_at = NOW()
+         WHERE id = $4`,
+        [isValid, latencyMs, validationError, row.id]
       );
-      results.push({ id: row.id, name: row.name, is_valid: isValid, validation_latency_ms: latencyMs });
+      const result: any = { id: row.id, name: row.name, is_valid: isValid, validation_latency_ms: latencyMs };
+      if (validationError) result.error = validationError;
+      results.push(result);
     } catch (err: any) {
       const latencyMs = Date.now() - startTime;
       const errorMsg = (err.response?.data?.error || err.message || '').slice(0, 500);
@@ -500,14 +503,17 @@ router.post('/:id/validate', async (req: Request, res: Response) => {
 
     const latencyMs = Date.now() - startTime;
     const isValid = response.data?.valid === true;
+    const validationError = isValid ? null : (response.data?.error || '').slice(0, 500) || null;
     await pool.query(
       `UPDATE provider_connections
        SET is_valid = $1, last_validated_at = NOW(), validation_latency_ms = $2,
-           last_validation_error = NULL, updated_at = NOW()
-       WHERE id = $3`,
-      [isValid, latencyMs, id]
+           last_validation_error = $3, updated_at = NOW()
+       WHERE id = $4`,
+      [isValid, latencyMs, validationError, id]
     );
-    res.json({ id, is_valid: isValid, validation_latency_ms: latencyMs });
+    const result: any = { id, is_valid: isValid, validation_latency_ms: latencyMs };
+    if (validationError) result.error = validationError;
+    res.json(result);
   } catch (err: any) {
     const latencyMs = Date.now() - startTime;
     const errorMsg = (err.response?.data?.error || err.message || '').slice(0, 500);


### PR DESCRIPTION
## Summary
- **Root cause**: When the AI service validates a provider connection and returns `{valid: false, error: "Incorrect API key"}` via HTTP 200, both `POST /:id/validate` and `POST /validate-all` ran the success path which hardcoded `last_validation_error = NULL`. The connection showed "Invalid" in the UI Health tab but with no error explanation.
- **Fix**: Both endpoints now check `response.data.error` when `valid === false` and persist it to `last_validation_error`. Error is cleared only when `valid === true`.
- 1 new test covering the HTTP-200-but-invalid case

Closes AI-172

## Test plan
- [x] New test: `validate connection invalid via HTTP 200 — preserves error message`
- [x] Existing test updated: `validate connection success — records latency and clears error` (checks null param instead of SQL literal)
- [x] All 24 provider-connections tests pass
- [ ] Verify on VPS: Test button on Connections page shows error detail for invalid keys (post-deploy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)