### PR TITLE
feat: browser automation tool via Playwright chromium (AI-177)

### DIFF
--- a/services/agentbox/Dockerfile
+++ b/services/agentbox/Dockerfile
@@ -56,6 +56,13 @@ COPY --from=builder /usr/local/lib/python3.12/site-packages /usr/local/lib/pytho
 # Copy AKM CLI binary from knowledge service image
 COPY --from=akm-source /usr/local/bin/akm /usr/local/bin/akm
 
+# Install Playwright chromium + system deps (AI-177: browser observation)
+# Runs as root — installs system libraries (libnss3, libatk, etc.) + chromium binary
+# playwright install --with-deps handles both apt packages and browser download
+RUN pip install --no-cache-dir playwright==1.52.0 && \
+    playwright install chromium --with-deps && \
+    rm -rf /var/lib/apt/lists/*
+
 # Create non-root user with zsh as default shell
 RUN useradd -m -u 1000 -s /usr/bin/zsh agentuser
 

--- a/services/agentbox/app/tools.py
+++ b/services/agentbox/app/tools.py
@@ -107,6 +107,48 @@ LIST_DIR_TOOL = {
 }
 
 
+BROWSER_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "browser",
+        "description": (
+            "Control a headless Chromium browser. "
+            "Actions: navigate (go to URL), screenshot (capture page), "
+            "click (click element by selector), get_text (extract visible text), "
+            "evaluate (run JavaScript)."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["navigate", "screenshot", "click", "get_text", "evaluate"],
+                    "description": "The browser action to perform",
+                },
+                "url": {
+                    "type": "string",
+                    "description": "URL to navigate to (for navigate)",
+                },
+                "selector": {
+                    "type": "string",
+                    "description": "CSS selector for the target element (for click, get_text)",
+                },
+                "script": {
+                    "type": "string",
+                    "description": "JavaScript to evaluate in the page (for evaluate)",
+                },
+                "full_page": {
+                    "type": "boolean",
+                    "description": "Capture full scrollable page (for screenshot, default true)",
+                    "default": True,
+                },
+            },
+            "required": ["action"],
+        },
+    },
+}
+
+
 TMUX_TOOL = {
     "type": "function",
     "function": {
@@ -165,6 +207,9 @@ def build_tool_definitions(tools_config: ToolsConfig) -> list[dict]:
     # tmux is always available when shell is enabled
     if tools_config.shell.enabled:
         definitions.append(TMUX_TOOL)
+    # browser is available when shell is enabled (chromium is pre-installed)
+    if tools_config.shell.enabled:
+        definitions.append(BROWSER_TOOL)
     return definitions
 
 
@@ -210,6 +255,9 @@ async def execute_tool_call(
 
     if name == "tmux":
         return await _execute_tmux(arguments)
+
+    if name == "browser":
+        return await _execute_browser(arguments)
 
     return json.dumps({"success": False, "error": f"Unknown tool: {name}"})
 
@@ -270,3 +318,108 @@ async def _execute_tmux(args: dict) -> str:
 
     except Exception as exc:
         return json.dumps({"success": False, "error": str(exc)[:200]})
+
+
+# ── Browser (Playwright chromium) ────────────────────────────────────
+
+# Lazy singleton — launched on first use, reused across calls within a work item
+_browser_context: object | None = None  # playwright BrowserContext
+_browser_page: object | None = None     # playwright Page
+_playwright_instance: object | None = None
+
+MAX_TEXT_LENGTH = 4000
+SCREENSHOT_DIR = "/workspace/screenshots"
+
+
+async def _get_browser_page():
+    """Get or create the singleton browser page."""
+    global _playwright_instance, _browser_context, _browser_page
+
+    if _browser_page is not None:
+        return _browser_page
+
+    import os
+    os.makedirs(SCREENSHOT_DIR, exist_ok=True)
+
+    from playwright.async_api import async_playwright
+
+    _playwright_instance = await async_playwright().start()
+    browser = await _playwright_instance.chromium.launch(
+        headless=True,
+        args=["--no-sandbox", "--disable-gpu", "--disable-dev-shm-usage"],
+    )
+    _browser_context = await browser.new_context(
+        viewport={"width": 1280, "height": 720},
+        user_agent="Hill90-Agent/1.0 (Headless Chromium)",
+    )
+    _browser_page = await _browser_context.new_page()
+    return _browser_page
+
+
+async def _execute_browser(args: dict) -> str:
+    """Execute a browser action via Playwright. Returns JSON result."""
+    action = args.get("action", "")
+
+    try:
+        page = await _get_browser_page()
+
+        if action == "navigate":
+            url = args.get("url", "")
+            if not url:
+                return json.dumps({"success": False, "error": "url is required"})
+            resp = await page.goto(url, wait_until="domcontentloaded", timeout=30000)
+            title = await page.title()
+            return json.dumps({
+                "success": True,
+                "title": title,
+                "url": page.url,
+                "status": resp.status if resp else None,
+            })
+
+        elif action == "screenshot":
+            import time
+            full_page = args.get("full_page", True)
+            filename = f"screenshot-{int(time.time())}.png"
+            path = f"{SCREENSHOT_DIR}/{filename}"
+            await page.screenshot(path=path, full_page=full_page)
+            return json.dumps({
+                "success": True,
+                "path": path,
+                "url": page.url,
+            })
+
+        elif action == "click":
+            selector = args.get("selector", "")
+            if not selector:
+                return json.dumps({"success": False, "error": "selector is required"})
+            await page.click(selector, timeout=10000)
+            await page.wait_for_load_state("domcontentloaded", timeout=10000)
+            return json.dumps({
+                "success": True,
+                "url": page.url,
+                "title": await page.title(),
+            })
+
+        elif action == "get_text":
+            selector = args.get("selector", "body")
+            element = page.locator(selector).first
+            text = await element.inner_text(timeout=10000)
+            if len(text) > MAX_TEXT_LENGTH:
+                text = text[:MAX_TEXT_LENGTH] + f"\n...(truncated, {len(text)} total chars)"
+            return json.dumps({"success": True, "text": text})
+
+        elif action == "evaluate":
+            script = args.get("script", "")
+            if not script:
+                return json.dumps({"success": False, "error": "script is required"})
+            result = await page.evaluate(script)
+            text = json.dumps(result, default=str)
+            if len(text) > MAX_TEXT_LENGTH:
+                text = text[:MAX_TEXT_LENGTH] + "...(truncated)"
+            return json.dumps({"success": True, "result": text})
+
+        else:
+            return json.dumps({"success": False, "error": f"Unknown browser action: {action}"})
+
+    except Exception as exc:
+        return json.dumps({"success": False, "error": str(exc)[:300]})

--- a/services/agentbox/poetry.lock
+++ b/services/agentbox/poetry.lock
@@ -314,6 +314,73 @@ files = [
 toml = ["tomli ; python_full_version <= \"3.11.0a6\""]
 
 [[package]]
+name = "greenlet"
+version = "3.3.2"
+description = "Lightweight in-process concurrent programming"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "greenlet-3.3.2-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:9bc885b89709d901859cf95179ec9f6bb67a3d2bb1f0e88456461bd4b7f8fd0d"},
+    {file = "greenlet-3.3.2-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b568183cf65b94919be4438dc28416b234b678c608cafac8874dfeeb2a9bbe13"},
+    {file = "greenlet-3.3.2-cp310-cp310-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:527fec58dc9f90efd594b9b700662ed3fb2493c2122067ac9c740d98080a620e"},
+    {file = "greenlet-3.3.2-cp310-cp310-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:508c7f01f1791fbc8e011bd508f6794cb95397fdb198a46cb6635eb5b78d85a7"},
+    {file = "greenlet-3.3.2-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ad0c8917dd42a819fe77e6bdfcb84e3379c0de956469301d9fd36427a1ca501f"},
+    {file = "greenlet-3.3.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:97245cc10e5515dbc8c3104b2928f7f02b6813002770cfaffaf9a6e0fc2b94ef"},
+    {file = "greenlet-3.3.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:8c1fdd7d1b309ff0da81d60a9688a8bd044ac4e18b250320a96fc68d31c209ca"},
+    {file = "greenlet-3.3.2-cp310-cp310-win_amd64.whl", hash = "sha256:5d0e35379f93a6d0222de929a25ab47b5eb35b5ef4721c2b9cbcc4036129ff1f"},
+    {file = "greenlet-3.3.2-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:c56692189a7d1c7606cb794be0a8381470d95c57ce5be03fb3d0ef57c7853b86"},
+    {file = "greenlet-3.3.2-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ebd458fa8285960f382841da585e02201b53a5ec2bac6b156fc623b5ce4499f"},
+    {file = "greenlet-3.3.2-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a443358b33c4ec7b05b79a7c8b466f5d275025e750298be7340f8fc63dff2a55"},
+    {file = "greenlet-3.3.2-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4375a58e49522698d3e70cc0b801c19433021b5c37686f7ce9c65b0d5c8677d2"},
+    {file = "greenlet-3.3.2-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8e2cd90d413acbf5e77ae41e5d3c9b3ac1d011a756d7284d7f3f2b806bbd6358"},
+    {file = "greenlet-3.3.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:442b6057453c8cb29b4fb36a2ac689382fc71112273726e2423f7f17dc73bf99"},
+    {file = "greenlet-3.3.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:45abe8eb6339518180d5a7fa47fa01945414d7cca5ecb745346fc6a87d2750be"},
+    {file = "greenlet-3.3.2-cp311-cp311-win_amd64.whl", hash = "sha256:1e692b2dae4cc7077cbb11b47d258533b48c8fde69a33d0d8a82e2fe8d8531d5"},
+    {file = "greenlet-3.3.2-cp311-cp311-win_arm64.whl", hash = "sha256:02b0a8682aecd4d3c6c18edf52bc8e51eacdd75c8eac52a790a210b06aa295fd"},
+    {file = "greenlet-3.3.2-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:ac8d61d4343b799d1e526db579833d72f23759c71e07181c2d2944e429eb09cd"},
+    {file = "greenlet-3.3.2-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ceec72030dae6ac0c8ed7591b96b70410a8be370b6a477b1dbc072856ad02bd"},
+    {file = "greenlet-3.3.2-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a2a5be83a45ce6188c045bcc44b0ee037d6a518978de9a5d97438548b953a1ac"},
+    {file = "greenlet-3.3.2-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ae9e21c84035c490506c17002f5c8ab25f980205c3e61ddb3a2a2a2e6c411fcb"},
+    {file = "greenlet-3.3.2-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:43e99d1749147ac21dde49b99c9abffcbc1e2d55c67501465ef0930d6e78e070"},
+    {file = "greenlet-3.3.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4c956a19350e2c37f2c48b336a3afb4bff120b36076d9d7fb68cb44e05d95b79"},
+    {file = "greenlet-3.3.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6c6f8ba97d17a1e7d664151284cb3315fc5f8353e75221ed4324f84eb162b395"},
+    {file = "greenlet-3.3.2-cp312-cp312-win_amd64.whl", hash = "sha256:34308836d8370bddadb41f5a7ce96879b72e2fdfb4e87729330c6ab52376409f"},
+    {file = "greenlet-3.3.2-cp312-cp312-win_arm64.whl", hash = "sha256:d3a62fa76a32b462a97198e4c9e99afb9ab375115e74e9a83ce180e7a496f643"},
+    {file = "greenlet-3.3.2-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:aa6ac98bdfd716a749b84d4034486863fd81c3abde9aa3cf8eff9127981a4ae4"},
+    {file = "greenlet-3.3.2-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ab0c7e7901a00bc0a7284907273dc165b32e0d109a6713babd04471327ff7986"},
+    {file = "greenlet-3.3.2-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d248d8c23c67d2291ffd47af766e2a3aa9fa1c6703155c099feb11f526c63a92"},
+    {file = "greenlet-3.3.2-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ccd21bb86944ca9be6d967cf7691e658e43417782bce90b5d2faeda0ff78a7dd"},
+    {file = "greenlet-3.3.2-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b6997d360a4e6a4e936c0f9625b1c20416b8a0ea18a8e19cabbefc712e7397ab"},
+    {file = "greenlet-3.3.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:64970c33a50551c7c50491671265d8954046cb6e8e2999aacdd60e439b70418a"},
+    {file = "greenlet-3.3.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1a9172f5bf6bd88e6ba5a84e0a68afeac9dc7b6b412b245dd64f52d83c81e55b"},
+    {file = "greenlet-3.3.2-cp313-cp313-win_amd64.whl", hash = "sha256:a7945dd0eab63ded0a48e4dcade82939783c172290a7903ebde9e184333ca124"},
+    {file = "greenlet-3.3.2-cp313-cp313-win_arm64.whl", hash = "sha256:394ead29063ee3515b4e775216cb756b2e3b4a7e55ae8fd884f17fa579e6b327"},
+    {file = "greenlet-3.3.2-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:8d1658d7291f9859beed69a776c10822a0a799bc4bfe1bd4272bb60e62507dab"},
+    {file = "greenlet-3.3.2-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:18cb1b7337bca281915b3c5d5ae19f4e76d35e1df80f4ad3c1a7be91fadf1082"},
+    {file = "greenlet-3.3.2-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c2e47408e8ce1c6f1ceea0dffcdf6ebb85cc09e55c7af407c99f1112016e45e9"},
+    {file = "greenlet-3.3.2-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e3cb43ce200f59483eb82949bf1835a99cf43d7571e900d7c8d5c62cdf25d2f9"},
+    {file = "greenlet-3.3.2-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:63d10328839d1973e5ba35e98cccbca71b232b14051fd957b6f8b6e8e80d0506"},
+    {file = "greenlet-3.3.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8e4ab3cfb02993c8cc248ea73d7dae6cec0253e9afa311c9b37e603ca9fad2ce"},
+    {file = "greenlet-3.3.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:94ad81f0fd3c0c0681a018a976e5c2bd2ca2d9d94895f23e7bb1af4e8af4e2d5"},
+    {file = "greenlet-3.3.2-cp314-cp314-win_amd64.whl", hash = "sha256:8c4dd0f3997cf2512f7601563cc90dfb8957c0cff1e3a1b23991d4ea1776c492"},
+    {file = "greenlet-3.3.2-cp314-cp314-win_arm64.whl", hash = "sha256:cd6f9e2bbd46321ba3bbb4c8a15794d32960e3b0ae2cc4d49a1a53d314805d71"},
+    {file = "greenlet-3.3.2-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:e26e72bec7ab387ac80caa7496e0f908ff954f31065b0ffc1f8ecb1338b11b54"},
+    {file = "greenlet-3.3.2-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8b466dff7a4ffda6ca975979bab80bdadde979e29fc947ac3be4451428d8b0e4"},
+    {file = "greenlet-3.3.2-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b8bddc5b73c9720bea487b3bffdb1840fe4e3656fba3bd40aa1489e9f37877ff"},
+    {file = "greenlet-3.3.2-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:59b3e2c40f6706b05a9cd299c836c6aa2378cabe25d021acd80f13abf81181cf"},
+    {file = "greenlet-3.3.2-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b26b0f4428b871a751968285a1ac9648944cea09807177ac639b030bddebcea4"},
+    {file = "greenlet-3.3.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:1fb39a11ee2e4d94be9a76671482be9398560955c9e568550de0224e41104727"},
+    {file = "greenlet-3.3.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:20154044d9085151bc309e7689d6f7ba10027f8f5a8c0676ad398b951913d89e"},
+    {file = "greenlet-3.3.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c04c5e06ec3e022cbfe2cd4a846e1d4e50087444f875ff6d2c2ad8445495cf1a"},
+    {file = "greenlet-3.3.2.tar.gz", hash = "sha256:2eaf067fc6d886931c7962e8c6bede15d2f01965560f3359b27c80bde2d151f2"},
+]
+
+[package.extras]
+docs = ["Sphinx", "furo"]
+test = ["objgraph", "psutil", "setuptools"]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
@@ -410,6 +477,28 @@ files = [
     {file = "packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529"},
     {file = "packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4"},
 ]
+
+[[package]]
+name = "playwright"
+version = "1.58.0"
+description = "A high-level API to automate web browsers"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "playwright-1.58.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:96e3204aac292ee639edbfdef6298b4be2ea0a55a16b7068df91adac077cc606"},
+    {file = "playwright-1.58.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:70c763694739d28df71ed578b9c8202bb83e8fe8fb9268c04dd13afe36301f71"},
+    {file = "playwright-1.58.0-py3-none-macosx_11_0_universal2.whl", hash = "sha256:185e0132578733d02802dfddfbbc35f42be23a45ff49ccae5081f25952238117"},
+    {file = "playwright-1.58.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:c95568ba1eda83812598c1dc9be60b4406dffd60b149bc1536180ad108723d6b"},
+    {file = "playwright-1.58.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8f9999948f1ab541d98812de25e3a8c410776aa516d948807140aff797b4bffa"},
+    {file = "playwright-1.58.0-py3-none-win32.whl", hash = "sha256:1e03be090e75a0fabbdaeab65ce17c308c425d879fa48bb1d7986f96bfad0b99"},
+    {file = "playwright-1.58.0-py3-none-win_amd64.whl", hash = "sha256:a2bf639d0ce33b3ba38de777e08697b0d8f3dc07ab6802e4ac53fb65e3907af8"},
+    {file = "playwright-1.58.0-py3-none-win_arm64.whl", hash = "sha256:32ffe5c303901a13a0ecab91d1c3f74baf73b84f4bedbb6b935f5bc11cc98e1b"},
+]
+
+[package.dependencies]
+greenlet = ">=3.1.1,<4.0.0"
+pyee = ">=13,<14"
 
 [[package]]
 name = "pluggy"
@@ -582,6 +671,24 @@ files = [
 
 [package.dependencies]
 typing-extensions = ">=4.14.1"
+
+[[package]]
+name = "pyee"
+version = "13.0.1"
+description = "A rough port of Node.js's EventEmitter to Python with a few tricks of its own"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "pyee-13.0.1-py3-none-any.whl", hash = "sha256:af2f8fede4171ef667dfded53f96e2ed0d6e6bd7ee3bb46437f77e3b57689228"},
+    {file = "pyee-13.0.1.tar.gz", hash = "sha256:0b931f7c14535667ed4c7e0d531716368715e860b988770fc7eb8578d1f67fc8"},
+]
+
+[package.dependencies]
+typing-extensions = "*"
+
+[package.extras]
+dev = ["black", "build", "flake8", "flake8-black", "isort", "jupyter-console", "mkdocs", "mkdocs-include-markdown-plugin", "mkdocstrings[python]", "mypy", "pytest", "pytest-asyncio ; python_version >= \"3.4\"", "pytest-trio ; python_version >= \"3.7\"", "sphinx", "toml", "tox", "trio", "trio ; python_version > \"3.6\"", "trio-typing ; python_version > \"3.6\"", "twine", "twisted", "validate-pyproject[all]"]
 
 [[package]]
 name = "pytest"
@@ -932,4 +1039,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "078bcc8e9c1e3501a2cff848d7c00b90810d44a2016d0910960abe257dc5bd6d"
+content-hash = "0210f99ba2ceacd2dc3558b047d7ae1346dedf186ae61ea787c76b91362a3feb"

--- a/services/agentbox/pyproject.toml
+++ b/services/agentbox/pyproject.toml
@@ -13,6 +13,7 @@ pydantic = "^2.5.0"
 pyyaml = "^6.0"
 requests = "^2.31.0"
 websockets = ">=12.0"
+playwright = "^1.52"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/services/agentbox/tests/test_tools.py
+++ b/services/agentbox/tests/test_tools.py
@@ -45,9 +45,10 @@ class TestBuildToolDefinitions:
         )
         defs = build_tool_definitions(config)
         names = [d["function"]["name"] for d in defs]
-        assert len(names) == 5
+        assert len(names) == 6
         assert "execute_command" in names
         assert "read_file" in names
+        assert "browser" in names
         assert "write_file" in names
         assert "list_directory" in names
         assert "tmux" in names

--- a/services/api/src/db/migrations/046_seed_browser_tool_and_skill.sql
+++ b/services/api/src/db/migrations/046_seed_browser_tool_and_skill.sql
@@ -1,0 +1,41 @@
+-- Register Playwright chromium as a platform tool and Browser as a skill (AI-177).
+-- Chromium is pre-installed in the agentbox image via `playwright install chromium --with-deps`.
+-- The tool definition (BROWSER_TOOL) is in agentbox/app/tools.py.
+
+-- 1. Seed playwright as a platform tool (builtin — pre-installed in image)
+INSERT INTO tools (name, description, install_method, install_ref, is_platform)
+VALUES ('playwright', 'Headless Chromium browser automation via Playwright', 'builtin', '', true)
+ON CONFLICT (name) DO NOTHING;
+
+-- 2. Seed the Browser skill
+INSERT INTO skills (name, description, tools_config, instructions_md, scope, is_platform)
+VALUES (
+  'Browser',
+  'Headless browser automation — navigate pages, take screenshots, click elements, extract text.',
+  '{"shell":{"enabled":true,"allowed_binaries":["bash"],"denied_patterns":["rm -rf /"],"max_timeout":60},"filesystem":{"enabled":true,"read_only":false,"allowed_paths":["/workspace"],"denied_paths":["/etc/shadow","/etc/passwd","/root"]},"health":{"enabled":true}}',
+  E'Automate a headless Chromium browser.\n- navigate: go to a URL and get page title/status\n- screenshot: capture the page to /workspace/screenshots/\n- click: click an element by CSS selector\n- get_text: extract visible text from a selector (default: body)\n- evaluate: run JavaScript in the page context\n\nScreenshots are saved to /workspace/screenshots/ with timestamp filenames.',
+  'container_local',
+  true
+)
+ON CONFLICT (name) DO UPDATE SET
+  description = EXCLUDED.description,
+  tools_config = EXCLUDED.tools_config,
+  instructions_md = EXCLUDED.instructions_md,
+  scope = EXCLUDED.scope,
+  is_platform = true;
+
+-- 3. Wire skill_tools mappings
+DELETE FROM skill_tools st
+USING skills s
+WHERE st.skill_id = s.id
+  AND s.name = 'Browser'
+  AND s.is_platform = true;
+
+INSERT INTO skill_tools (skill_id, tool_id)
+SELECT s.id, t.id
+FROM (VALUES
+  ('Browser', 'playwright'), ('Browser', 'bash')
+) AS mappings(skill_name, tool_name)
+JOIN skills s ON s.name = mappings.skill_name
+JOIN tools t ON t.name = mappings.tool_name
+ON CONFLICT DO NOTHING;


### PR DESCRIPTION
## Summary
- Adds headless Chromium browser automation to agentbox containers via Playwright
- 5 actions: **navigate** (go to URL), **screenshot** (capture page to file), **click** (CSS selector), **get_text** (extract visible text), **evaluate** (run JS)
- Lazy singleton browser context (launched on first use, 1280x720 viewport)
- Screenshots saved to `/workspace/screenshots/` with timestamp filenames
- Text output truncated to 4000 chars to avoid context bloat

## Changes (4 files, 202 lines)
- **Dockerfile**: `playwright install chromium --with-deps` (installs browser + system libs, ~250 MB)
- **pyproject.toml**: `playwright = "^1.52"`
- **tools.py**: `BROWSER_TOOL` definition + `_execute_browser()` async handler
- **Migration 046**: seeds `playwright` tool (builtin) + `Browser` skill (container_local) in DB

## Design decisions
- **Chromium only** (not Firefox/WebKit) to minimize image size
- **`--no-sandbox`** flag since the container itself is the sandbox (agent_sandbox network)
- **Singleton page** — one page at a time, simple mental model for the LLM
- **Builtin install method** — Playwright and Chromium are baked into the Docker image, no runtime download
- **Plan**: written to `/tmp/browser-observation-plan.md`

## Test plan
- [x] All 50 API test suites pass (migration syntax valid)
- [x] Python syntax check passes on tools.py
- [ ] Rebuild agentbox image: `docker build --no-cache` on VPS
- [ ] Assign Browser skill to an agent
- [ ] Chat: "Navigate to https://example.com and take a screenshot"
- [ ] Verify screenshot saved to `/workspace/screenshots/`
- [ ] Chat: "Get the heading text from the page" → returns "Example Domain"
- [ ] Chat: "Click the 'More information...' link" → navigates to IANA page

🤖 Generated with [Claude Code](https://claude.com/claude-code)