### PR TITLE
fix: terminal WebSocket disconnects after 5 minutes (AI-191)

### DIFF
--- a/services/api/src/services/terminal-proxy.ts
+++ b/services/api/src/services/terminal-proxy.ts
@@ -13,6 +13,7 @@ import { getPool } from '../db/pool';
 
 const CONTAINER_PREFIX = 'agentbox-';
 const AGENTBOX_PORT = 8054;
+const PING_INTERVAL_MS = 30_000; // 30s keep-alive ping
 
 /**
  * Extract threadId from upgrade path: /chat/threads/:id/terminal
@@ -138,6 +139,23 @@ export function attachTerminalProxy(
           if (clientWs.readyState === WebSocket.OPEN) clientWs.close(1011, 'upstream error');
         });
 
+        // Keep-alive: ping both sides every 30s to prevent idle timeout
+        // from Traefik, load balancers, or browser network stack
+        const pingInterval = setInterval(() => {
+          if (clientWs.readyState === WebSocket.OPEN) {
+            clientWs.ping();
+          }
+          if (agentWs.readyState === WebSocket.OPEN) {
+            agentWs.ping();
+          }
+        }, PING_INTERVAL_MS);
+
+        function cleanupAll() {
+          clearInterval(pingInterval);
+          if (clientWs.readyState === WebSocket.OPEN) clientWs.close();
+          if (agentWs.readyState === WebSocket.OPEN) agentWs.close();
+        }
+
         // Relay: agentbox → client
         agentWs.on('message', (data, isBinary) => {
           if (clientWs.readyState === WebSocket.OPEN) {
@@ -153,20 +171,16 @@ export function attachTerminalProxy(
         });
 
         // Cleanup on either side close
-        agentWs.on('close', () => {
-          if (clientWs.readyState === WebSocket.OPEN) clientWs.close();
-        });
-        clientWs.on('close', () => {
-          if (agentWs.readyState === WebSocket.OPEN) agentWs.close();
-        });
+        agentWs.on('close', cleanupAll);
+        clientWs.on('close', cleanupAll);
 
         agentWs.on('error', (err) => {
           console.error(`[terminal-proxy] Agentbox WS error: ${err.message}`);
-          if (clientWs.readyState === WebSocket.OPEN) clientWs.close();
+          cleanupAll();
         });
         clientWs.on('error', (err) => {
           console.error(`[terminal-proxy] Client WS error: ${err.message}`);
-          if (agentWs.readyState === WebSocket.OPEN) agentWs.close();
+          cleanupAll();
         });
       });
 

--- a/services/ui/src/app/chat/XTerminal.tsx
+++ b/services/ui/src/app/chat/XTerminal.tsx
@@ -20,12 +20,15 @@ interface Props {
   threadId: string
 }
 
+const PING_INTERVAL_MS = 30_000 // 30s client-side keep-alive
+
 export default function XTerminal({ threadId }: Props) {
   const containerRef = useRef<HTMLDivElement>(null)
   const termRef = useRef<any>(null)
   const wsRef = useRef<WebSocket | null>(null)
   const fitRef = useRef<any>(null)
   const dataListenerRef = useRef<any>(null)
+  const pingRef = useRef<ReturnType<typeof setInterval> | null>(null)
   const reconnectRef = useRef(0)
   const maxReconnects = 5
   const { data: session } = useSession()
@@ -103,6 +106,14 @@ export default function XTerminal({ threadId }: Props) {
       if (dims) {
         ws.send(JSON.stringify({ type: 'resize', cols: dims.cols, rows: dims.rows }))
       }
+      // Start keep-alive ping to prevent idle disconnects from
+      // Traefik, reverse proxies, and browser network stacks
+      if (pingRef.current) clearInterval(pingRef.current)
+      pingRef.current = setInterval(() => {
+        if (ws.readyState === WebSocket.OPEN) {
+          ws.send(JSON.stringify({ type: 'ping' }))
+        }
+      }, PING_INTERVAL_MS)
     }
 
     ws.onmessage = (event) => {
@@ -114,6 +125,10 @@ export default function XTerminal({ threadId }: Props) {
     }
 
     ws.onclose = (event) => {
+      if (pingRef.current) {
+        clearInterval(pingRef.current)
+        pingRef.current = null
+      }
       setConnected(false)
       setControlling(false)
 
@@ -156,6 +171,10 @@ export default function XTerminal({ threadId }: Props) {
     resizeObserver.observe(containerRef.current)
 
     return () => {
+      if (pingRef.current) {
+        clearInterval(pingRef.current)
+        pingRef.current = null
+      }
       resizeObserver.disconnect()
       ws.close()
       term.dispose()


### PR DESCRIPTION
## Summary
- Add 30-second ping/pong keep-alive to the API terminal proxy (`terminal-proxy.ts`) — pings both client and agentbox WebSockets every 30s
- Add 30-second client-side ping in `XTerminal.tsx` — sends `{"type":"ping"}` JSON messages to generate traffic through Traefik
- Clean up ping intervals on close/disconnect/unmount to prevent leaks

## Root Cause
The terminal WebSocket had no keep-alive mechanism at any layer. After ~5 minutes of idle time (matching Keycloak token TTL + Traefik idle timeout), the connection was killed by intermediaries. The token was only validated at connect time and couldn't be refreshed mid-connection.

## Why This Fixes It
The 30s ping/pong prevents the connection from ever appearing idle to Traefik, load balancers, or browser network stacks. The token expiry is irrelevant once the connection is established — the proxy validates once at upgrade time, then relays indefinitely.

## Test Plan
- [ ] Open terminal, leave idle for 6+ minutes — should stay connected
- [ ] Open terminal, use Take Control, type commands — should work after 6+ minutes
- [ ] Close terminal tab — no leaked intervals (check devtools)
- [ ] Agent stops while terminal open — should disconnect cleanly (no reconnect loop)

Linear: AI-191

🤖 Generated with [Claude Code](https://claude.com/claude-code)