### PR TITLE
feat: add user preferences API endpoint

### DIFF
--- a/docs/site/openapi.yaml
+++ b/docs/site/openapi.yaml
@@ -1664,6 +1664,70 @@ paths:
         "403":
           description: Requires user role
 
+  /profile/preferences:
+    get:
+      summary: Get user preferences
+      tags: [Profile]
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: User preferences object
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  theme:
+                    type: string
+                    example: dark
+                  notifications_enabled:
+                    type: boolean
+                  sidebar_collapsed:
+                    type: boolean
+        "401":
+          description: Not authenticated
+        "403":
+          description: Requires user role
+    put:
+      summary: Update user preferences (shallow merge)
+      tags: [Profile]
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                theme:
+                  type: string
+                notifications_enabled:
+                  type: boolean
+                sidebar_collapsed:
+                  type: boolean
+      responses:
+        "200":
+          description: Merged preferences
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  theme:
+                    type: string
+                  notifications_enabled:
+                    type: boolean
+                  sidebar_collapsed:
+                    type: boolean
+        "400":
+          description: Invalid request body
+        "401":
+          description: Not authenticated
+        "403":
+          description: Requires user role
+
   /knowledge/agents:
     get:
       summary: List agents with knowledge

--- a/services/api/src/__tests__/docs.test.ts
+++ b/services/api/src/__tests__/docs.test.ts
@@ -172,6 +172,7 @@ const EXPECTED_PATHS = [
   '/profile',
   '/profile/avatar',
   '/profile/password',
+  '/profile/preferences',
   '/shared-knowledge/stats',
   '/shared-knowledge/collections',
   '/shared-knowledge/collections/{id}',

--- a/services/api/src/__tests__/routes-profile-preferences.test.ts
+++ b/services/api/src/__tests__/routes-profile-preferences.test.ts
@@ -1,0 +1,127 @@
+import request from 'supertest';
+import * as crypto from 'crypto';
+import * as jwt from 'jsonwebtoken';
+import { createApp } from '../app';
+
+const { privateKey, publicKey } = crypto.generateKeyPairSync('rsa', {
+  modulusLength: 2048,
+  publicKeyEncoding: { type: 'spki', format: 'pem' },
+  privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+});
+
+const TEST_ISSUER = 'https://auth.hill90.com/realms/hill90';
+
+const mockQuery = jest.fn();
+jest.mock('../db/pool', () => ({
+  getPool: () => ({ query: mockQuery }),
+}));
+
+jest.mock('../services/s3', () => ({
+  getS3Client: jest.fn(),
+}));
+
+function makeToken(sub: string, roles: string[]) {
+  return jwt.sign(
+    { sub, realm_roles: roles },
+    privateKey,
+    { algorithm: 'RS256', issuer: TEST_ISSUER, expiresIn: '5m' }
+  );
+}
+
+const userToken = makeToken('user-1', ['user']);
+
+const app = createApp({
+  issuer: TEST_ISSUER,
+  getSigningKey: async () => publicKey,
+});
+
+describe('Profile Preferences', () => {
+  beforeEach(() => {
+    mockQuery.mockReset();
+  });
+
+  it('GET /profile/preferences returns defaults when no row exists', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    const res = await request(app)
+      .get('/profile/preferences')
+      .set('Authorization', `Bearer ${userToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      theme: 'dark',
+      notifications_enabled: true,
+      sidebar_collapsed: false,
+    });
+  });
+
+  it('GET /profile/preferences returns stored preferences', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ preferences: { theme: 'dark', notifications_enabled: false, sidebar_collapsed: true } }],
+    });
+
+    const res = await request(app)
+      .get('/profile/preferences')
+      .set('Authorization', `Bearer ${userToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.notifications_enabled).toBe(false);
+    expect(res.body.sidebar_collapsed).toBe(true);
+  });
+
+  it('PUT /profile/preferences upserts with shallow merge', async () => {
+    // First query: SELECT existing
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ preferences: { theme: 'dark', notifications_enabled: true, sidebar_collapsed: false } }],
+    });
+    // Second query: INSERT ON CONFLICT
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ preferences: { theme: 'dark', notifications_enabled: false, sidebar_collapsed: false } }],
+    });
+
+    const res = await request(app)
+      .put('/profile/preferences')
+      .set('Authorization', `Bearer ${userToken}`)
+      .send({ notifications_enabled: false });
+
+    expect(res.status).toBe(200);
+    expect(res.body.notifications_enabled).toBe(false);
+    // Unchanged keys preserved
+    expect(res.body.theme).toBe('dark');
+
+    // Verify the merged object was written
+    const upsertCall = mockQuery.mock.calls[1];
+    expect(upsertCall[0]).toContain('ON CONFLICT');
+    const written = JSON.parse(upsertCall[1][1]);
+    expect(written.notifications_enabled).toBe(false);
+    expect(written.theme).toBe('dark');
+    expect(written.sidebar_collapsed).toBe(false);
+  });
+
+  it('PUT /profile/preferences merges with defaults when no row exists', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] }); // no existing row
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ preferences: { theme: 'light', notifications_enabled: true, sidebar_collapsed: false } }],
+    });
+
+    const res = await request(app)
+      .put('/profile/preferences')
+      .set('Authorization', `Bearer ${userToken}`)
+      .send({ theme: 'light' });
+
+    expect(res.status).toBe(200);
+    const written = JSON.parse(mockQuery.mock.calls[1][1][1]);
+    expect(written.theme).toBe('light');
+    expect(written.notifications_enabled).toBe(true); // from defaults
+  });
+
+  it('PUT /profile/preferences rejects array body', async () => {
+    const res = await request(app)
+      .put('/profile/preferences')
+      .set('Authorization', `Bearer ${userToken}`)
+      .send([1, 2, 3]);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain('JSON object');
+  });
+});

