### PR TITLE
feat: add autonomy level setting to agent config (AI-227)

### DIFF
--- a/docs/site/openapi.yaml
+++ b/docs/site/openapi.yaml
@@ -88,6 +88,11 @@ components:
           type: string
         rules_md:
           type: string
+        autonomy_level:
+          type: string
+          enum: [ask_before_acting, act_within_scope, full_autonomy]
+          default: act_within_scope
+          description: Controls how much freedom the agent has when executing commands.
         status:
           type: string
           enum: [stopped, running, error]
@@ -1045,6 +1050,10 @@ paths:
                   format: uuid
                   nullable: true
                   description: Container profile to assign. Determines Docker image. Omit for default.
+                autonomy_level:
+                  type: string
+                  enum: [ask_before_acting, act_within_scope, full_autonomy]
+                  description: Controls agent autonomy. Defaults to act_within_scope.
       responses:
         "201":
           description: Agent created
@@ -1138,6 +1147,10 @@ paths:
                   format: uuid
                   nullable: true
                   description: Container profile to assign. Omit for no change; explicit null to clear.
+                autonomy_level:
+                  type: string
+                  enum: [ask_before_acting, act_within_scope, full_autonomy]
+                  description: Controls agent autonomy. Omit for no change.
       responses:
         "200":
           description: Agent updated

--- a/services/api/src/db/migrations/047_add_autonomy_level.sql
+++ b/services/api/src/db/migrations/047_add_autonomy_level.sql
@@ -1,0 +1,6 @@
+-- Add autonomy_level column to agents table (AI-227).
+-- Valid values: 'ask_before_acting', 'act_within_scope', 'full_autonomy'.
+-- Default: 'act_within_scope' — agent acts freely within its skill/tool permissions.
+
+ALTER TABLE agents
+  ADD COLUMN IF NOT EXISTS autonomy_level VARCHAR(32) NOT NULL DEFAULT 'act_within_scope';

--- a/services/api/src/openapi/openapi.yaml
+++ b/services/api/src/openapi/openapi.yaml
@@ -88,6 +88,11 @@ components:
           type: string
         rules_md:
           type: string
+        autonomy_level:
+          type: string
+          enum: [ask_before_acting, act_within_scope, full_autonomy]
+          default: act_within_scope
+          description: Controls how much freedom the agent has when executing commands.
         status:
           type: string
           enum: [stopped, running, error]
@@ -1045,6 +1050,10 @@ paths:
                   format: uuid
                   nullable: true
                   description: Container profile to assign. Determines Docker image. Omit for default.
+                autonomy_level:
+                  type: string
+                  enum: [ask_before_acting, act_within_scope, full_autonomy]
+                  description: Controls agent autonomy. Defaults to act_within_scope.
       responses:
         "201":
           description: Agent created
@@ -1138,6 +1147,10 @@ paths:
                   format: uuid
                   nullable: true
                   description: Container profile to assign. Omit for no change; explicit null to clear.
+                autonomy_level:
+                  type: string
+                  enum: [ask_before_acting, act_within_scope, full_autonomy]
+                  description: Controls agent autonomy. Omit for no change.
       responses:
         "200":
           description: Agent updated

