### PR TITLE
feat: add agent progression display with levels and XP (AI-225)

### DIFF
--- a/services/ui/src/__tests__/AgentLevelBadge.test.tsx
+++ b/services/ui/src/__tests__/AgentLevelBadge.test.tsx
@@ -1,0 +1,59 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, cleanup, waitFor } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+
+import AgentLevelBadge from '@/components/AgentLevelBadge'
+
+const mockFetch = vi.fn()
+vi.stubGlobal('fetch', mockFetch)
+
+describe('AgentLevelBadge', () => {
+  beforeEach(() => {
+    mockFetch.mockReset()
+  })
+
+  afterEach(() => cleanup())
+
+  it('renders level badge when stats load', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ total_inferences: 500, chat_messages: 20 }),
+    })
+
+    render(<AgentLevelBadge agentId="uuid-1" />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('level-badge')).toBeInTheDocument()
+    })
+
+    // 500 + 20*0.5 = 510 XP -> Level 5 Journeyman
+    expect(screen.getByTestId('level-badge')).toHaveTextContent('Lv.5 Journeyman')
+  })
+
+  it('renders nothing when stats fail', async () => {
+    mockFetch.mockResolvedValue({ ok: false })
+
+    const { container } = render(<AgentLevelBadge agentId="uuid-1" />)
+
+    // Wait a tick for the effect to run
+    await new Promise((r) => setTimeout(r, 50))
+
+    expect(container.innerHTML).toBe('')
+  })
+
+  it('renders level 1 for zero stats', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ total_inferences: 0, chat_messages: 0 }),
+    })
+
+    render(<AgentLevelBadge agentId="uuid-1" />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('level-badge')).toBeInTheDocument()
+    })
+
+    expect(screen.getByTestId('level-badge')).toHaveTextContent('Lv.1 Novice')
+  })
+})

--- a/services/ui/src/__tests__/AgentProgression.test.tsx
+++ b/services/ui/src/__tests__/AgentProgression.test.tsx
@@ -46,6 +46,22 @@ describe('AgentProgression', () => {
 
   afterEach(() => cleanup())
 
+  it('renders level section with XP bar', async () => {
+    render(<AgentProgression agentId="uuid-1" />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('level-section')).toBeInTheDocument()
+    })
+
+    // 1234 inferences + 89*0.5 = 1278 XP -> Level 5 (Journeyman, threshold 400)
+    // But 1278 >= 800 -> Level 6 (Journeyman, threshold 800)
+    // 1278 < 1500 -> Level 6
+    expect(screen.getByText(/Level 6/)).toBeInTheDocument()
+    expect(screen.getByText('Journeyman')).toBeInTheDocument()
+    expect(screen.getByTestId('xp-bar')).toBeInTheDocument()
+    expect(screen.getByTestId('xp-fill')).toBeInTheDocument()
+  })
+
   it('renders stats grid with formatted values', async () => {
     render(<AgentProgression agentId="uuid-1" />)
 
@@ -90,5 +106,16 @@ describe('AgentProgression', () => {
     render(<AgentProgression agentId="uuid-1" />)
 
     expect(screen.getByTestId('progression-loading')).toBeInTheDocument()
+  })
+
+  it('shows XP to next level text', async () => {
+    render(<AgentProgression agentId="uuid-1" />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('level-section')).toBeInTheDocument()
+    })
+
+    // XP to Level 7 = 1500 - 1278 = 222
+    expect(screen.getByText(/XP to Level 7/)).toBeInTheDocument()
   })
 })

--- a/services/ui/src/__tests__/agent-level.test.ts
+++ b/services/ui/src/__tests__/agent-level.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest'
+import { calculateXp, getLevelInfo, getAgentLevel } from '@/utils/agent-level'
+
+describe('calculateXp', () => {
+  it('returns 0 for null stats', () => {
+    expect(calculateXp(null)).toBe(0)
+  })
+
+  it('counts inferences as 1 XP each', () => {
+    expect(calculateXp({ total_inferences: 100, chat_messages: 0 })).toBe(100)
+  })
+
+  it('counts chat messages as 0.5 XP each', () => {
+    expect(calculateXp({ total_inferences: 0, chat_messages: 100 })).toBe(50)
+  })
+
+  it('combines inferences and messages', () => {
+    expect(calculateXp({ total_inferences: 100, chat_messages: 100 })).toBe(150)
+  })
+
+  it('handles undefined fields', () => {
+    expect(calculateXp({})).toBe(0)
+  })
+})
+
+describe('getLevelInfo', () => {
+  it('returns level 1 for 0 XP', () => {
+    const info = getLevelInfo(0)
+    expect(info.level).toBe(1)
+    expect(info.title).toBe('Novice')
+    expect(info.progress).toBe(0)
+  })
+
+  it('returns level 2 at 10 XP', () => {
+    const info = getLevelInfo(10)
+    expect(info.level).toBe(2)
+    expect(info.title).toBe('Novice')
+  })
+
+  it('returns level 5 Journeyman at 400 XP', () => {
+    const info = getLevelInfo(400)
+    expect(info.level).toBe(5)
+    expect(info.title).toBe('Journeyman')
+  })
+
+  it('returns level 10 Master at 10000 XP', () => {
+    const info = getLevelInfo(10000)
+    expect(info.level).toBe(10)
+    expect(info.title).toBe('Master')
+    expect(info.progress).toBe(100)
+  })
+
+  it('calculates progress correctly mid-level', () => {
+    // Level 1 threshold: 0, Level 2 threshold: 10
+    const info = getLevelInfo(5)
+    expect(info.level).toBe(1)
+    expect(info.progress).toBe(50)
+  })
+
+  it('provides xpForNextLevel', () => {
+    const info = getLevelInfo(5)
+    expect(info.xpForCurrentLevel).toBe(0)
+    expect(info.xpForNextLevel).toBe(10)
+  })
+})
+
+describe('getAgentLevel', () => {
+  it('computes level from stats in one call', () => {
+    const info = getAgentLevel({ total_inferences: 1234, chat_messages: 89 })
+    // 1234 + 89*0.5 = 1278 XP -> Level 6 (800 threshold)
+    expect(info.level).toBe(6)
+    expect(info.title).toBe('Journeyman')
+  })
+
+  it('returns level 1 for null stats', () => {
+    const info = getAgentLevel(null)
+    expect(info.level).toBe(1)
+    expect(info.title).toBe('Novice')
+  })
+})

