### PR TITLE
feat: add autonomy_level to agents API (AI-227)

### DIFF
--- a/docs/site/openapi.yaml
+++ b/docs/site/openapi.yaml
@@ -88,6 +88,11 @@ components:
           type: string
         rules_md:
           type: string
+        autonomy_level:
+          type: string
+          enum: [ask_before_acting, act_within_scope, full_autonomy]
+          default: act_within_scope
+          description: Controls how much freedom the agent has when executing commands.
         status:
           type: string
           enum: [stopped, running, error]
@@ -1045,6 +1050,10 @@ paths:
                   format: uuid
                   nullable: true
                   description: Container profile to assign. Determines Docker image. Omit for default.
+                autonomy_level:
+                  type: string
+                  enum: [ask_before_acting, act_within_scope, full_autonomy]
+                  description: Controls agent autonomy. Defaults to act_within_scope.
       responses:
         "201":
           description: Agent created
@@ -1138,6 +1147,10 @@ paths:
                   format: uuid
                   nullable: true
                   description: Container profile to assign. Omit for no change; explicit null to clear.
+                autonomy_level:
+                  type: string
+                  enum: [ask_before_acting, act_within_scope, full_autonomy]
+                  description: Controls agent autonomy. Omit for no change.
       responses:
         "200":
           description: Agent updated

--- a/services/api/src/db/migrations/047_add_autonomy_level.sql
+++ b/services/api/src/db/migrations/047_add_autonomy_level.sql
@@ -1,0 +1,6 @@
+-- Add autonomy_level column to agents table (AI-227).
+-- Valid values: 'ask_before_acting', 'act_within_scope', 'full_autonomy'.
+-- Default: 'act_within_scope' — agent acts freely within its skill/tool permissions.
+
+ALTER TABLE agents
+  ADD COLUMN IF NOT EXISTS autonomy_level VARCHAR(32) NOT NULL DEFAULT 'act_within_scope';

--- a/services/api/src/openapi/openapi.yaml
+++ b/services/api/src/openapi/openapi.yaml
@@ -88,6 +88,11 @@ components:
           type: string
         rules_md:
           type: string
+        autonomy_level:
+          type: string
+          enum: [ask_before_acting, act_within_scope, full_autonomy]
+          default: act_within_scope
+          description: Controls how much freedom the agent has when executing commands.
         status:
           type: string
           enum: [stopped, running, error]
@@ -1045,6 +1050,10 @@ paths:
                   format: uuid
                   nullable: true
                   description: Container profile to assign. Determines Docker image. Omit for default.
+                autonomy_level:
+                  type: string
+                  enum: [ask_before_acting, act_within_scope, full_autonomy]
+                  description: Controls agent autonomy. Defaults to act_within_scope.
       responses:
         "201":
           description: Agent created
@@ -1138,6 +1147,10 @@ paths:
                   format: uuid
                   nullable: true
                   description: Container profile to assign. Omit for no change; explicit null to clear.
+                autonomy_level:
+                  type: string
+                  enum: [ask_before_acting, act_within_scope, full_autonomy]
+                  description: Controls agent autonomy. Omit for no change.
       responses:
         "200":
           description: Agent updated

