### PR TITLE
fix: oh-my-zsh prompt rendering in xterm.js terminal (AI-180)

### DIFF
--- a/services/agentbox/Dockerfile
+++ b/services/agentbox/Dockerfile
@@ -59,8 +59,9 @@ COPY --from=akm-source /usr/local/bin/akm /usr/local/bin/akm
 RUN useradd -m -u 1000 -s /usr/bin/zsh agentuser
 
 # Install oh-my-zsh for agentuser (non-interactive)
+# Theme: bira — two-line, colorful, shows git branch, no powerline fonts needed
 RUN su - agentuser -c 'sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended' && \
-    sed -i 's/ZSH_THEME="robbyrussell"/ZSH_THEME="agnoster"/' /home/agentuser/.zshrc
+    sed -i 's/ZSH_THEME="robbyrussell"/ZSH_THEME="bira"/' /home/agentuser/.zshrc
 
 # Install Claude Code CLI (native binary) for agentuser
 # Installs to ~/.local/bin/claude with auto-updates disabled (container is ephemeral)

--- a/services/agentbox/app/ws_terminal.py
+++ b/services/agentbox/app/ws_terminal.py
@@ -101,6 +101,8 @@ async def ws_terminal_handler(websocket: WebSocket, work_token: str | None) -> N
             env = {
                 "PATH": "/home/agentuser/.local/bin:/usr/local/bin:/usr/bin:/bin",
                 "HOME": "/home/agentuser",
+                "USER": "agentuser",
+                "LOGNAME": "agentuser",
                 "LANG": "C.UTF-8",
                 "TERM": "xterm-256color",
                 "SHELL": shutil.which("zsh") or shutil.which("bash") or "/bin/bash",


### PR DESCRIPTION
## Summary
- Switched oh-my-zsh theme from `agnoster` to `bira` — agnoster requires powerline-patched fonts for its arrow glyphs (`, `), but the xterm.js font stack (JetBrains Mono, Fira Code, Cascadia Code) doesn't include them, causing boxes/tofu in the prompt
- Added `USER` and `LOGNAME` env vars to the PTY environment dict — these were missing, causing blank username in prompt segments

## Root cause
The `agnoster` theme was chosen for aesthetics but depends on powerline glyphs that aren't available in any standard web-safe monospace font. The `bira` theme provides a clean two-line prompt with colors, git branch info, and user@host — all using standard Unicode characters.

The PTY `env` dict in `ws_terminal.py` completely replaces the process environment (via `os.execvpe`), so any env vars not explicitly listed are lost. `USER`/`LOGNAME` are needed by oh-my-zsh's prompt segments.

## Test plan
- [ ] Deploy agentbox — requires image rebuild (`deploy.sh agentbox prod` or `deploy.sh api prod`)
- [ ] Open terminal observer in chat — prompt should show `agentuser@<container> ~/workspace` on two lines with colors
- [ ] Verify no tofu/boxes in prompt — all characters should render in the xterm.js font stack
- [ ] Verify 256-color support — `TERM=xterm-256color` in outer shell, tmux negotiates `screen-256color` for inner shell
- [ ] Verify git branch shows in prompt when inside a git repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)