### PR TITLE
feat: add AgentAvatar component with fallback initials (AI-211)

### DIFF
--- a/services/ui/src/app/agents/AgentsClient.tsx
+++ b/services/ui/src/app/agents/AgentsClient.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback } from 'react'
 import Link from 'next/link'
 import type { Session } from 'next-auth'
+import AgentAvatar from '@/components/AgentAvatar'
 
 interface Agent {
   id: string
@@ -166,12 +167,15 @@ export default function AgentsClient({ session }: { session: Session }) {
                 className="rounded-lg border border-navy-700 bg-navy-800 p-5 flex flex-col"
               >
                 <div className="flex items-center justify-between mb-2">
-                  <Link
-                    href={`/agents/${agent.id}`}
-                    className="font-semibold text-white hover:text-brand-400 transition-colors truncate"
-                  >
-                    {agent.name}
-                  </Link>
+                  <div className="flex items-center gap-2.5 min-w-0">
+                    <AgentAvatar name={agent.name} size="md" />
+                    <Link
+                      href={`/agents/${agent.id}`}
+                      className="font-semibold text-white hover:text-brand-400 transition-colors truncate"
+                    >
+                      {agent.name}
+                    </Link>
+                  </div>
                   <StatusBadge status={agent.status} />
                 </div>
 

--- a/services/ui/src/app/agents/[id]/AgentDetailClient.tsx
+++ b/services/ui/src/app/agents/[id]/AgentDetailClient.tsx
@@ -10,6 +10,7 @@ import AgentMemory from './AgentMemory'
 import AgentNotebook from './AgentNotebook'
 import AgentProgression from './AgentProgression'
 import WorkspaceBrowser from './WorkspaceBrowser'
+import AgentAvatar from '@/components/AgentAvatar'
 
 interface Agent {
   id: string
@@ -395,9 +396,12 @@ export default function AgentDetailClient({
     <>
       {/* Header */}
       <div className="flex items-center justify-between mb-6">
-        <div>
-          <h1 className="text-2xl font-bold">{agent.name}</h1>
-          <p className="text-sm text-mountain-400 mt-1 font-mono">{agent.agent_id}</p>
+        <div className="flex items-center gap-4">
+          <AgentAvatar name={agent.name} size="xl" />
+          <div>
+            <h1 className="text-2xl font-bold">{agent.name}</h1>
+            <p className="text-sm text-mountain-400 mt-1 font-mono">{agent.agent_id}</p>
+          </div>
         </div>
         <div className="flex items-center gap-2">
           {isAdmin && agent.status !== 'running' && (

--- a/services/ui/src/components/AgentAvatar.tsx
+++ b/services/ui/src/components/AgentAvatar.tsx
@@ -1,6 +1,7 @@
 interface Props {
   name: string
-  size?: 'sm' | 'md'
+  avatarUrl?: string | null
+  size?: 'sm' | 'md' | 'lg' | 'xl'
 }
 
 const COLORS = [
@@ -12,6 +13,8 @@ const COLORS = [
   'bg-cyan-600',
   'bg-orange-600',
   'bg-indigo-600',
+  'bg-teal-600',
+  'bg-pink-600',
 ]
 
 function hashName(name: string): number {
@@ -28,17 +31,32 @@ function initials(name: string): string {
   return name.slice(0, 2).toUpperCase()
 }
 
-const SIZE_CLASSES = {
-  sm: 'w-5 h-5 text-[9px]',
-  md: 'w-7 h-7 text-[11px]',
+const SIZE_CLASSES: Record<string, string> = {
+  sm: 'w-6 h-6 text-[9px]',
+  md: 'w-8 h-8 text-[11px]',
+  lg: 'w-12 h-12 text-base',
+  xl: 'w-16 h-16 text-lg',
 }
 
-export default function AgentAvatar({ name, size = 'md' }: Props) {
+export default function AgentAvatar({ name, avatarUrl, size = 'md' }: Props) {
   const color = COLORS[hashName(name) % COLORS.length]
+  const sizeClass = SIZE_CLASSES[size]
+
+  if (avatarUrl) {
+    return (
+      <img
+        src={avatarUrl}
+        alt={name}
+        className={`${sizeClass} rounded-full object-cover flex-shrink-0`}
+        title={name}
+        data-testid="agent-avatar"
+      />
+    )
+  }
 
   return (
     <div
-      className={`${SIZE_CLASSES[size]} rounded-full flex items-center justify-center flex-shrink-0 ${color} text-white font-semibold select-none`}
+      className={`${sizeClass} rounded-full flex items-center justify-center flex-shrink-0 ${color} text-white font-semibold select-none`}
       title={name}
       data-testid="agent-avatar"
     >


### PR DESCRIPTION
## Summary
- Add reusable `AgentAvatar` component with 4 sizes (sm/md/lg/xl), optional `avatarUrl` prop, and deterministic 10-color palette based on name hash
- Display agent avatars on the agents list page (card headers), agent detail page header (xl size), and chat messages (already wired)
- Pure display component — no upload functionality in this PR

## Linear
- Issue: AI-211

## Validation Evidence
- UI: All 631 vitest tests pass (53 test files), no regressions
- API/MCP: N/A (UI-only change)
- Infra/Deploy: N/A

## Test plan
- [x] Local checks run (`vitest run` — 631 passed, 7 skipped)
- [ ] CI checks pass

## Notes
- ChatMessage.tsx already imported and used AgentAvatar before this PR; this change enhances the component and adds it to agents list + detail pages
- The `avatarUrl` prop is forward-compatible for when agent avatar upload is added later

🤖 Generated with [Claude Code](https://claude.com/claude-code)