--- a/services/api/src/db/migrations/048_create_user_preferences.sql
+++ b/services/api/src/db/migrations/048_create_user_preferences.sql
@@ -1,0 +1,11 @@
+-- Migration 048: Create user_preferences table
+--
+-- Stores per-user UI/platform preferences as JSONB.
+-- One row per Keycloak user ID, upserted on PUT.
+
+CREATE TABLE IF NOT EXISTS user_preferences (
+  keycloak_id VARCHAR(255) PRIMARY KEY,
+  preferences JSONB NOT NULL DEFAULT '{"theme": "dark", "notifications_enabled": true, "sidebar_collapsed": false}'::jsonb,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/services/api/src/openapi/openapi.yaml
+++ b/services/api/src/openapi/openapi.yaml
@@ -1664,6 +1664,70 @@ paths:
         "403":
           description: Requires user role
 
+  /profile/preferences:
+    get:
+      summary: Get user preferences
+      tags: [Profile]
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: User preferences object
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  theme:
+                    type: string
+                    example: dark
+                  notifications_enabled:
+                    type: boolean
+                  sidebar_collapsed:
+                    type: boolean
+        "401":
+          description: Not authenticated
+        "403":
+          description: Requires user role
+    put:
+      summary: Update user preferences (shallow merge)
+      tags: [Profile]
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                theme:
+                  type: string
+                notifications_enabled:
+                  type: boolean
+                sidebar_collapsed:
+                  type: boolean
+      responses:
+        "200":
+          description: Merged preferences
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  theme:
+                    type: string
+                  notifications_enabled:
+                    type: boolean
+                  sidebar_collapsed:
+                    type: boolean
+        "400":
+          description: Invalid request body
+        "401":
+          description: Not authenticated
+        "403":
+          description: Requires user role
+
   /knowledge/agents:
     get:
       summary: List agents with knowledge

--- a/services/api/src/routes/profile.ts
+++ b/services/api/src/routes/profile.ts
@@ -213,6 +213,64 @@ router.get('/avatar', requireRole('user'), async (req: Request, res: Response) =
   }
 });
 
