### PR TITLE
feat: notification dropdown panel in TopBar

### DIFF
--- a/services/ui/src/__tests__/TopBar.test.tsx
+++ b/services/ui/src/__tests__/TopBar.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, screen, cleanup } from '@testing-library/react'
+import { render, screen, cleanup, fireEvent } from '@testing-library/react'
 import '@testing-library/jest-dom/vitest'
 
 // Mock next-auth/react
@@ -83,5 +83,73 @@ describe('TopBar', () => {
     render(<TopBar />)
 
     expect(screen.queryByRole('button', { name: /open menu/i })).not.toBeInTheDocument()
+  })
+})
+
+describe('TopBar — Notification dropdown', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSession = {
+      data: { user: { name: 'Jon', roles: ['admin', 'user'] } },
+      status: 'authenticated',
+    }
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('shows notification bell when authenticated', () => {
+    render(<TopBar />)
+    expect(screen.getByTestId('notifications-bell')).toBeInTheDocument()
+  })
+
+  it('shows unread badge count', () => {
+    render(<TopBar />)
+    // Mock data has 3 unread notifications
+    expect(screen.getByText('3')).toBeInTheDocument()
+  })
+
+  it('opens dropdown on bell click', () => {
+    render(<TopBar />)
+    fireEvent.click(screen.getByTestId('notifications-bell'))
+    expect(screen.getByTestId('notifications-dropdown')).toBeInTheDocument()
+    expect(screen.getByText('Notifications')).toBeInTheDocument()
+  })
+
+  it('shows notification items', () => {
+    render(<TopBar />)
+    fireEvent.click(screen.getByTestId('notifications-bell'))
+    const items = screen.getAllByTestId('notification-item')
+    expect(items.length).toBe(5)
+  })
+
+  it('shows agent names on notifications', () => {
+    render(<TopBar />)
+    fireEvent.click(screen.getByTestId('notifications-bell'))
+    expect(screen.getAllByText('ResearchBot').length).toBeGreaterThanOrEqual(1)
+    expect(screen.getAllByText('CodeAssistant').length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('shows mark all read button when unread exist', () => {
+    render(<TopBar />)
+    fireEvent.click(screen.getByTestId('notifications-bell'))
+    expect(screen.getByTestId('mark-all-read')).toBeInTheDocument()
+  })
+
+  it('mark all read clears unread badge', () => {
+    render(<TopBar />)
+    fireEvent.click(screen.getByTestId('notifications-bell'))
+    fireEvent.click(screen.getByTestId('mark-all-read'))
+    // Badge should be gone (0 unread)
+    expect(screen.queryByText('3')).not.toBeInTheDocument()
+  })
+
+  it('closes dropdown on second bell click', () => {
+    render(<TopBar />)
+    fireEvent.click(screen.getByTestId('notifications-bell'))
+    expect(screen.getByTestId('notifications-dropdown')).toBeInTheDocument()
+    fireEvent.click(screen.getByTestId('notifications-bell'))
+    expect(screen.queryByTestId('notifications-dropdown')).not.toBeInTheDocument()
   })
 })

--- a/services/ui/src/components/TopBar.tsx
+++ b/services/ui/src/components/TopBar.tsx
@@ -1,12 +1,91 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useRef, useEffect, useCallback } from 'react'
 import Link from 'next/link'
 import { useSession } from 'next-auth/react'
-import { Menu, Bell } from 'lucide-react'
+import { Menu, Bell, Bot, CheckCircle, AlertCircle, Play } from 'lucide-react'
 import HillLogo from '@/components/HillLogo'
 import AuthButtons from '@/components/AuthButtons'
 import MobileDrawer from '@/components/MobileDrawer'
+
+interface Notification {
+  id: string
+  type: 'success' | 'error' | 'info'
+  title: string
+  message: string
+  agentName: string
+  timestamp: string
+  read: boolean
+}
+
+const MOCK_NOTIFICATIONS: Notification[] = [
+  {
+    id: 'n1',
+    type: 'success',
+    title: 'Task completed',
+    message: 'Finished analyzing repository structure',
+    agentName: 'ResearchBot',
+    timestamp: new Date(Date.now() - 3 * 60_000).toISOString(),
+    read: false,
+  },
+  {
+    id: 'n2',
+    type: 'info',
+    title: 'Agent started',
+    message: 'Container provisioned and running',
+    agentName: 'CodeAssistant',
+    timestamp: new Date(Date.now() - 12 * 60_000).toISOString(),
+    read: false,
+  },
+  {
+    id: 'n3',
+    type: 'error',
+    title: 'Inference error',
+    message: 'Provider returned 429 — rate limit exceeded',
+    agentName: 'WriterBot',
+    timestamp: new Date(Date.now() - 45 * 60_000).toISOString(),
+    read: false,
+  },
+  {
+    id: 'n4',
+    type: 'success',
+    title: 'Agent stopped',
+    message: 'Graceful shutdown complete',
+    agentName: 'ResearchBot',
+    timestamp: new Date(Date.now() - 2 * 3600_000).toISOString(),
+    read: true,
+  },
+  {
+    id: 'n5',
+    type: 'info',
+    title: 'New chat message',
+    message: 'Responded to your question about auth flow',
+    agentName: 'CodeAssistant',
+    timestamp: new Date(Date.now() - 5 * 3600_000).toISOString(),
+    read: true,
+  },
+]
+
+function formatRelative(iso: string): string {
+  const diffMs = Date.now() - new Date(iso).getTime()
+  const min = Math.floor(diffMs / 60_000)
+  if (min < 1) return 'just now'
+  if (min < 60) return `${min}m ago`
+  const hr = Math.floor(min / 60)
+  if (hr < 24) return `${hr}h ago`
+  return `${Math.floor(hr / 24)}d ago`
+}
+
+function NotificationIcon({ type }: { type: Notification['type'] }) {
+  switch (type) {
+    case 'success':
+      return <CheckCircle size={16} className="text-brand-400 flex-shrink-0" />
+    case 'error':
+      return <AlertCircle size={16} className="text-red-400 flex-shrink-0" />
+    case 'info':
+      return <Play size={16} className="text-blue-400 flex-shrink-0" />
+  }
+}
 
 interface TopBarProps {
   navExtra?: React.ReactNode
@@ -14,7 +93,39 @@ interface TopBarProps {
 
 export default function TopBar({ navExtra }: TopBarProps) {
   const [mobileOpen, setMobileOpen] = useState(false)
+  const [notifOpen, setNotifOpen] = useState(false)
+  const [notifications, setNotifications] = useState(MOCK_NOTIFICATIONS)
+  const notifRef = useRef<HTMLDivElement>(null)
   const { data: session } = useSession()
+
+  const unreadCount = notifications.filter(n => !n.read).length
+
+  const closeNotif = useCallback(() => setNotifOpen(false), [])
+
+  useEffect(() => {
+    if (!notifOpen) return
+
+    function handleMouseDown(e: MouseEvent) {
+      if (notifRef.current && !notifRef.current.contains(e.target as Node)) {
+        closeNotif()
+      }
+    }
+
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') closeNotif()
+    }
+
+    document.addEventListener('mousedown', handleMouseDown)
+    document.addEventListener('keydown', handleKeyDown)
+    return () => {
+      document.removeEventListener('mousedown', handleMouseDown)
+      document.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [notifOpen, closeNotif])
+
+  const markAllRead = () => {
+    setNotifications(prev => prev.map(n => ({ ...n, read: true })))
+  }
 
   return (
     <>
@@ -45,16 +156,77 @@ export default function TopBar({ navExtra }: TopBarProps) {
         {/* Right: notifications + auth */}
         <div className="flex items-center gap-3">
           {session && (
-            <button
-              className="relative p-1.5 text-mountain-400 hover:text-white transition-colors rounded-md hover:bg-navy-700"
-              aria-label="Notifications"
-              data-testid="notifications-bell"
-            >
-              <Bell size={20} />
-              <span className="absolute -top-0.5 -right-0.5 w-4 h-4 text-[10px] font-bold leading-4 text-center text-white bg-red-500 rounded-full">
-                3
-              </span>
-            </button>
+            <div className="relative" ref={notifRef}>
+              <button
+                onClick={() => setNotifOpen(prev => !prev)}
+                className="relative p-1.5 text-mountain-400 hover:text-white transition-colors rounded-md hover:bg-navy-700"
+                aria-label="Notifications"
+                aria-haspopup="true"
+                aria-expanded={notifOpen}
+                data-testid="notifications-bell"
+              >
+                <Bell size={20} />
+                {unreadCount > 0 && (
+                  <span className="absolute -top-0.5 -right-0.5 w-4 h-4 text-[10px] font-bold leading-4 text-center text-white bg-red-500 rounded-full">
+                    {unreadCount}
+                  </span>
+                )}
+              </button>
+
+              {notifOpen && (
+                <div
+                  className="absolute right-0 top-full mt-2 z-50 bg-navy-800 border border-navy-700 rounded-lg shadow-lg w-80 max-h-96 overflow-hidden flex flex-col"
+                  data-testid="notifications-dropdown"
+                >
+                  <div className="flex items-center justify-between px-4 py-2.5 border-b border-navy-700">
+                    <h3 className="text-sm font-semibold text-white">Notifications</h3>
+                    {unreadCount > 0 && (
+                      <button
+                        onClick={markAllRead}
+                        className="text-xs text-brand-400 hover:text-brand-300 transition-colors"
+                        data-testid="mark-all-read"
+                      >
+                        Mark all read
+                      </button>
+                    )}
+                  </div>
+
+                  <div className="overflow-y-auto flex-1">
+                    {notifications.map(n => (
+                      <div
+                        key={n.id}
+                        className={`px-4 py-3 border-b border-navy-700/50 hover:bg-navy-700/30 transition-colors ${
+                          !n.read ? 'bg-navy-700/10' : ''
+                        }`}
+                        data-testid="notification-item"
+                      >
+                        <div className="flex items-start gap-2.5">
+                          <NotificationIcon type={n.type} />
+                          <div className="min-w-0 flex-1">
+                            <div className="flex items-center justify-between gap-2">
+                              <p className={`text-sm font-medium truncate ${!n.read ? 'text-white' : 'text-mountain-400'}`}>
+                                {n.title}
+                              </p>
+                              <span className="text-[10px] text-mountain-500 flex-shrink-0">
+                                {formatRelative(n.timestamp)}
+                              </span>
+                            </div>
+                            <p className="text-xs text-mountain-500 truncate mt-0.5">{n.message}</p>
+                            <div className="flex items-center gap-1 mt-1">
+                              <Bot size={10} className="text-mountain-500" />
+                              <span className="text-[10px] text-mountain-500">{n.agentName}</span>
+                            </div>
+                          </div>
+                          {!n.read && (
+                            <span className="w-2 h-2 rounded-full bg-brand-500 flex-shrink-0 mt-1.5" />
+                          )}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </div>
           )}
           <AuthButtons />
         </div>


### PR DESCRIPTION
## Summary
- Click notification bell to open dropdown panel styled like user menu
- 5 mock notifications with type icons: success (CheckCircle), error (AlertCircle), info (Play)
- Each item shows: title, message, agent name (with Bot icon), relative timestamp, unread dot
- Dynamic unread badge count on bell icon (disappears when all read)
- "Mark all read" button clears unread state
- Closes on outside click, Escape, or second bell click
- 8 new Vitest tests (13 total for TopBar)

## Test Plan
- [x] 13 TopBar tests pass (5 existing + 8 new notification tests)
- [ ] Visual: click bell — dropdown opens with notifications
- [ ] Visual: click "Mark all read" — badge disappears
- [ ] Visual: click outside — dropdown closes

🤖 Generated with [Claude Code](https://claude.com/claude-code)