### PR TITLE
feat: add file attachment button to chat input

### DIFF
--- a/services/ui/src/__tests__/ChatView.test.tsx
+++ b/services/ui/src/__tests__/ChatView.test.tsx
@@ -18,6 +18,7 @@ vi.mock('lucide-react', () => ({
   Send: (props: any) => <span data-testid="icon-send" {...props} />,
   Terminal: (props: any) => <span data-testid="icon-terminal" {...props} />,
   Users: (props: any) => <span data-testid="icon-users" {...props} />,
+  Paperclip: (props: any) => <span data-testid="icon-paperclip" {...props} />,
 }))
 
 vi.mock('@/app/chat/ChatMessage', () => ({
@@ -153,5 +154,18 @@ describe('ChatView', () => {
     render(<ChatView {...defaultProps} />)
     expect(MockEventSource.instances.length).toBe(1)
     expect(MockEventSource.instances[0].url).toBe('/api/chat/thread-1/stream')
+  })
+
+  it('renders attach file button', () => {
+    render(<ChatView {...defaultProps} />)
+    expect(screen.getByTestId('attach-file-button')).toBeInTheDocument()
+    expect(screen.getByTestId('icon-paperclip')).toBeInTheDocument()
+  })
+
+  it('shows file upload toast when attach button clicked', () => {
+    render(<ChatView {...defaultProps} />)
+    fireEvent.click(screen.getByTestId('attach-file-button'))
+    expect(screen.getByTestId('file-toast')).toBeInTheDocument()
+    expect(screen.getByText('File upload coming soon')).toBeInTheDocument()
   })
 })

--- a/services/ui/src/app/chat/ChatView.tsx
+++ b/services/ui/src/app/chat/ChatView.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useRef, useCallback } from 'react'
 import { useRouter } from 'next/navigation'
-import { ArrowLeft, Send, Terminal, Users } from 'lucide-react'
+import { ArrowLeft, Send, Terminal, Users, Paperclip } from 'lucide-react'
 import type { Session } from 'next-auth'
 import type { ChatThread } from './ChatLayout'
 import ChatMessage from './ChatMessage'
@@ -46,6 +46,7 @@ export default function ChatView({ threadId, session, thread, onBack, onThreadUp
   const [input, setInput] = useState('')
   const [sending, setSending] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [fileToast, setFileToast] = useState(false)
   const [sessionPaneOpen, setSessionPaneOpen] = useState(false)
   const [participantPanelOpen, setParticipantPanelOpen] = useState(false)
   const messagesEndRef = useRef<HTMLDivElement>(null)
@@ -280,9 +281,27 @@ export default function ChatView({ threadId, session, thread, onBack, onThreadUp
           </div>
         )}
 
+        {/* File upload toast */}
+        {fileToast && (
+          <div className="px-4 py-2 bg-navy-800 border-t border-navy-700" data-testid="file-toast">
+            <p className="text-sm text-mountain-400">File upload coming soon</p>
+          </div>
+        )}
+
         {/* Input */}
         <div className="px-4 py-3 border-t border-navy-700 bg-navy-900/50">
           <div className="flex gap-2 items-end">
+            <button
+              onClick={() => {
+                setFileToast(true)
+                setTimeout(() => setFileToast(false), 3000)
+              }}
+              className="p-2 text-mountain-400 hover:text-white hover:bg-navy-700 rounded-lg transition-colors flex-shrink-0"
+              aria-label="Attach file"
+              data-testid="attach-file-button"
+            >
+              <Paperclip size={18} />
+            </button>
             <MentionInput
               agents={agents}
               value={input}


### PR DESCRIPTION
## Summary
- Add Paperclip icon button to the left of the message input in ChatView
- Clicking shows "File upload coming soon" toast that auto-dismisses after 3s
- Button styled to match input area (mountain-400 text, navy-700 hover bg)
- 2 new Vitest tests (7 total for ChatView)

## Test Plan
- [x] 7 ChatView tests pass (5 existing + 2 new)
- [ ] Visual: Paperclip button visible next to message input
- [ ] Visual: click Paperclip — toast appears and dismisses after 3s

🤖 Generated with [Claude Code](https://claude.com/claude-code)