+// ── Preferences ──────────────────────────────────────────────────
+
+const DEFAULT_PREFERENCES = {
+  theme: 'dark',
+  notifications_enabled: true,
+  sidebar_collapsed: false,
+};
+
+// GET /profile/preferences — fetch user preferences
+router.get('/preferences', requireRole('user'), async (req: Request, res: Response) => {
+  try {
+    const user = (req as any).user;
+    const { rows } = await getPool().query(
+      'SELECT preferences FROM user_preferences WHERE keycloak_id = $1',
+      [user.sub]
+    );
+
+    res.json(rows[0]?.preferences ?? DEFAULT_PREFERENCES);
+  } catch (err) {
+    console.error('[profile] GET preferences error:', err);
+    res.status(500).json({ error: 'Failed to fetch preferences' });
+  }
+});
+
+// PUT /profile/preferences — upsert user preferences (shallow merge)
+router.put('/preferences', requireRole('user'), async (req: Request, res: Response) => {
+  try {
+    const user = (req as any).user;
+    const incoming = req.body;
+
+    if (!incoming || typeof incoming !== 'object' || Array.isArray(incoming)) {
+      res.status(400).json({ error: 'Request body must be a JSON object' });
+      return;
+    }
+
+    // Shallow merge: incoming keys overwrite, unspecified keys kept from DB/default
+    const { rows: existing } = await getPool().query(
+      'SELECT preferences FROM user_preferences WHERE keycloak_id = $1',
+      [user.sub]
+    );
+    const current = existing[0]?.preferences ?? DEFAULT_PREFERENCES;
+    const merged = { ...current, ...incoming };
+
+    const { rows } = await getPool().query(
+      `INSERT INTO user_preferences (keycloak_id, preferences)
+       VALUES ($1, $2)
+       ON CONFLICT (keycloak_id) DO UPDATE SET preferences = $2, updated_at = NOW()
+       RETURNING preferences`,
+      [user.sub, JSON.stringify(merged)]
+    );
+
+    res.json(rows[0].preferences);
+  } catch (err) {
+    console.error('[profile] PUT preferences error:', err);
+    res.status(500).json({ error: 'Failed to save preferences' });
+  }
+});
+
 // POST /profile/password — change password
 // NOTE: Keycloak 12+ removed the /account/credentials/password REST endpoint.
 // Password changes now require a browser redirect via kc_action=UPDATE_PASSWORD.


### PR DESCRIPTION
## Summary
- **Migration 048**: `user_preferences` table — `keycloak_id` PK, `preferences` JSONB with defaults
- **`GET /profile/preferences`**: Returns user's preferences, or defaults if no row exists
- **`PUT /profile/preferences`**: Shallow merge upsert — send only changed keys, rest preserved from DB/defaults
- Default preferences: `{ theme: "dark", notifications_enabled: true, sidebar_collapsed: false }`
- OpenAPI spec updated, EXPECTED_PATHS synced, docs drift test passes

## Changed files
| File | Change |
|------|--------|
| `048_create_user_preferences.sql` | New table with JSONB defaults |
| `routes/profile.ts` | GET + PUT `/preferences` routes |
| `openapi.yaml` | Both endpoints documented |
| `docs.test.ts` | Added to EXPECTED_PATHS |
| `routes-profile-preferences.test.ts` | 5 tests |

## Test plan
- [x] GET returns defaults when no row exists
- [x] GET returns stored preferences
- [x] PUT shallow-merges with existing row
- [x] PUT merges with defaults when no row exists
- [x] PUT rejects array body (400)
- [x] Docs drift test passes (13/13)

🤖 Generated with [Claude Code](https://claude.com/claude-code)