### PR TITLE
fix: pin SOPS to v3.9.4 and verify binary download

### DIFF
--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -39,10 +39,18 @@ jobs:
           chmod 600 ~/.ssh/vps_key
 
       - name: Setup SOPS/age for secrets
+        env:
+          SOPS_VERSION: "3.9.4"
         run: |
-          curl -L -o /tmp/sops https://github.com/getsops/sops/releases/download/v3.8.1/sops-v3.8.1.linux.amd64
+          SOPS_URL="https://github.com/getsops/sops/releases/download/v${SOPS_VERSION}/sops-v${SOPS_VERSION}.linux.amd64"
+          curl -fsSL -o /tmp/sops "$SOPS_URL"
+          if file /tmp/sops | grep -q "HTML"; then
+            echo "::error::SOPS download returned HTML instead of binary — check URL: $SOPS_URL"
+            exit 1
+          fi
           chmod +x /tmp/sops
           sudo mv /tmp/sops /usr/local/bin/sops
+          sops --version
 
           mkdir -p ~/.config/sops/age
           echo "${{ secrets.SOPS_AGE_KEY }}" > ~/.config/sops/age/keys.txt

--- a/.github/workflows/reusable-deploy-service.yml
+++ b/.github/workflows/reusable-deploy-service.yml
@@ -34,10 +34,19 @@ jobs:
           chmod 600 ~/.ssh/vps_key
 
       - name: Setup SOPS/age for secrets
+        env:
+          SOPS_VERSION: "3.9.4"
         run: |
-          curl -L -o /tmp/sops https://github.com/getsops/sops/releases/download/v3.8.1/sops-v3.8.1.linux.amd64
+          SOPS_URL="https://github.com/getsops/sops/releases/download/v${SOPS_VERSION}/sops-v${SOPS_VERSION}.linux.amd64"
+          curl -fsSL -o /tmp/sops "$SOPS_URL"
+          # Verify we got a binary, not an HTML error page
+          if file /tmp/sops | grep -q "HTML"; then
+            echo "::error::SOPS download returned HTML instead of binary — check URL: $SOPS_URL"
+            exit 1
+          fi
           chmod +x /tmp/sops
           sudo mv /tmp/sops /usr/local/bin/sops
+          sops --version
 
           mkdir -p ~/.config/sops/age
           echo "${{ secrets.SOPS_AGE_KEY }}" > ~/.config/sops/age/keys.txt

--- a/.github/workflows/vault-sync-to-sops.yml
+++ b/.github/workflows/vault-sync-to-sops.yml
@@ -38,10 +38,18 @@ jobs:
           chmod 600 ~/.ssh/vps_key
 
       - name: Setup SOPS/age for secrets
+        env:
+          SOPS_VERSION: "3.9.4"
         run: |
-          curl -L -o /tmp/sops https://github.com/getsops/sops/releases/download/v3.8.1/sops-v3.8.1.linux.amd64
+          SOPS_URL="https://github.com/getsops/sops/releases/download/v${SOPS_VERSION}/sops-v${SOPS_VERSION}.linux.amd64"
+          curl -fsSL -o /tmp/sops "$SOPS_URL"
+          if file /tmp/sops | grep -q "HTML"; then
+            echo "::error::SOPS download returned HTML instead of binary — check URL: $SOPS_URL"
+            exit 1
+          fi
           chmod +x /tmp/sops
           sudo mv /tmp/sops /usr/local/bin/sops
+          sops --version
 
           mkdir -p ~/.config/sops/age
           echo "${{ secrets.SOPS_AGE_KEY }}" > ~/.config/sops/age/keys.txt


### PR DESCRIPTION
## Summary
- Pin SOPS from v3.8.1 to **v3.9.4** across all three workflows that install it
- Use `curl -fsSL` (fail fast on HTTP errors) instead of `curl -L`
- Add binary verification guard: if `file` detects HTML, the step fails with a clear error
- Print `sops --version` after install for CI log confirmation
- Version is set via `SOPS_VERSION` env var for single-point updates

## Root cause
The SOPS v3.8.1 download URL was returning an HTML page instead of the binary, causing deploy workflows to fail when trying to execute an HTML file as SOPS.

## Files changed
| File | Change |
|------|--------|
| `reusable-deploy-service.yml` | v3.8.1 → v3.9.4, add verification |
| `deploy-infra.yml` | v3.8.1 → v3.9.4, add verification |
| `vault-sync-to-sops.yml` | v3.8.1 → v3.9.4, add verification |

## Test plan
- [ ] Trigger a deploy workflow and confirm SOPS installs correctly
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)