### PR TITLE
feat: storage API routes for MinIO bucket operations

### DIFF
--- a/docs/site/openapi.yaml
+++ b/docs/site/openapi.yaml
@@ -4122,3 +4122,100 @@ paths:
           description: Not authenticated
         "403":
           description: Requires admin role
+
+  # ── Storage (MinIO) ──────────────────────────────────────────────
+
+  /storage/buckets:
+    get:
+      summary: List MinIO buckets
+      tags: [Storage]
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Array of buckets
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    created_at:
+                      type: string
+                      nullable: true
+        "401":
+          description: Not authenticated
+        "403":
+          description: Requires admin role
+        "502":
+          description: Storage service unavailable
+
+  /storage/buckets/{name}/objects:
+    get:
+      summary: List objects in a bucket
+      tags: [Storage]
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: name
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: prefix
+          in: query
+          schema:
+            type: string
+        - name: max_keys
+          in: query
+          schema:
+            type: integer
+            default: 100
+        - name: continuation_token
+          in: query
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Objects and common prefixes
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  objects:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          type: string
+                        size:
+                          type: integer
+                        last_modified:
+                          type: string
+                          nullable: true
+                        etag:
+                          type: string
+                  prefixes:
+                    type: array
+                    items:
+                      type: string
+                  is_truncated:
+                    type: boolean
+                  next_continuation_token:
+                    type: string
+                    nullable: true
+                  key_count:
+                    type: integer
+        "401":
+          description: Not authenticated
+        "403":
+          description: Requires admin role
+        "404":
+          description: Bucket not found
+        "502":
+          description: Storage service unavailable

--- a/services/api/src/__tests__/docs.test.ts
+++ b/services/api/src/__tests__/docs.test.ts
@@ -196,6 +196,8 @@ const EXPECTED_PATHS = [
   '/tasks',
   '/tasks/{id}',
   '/tasks/{id}/transition',
+  '/storage/buckets',
+  '/storage/buckets/{name}/objects',
   '/admin/secrets',
   '/admin/secrets/status',
 ];

