### PR TITLE
feat: add timestamps to chat messages

### DIFF
--- a/services/ui/src/__tests__/ChatMessage.test.tsx
+++ b/services/ui/src/__tests__/ChatMessage.test.tsx
@@ -274,6 +274,35 @@ describe('ChatMessage', () => {
     expect(screen.getByTestId('stale-message')).toHaveTextContent('Stale error (resolved)')
   })
 
+  // Timestamps
+  it('shows timestamp on complete messages', () => {
+    render(<ChatMessage message={makeMessage()} isOwnMessage={true} />)
+    expect(screen.getByTestId('message-timestamp')).toBeInTheDocument()
+  })
+
+  it('shows relative time for recent messages', () => {
+    const fiveMinAgo = new Date(Date.now() - 5 * 60_000).toISOString()
+    render(<ChatMessage message={makeMessage({ created_at: fiveMinAgo })} isOwnMessage={true} />)
+    expect(screen.getByTestId('message-timestamp')).toHaveTextContent('5m ago')
+  })
+
+  it('shows absolute date for old messages', () => {
+    render(<ChatMessage message={makeMessage({ created_at: '2026-01-15T22:30:00Z' })} isOwnMessage={false} />)
+    const ts = screen.getByTestId('message-timestamp')
+    // Should contain month and day
+    expect(ts.textContent).toMatch(/Jan\s+15/)
+  })
+
+  it('does not show timestamp on pending messages', () => {
+    render(
+      <ChatMessage
+        message={makeMessage({ status: 'pending', role: 'assistant', author_type: 'agent', content: '' })}
+        isOwnMessage={false}
+      />
+    )
+    expect(screen.queryByTestId('message-timestamp')).not.toBeInTheDocument()
+  })
+
   it('stale message does not render red error styling', () => {
     const { container } = render(
       <ChatMessage

--- a/services/ui/src/app/chat/ChatMessage.tsx
+++ b/services/ui/src/app/chat/ChatMessage.tsx
@@ -30,6 +30,27 @@ function getAgentColor(agentId: string, agents: ChatAgent[]): string {
   return AGENT_COLORS[idx >= 0 ? idx % AGENT_COLORS.length : 0]
 }
 
+function formatTimestamp(iso: string): string {
+  const date = new Date(iso)
+  const now = Date.now()
+  const diffMs = now - date.getTime()
+  const diffMin = Math.floor(diffMs / 60_000)
+
+  if (diffMin < 1) return 'just now'
+  if (diffMin < 60) return `${diffMin}m ago`
+
+  const diffHr = Math.floor(diffMin / 60)
+  if (diffHr < 24) return `${diffHr}h ago`
+
+  return date.toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true,
+  })
+}
+
 export default function ChatMessage({ message, isOwnMessage, isGroup, agents = [], triggerAgentName }: Props) {
   const isUser = message.role === 'user'
   const isPending = message.status === 'pending'
@@ -120,6 +141,13 @@ export default function ChatMessage({ message, isOwnMessage, isGroup, agents = [
             {message.input_tokens != null && message.output_tokens != null && (
               <span>{message.input_tokens + message.output_tokens} tok</span>
             )}
+          </div>
+        )}
+
+        {/* Timestamp */}
+        {!isPending && (
+          <div className={`mt-1 text-[10px] text-mountain-500 ${isUser ? 'text-right' : ''}`} data-testid="message-timestamp">
+            {formatTimestamp(message.created_at)}
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary
- Show Discord-style timestamps below each chat message bubble
- Relative time for recent messages: "just now", "2m ago", "3h ago"
- Absolute date for older messages: "Jan 15, 10:30 PM"
- Pending (thinking) messages excluded — no timestamp until complete
- User messages right-aligned, agent messages left-aligned

## Test Plan
- [x] 19 ChatMessage Vitest tests pass (15 existing + 4 new timestamp tests)
- [ ] Visual: send a message in chat — timestamp appears below bubble
- [ ] Visual: old messages show absolute date format

🤖 Generated with [Claude Code](https://claude.com/claude-code)