### PR TITLE
feat: default agents to Claude Sonnet instead of gpt-4o-mini (AI-168)

### DIFF
--- a/services/api/src/routes/agents.ts
+++ b/services/api/src/routes/agents.ts
@@ -293,7 +293,9 @@ router.post('/', requireRole('user'), async (req: Request, res: Response) => {
 
     const { rows } = await getPool().query(
       `INSERT INTO agents (agent_id, name, description, tools_config, cpus, mem_limit, pids_limit, soul_md, rules_md, model_policy_id, container_profile_id, created_by)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9,
+               COALESCE($10::uuid, (SELECT id FROM model_policies WHERE name = 'default' AND created_by IS NULL LIMIT 1)),
+               $11, $12)
        RETURNING id, agent_id, name, description, status, tools_config,
                  cpus, mem_limit, pids_limit, soul_md, rules_md, container_id,
                  model_policy_id, container_profile_id, error_message, created_at, updated_at, created_by`,

--- a/services/api/src/routes/chat.ts
+++ b/services/api/src/routes/chat.ts
@@ -38,6 +38,7 @@ const STALE_TIMEOUT_MS = 2 * 60 * 1000; // 2 minutes
 const MAX_AGENTS_PER_GROUP = 8;
 const MAX_CHAIN_HOPS = parseInt(process.env.MAX_CHAIN_HOPS || '5', 10);
 const MAX_CHAIN_DURATION_MS = parseInt(process.env.MAX_CHAIN_DURATION_MS || '60000', 10);
+const DEFAULT_CHAT_MODEL = process.env.DEFAULT_CHAT_MODEL || 'claude-sonnet-4-20250514';
 
 // ───────────────────────────────────────────────────────────────────
 // Helpers
@@ -186,7 +187,7 @@ async function dispatchToAgents(opts: {
   const placeholders: { agent: typeof opts.agents[0]; placeholderId: string; model: string }[] = [];
   for (const agent of opts.agents) {
     const models: string[] = Array.isArray(agent.models) ? agent.models : [];
-    const model = models[0] || 'gpt-4o-mini';
+    const model = models[0] || DEFAULT_CHAT_MODEL;
 
     const chainCols = opts.chainId ? ', chain_id, chain_hop, triggered_by' : '';
     const chainPlaceholders = opts.chainId ? ', $4, $5, $6' : '';


### PR DESCRIPTION
## Summary
- **Agent creation**: INSERT now uses `COALESCE($10::uuid, (SELECT id FROM model_policies WHERE name = 'default' ...))` — agents created without a model policy automatically get the platform default policy, which includes `claude-sonnet-4-20250514` as the first (primary) model
- **Chat dispatch fallback**: Changed hardcoded `gpt-4o-mini` fallback to `claude-sonnet-4-20250514`, configurable via `DEFAULT_CHAT_MODEL` env var

### Infrastructure already in place
- LiteLLM config has `claude-sonnet-4-20250514` model (anthropic provider)
- `ANTHROPIC_API_KEY` is in SOPS secrets and injected into LiteLLM
- Default model policy seeds with `["claude-sonnet-4-20250514", "gpt-4o-mini"]`
- AI service policy resolution already supports the model

Closes AI-168

## Test plan
- [x] All 231 agent + chat tests pass (8 suites)
- [x] No test changes needed — COALESCE subquery is transparent to mocked queries (returns NULL when no `model_policies` table in test DB)
- [ ] Post-deploy: create new agent without model policy, verify it gets default policy with Claude Sonnet
- [ ] Post-deploy: send chat message, verify inference uses `claude-sonnet-4-20250514`

🤖 Generated with [Claude Code](https://claude.com/claude-code)