--- a/services/api/src/routes/agents.ts
+++ b/services/api/src/routes/agents.ts
@@ -141,7 +141,7 @@ router.get('/', requireRole('user'), async (req: Request, res: Response) => {
     const scope = scopeToOwner(req);
     const { rows } = await getPool().query(
       `SELECT a.id, a.agent_id, a.name, a.description, a.status, a.tools_config,
-              a.cpus, a.mem_limit, a.pids_limit, a.model_policy_id,
+              a.cpus, a.mem_limit, a.pids_limit, a.model_policy_id, a.autonomy_level,
               COALESCE(mp.allowed_models, '[]'::jsonb) AS models,
               a.created_at, a.updated_at, a.created_by,
               a.container_profile_id,
@@ -183,7 +183,16 @@ router.get('/', requireRole('user'), async (req: Request, res: Response) => {
 router.post('/', requireRole('user'), async (req: Request, res: Response) => {
   try {
     const user = (req as any).user;
-    const { agent_id, name, description, tools_config, cpus, mem_limit, pids_limit, soul_md, rules_md, model_policy_id, model_names, skill_ids, container_profile_id } = req.body;
+    const { agent_id, name, description, tools_config, cpus, mem_limit, pids_limit, soul_md, rules_md, model_policy_id, model_names, skill_ids, container_profile_id, autonomy_level } = req.body;
+
+    // Validate autonomy_level if provided
+    if (autonomy_level !== undefined) {
+      const validLevels = ['ask_before_acting', 'act_within_scope', 'full_autonomy'];
+      if (!validLevels.includes(autonomy_level)) {
+        res.status(400).json({ error: `autonomy_level must be one of: ${validLevels.join(', ')}` });
+        return;
+      }
+    }
 
     // Reject legacy field
     if (req.body.tool_preset_id !== undefined) {
@@ -292,13 +301,13 @@ router.post('/', requireRole('user'), async (req: Request, res: Response) => {
     }
 
     const { rows } = await getPool().query(
-      `INSERT INTO agents (agent_id, name, description, tools_config, cpus, mem_limit, pids_limit, soul_md, rules_md, model_policy_id, container_profile_id, created_by)
+      `INSERT INTO agents (agent_id, name, description, tools_config, cpus, mem_limit, pids_limit, soul_md, rules_md, model_policy_id, container_profile_id, autonomy_level, created_by)
        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9,
                COALESCE($10::uuid, (SELECT id FROM model_policies WHERE name = 'default' AND created_by IS NULL LIMIT 1)),
-               $11, $12)
+               $11, $12, $13)
        RETURNING id, agent_id, name, description, status, tools_config,
                  cpus, mem_limit, pids_limit, soul_md, rules_md, container_id,
-                 model_policy_id, container_profile_id, error_message, created_at, updated_at, created_by`,
+                 model_policy_id, container_profile_id, autonomy_level, error_message, created_at, updated_at, created_by`,
       [
         agent_id,
         name,
@@ -311,6 +320,7 @@ router.post('/', requireRole('user'), async (req: Request, res: Response) => {
         rules_md || '',
         validatedPolicyId,
         container_profile_id || null,
+        autonomy_level || 'act_within_scope',
         user.sub,
       ]
     );
@@ -375,7 +385,7 @@ router.get('/:id', requireRole('user'), async (req: Request, res: Response) => {
     const { rows } = await getPool().query(
       `SELECT a.id, a.agent_id, a.name, a.description, a.status, a.tools_config,
               cpus, mem_limit, pids_limit, soul_md, rules_md, container_id,
-              model_policy_id, a.container_profile_id,
+              model_policy_id, a.autonomy_level, a.container_profile_id,
               cp.name AS cp_name, cp.docker_image AS cp_docker_image,
               COALESCE(mp.allowed_models, '[]'::jsonb) AS models,
               error_message, a.created_at, a.updated_at, a.created_by
@@ -444,7 +454,16 @@ router.put('/:id', requireRole('user'), async (req: Request, res: Response) => {
     }
 
     const user = (req as any).user;
-    const { name, description, tools_config, cpus, mem_limit, pids_limit, soul_md, rules_md, model_policy_id, model_names, skill_ids, container_profile_id } = req.body;
+    const { name, description, tools_config, cpus, mem_limit, pids_limit, soul_md, rules_md, model_policy_id, model_names, skill_ids, container_profile_id, autonomy_level } = req.body;
+
+    // Validate autonomy_level if provided
+    if (autonomy_level !== undefined) {
+      const validLevels = ['ask_before_acting', 'act_within_scope', 'full_autonomy'];
+      if (!validLevels.includes(autonomy_level)) {
+        res.status(400).json({ error: `autonomy_level must be one of: ${validLevels.join(', ')}` });
+        return;
+      }
+    }
 
     // Validate skill_ids
     if (skill_ids !== undefined) {
@@ -601,11 +620,12 @@ router.put('/:id', requireRole('user'), async (req: Request, res: Response) => {
         rules_md = COALESCE($8, rules_md),
         model_policy_id = CASE WHEN $9::boolean THEN $10::uuid ELSE model_policy_id END,
         container_profile_id = CASE WHEN $11::boolean THEN $12::uuid ELSE container_profile_id END,
+        autonomy_level = COALESCE($13, autonomy_level),
         updated_at = NOW()
-       WHERE id = $13
+       WHERE id = $14
        RETURNING id, agent_id, name, description, status, tools_config,
                  cpus, mem_limit, pids_limit, soul_md, rules_md, container_id,
-                 model_policy_id, container_profile_id, error_message, created_at, updated_at, created_by`,
+                 model_policy_id, container_profile_id, autonomy_level, error_message, created_at, updated_at, created_by`,
       [
         name || null,
         description ?? null,
@@ -619,6 +639,7 @@ router.put('/:id', requireRole('user'), async (req: Request, res: Response) => {
         modelPolicyProvided ? (effectiveModelPolicyId ?? null) : null,
         containerProfileProvided,
         containerProfileProvided ? (container_profile_id ?? null) : null,
+        autonomy_level || null,
         req.params.id,
       ]
     );


### PR DESCRIPTION
## Summary
- Add `autonomy_level` column to agents table via migration 047
- Update agent create/update/get routes to include and validate autonomy_level
- Valid values: `ask_before_acting`, `act_within_scope` (default), `full_autonomy`
- Sync OpenAPI spec with new field definitions
- UI already merged in PR #368; this adds the API backend

## Test plan
- [x] All 685 API tests pass
- [x] docs spec contract test passes (no phantom paths)
- [x] OpenAPI spec synced to docs/site/
- [ ] Verify migration runs on VPS deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)