--- a/services/api/src/__tests__/routes-storage.test.ts
+++ b/services/api/src/__tests__/routes-storage.test.ts
@@ -1,0 +1,142 @@
+import request from 'supertest';
+import * as crypto from 'crypto';
+import * as jwt from 'jsonwebtoken';
+import { createApp } from '../app';
+
+const { privateKey, publicKey } = crypto.generateKeyPairSync('rsa', {
+  modulusLength: 2048,
+  publicKeyEncoding: { type: 'spki', format: 'pem' },
+  privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+});
+
+const TEST_ISSUER = 'https://auth.hill90.com/realms/hill90';
+
+const mockQuery = jest.fn();
+jest.mock('../db/pool', () => ({
+  getPool: () => ({ query: mockQuery }),
+}));
+
+const mockS3Send = jest.fn();
+jest.mock('../services/s3', () => ({
+  getS3Client: () => ({ send: mockS3Send }),
+}));
+
+function makeToken(sub: string, roles: string[]): string {
+  return jwt.sign(
+    { sub, realm_roles: roles },
+    privateKey,
+    { algorithm: 'RS256', issuer: TEST_ISSUER, expiresIn: '1h' }
+  );
+}
+
+const adminToken = makeToken('admin-user', ['admin', 'user']);
+const userToken = makeToken('regular-user', ['user']);
+
+const app = createApp({
+  issuer: TEST_ISSUER,
+  getSigningKey: async () => publicKey,
+});
+
+describe('Storage routes', () => {
+  beforeEach(() => {
+    mockS3Send.mockReset();
+  });
+
+  it('GET /storage/buckets requires admin role', async () => {
+    const res = await request(app)
+      .get('/storage/buckets')
+      .set('Authorization', `Bearer ${userToken}`);
+    expect(res.status).toBe(403);
+  });
+
+  it('GET /storage/buckets lists buckets', async () => {
+    mockS3Send.mockResolvedValueOnce({
+      Buckets: [
+        { Name: 'user-avatars', CreationDate: new Date('2026-01-01T00:00:00Z') },
+        { Name: 'agent-data', CreationDate: new Date('2026-02-01T00:00:00Z') },
+      ],
+    });
+
+    const res = await request(app)
+      .get('/storage/buckets')
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(2);
+    expect(res.body[0].name).toBe('user-avatars');
+    expect(res.body[1].name).toBe('agent-data');
+    expect(res.body[0].created_at).toBe('2026-01-01T00:00:00.000Z');
+  });
+
+  it('GET /storage/buckets returns 502 on S3 error', async () => {
+    mockS3Send.mockRejectedValueOnce(new Error('Connection refused'));
+
+    const res = await request(app)
+      .get('/storage/buckets')
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(res.status).toBe(502);
+    expect(res.body.error).toContain('storage service');
+  });
+
+  it('GET /storage/buckets/:name/objects requires admin role', async () => {
+    const res = await request(app)
+      .get('/storage/buckets/test-bucket/objects')
+      .set('Authorization', `Bearer ${userToken}`);
+    expect(res.status).toBe(403);
+  });
+
+  it('GET /storage/buckets/:name/objects lists objects', async () => {
+    mockS3Send.mockResolvedValueOnce({
+      Contents: [
+        { Key: 'file1.txt', Size: 1234, LastModified: new Date('2026-03-01'), ETag: '"abc"' },
+      ],
+      CommonPrefixes: [{ Prefix: 'subdir/' }],
+      IsTruncated: false,
+      KeyCount: 1,
+    });
+
+    const res = await request(app)
+      .get('/storage/buckets/my-bucket/objects')
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.objects).toHaveLength(1);
+    expect(res.body.objects[0].key).toBe('file1.txt');
+    expect(res.body.objects[0].size).toBe(1234);
+    expect(res.body.prefixes).toEqual(['subdir/']);
+    expect(res.body.is_truncated).toBe(false);
+  });
+
+  it('GET /storage/buckets/:name/objects supports prefix query', async () => {
+    mockS3Send.mockResolvedValueOnce({
+      Contents: [],
+      CommonPrefixes: [],
+      IsTruncated: false,
+      KeyCount: 0,
+    });
+
+    const res = await request(app)
+      .get('/storage/buckets/my-bucket/objects?prefix=logs/')
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(res.status).toBe(200);
+    // Verify the S3 command received the prefix
+    const sendCall = mockS3Send.mock.calls[0][0];
+    expect(sendCall.input.Prefix).toBe('logs/');
+    expect(sendCall.input.Delimiter).toBe('/');
+  });
+
+  it('GET /storage/buckets/:name/objects returns 404 for missing bucket', async () => {
+    const err: any = new Error('NoSuchBucket');
+    err.name = 'NoSuchBucket';
+    mockS3Send.mockRejectedValueOnce(err);
+
+    const res = await request(app)
+      .get('/storage/buckets/nonexistent/objects')
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toContain('nonexistent');
+  });
+});

--- a/services/api/src/app.ts
+++ b/services/api/src/app.ts
@@ -20,6 +20,7 @@ import secretsRouter from './routes/secrets';
 import { delegationTokenHandler } from './services/model-router-delegation';
 import chatRouter, { chatCallbackHandler, startStaleSweeper } from './routes/chat';
 import tasksRouter from './routes/tasks';
