### PR TITLE
enhance: clear agent status indicator in chat header

### DIFF
--- a/services/ui/src/app/chat/ChatView.tsx
+++ b/services/ui/src/app/chat/ChatView.tsx
@@ -184,11 +184,17 @@ export default function ChatView({ threadId, session, thread, onBack, onThreadUp
               thread?.agent && (
                 <div className="flex items-center gap-1.5 mt-0.5">
                   <span
-                    className={`w-1.5 h-1.5 rounded-full ${
-                      thread.agent.status === 'running' ? 'bg-brand-400' : 'bg-mountain-500'
+                    className={`w-2 h-2 rounded-full flex-shrink-0 ${
+                      thread.agent.status === 'running' ? 'bg-green-400 animate-pulse' : 'bg-red-400'
                     }`}
+                    data-testid="agent-status-dot"
                   />
                   <span className="text-xs text-mountain-500">{agentName}</span>
+                  <span className={`text-[10px] font-medium ${
+                    thread.agent.status === 'running' ? 'text-green-400' : 'text-red-400'
+                  }`}>
+                    {thread.agent.status === 'running' ? 'Running' : 'Stopped'}
+                  </span>
                 </div>
               )
             )}
@@ -225,6 +231,17 @@ export default function ChatView({ threadId, session, thread, onBack, onThreadUp
             </button>
           </div>
         </div>
+
+        {/* Agent stopped warning */}
+        {!anyAgentRunning && agents.length > 0 && (
+          <div className="px-4 py-2 bg-yellow-900/20 border-b border-yellow-800/40 flex items-center gap-2" data-testid="agent-stopped-warning">
+            <span className="w-2 h-2 rounded-full bg-red-400 flex-shrink-0" />
+            <p className="text-xs text-yellow-300">
+              {isGroup ? 'All agents are stopped.' : `${agentName} is stopped.`}
+              {' '}Start the agent from the Agents page to resume chatting.
+            </p>
+          </div>
+        )}
 
         {/* Messages */}
         <div className="flex-1 overflow-y-auto px-4 py-4 space-y-3">


### PR DESCRIPTION
## Summary
- Larger status dot (w-2 h-2) with explicit **green** (running) / **red** (stopped) colors
- Green dot pulses when agent is running for visual activity cue
- Text label "Running" / "Stopped" next to agent name in header
- Yellow warning banner below header when agent is stopped: "Start the agent from the Agents page to resume chatting"
- Group threads show "All agents are stopped" when none running

## Changes
| File | What |
|------|------|
| `ChatView.tsx` | Status dot, label, warning banner (+19/-2 lines) |

## Test plan
- [x] TypeScript type-check clean
- [ ] Visual: running agent shows green pulsing dot + "Running" label
- [ ] Visual: stopped agent shows red dot + "Stopped" label + warning banner
- [ ] Visual: warning banner hidden when agent is running
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)