### PR TITLE
feat: dynamic participant management — responsive panel + direct→group upgrade (AI-176)

### DIFF
--- a/services/api/src/__tests__/routes-chat.test.ts
+++ b/services/api/src/__tests__/routes-chat.test.ts
@@ -381,9 +381,11 @@ describe('Chat participant management', () => {
   it('PUT /chat/threads/:id/participants adds agent (I5)', async () => {
     mockQuery
       .mockResolvedValueOnce({ rows: [{ id: 1 }] })  // isThreadOwner
-      .mockResolvedValueOnce({ rows: ['agent-1'] })  // getThreadAgents
+      .mockResolvedValueOnce({ rows: ['agent-1'] })  // getThreadAgents (count check)
       .mockResolvedValueOnce({ rows: [] })  // elevated scope check
       .mockResolvedValueOnce({ rows: [] })  // INSERT participant
+      .mockResolvedValueOnce({ rows: [{ participant_id: 'agent-1' }, { participant_id: 'agent-2' }] })  // getThreadAgents (auto-promote)
+      .mockResolvedValueOnce({ rowCount: 1 })  // UPDATE type = 'group'
       .mockResolvedValueOnce({ rows: [  // return participants
         { participant_id: 'agent-1', participant_type: 'agent', role: 'member',
           joined_at: new Date(), left_at: null, agent_id: 'alpha', agent_name: 'Alpha', agent_status: 'running' },

--- a/services/api/src/routes/chat.ts
+++ b/services/api/src/routes/chat.ts
@@ -702,6 +702,15 @@ router.put('/threads/:id/participants', requireRole('user'), async (req: Request
           [threadId, agentUuid]
         );
       }
+
+      // Auto-promote direct → group when more than 1 agent
+      const postAddAgents = await getThreadAgents(threadId);
+      if (postAddAgents.length > 1) {
+        await pool.query(
+          `UPDATE chat_threads SET type = 'group' WHERE id = $1 AND type = 'direct'`,
+          [threadId]
+        );
+      }
     }
 
     // Process removals

--- a/services/ui/src/__tests__/ChatView.test.tsx
+++ b/services/ui/src/__tests__/ChatView.test.tsx
@@ -17,6 +17,7 @@ vi.mock('lucide-react', () => ({
   ArrowLeft: (props: any) => <span data-testid="icon-arrow-left" {...props} />,
   Send: (props: any) => <span data-testid="icon-send" {...props} />,
   Terminal: (props: any) => <span data-testid="icon-terminal" {...props} />,
+  Users: (props: any) => <span data-testid="icon-users" {...props} />,
 }))
 
 vi.mock('@/app/chat/ChatMessage', () => ({

--- a/services/ui/src/app/chat/ChatView.tsx
+++ b/services/ui/src/app/chat/ChatView.tsx
@@ -193,20 +193,18 @@ export default function ChatView({ threadId, session, thread, onBack, onThreadUp
               hasPending={hasPending}
               onCancelled={onThreadUpdated}
             />
-            {isGroup && (
-              <button
-                onClick={() => setParticipantPanelOpen(prev => !prev)}
-                className={`p-1.5 rounded transition-colors ${
-                  participantPanelOpen
-                    ? 'bg-brand-600/20 text-brand-400'
-                    : 'text-mountain-400 hover:text-gray-200 hover:bg-navy-700'
-                }`}
-                title="Manage Participants"
-                data-testid="participants-toggle"
-              >
-                <Users size={18} />
-              </button>
-            )}
+            <button
+              onClick={() => setParticipantPanelOpen(prev => !prev)}
+              className={`p-1.5 rounded transition-colors ${
+                participantPanelOpen
+                  ? 'bg-brand-600/20 text-brand-400'
+                  : 'text-mountain-400 hover:text-gray-200 hover:bg-navy-700'
+              }`}
+              title="Manage Participants"
+              data-testid="participants-toggle"
+            >
+              <Users size={18} />
+            </button>
             <button
               onClick={() => setSessionPaneOpen(prev => !prev)}
               className={`p-1.5 rounded transition-colors ${
@@ -281,16 +279,23 @@ export default function ChatView({ threadId, session, thread, onBack, onThreadUp
         </div>
       </div>
 
-      {/* Participant panel (collapsible, group threads only) */}
-      {participantPanelOpen && isGroup && (
-        <div className="hidden xl:flex w-[300px] flex-shrink-0 border-l border-navy-700 bg-navy-900">
-          <ParticipantPanel
-            threadId={threadId}
-            currentAgents={agents}
-            onUpdated={onThreadUpdated}
-            onClose={() => setParticipantPanelOpen(false)}
+      {/* Participant panel — overlay on small screens, side-panel on xl+ */}
+      {participantPanelOpen && (
+        <>
+          {/* Backdrop (below xl) */}
+          <div
+            className="fixed inset-0 bg-black/40 z-40 xl:hidden"
+            onClick={() => setParticipantPanelOpen(false)}
           />
-        </div>
+          <div className="fixed right-0 top-0 bottom-0 w-[300px] z-50 xl:relative xl:z-auto flex-shrink-0 border-l border-navy-700 bg-navy-900">
+            <ParticipantPanel
+              threadId={threadId}
+              currentAgents={agents}
+              onUpdated={onThreadUpdated}
+              onClose={() => setParticipantPanelOpen(false)}
+            />
+          </div>
+        </>
       )}
 
     </div>


### PR DESCRIPTION
## Summary
- **Fixed participant panel visibility**: Was `hidden xl:flex` — clicking the toggle on screens below 1280px showed nothing. Now uses a slide-over overlay with backdrop on small screens, side-panel on xl+
- **Exposed Users toggle on all thread types**: Previously only shown for group threads, now visible on direct threads too so users can discover the ability to add more agents
- **Auto-promote direct→group**: When adding agents to a direct thread causes the agent count to exceed 1, the API automatically updates the thread type from `direct` to `group`
- Updated test mocks for the new rendering behavior

## Test plan
- [x] UI: 612 tests pass (53 suites)
- [x] API: 82 chat tests pass (all 677 tests across 50 suites)
- [ ] Open a group thread on a laptop (< 1280px) — participant panel slides over chat with backdrop
- [ ] Open a group thread on a wide monitor (xl+) — participant panel appears as side column
- [ ] Click backdrop on small screen to close panel
- [ ] Add an agent to a direct thread — thread auto-promotes to group, Group badge appears
- [ ] Remove an agent from a group thread — agent removed, pending messages marked as error

🤖 Generated with [Claude Code](https://claude.com/claude-code)