--- a/services/ui/src/app/agents/AgentsClient.tsx
+++ b/services/ui/src/app/agents/AgentsClient.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback } from 'react'
 import Link from 'next/link'
 import type { Session } from 'next-auth'
 import AgentAvatar from '@/components/AgentAvatar'
+import AgentLevelBadge from '@/components/AgentLevelBadge'
 
 interface Agent {
   id: string
@@ -176,7 +177,10 @@ export default function AgentsClient({ session }: { session: Session }) {
                       {agent.name}
                     </Link>
                   </div>
-                  <StatusBadge status={agent.status} />
+                  <div className="flex items-center gap-2">
+                    <AgentLevelBadge agentId={agent.id} />
+                    <StatusBadge status={agent.status} />
+                  </div>
                 </div>
 
                 <p className="text-sm text-mountain-400 mb-3 line-clamp-2 flex-1">

--- a/services/ui/src/app/agents/[id]/AgentProgression.tsx
+++ b/services/ui/src/app/agents/[id]/AgentProgression.tsx
@@ -1,6 +1,8 @@
 'use client'
 
 import React, { useState, useEffect, useCallback } from 'react'
+import { Shield } from 'lucide-react'
+import { getAgentLevel } from '@/utils/agent-level'
 
 interface Stats {
   total_inferences: number
@@ -85,6 +87,8 @@ export default function AgentProgression({ agentId }: Props) {
 
   if (!stats) return null
 
+  const levelInfo = getAgentLevel(stats)
+
   const statCards = [
     { label: 'Inferences', value: formatNumber(stats.total_inferences) },
     { label: 'Tokens', value: formatNumber(stats.total_tokens) },
@@ -96,6 +100,34 @@ export default function AgentProgression({ agentId }: Props) {
 
   return (
     <div className="space-y-4" data-testid="progression">
+      {/* Level & XP */}
+      <div className="rounded-lg border border-navy-700 bg-navy-800 p-5" data-testid="level-section">
+        <div className="flex items-center justify-between mb-3">
+          <div className="flex items-center gap-2">
+            <Shield className="h-5 w-5 text-brand-500" />
+            <h2 className="text-lg font-semibold text-white">
+              Level {levelInfo.level}
+              <span className="ml-2 text-sm font-normal text-mountain-400">{levelInfo.title}</span>
+            </h2>
+          </div>
+          <span className="text-xs text-mountain-400" data-testid="xp-label">
+            {formatNumber(levelInfo.currentXp)} XP
+          </span>
+        </div>
+        <div className="w-full h-2 rounded-full bg-navy-900 overflow-hidden" data-testid="xp-bar">
+          <div
+            className="h-full rounded-full bg-brand-600 transition-all duration-500"
+            style={{ width: `${levelInfo.progress}%` }}
+            data-testid="xp-fill"
+          />
+        </div>
+        {levelInfo.progress < 100 && (
+          <p className="text-[10px] text-mountain-500 mt-1">
+            {formatNumber(levelInfo.xpForNextLevel - levelInfo.currentXp)} XP to Level {levelInfo.level + 1}
+          </p>
+        )}
+      </div>
+
       {/* Stats Grid */}
       <div className="rounded-lg border border-navy-700 bg-navy-800 p-5">
         <h2 className="text-lg font-semibold text-white mb-3">Stats</h2>

--- a/services/ui/src/components/AgentLevelBadge.tsx
+++ b/services/ui/src/components/AgentLevelBadge.tsx
@@ -1,0 +1,47 @@
+'use client'
+
+import React, { useState, useEffect } from 'react'
+import { getAgentLevel } from '@/utils/agent-level'
+
+interface Props {
+  agentId: string
+}
+
+/**
+ * Compact level badge for agent list cards. Fetches stats on mount
+ * and displays "Lv.N Title".
+ */
+export default function AgentLevelBadge({ agentId }: Props) {
+  const [label, setLabel] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+
+    async function load() {
+      try {
+        const res = await fetch(`/api/agents/${agentId}/stats`)
+        if (!res.ok) return
+        const stats = await res.json()
+        if (cancelled) return
+        const info = getAgentLevel(stats)
+        setLabel(`Lv.${info.level} ${info.title}`)
+      } catch {
+        // Non-fatal — badge simply won't render
+      }
+    }
+
+    load()
+    return () => { cancelled = true }
+  }, [agentId])
+
+  if (!label) return null
+
+  return (
+    <span
+      className="inline-flex items-center px-1.5 py-0.5 text-[10px] font-medium rounded bg-brand-900/30 text-brand-400 border border-brand-800"
+      data-testid="level-badge"
+    >
+      {label}
+    </span>
+  )
+}

--- a/services/ui/src/utils/agent-level.ts
+++ b/services/ui/src/utils/agent-level.ts
@@ -1,0 +1,81 @@
+/**
+ * Agent level/progression system.
+ *
+ * XP is derived from total_inferences + chat_messages. Levels follow a
+ * non-linear curve so early progression feels fast and later levels require
+ * sustained usage.
+ */
+
+export interface LevelInfo {
+  level: number
+  title: string
+  currentXp: number
+  xpForCurrentLevel: number
+  xpForNextLevel: number
+  progress: number // 0-100
+}
+
+interface LevelThreshold {
+  level: number
+  xp: number
+  title: string
+}
+
+const LEVEL_THRESHOLDS: readonly LevelThreshold[] = [
+  { level: 1, xp: 0, title: 'Novice' },
+  { level: 2, xp: 10, title: 'Novice' },
+  { level: 3, xp: 50, title: 'Apprentice' },
+  { level: 4, xp: 150, title: 'Apprentice' },
+  { level: 5, xp: 400, title: 'Journeyman' },
+  { level: 6, xp: 800, title: 'Journeyman' },
+  { level: 7, xp: 1500, title: 'Expert' },
+  { level: 8, xp: 3000, title: 'Expert' },
+  { level: 9, xp: 6000, title: 'Master' },
+  { level: 10, xp: 10000, title: 'Master' },
+]
+
+/**
+ * Calculate XP from agent stats. Each inference counts as 1 XP,
+ * each chat message counts as 0.5 XP.
+ */
+export function calculateXp(stats: { total_inferences?: number; chat_messages?: number } | null): number {
+  if (!stats) return 0
+  return Math.floor((stats.total_inferences || 0) + (stats.chat_messages || 0) * 0.5)
+}
+
+/**
+ * Derive level info from raw XP value.
+ */
+export function getLevelInfo(xp: number): LevelInfo {
+  let current = LEVEL_THRESHOLDS[0]
+
+  for (let i = LEVEL_THRESHOLDS.length - 1; i >= 0; i--) {
+    if (xp >= LEVEL_THRESHOLDS[i].xp) {
+      current = LEVEL_THRESHOLDS[i]
+      break
+    }
+  }
+
+  const nextIndex = LEVEL_THRESHOLDS.findIndex((t) => t.level === current.level) + 1
+  const next = nextIndex < LEVEL_THRESHOLDS.length ? LEVEL_THRESHOLDS[nextIndex] : null
+
+  const xpIntoLevel = xp - current.xp
+  const xpNeeded = next ? next.xp - current.xp : 1
+  const progress = next ? Math.min(100, Math.floor((xpIntoLevel / xpNeeded) * 100)) : 100
+
+  return {
+    level: current.level,
+    title: current.title,
+    currentXp: xp,
+    xpForCurrentLevel: current.xp,
+    xpForNextLevel: next ? next.xp : current.xp,
+    progress,
+  }
+}
+
+/**
+ * Convenience: stats object -> LevelInfo in one call.
+ */
+export function getAgentLevel(stats: { total_inferences?: number; chat_messages?: number } | null): LevelInfo {
+  return getLevelInfo(calculateXp(stats))
+}


### PR DESCRIPTION
## Summary
- Add level/XP progression system to agents derived from usage stats (inferences + chat messages)
- Agent detail page shows level section with title, XP count, and progress bar (brand-600) above existing stats grid
- Agent list cards show a compact level badge (e.g., "Lv.5 Journeyman") next to the status badge
- 10-level system: Novice (1-2), Apprentice (3-4), Journeyman (5-6), Expert (7-8), Master (9-10)

## Test plan
- [x] 13 unit tests for level calculation utility (`agent-level.test.ts`)
- [x] 6 tests for AgentProgression component (level section, stats grid, artifacts, loading, XP-to-next)
- [x] 3 tests for AgentLevelBadge component (renders badge, handles failure, zero stats)
- [x] TypeScript type check passes (no new errors)
- [ ] Visual review on agent detail page
- [ ] Visual review on agents list page

Linear: AI-225

🤖 Generated with [Claude Code](https://claude.com/claude-code)