--- a/services/api/src/routes/agents.ts
+++ b/services/api/src/routes/agents.ts
@@ -141,7 +141,7 @@ router.get('/', requireRole('user'), async (req: Request, res: Response) => {
     const scope = scopeToOwner(req);
     const { rows } = await getPool().query(
       `SELECT a.id, a.agent_id, a.name, a.description, a.status, a.tools_config,
-              a.cpus, a.mem_limit, a.pids_limit, a.model_policy_id,
+              a.cpus, a.mem_limit, a.pids_limit, a.model_policy_id, a.autonomy_level,
               COALESCE(mp.allowed_models, '[]'::jsonb) AS models,
               a.created_at, a.updated_at, a.created_by,
               a.container_profile_id,
@@ -183,7 +183,16 @@ router.get('/', requireRole('user'), async (req: Request, res: Response) => {
 router.post('/', requireRole('user'), async (req: Request, res: Response) => {
   try {
     const user = (req as any).user;
-    const { agent_id, name, description, tools_config, cpus, mem_limit, pids_limit, soul_md, rules_md, model_policy_id, model_names, skill_ids, container_profile_id } = req.body;
+    const { agent_id, name, description, tools_config, cpus, mem_limit, pids_limit, soul_md, rules_md, model_policy_id, model_names, skill_ids, container_profile_id, autonomy_level } = req.body;
+
+    // Validate autonomy_level if provided
+    if (autonomy_level !== undefined) {
+      const validLevels = ['ask_before_acting', 'act_within_scope', 'full_autonomy'];
+      if (!validLevels.includes(autonomy_level)) {
+        res.status(400).json({ error: `autonomy_level must be one of: ${validLevels.join(', ')}` });
+        return;
+      }
+    }
 
     // Reject legacy field
     if (req.body.tool_preset_id !== undefined) {
@@ -292,13 +301,13 @@ router.post('/', requireRole('user'), async (req: Request, res: Response) => {
     }
 
     const { rows } = await getPool().query(
-      `INSERT INTO agents (agent_id, name, description, tools_config, cpus, mem_limit, pids_limit, soul_md, rules_md, model_policy_id, container_profile_id, created_by)
+      `INSERT INTO agents (agent_id, name, description, tools_config, cpus, mem_limit, pids_limit, soul_md, rules_md, model_policy_id, container_profile_id, autonomy_level, created_by)
        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9,
                COALESCE($10::uuid, (SELECT id FROM model_policies WHERE name = 'default' AND created_by IS NULL LIMIT 1)),
-               $11, $12)
+               $11, $12, $13)
        RETURNING id, agent_id, name, description, status, tools_config,
                  cpus, mem_limit, pids_limit, soul_md, rules_md, container_id,
-                 model_policy_id, container_profile_id, error_message, created_at, updated_at, created_by`,
+                 model_policy_id, container_profile_id, autonomy_level, error_message, created_at, updated_at, created_by`,
       [
         agent_id,
         name,
@@ -311,6 +320,7 @@ router.post('/', requireRole('user'), async (req: Request, res: Response) => {
         rules_md || '',
         validatedPolicyId,
         container_profile_id || null,
+        autonomy_level || 'act_within_scope',
         user.sub,
       ]
     );
@@ -375,7 +385,7 @@ router.get('/:id', requireRole('user'), async (req: Request, res: Response) => {
     const { rows } = await getPool().query(
       `SELECT a.id, a.agent_id, a.name, a.description, a.status, a.tools_config,
               cpus, mem_limit, pids_limit, soul_md, rules_md, container_id,
-              model_policy_id, a.container_profile_id,
+              model_policy_id, a.autonomy_level, a.container_profile_id,
               cp.name AS cp_name, cp.docker_image AS cp_docker_image,
               COALESCE(mp.allowed_models, '[]'::jsonb) AS models,
               error_message, a.created_at, a.updated_at, a.created_by
@@ -444,7 +454,16 @@ router.put('/:id', requireRole('user'), async (req: Request, res: Response) => {
     }
 
     const user = (req as any).user;
-    const { name, description, tools_config, cpus, mem_limit, pids_limit, soul_md, rules_md, model_policy_id, model_names, skill_ids, container_profile_id } = req.body;
+    const { name, description, tools_config, cpus, mem_limit, pids_limit, soul_md, rules_md, model_policy_id, model_names, skill_ids, container_profile_id, autonomy_level } = req.body;
+
+    // Validate autonomy_level if provided
+    if (autonomy_level !== undefined) {
+      const validLevels = ['ask_before_acting', 'act_within_scope', 'full_autonomy'];
+      if (!validLevels.includes(autonomy_level)) {
+        res.status(400).json({ error: `autonomy_level must be one of: ${validLevels.join(', ')}` });
+        return;
+      }
+    }
 
     // Validate skill_ids
     if (skill_ids !== undefined) {
@@ -601,11 +620,12 @@ router.put('/:id', requireRole('user'), async (req: Request, res: Response) => {
         rules_md = COALESCE($8, rules_md),
         model_policy_id = CASE WHEN $9::boolean THEN $10::uuid ELSE model_policy_id END,
         container_profile_id = CASE WHEN $11::boolean THEN $12::uuid ELSE container_profile_id END,
+        autonomy_level = COALESCE($13, autonomy_level),
         updated_at = NOW()
-       WHERE id = $13
+       WHERE id = $14
        RETURNING id, agent_id, name, description, status, tools_config,
                  cpus, mem_limit, pids_limit, soul_md, rules_md, container_id,
-                 model_policy_id, container_profile_id, error_message, created_at, updated_at, created_by`,
+                 model_policy_id, container_profile_id, autonomy_level, error_message, created_at, updated_at, created_by`,
       [
         name || null,
         description ?? null,
@@ -619,6 +639,7 @@ router.put('/:id', requireRole('user'), async (req: Request, res: Response) => {
         modelPolicyProvided ? (effectiveModelPolicyId ?? null) : null,
         containerProfileProvided,
         containerProfileProvided ? (container_profile_id ?? null) : null,
+        autonomy_level || null,
         req.params.id,
       ]
     );

--- a/services/ui/src/app/agents/[id]/AgentDetailClient.tsx
+++ b/services/ui/src/app/agents/[id]/AgentDetailClient.tsx
@@ -27,6 +27,7 @@ interface Agent {
   model_policy_id: string | null
   models: string[]
   skills: Array<{ id: string; name: string; scope: string; tools?: Array<{ id: string; name: string }>; instructions_md?: string }>
+  autonomy_level: string
   error_message: string | null
   created_at: string
   updated_at: string
@@ -108,6 +109,9 @@ export default function AgentDetailClient({
   const [soulDraft, setSoulDraft] = useState('')
   const [rulesDraft, setRulesDraft] = useState('')
   const [identitySaving, setIdentitySaving] = useState(false)
+
+  // Autonomy level
+  const [autonomySaving, setAutonomySaving] = useState(false)
 
   const isAdmin = session.user?.roles?.includes('admin')
 
@@ -341,6 +345,28 @@ export default function AgentDetailClient({
       alert(`Failed to save ${field}`)
     } finally {
       setIdentitySaving(false)
+    }
+  }
+
+  const handleSaveAutonomy = async (level: string) => {
+    setAutonomySaving(true)
+    try {
+      const res = await fetch(`/api/agents/${agentId}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ autonomy_level: level }),
+      })
+      if (!res.ok) {
+        const data = await res.json()
+        alert(data.error || 'Failed to save autonomy level')
+        return
+      }
+      await fetchAgent()
+    } catch (err) {
+      console.error('Failed to save autonomy level:', err)
+      alert('Failed to save autonomy level')
+    } finally {
+      setAutonomySaving(false)
     }
   }
 
@@ -693,6 +719,74 @@ export default function AgentDetailClient({
                 <dd className="text-white mt-1">{agent.pids_limit}</dd>
               </div>
             </dl>
+          </div>
+
+          {/* Autonomy Level */}
+          <div className="rounded-lg border border-navy-700 bg-navy-800 p-5">
+            <h2 className="text-lg font-semibold text-white mb-1">Autonomy Level</h2>
+            <p className="text-xs text-mountain-500 mb-4">
+              Controls how much freedom the agent has when executing commands.
+            </p>
+            <div className="space-y-3">
+              {([
+                {
+                  value: 'ask_before_acting',
+                  label: 'Ask before acting',
+                  description: 'Agent requests approval before executing commands',
+                },
+                {
+                  value: 'act_within_scope',
+                  label: 'Act within scope',
+                  description: 'Agent acts freely within its skill and tool permissions',
+                },
+                {
+                  value: 'full_autonomy',
+                  label: 'Full autonomy',
+                  description: 'Agent operates with minimal guardrails',
+                },
+              ] as const).map((option) => {
+                const isSelected = (agent.autonomy_level || 'act_within_scope') === option.value
+                const isRunning = agent.status === 'running'
+                return (
+                  <label
+                    key={option.value}
+                    className={`flex items-start gap-3 rounded-lg border p-3 transition-colors ${
+                      isRunning
+                        ? 'cursor-not-allowed opacity-60'
+                        : 'cursor-pointer'
+                    } ${
+                      isSelected
+                        ? 'border-brand-500 bg-brand-900/20'
+                        : 'border-navy-600 bg-navy-900 hover:border-navy-500'
+                    }`}
+                    title={isRunning ? 'Stop agent to change autonomy level' : undefined}
+                  >
+                    <input
+                      type="radio"
+                      name="autonomy_level"
+                      value={option.value}
+                      checked={isSelected}
+                      disabled={isRunning || autonomySaving}
+                      onChange={() => handleSaveAutonomy(option.value)}
+                      className="mt-0.5 accent-brand-500"
+                      data-testid={`autonomy-${option.value}`}
+                    />
+                    <div>
+                      <span className={`text-sm font-medium ${isSelected ? 'text-white' : 'text-mountain-300'}`}>
+                        {option.label}
+                      </span>
+                      {option.value === 'act_within_scope' && (
+                        <span className="ml-2 text-xs text-mountain-500">(default)</span>
+                      )}
+                      <p className="text-xs text-mountain-500 mt-0.5">{option.description}</p>
+                    </div>
+                  </label>
+                )
+              })}
+            </div>
+            {autonomySaving && (
+              <p className="text-xs text-mountain-400 mt-2">Saving...</p>
+            )}
           </div>
 
           {/* Identity — SOUL.md */}


### PR DESCRIPTION
## Summary
- Adds `autonomy_level` column to agents table (migration 047) with three levels: `ask_before_acting`, `act_within_scope` (default), `full_autonomy`
- Adds radio-button selector to the agent Configuration tab, auto-saves on selection, disabled while agent is running with tooltip explanation
- API validates autonomy_level on both create and update, OpenAPI spec updated

## Test plan
- [ ] Migration applies cleanly on fresh DB
- [ ] PUT /api/agents/:id with `autonomy_level` persists and returns the value
- [ ] PUT /api/agents/:id with invalid autonomy_level returns 400
- [ ] UI Configuration tab shows radio buttons with correct selection state
- [ ] Selecting a radio saves immediately and refreshes agent state
- [ ] Radio buttons are disabled when agent is running
- [ ] Existing agents default to `act_within_scope`
- [ ] All existing UI tests pass (21/21)

🤖 Generated with [Claude Code](https://claude.com/claude-code)