### PR TITLE
feat: add storage management page for MinIO buckets (AI-216)

### DIFF
--- a/services/ui/src/app/api/storage/[...path]/route.ts
+++ b/services/ui/src/app/api/storage/[...path]/route.ts
@@ -1,0 +1,10 @@
+import { NextRequest } from 'next/server'
+import { proxyToApi } from '@/utils/api-proxy'
+
+async function proxyRequest(req: NextRequest, { params }: { params: Promise<{ path: string[] }> }) {
+  const { path } = await params
+  const pathStr = path.join('/')
+  return proxyToApi(req, `/storage/${pathStr}`, { label: 'storage-proxy' })
+}
+
+export const GET = proxyRequest

--- a/services/ui/src/app/harness/storage/StorageClient.tsx
+++ b/services/ui/src/app/harness/storage/StorageClient.tsx
@@ -1,48 +1,363 @@
 'use client'
 
-import React from 'react'
-import { HardDrive } from 'lucide-react'
+import { useState, useEffect, useCallback } from 'react'
+import { HardDrive, FolderOpen, File, ChevronRight, ArrowLeft, RefreshCw } from 'lucide-react'
 
-const BUCKETS = [
-  { name: 'agent-avatars', description: 'Agent profile images', status: 'active' },
-  { name: 'agent-artifacts', description: 'Build outputs and agent-generated files', status: 'active' },
-  { name: 'backups', description: 'Automated database and config backups', status: 'active' },
-]
+interface Bucket {
+  name: string
+  created_at: string
+}
+
+interface StorageObject {
+  key: string
+  size: number
+  last_modified: string
+  etag: string
+}
+
+interface ObjectsResponse {
+  objects: StorageObject[]
+  prefixes: string[]
+  is_truncated: boolean
+  next_continuation_token: string | null
+  key_count: number
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes === 0) return '0 B'
+  const units = ['B', 'KB', 'MB', 'GB', 'TB']
+  const i = Math.floor(Math.log(bytes) / Math.log(1024))
+  const value = bytes / Math.pow(1024, i)
+  return `${value.toFixed(i === 0 ? 0 : 1)} ${units[i]}`
+}
+
+function formatDate(dateStr: string): string {
+  const date = new Date(dateStr)
+  return date.toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
 
 export default function StorageClient() {
+  const [buckets, setBuckets] = useState<Bucket[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  // Object browser state
+  const [activeBucket, setActiveBucket] = useState<string | null>(null)
+  const [prefix, setPrefix] = useState('')
+  const [objects, setObjects] = useState<StorageObject[]>([])
+  const [prefixes, setPrefixes] = useState<string[]>([])
+  const [objectsLoading, setObjectsLoading] = useState(false)
+  const [objectsError, setObjectsError] = useState<string | null>(null)
+
+  const fetchBuckets = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const res = await fetch('/api/storage/buckets')
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}))
+        throw new Error(data.error || `Failed to fetch buckets (${res.status})`)
+      }
+      setBuckets(await res.json())
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to fetch buckets')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  const fetchObjects = useCallback(async (bucketName: string, objectPrefix: string) => {
+    setObjectsLoading(true)
+    setObjectsError(null)
+    try {
+      const params = new URLSearchParams()
+      if (objectPrefix) params.set('prefix', objectPrefix)
+      params.set('delimiter', '/')
+      const url = `/api/storage/buckets/${bucketName}/objects${params.toString() ? `?${params}` : ''}`
+      const res = await fetch(url)
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}))
+        throw new Error(data.error || `Failed to fetch objects (${res.status})`)
+      }
+      const data: ObjectsResponse = await res.json()
+      setObjects(data.objects)
+      setPrefixes(data.prefixes)
+    } catch (err) {
+      setObjectsError(err instanceof Error ? err.message : 'Failed to fetch objects')
+    } finally {
+      setObjectsLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    fetchBuckets()
+  }, [fetchBuckets])
+
+  useEffect(() => {
+    if (activeBucket) {
+      fetchObjects(activeBucket, prefix)
+    }
+  }, [activeBucket, prefix, fetchObjects])
+
+  const openBucket = (name: string) => {
+    setActiveBucket(name)
+    setPrefix('')
+    setObjects([])
+    setPrefixes([])
+  }
+
+  const navigateToPrefix = (newPrefix: string) => {
+    setPrefix(newPrefix)
+  }
+
+  const navigateUp = () => {
+    // Remove last path segment: "a/b/c/" -> "a/b/"
+    const parts = prefix.replace(/\/$/, '').split('/')
+    parts.pop()
+    setPrefix(parts.length > 0 ? parts.join('/') + '/' : '')
+  }
+
+  const backToBuckets = () => {
+    setActiveBucket(null)
+    setPrefix('')
+    setObjects([])
+    setPrefixes([])
+    setObjectsError(null)
+  }
+
+  // Build breadcrumb segments from prefix
+  const breadcrumbs = prefix
+    ? prefix
+        .replace(/\/$/, '')
+        .split('/')
+        .map((segment, i, arr) => ({
+          label: segment,
+          prefix: arr.slice(0, i + 1).join('/') + '/',
+        }))
+    : []
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-24">
+        <div className="h-8 w-8 rounded-full border-2 border-brand-500 border-t-transparent animate-spin" />
+      </div>
+    )
+  }
+
+  // Object browser view
+  if (activeBucket) {
+    return (
+      <div>
+        {/* Header */}
+        <div className="flex items-center gap-3 mb-6">
+          <button
+            onClick={backToBuckets}
+            className="p-1.5 rounded-md text-mountain-400 hover:text-white hover:bg-navy-700 transition-colors cursor-pointer"
+            title="Back to buckets"
+          >
+            <ArrowLeft className="h-5 w-5" />
+          </button>
+          <HardDrive className="h-6 w-6 text-brand-400" />
+          <h1 className="text-2xl font-bold text-white">{activeBucket}</h1>
+          <button
+            onClick={() => fetchObjects(activeBucket, prefix)}
+            className="ml-auto p-1.5 rounded-md text-mountain-400 hover:text-white hover:bg-navy-700 transition-colors cursor-pointer"
+            title="Refresh"
+          >
+            <RefreshCw className="h-4 w-4" />
+          </button>
+        </div>
+
+        {/* Breadcrumbs */}
+        <nav className="flex items-center gap-1 text-sm mb-4 text-mountain-400 flex-wrap">
+          <button
+            onClick={() => setPrefix('')}
+            className="hover:text-white transition-colors cursor-pointer"
+          >
+            {activeBucket}
+          </button>
+          {breadcrumbs.map((crumb, i) => (
+            <span key={crumb.prefix} className="flex items-center gap-1">
+              <ChevronRight className="h-3 w-3" />
+              {i === breadcrumbs.length - 1 ? (
+                <span className="text-white">{crumb.label}</span>
+              ) : (
+                <button
+                  onClick={() => navigateToPrefix(crumb.prefix)}
+                  className="hover:text-white transition-colors cursor-pointer"
+                >
+                  {crumb.label}
+                </button>
+              )}
+            </span>
+          ))}
+        </nav>
+
+        {/* Error state */}
+        {objectsError && (
+          <div className="rounded-lg border border-red-700 bg-red-900/20 p-4 mb-4">
+            <p className="text-sm text-red-400">{objectsError}</p>
+          </div>
+        )}
+
+        {/* Loading */}
+        {objectsLoading ? (
+          <div className="flex items-center justify-center py-16">
+            <div className="h-6 w-6 rounded-full border-2 border-brand-500 border-t-transparent animate-spin" />
+          </div>
+        ) : prefixes.length === 0 && objects.length === 0 && !objectsError ? (
+          /* Empty state */
+          <div className="rounded-lg border border-navy-700 bg-navy-800 p-12 text-center">
+            <FolderOpen className="h-10 w-10 text-mountain-500 mx-auto mb-3" />
+            <p className="text-mountain-400">
+              {prefix ? 'This folder is empty' : 'This bucket is empty'}
+            </p>
+          </div>
+        ) : (
+          /* Objects table */
+          <div className="rounded-lg border border-navy-700 bg-navy-800 overflow-hidden">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-navy-700 text-left text-mountain-400">
+                  <th className="px-4 py-3 font-medium">Name</th>
+                  <th className="px-4 py-3 font-medium w-28 text-right">Size</th>
+                  <th className="px-4 py-3 font-medium w-48 text-right">Last Modified</th>
+                </tr>
+              </thead>
+              <tbody>
+                {/* Navigate up row */}
+                {prefix && (
+                  <tr
+                    className="border-b border-navy-700/50 hover:bg-navy-700/30 cursor-pointer transition-colors"
+                    onClick={navigateUp}
+                  >
+                    <td className="px-4 py-2.5" colSpan={3}>
+                      <span className="flex items-center gap-2 text-mountain-400 hover:text-white">
+                        <FolderOpen className="h-4 w-4 text-mountain-500" />
+                        ..
+                      </span>
+                    </td>
+                  </tr>
+                )}
+
+                {/* Folders (prefixes) */}
+                {prefixes.map((p) => {
+                  const folderName = p.replace(prefix, '').replace(/\/$/, '')
+                  return (
+                    <tr
+                      key={p}
+                      className="border-b border-navy-700/50 hover:bg-navy-700/30 cursor-pointer transition-colors"
+                      onClick={() => navigateToPrefix(p)}
+                    >
+                      <td className="px-4 py-2.5">
+                        <span className="flex items-center gap-2 text-white">
+                          <FolderOpen className="h-4 w-4 text-brand-400" />
+                          {folderName}/
+                        </span>
+                      </td>
+                      <td className="px-4 py-2.5 text-right text-mountain-500">--</td>
+                      <td className="px-4 py-2.5 text-right text-mountain-500">--</td>
+                    </tr>
+                  )
+                })}
+
+                {/* Files (objects) */}
+                {objects.map((obj) => {
+                  const fileName = obj.key.replace(prefix, '')
+                  return (
+                    <tr
+                      key={obj.key}
+                      className="border-b border-navy-700/50 hover:bg-navy-700/30 transition-colors"
+                    >
+                      <td className="px-4 py-2.5">
+                        <span className="flex items-center gap-2 text-white">
+                          <File className="h-4 w-4 text-mountain-400" />
+                          {fileName}
+                        </span>
+                      </td>
+                      <td className="px-4 py-2.5 text-right text-mountain-400">
+                        {formatBytes(obj.size)}
+                      </td>
+                      <td className="px-4 py-2.5 text-right text-mountain-400">
+                        {formatDate(obj.last_modified)}
+                      </td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    )
+  }
+
+  // Bucket list view
   return (
     <div>
-      <div className="flex items-center gap-3 mb-6">
-        <HardDrive className="h-6 w-6 text-brand-400" />
-        <h1 className="text-2xl font-bold text-white">Storage</h1>
-      </div>
-
-      <p className="text-sm text-mountain-400 mb-6">
-        MinIO object storage buckets used by the platform.
-      </p>
-
-      <div className="space-y-3">
-        {BUCKETS.map(bucket => (
-          <div
-            key={bucket.name}
-            className="rounded-lg border border-navy-700 bg-navy-800 p-4 flex items-center justify-between"
-          >
-            <div>
-              <h3 className="text-sm font-medium text-white">{bucket.name}</h3>
-              <p className="text-xs text-mountain-400 mt-0.5">{bucket.description}</p>
-            </div>
-            <span className="px-2 py-0.5 text-xs rounded-md border bg-brand-900/50 text-brand-400 border-brand-700">
-              {bucket.status}
-            </span>
+      <div className="flex items-center justify-between mb-6">
+        <div className="flex items-center gap-3">
+          <HardDrive className="h-6 w-6 text-brand-400" />
+          <div>
+            <h1 className="text-2xl font-bold text-white">Storage</h1>
+            <p className="text-sm text-mountain-400 mt-0.5">
+              {buckets.length} bucket{buckets.length !== 1 ? 's' : ''}
+            </p>
           </div>
-        ))}
+        </div>
+        <button
+          onClick={fetchBuckets}
+          className="p-2 rounded-md text-mountain-400 hover:text-white hover:bg-navy-700 transition-colors cursor-pointer"
+          title="Refresh"
+        >
+          <RefreshCw className="h-4 w-4" />
+        </button>
       </div>
 
-      <div className="mt-8 rounded-lg border border-navy-700 bg-navy-800/50 p-6 text-center">
-        <p className="text-sm text-mountain-500">
-          Bucket browsing, upload, and usage metrics coming soon.
-        </p>
-      </div>
+      {error && (
+        <div className="rounded-lg border border-red-700 bg-red-900/20 p-4 mb-4">
+          <p className="text-sm text-red-400">{error}</p>
+        </div>
+      )}
+
+      {buckets.length === 0 && !error ? (
+        <div className="rounded-lg border border-navy-700 bg-navy-800 p-12 text-center">
+          <HardDrive className="h-10 w-10 text-mountain-500 mx-auto mb-3" />
+          <p className="text-mountain-400">No buckets found</p>
+          <p className="text-xs text-mountain-500 mt-1">
+            MinIO buckets will appear here once created.
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {buckets.map((bucket) => (
+            <button
+              key={bucket.name}
+              onClick={() => openBucket(bucket.name)}
+              className="w-full text-left rounded-lg border border-navy-700 bg-navy-800 p-4 flex items-center justify-between hover:border-navy-600 hover:bg-navy-750 transition-colors cursor-pointer group"
+            >
+              <div className="flex items-center gap-3">
+                <FolderOpen className="h-5 w-5 text-brand-400" />
+                <div>
+                  <h3 className="text-sm font-medium text-white group-hover:text-brand-400 transition-colors">
+                    {bucket.name}
+                  </h3>
+                  <p className="text-xs text-mountain-500 mt-0.5">
+                    Created {formatDate(bucket.created_at)}
+                  </p>
+                </div>
+              </div>
+              <ChevronRight className="h-4 w-4 text-mountain-500 group-hover:text-mountain-400 transition-colors" />
+            </button>
+          ))}
+        </div>
+      )}
     </div>
   )
 }

--- a/services/ui/src/app/harness/storage/page.tsx
+++ b/services/ui/src/app/harness/storage/page.tsx
@@ -20,6 +20,23 @@ export default function StoragePage() {
     redirect('/api/auth/signin')
   }
 
+  const isAdmin = (session.user as any)?.roles?.includes('admin')
+
+  if (!isAdmin) {
+    return (
+      <AppShell>
+        <main className="flex-1 px-6 py-12 max-w-6xl mx-auto w-full">
+          <div className="rounded-lg border border-red-700 bg-red-900/20 p-12 text-center">
+            <p className="text-red-400 font-medium">Access denied</p>
+            <p className="text-sm text-mountain-400 mt-2">
+              You need admin privileges to view storage management.
+            </p>
+          </div>
+        </main>
+      </AppShell>
+    )
+  }
+
   return (
     <AppShell>
       <main className="flex-1 px-6 py-12 max-w-6xl mx-auto w-full">


### PR DESCRIPTION
## Summary
- Replaces placeholder storage page with a full MinIO bucket browser at `/harness/storage`
- Adds admin-only access check with "Access denied" message for non-admin users
- Bucket list view fetches from `GET /api/storage/buckets` with name and creation date
- Object browser with prefix-based folder navigation, breadcrumbs, human-readable file sizes, and last modified dates
- Empty states for no buckets and empty buckets/folders
- Adds `GET`-only API proxy route at `/api/storage/[...path]` using existing `proxyToApi` pattern

## Test plan
- [ ] Verify `/harness/storage` loads for admin users and shows bucket list
- [ ] Verify non-admin users see "Access denied" message
- [ ] Click a bucket to open object browser, verify objects and folders render
- [ ] Navigate into a folder via click, verify breadcrumbs update
- [ ] Navigate up via ".." row and breadcrumb links
- [ ] Verify empty bucket shows "This bucket is empty" state
- [ ] Verify human-readable file sizes (B, KB, MB, GB)
- [ ] Verify refresh button re-fetches data
- [ ] Verify error state renders when API is unavailable

🤖 Generated with [Claude Code](https://claude.com/claude-code)