+import storageRouter from './routes/storage';
 import { modelRouterRefreshHandler } from './services/model-router-refresh';
 
 interface AppOptions {
@@ -97,6 +98,9 @@ export function createApp(opts: AppOptions = {}): Application {
 
   // User profile routes
   app.use('/profile', requireAuth, profileRouter);
+
+  // Storage routes (admin-only, MinIO bucket operations)
+  app.use('/storage', requireAuth, storageRouter);
 
   // Secrets vault inventory (admin-only, AI-147)
   app.use('/admin/secrets', requireAuth, requireRole('admin'), secretsRouter);

--- a/services/api/src/openapi/openapi.yaml
+++ b/services/api/src/openapi/openapi.yaml
@@ -4122,3 +4122,100 @@ paths:
           description: Not authenticated
         "403":
           description: Requires admin role
+
+  # ── Storage (MinIO) ──────────────────────────────────────────────
+
+  /storage/buckets:
+    get:
+      summary: List MinIO buckets
+      tags: [Storage]
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Array of buckets
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    created_at:
+                      type: string
+                      nullable: true
+        "401":
+          description: Not authenticated
+        "403":
+          description: Requires admin role
+        "502":
+          description: Storage service unavailable
+
+  /storage/buckets/{name}/objects:
+    get:
+      summary: List objects in a bucket
+      tags: [Storage]
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: name
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: prefix
+          in: query
+          schema:
+            type: string
+        - name: max_keys
+          in: query
+          schema:
+            type: integer
+            default: 100
+        - name: continuation_token
+          in: query
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Objects and common prefixes
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  objects:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          type: string
+                        size:
+                          type: integer
+                        last_modified:
+                          type: string
+                          nullable: true
+                        etag:
+                          type: string
+                  prefixes:
+                    type: array
+                    items:
+                      type: string
+                  is_truncated:
+                    type: boolean
+                  next_continuation_token:
+                    type: string
+                    nullable: true
+                  key_count:
+                    type: integer
+        "401":
+          description: Not authenticated
+        "403":
+          description: Requires admin role
+        "404":
+          description: Bucket not found
+        "502":
+          description: Storage service unavailable

--- a/services/api/src/routes/storage.ts
+++ b/services/api/src/routes/storage.ts
@@ -1,0 +1,75 @@
+import { Router, Request, Response } from 'express';
+import {
+  ListBucketsCommand,
+  ListObjectsV2Command,
+} from '@aws-sdk/client-s3';
+import { getS3Client } from '../services/s3';
+import { requireRole } from '../middleware/role';
+
+const router = Router();
+
+// All storage routes require admin role
+router.use(requireRole('admin'));
+
+// GET /storage/buckets — list all MinIO buckets
+router.get('/buckets', async (_req: Request, res: Response) => {
+  try {
+    const s3 = getS3Client();
+    const result = await s3.send(new ListBucketsCommand({}));
+
+    const buckets = (result.Buckets || []).map((b) => ({
+      name: b.Name,
+      created_at: b.CreationDate?.toISOString() || null,
+    }));
+
+    res.json(buckets);
+  } catch (err: any) {
+    console.error('[storage] Failed to list buckets:', err);
+    res.status(502).json({ error: 'Failed to connect to storage service' });
+  }
+});
+
+// GET /storage/buckets/:name/objects — list objects in a bucket
+router.get('/buckets/:name/objects', async (req: Request, res: Response) => {
+  const { name } = req.params;
+  const prefix = (req.query.prefix as string) || '';
+  const maxKeys = Math.min(parseInt(req.query.max_keys as string) || 100, 1000);
+  const continuationToken = (req.query.continuation_token as string) || undefined;
+
+  try {
+    const s3 = getS3Client();
+    const result = await s3.send(new ListObjectsV2Command({
+      Bucket: name,
+      Prefix: prefix || undefined,
+      Delimiter: '/',
+      MaxKeys: maxKeys,
+      ContinuationToken: continuationToken,
+    }));
+
+    const objects = (result.Contents || []).map((obj) => ({
+      key: obj.Key,
+      size: obj.Size,
+      last_modified: obj.LastModified?.toISOString() || null,
+      etag: obj.ETag,
+    }));
+
+    const prefixes = (result.CommonPrefixes || []).map((p) => p.Prefix);
+
+    res.json({
+      objects,
+      prefixes,
+      is_truncated: result.IsTruncated || false,
+      next_continuation_token: result.NextContinuationToken || null,
+      key_count: result.KeyCount || 0,
+    });
+  } catch (err: any) {
+    if (err.name === 'NoSuchBucket' || err.$metadata?.httpStatusCode === 404) {
+      res.status(404).json({ error: `Bucket '${name}' not found` });
+      return;
+    }
+    console.error(`[storage] Failed to list objects in ${name}:`, err);
+    res.status(502).json({ error: 'Failed to list objects from storage service' });
+  }
+});
+
+export default router;


### PR DESCRIPTION
## Summary
- **`GET /storage/buckets`** — lists all MinIO buckets (name + creation date)
- **`GET /storage/buckets/:name/objects`** — lists objects in a bucket with:
  - `prefix` query param for directory-like navigation
  - `delimiter=/` for folder grouping (returns `prefixes` array)
  - `max_keys` (default 100, max 1000) and `continuation_token` for pagination
- Admin-only (enforced via `requireRole('admin')`)
- Uses existing `getS3Client()` from `services/s3.ts` — no new dependencies
- OpenAPI spec updated with both endpoints

## Test plan
- [x] 7 tests in `routes-storage.test.ts`
  - [x] Admin role required (2 tests)
  - [x] List buckets success + S3 error → 502
  - [x] List objects success + prefix query + bucket not found → 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)