### PR TITLE
feat: agent auto-journaling after chat interactions (AI-175)

### DIFF
--- a/services/api/src/routes/chat.ts
+++ b/services/api/src/routes/chat.ts
@@ -25,6 +25,7 @@ import { isAdmin, getAgentElevatedScope } from '../helpers/elevated-scope';
 import { auditLog } from '../helpers/audit';
 import { dispatchChatWork } from '../services/chat-dispatch';
 import { execInContainer } from '../services/docker';
+import { appendJournal } from '../services/akm-proxy';
 
 const router = Router();
 
@@ -1338,6 +1339,33 @@ export async function chatCallbackHandler(req: Request, res: Response): Promise<
      WHERE id = (SELECT thread_id FROM chat_messages WHERE id = $1)`,
     [message_id]
   );
+
+  // ── Auto-journal: persist interaction to agent memory (fire-and-forget) ──
+  if (finalStatus === 'complete' && content && process.env.AKM_INTERNAL_SERVICE_TOKEN) {
+    try {
+      const { rows: journalRows } = await pool.query(
+        `SELECT m.author_id, a.agent_id AS agent_slug
+         FROM chat_messages m
+         JOIN agents a ON a.id = m.author_id
+         WHERE m.id = $1 AND m.author_type = 'agent'`,
+        [message_id]
+      );
+      if (journalRows.length > 0) {
+        const agentSlug = journalRows[0].agent_slug;
+        const tokenCount = (input_tokens || 0) + (output_tokens || 0);
+        const preview = (content || '').length > 300
+          ? content.slice(0, 300) + '…'
+          : content;
+        const journalContent =
+          `**Chat response** (${model || 'unknown'}, ${tokenCount} tokens, ${duration_ms || 0}ms)\n\n${preview}`;
+        appendJournal(agentSlug, journalContent).catch((err: unknown) => {
+          console.error('[chat-callback] Journal append failed (non-blocking):', err);
+        });
+      }
+    } catch (journalErr) {
+      console.error('[chat-callback] Journal lookup failed (non-blocking):', journalErr);
+    }
+  }
 
   // ── Batch completion detection for group threads ──
   // Check if all sibling messages (same reply_to) are terminal

--- a/services/api/src/services/akm-proxy.ts
+++ b/services/api/src/services/akm-proxy.ts
@@ -59,3 +59,28 @@ export async function searchEntries(q: string, agentId?: string): Promise<ProxyR
   if (agentId) params.agent_id = agentId;
   return proxyGet('/internal/admin/search', params);
 }
+
+export async function appendJournal(agentId: string, content: string): Promise<ProxyResponse> {
+  if (!AKM_INTERNAL_SERVICE_TOKEN) {
+    return { status: 503, data: { error: 'Knowledge service not configured' } };
+  }
+
+  const url = `${AKM_SERVICE_URL}/internal/admin/journal/${encodeURIComponent(agentId)}`;
+
+  let resp: Response;
+  try {
+    resp = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${AKM_INTERNAL_SERVICE_TOKEN}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ content }),
+    });
+  } catch {
+    return { status: 502, data: { error: 'Knowledge service unavailable' } };
+  }
+
+  const data = await resp.json();
+  return { status: resp.status, data };
+}

--- a/services/knowledge/app/routes/internal_admin.py
+++ b/services/knowledge/app/routes/internal_admin.py
@@ -1,4 +1,4 @@
-"""Internal admin read-only endpoints for the API proxy layer.
+"""Internal admin endpoints for the API proxy layer.
 
 Authenticated with AKM_INTERNAL_SERVICE_TOKEN only. The API service
 enforces user-level authorization (ownership/admin scoping) before
@@ -8,9 +8,14 @@ to pass the correct agent_id filters.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from datetime import date, datetime, timezone
 from typing import Any
 
 from fastapi import APIRouter, HTTPException, Query, Request
+from pydantic import BaseModel
+
+from app.services import knowledge_store
 
 router = APIRouter(prefix="/internal/admin", tags=["internal-admin"])
 
@@ -163,3 +168,62 @@ async def search_entries(
         "search_type": "fts",
         "score_type": "ts_rank",
     }
+
+
+# ── Journal append (service-to-service) ──────────────────────────────
+
+
+@dataclass
+class _ServiceClaims:
+    """Minimal AgentClaims-compatible struct for service-to-service calls."""
+
+    sub: str
+
+
+class JournalAppendBody(BaseModel):
+    content: str
+
+
+@router.post("/journal/{agent_id}", status_code=201)
+async def append_journal(
+    agent_id: str,
+    body: JournalAppendBody,
+    request: Request,
+) -> dict[str, Any]:
+    """Append to an agent's daily journal (service-to-service).
+
+    Reuses the same date-based, timestamp-batched logic as the
+    agent-facing ``POST /api/v1/journal`` endpoint.
+    """
+    _verify_service_token(request)
+    pool = request.app.state.pool
+    data_dir = request.app.state.settings.data_dir
+
+    claims = _ServiceClaims(sub=agent_id)
+    today = date.today().isoformat()
+    journal_path = f"journal/{today}.md"
+    now_ts = datetime.now(timezone.utc).strftime("%H:%M:%S UTC")
+
+    existing = await knowledge_store.read_entry(pool, claims, journal_path)
+
+    if existing is not None:
+        existing_content = existing["content"]
+        new_content = f"{existing_content}\n\n## {now_ts}\n\n{body.content}"
+        entry = await knowledge_store.update_entry(
+            pool, data_dir, claims, journal_path, new_content
+        )
+        if entry is None:
+            raise HTTPException(status_code=500, detail="failed to update journal")
+    else:
+        frontmatter = (
+            f"---\ntitle: Journal {today}\ntype: journal\n---\n\n"
+            f"## {now_ts}\n\n{body.content}"
+        )
+        try:
+            entry = await knowledge_store.create_entry(
+                pool, data_dir, claims, journal_path, frontmatter
+            )
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e))
+
+    return _serialize(entry)


### PR DESCRIPTION
## Summary
- Agents now automatically journal every completed chat interaction to AKM (Agent Knowledge Management)
- Each journal entry records: model used, total tokens, duration, and a 300-char content preview
- Entries are organized as date-based journal files (`journal/YYYY-MM-DD.md`) with UTC timestamps, batched throughout the day
- Three changes across two services:
  - **Knowledge service**: `POST /internal/admin/journal/{agent_id}` — reuses existing date-based append logic, authenticated via internal service token
  - **API akm-proxy**: `appendJournal()` function for service-to-service calls
  - **Chat callback handler**: fire-and-forget journal append on terminal `complete` callbacks, guarded by `AKM_INTERNAL_SERVICE_TOKEN` presence

## Design decisions
- **Fire-and-forget**: Journal append never blocks the callback response or affects chat flow
- **Env-guarded**: Skips entirely when `AKM_INTERNAL_SERVICE_TOKEN` is not set (avoids unnecessary DB queries in test environments)
- **Reuses existing journal pattern**: Same date-based, timestamp-batched approach as the agent-facing `POST /api/v1/journal` endpoint
- **`_ServiceClaims` dataclass**: Minimal `AgentClaims`-compatible struct for service-to-service calls (only `.sub` is accessed by knowledge_store)

## Test plan
- [x] API: 82 chat tests pass (all 677 non-docs tests pass)
- [x] Knowledge: 58 unit tests pass
- [ ] Deploy API + Knowledge services
- [ ] Send a chat message to an agent, verify a journal entry appears in the agent's Memory tab
- [ ] Send multiple messages in one day, verify they're batched under the same `journal/YYYY-MM-DD.md` entry with separate timestamps
- [ ] Verify journal entries are searchable via FTS in the Memory tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)