### PR TITLE
feat: add settings page scaffold

### DIFF
--- a/services/ui/src/app/settings/SettingsClient.tsx
+++ b/services/ui/src/app/settings/SettingsClient.tsx
@@ -1,0 +1,90 @@
+'use client'
+
+import { useState } from 'react'
+import { Moon, Bell, KeyRound } from 'lucide-react'
+
+export default function SettingsClient() {
+  const [theme] = useState('dark')
+  const [emailNotifs, setEmailNotifs] = useState(false)
+  const [inAppNotifs, setInAppNotifs] = useState(true)
+
+  return (
+    <>
+      <h1 className="text-2xl font-bold mb-6">Settings</h1>
+
+      <div className="space-y-6">
+        {/* Theme */}
+        <div className="rounded-lg border border-navy-700 bg-navy-800 p-5">
+          <div className="flex items-center gap-2 mb-3">
+            <Moon size={18} className="text-mountain-400" />
+            <h2 className="text-lg font-semibold text-white">Theme</h2>
+          </div>
+          <div className="flex items-center gap-3">
+            <span className="inline-flex items-center gap-2 px-3 py-1.5 rounded-md bg-navy-900 border border-brand-600 text-sm text-white">
+              <Moon size={14} /> Dark
+            </span>
+            <span className="text-xs text-mountain-500">More themes coming soon</span>
+          </div>
+        </div>
+
+        {/* Notifications */}
+        <div className="rounded-lg border border-navy-700 bg-navy-800 p-5">
+          <div className="flex items-center gap-2 mb-3">
+            <Bell size={18} className="text-mountain-400" />
+            <h2 className="text-lg font-semibold text-white">Notifications</h2>
+          </div>
+          <div className="space-y-3">
+            <label className="flex items-center gap-3 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={inAppNotifs}
+                onChange={(e) => setInAppNotifs(e.target.checked)}
+                className="h-4 w-4 rounded border-navy-600 bg-navy-900 text-brand-500 focus:ring-brand-500"
+              />
+              <div>
+                <span className="text-sm text-white">In-app notifications</span>
+                <p className="text-xs text-mountain-500">Show alerts in the notification panel</p>
+              </div>
+            </label>
+            <label className="flex items-center gap-3 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={emailNotifs}
+                onChange={(e) => setEmailNotifs(e.target.checked)}
+                className="h-4 w-4 rounded border-navy-600 bg-navy-900 text-brand-500 focus:ring-brand-500"
+              />
+              <div>
+                <span className="text-sm text-white">Email notifications</span>
+                <p className="text-xs text-mountain-500">Receive email digests for important events</p>
+              </div>
+            </label>
+          </div>
+          <p className="text-xs text-mountain-500 mt-3 italic">Notification delivery is not yet active. Preferences will be saved once the backend is implemented.</p>
+        </div>
+
+        {/* API Keys */}
+        <div className="rounded-lg border border-navy-700 bg-navy-800 p-5">
+          <div className="flex items-center gap-2 mb-3">
+            <KeyRound size={18} className="text-mountain-400" />
+            <h2 className="text-lg font-semibold text-white">API Keys</h2>
+          </div>
+          <div className="rounded-md border border-navy-700 bg-navy-900 p-3">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-sm text-white font-mono">hill90_sk_••••••••••••••••</p>
+                <p className="text-xs text-mountain-500 mt-1">Personal API key</p>
+              </div>
+              <button
+                disabled
+                className="px-3 py-1.5 text-xs font-medium rounded-md border border-navy-600 text-mountain-500 cursor-not-allowed"
+              >
+                Reveal
+              </button>
+            </div>
+          </div>
+          <p className="text-xs text-mountain-500 mt-3 italic">API key management coming soon. Keys will allow programmatic access to the Hill90 API.</p>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/services/ui/src/app/settings/page.tsx
+++ b/services/ui/src/app/settings/page.tsx
@@ -2,9 +2,10 @@
 
 import { useSession } from 'next-auth/react'
 import { redirect } from 'next/navigation'
-import AppShell from '@/components/AppShell';
+import AppShell from '@/components/AppShell'
+import SettingsClient from './SettingsClient'
 
-export default function Settings() {
+export default function SettingsPage() {
   const { data: session, status } = useSession()
 
   if (status === 'loading') {
@@ -20,13 +21,9 @@ export default function Settings() {
   }
 
   return (
-    <AppShell navExtra={<span className="text-sm font-medium text-white">Settings</span>}>
-      <main className="flex-1 px-6 py-12 max-w-2xl mx-auto w-full">
-        <h1 className="text-2xl font-bold text-white mb-8">Settings</h1>
-
-        <div className="rounded-lg border border-navy-700 bg-navy-800 p-6">
-          <p className="text-sm text-mountain-400">Settings options coming soon.</p>
-        </div>
+    <AppShell>
+      <main className="flex-1 px-6 py-12 max-w-6xl mx-auto w-full">
+        <SettingsClient />
       </main>
     </AppShell>
   )

--- a/services/ui/src/components/nav-items.ts
+++ b/services/ui/src/components/nav-items.ts
@@ -65,6 +65,7 @@ export const NAV_ITEMS: NavItem[] = [
     adminOnly: true,
     children: [
       { type: 'link', id: 'admin-services', label: 'Services', href: '/admin/services', icon: Server },
+      { type: 'link', id: 'settings', label: 'Settings', href: '/settings', icon: Settings },
     ],
   },
 ]


### PR DESCRIPTION
## Summary
- New `/settings` page with three placeholder sections:
  - **Theme**: Dark mode shown as active, "more themes coming soon"
  - **Notifications**: In-app and email checkboxes (local state only, backend not wired)
  - **API Keys**: Masked key display with disabled Reveal button, "coming soon" note
- Nav item added to Admin group using the existing `Settings` lucide icon

## Test plan
- [ ] Settings link visible in Admin nav group
- [ ] Page renders at /settings with auth guard
- [ ] Notification checkboxes toggle (client-side only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)