### PR TITLE
fix: close overflow gap in chat viewport containment

### DIFF
--- a/services/ui/src/components/AppShell.tsx
+++ b/services/ui/src/components/AppShell.tsx
@@ -19,7 +19,7 @@ export default function AppShell({
         <Sidebar />
 
         {/* Main content + footer */}
-        <div className={`flex flex-col flex-1 min-w-0 ${noFooter ? 'min-h-0' : ''}`}>
+        <div className={`flex flex-col flex-1 min-w-0 ${noFooter ? 'min-h-0 overflow-hidden' : ''}`}>
           {children}
 
           {!noFooter && (


### PR DESCRIPTION
## Summary
Add `overflow-hidden` to AppShell's content wrapper div when in `noFooter` (chat) mode.

## Root cause
PR #347 added `h-screen` + `min-h-0` to the flex chain but missed `overflow-hidden` on the content wrapper. Without it, children can still expand the wrapper beyond its flex allocation, allowing page-level scroll.

## The fix (1 line)
```diff
- <div className={`flex flex-col flex-1 min-w-0 ${noFooter ? 'min-h-0' : ''}`}>
+ <div className={`flex flex-col flex-1 min-w-0 ${noFooter ? 'min-h-0 overflow-hidden' : ''}`}>
```

## Containment chain (noFooter=true)
```
div.h-screen.overflow-hidden          ← viewport locked
  TopBar                               ← intrinsic height
  div.flex-1.overflow-hidden.min-h-0   ← clips, shrinks
    Sidebar
    div.flex-1.min-h-0.overflow-hidden ← THIS FIX — clips children
      ChatLayout div.h-full            ← fills exactly
        ThreadList (overflow-y-auto)   ← internal scroll
        ChatView
          Messages (overflow-y-auto)   ← internal scroll
```

## Test plan
- [x] AppShell tests: 3/3 pass
- [x] TypeScript clean
- [ ] Non-chat pages unaffected (`min-h-screen` path unchanged)
- [ ] Chat page: no page scroll, messages scroll internally

🤖 Generated with [Claude Code](https://claude.com/claude-code)