### PR TITLE
feat: add Workflows placeholder page (AI-230)

### DIFF
--- a/services/ui/src/app/harness/workflows/page.tsx
+++ b/services/ui/src/app/harness/workflows/page.tsx
@@ -1,0 +1,50 @@
+'use client'
+
+import { useSession } from 'next-auth/react'
+import { redirect } from 'next/navigation'
+import { Zap } from 'lucide-react'
+import AppShell from '@/components/AppShell'
+
+export default function WorkflowsPage() {
+  const { data: session, status } = useSession()
+
+  if (status === 'loading') {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-navy-900">
+        <div className="h-8 w-8 rounded-full border-2 border-brand-500 border-t-transparent animate-spin" />
+      </div>
+    )
+  }
+
+  if (!session) {
+    redirect('/api/auth/signin')
+  }
+
+  return (
+    <AppShell>
+      <main className="flex-1 px-6 py-12 max-w-6xl mx-auto w-full">
+        <div className="mb-8">
+          <div className="flex items-center gap-3 mb-2">
+            <h1 className="text-2xl font-bold text-white">Workflows</h1>
+            <span className="text-xs font-medium px-2 py-0.5 rounded-full bg-brand-500/20 text-brand-400 border border-brand-500/30">
+              Coming soon
+            </span>
+          </div>
+          <p className="text-mountain-400">
+            Define event-triggered agent workflows to automate multi-step tasks across your platform.
+          </p>
+        </div>
+
+        <div className="rounded-lg border border-navy-700 bg-navy-800 p-12 flex flex-col items-center justify-center text-center">
+          <div className="mb-4 rounded-full bg-navy-700 p-4">
+            <Zap className="h-8 w-8 text-mountain-400" />
+          </div>
+          <h2 className="text-lg font-semibold text-white mb-2">No workflows configured</h2>
+          <p className="text-mountain-400 max-w-md">
+            Workflows will let you chain agent actions with event triggers, schedules, and conditional logic.
+          </p>
+        </div>
+      </main>
+    </AppShell>
+  )
+}

--- a/services/ui/src/components/nav-items.ts
+++ b/services/ui/src/components/nav-items.ts
@@ -1,4 +1,4 @@
-import { Home, LayoutDashboard, Bot, FileText, Book, ExternalLink, KeyRound, Cpu, BarChart3, BookOpen, Library, Wrench, Layers, Settings, Server, MessageSquare, Package, CheckSquare, Shield, HardDrive, Activity } from 'lucide-react'
+import { Home, LayoutDashboard, Bot, FileText, Book, ExternalLink, KeyRound, Cpu, BarChart3, BookOpen, Library, Wrench, Layers, Settings, Server, MessageSquare, Package, CheckSquare, Shield, HardDrive, Activity, Zap } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
 
 export interface NavLink {
@@ -43,6 +43,7 @@ export const NAV_ITEMS: NavItem[] = [
       { type: 'link', id: 'library', label: 'Library', href: '/harness/shared-knowledge', icon: Library },
       { type: 'link', id: 'storage', label: 'Storage', href: '/harness/storage', icon: HardDrive },
       { type: 'link', id: 'monitoring', label: 'Monitoring', href: '/harness/monitoring', icon: Activity },
+      { type: 'link', id: 'workflows', label: 'Workflows', href: '/harness/workflows', icon: Zap },
       { type: 'link', id: 'secrets', label: 'Secrets', href: '/harness/secrets', icon: Shield, adminOnly: true },
     ],
   },


### PR DESCRIPTION
## Summary
- Adds "Workflows" nav item (Zap icon) to the Harness group in `nav-items.ts`
- Creates placeholder page at `/harness/workflows` with empty state card, coming-soon badge, and descriptive subtitle
- Follows existing harness page patterns (client component, session guard, AppShell wrapper, navy/mountain/brand tokens)

## Test plan
- [ ] Navigate to `/harness/workflows` — page renders with title, subtitle, and empty state card
- [ ] Sidebar shows "Workflows" under Harness group with Zap icon
- [ ] "Coming soon" badge is visible next to the page title
- [ ] Unauthenticated users are redirected to sign-in

🤖 Generated with [Claude Code](https://claude.com/claude-code)