### PR TITLE
enhance: thread list UX — unread indicator dot

### DIFF
--- a/services/ui/src/__tests__/ThreadList.test.tsx
+++ b/services/ui/src/__tests__/ThreadList.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { describe, it, expect, vi, afterEach } from 'vitest'
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest'
 import { render, screen, cleanup, fireEvent } from '@testing-library/react'
 import '@testing-library/jest-dom/vitest'
 
@@ -11,6 +11,18 @@ vi.mock('lucide-react', () => ({
   Users: (props: any) => <span data-testid="icon-users" {...props} />,
   Trash2: (props: any) => <span data-testid="icon-trash" {...props} />,
 }))
+
+// Mock localStorage
+const localStorageMock = (() => {
+  let store: Record<string, string> = {}
+  return {
+    getItem: vi.fn((key: string) => store[key] ?? null),
+    setItem: vi.fn((key: string, value: string) => { store[key] = value }),
+    removeItem: vi.fn((key: string) => { delete store[key] }),
+    clear: vi.fn(() => { store = {} }),
+  }
+})()
+Object.defineProperty(window, 'localStorage', { value: localStorageMock })
 
 import ThreadList from '@/app/chat/ThreadList'
 import type { ChatThread } from '@/app/chat/ChatLayout'
@@ -31,6 +43,11 @@ function makeThread(overrides: Partial<ChatThread> = {}): ChatThread {
 }
 
 describe('ThreadList', () => {
+  beforeEach(() => {
+    localStorageMock.clear()
+    vi.clearAllMocks()
+  })
+
   afterEach(() => {
     cleanup()
   })
@@ -81,5 +98,38 @@ describe('ThreadList', () => {
     fireEvent.click(screen.getByTestId('delete-thread-thread-1'))
     fireEvent.click(screen.getByTestId('confirm-yes-thread-1'))
     expect(onDelete).toHaveBeenCalledWith('thread-1')
+  })
+
+  it('shows unread dot for threads not yet seen', () => {
+    const threads = [makeThread({
+      id: 'thread-1',
+      title: 'Unread Thread',
+      last_message: 'New message',
+      updated_at: new Date().toISOString(),
+    })]
+    render(<ThreadList threads={threads} loading={false} onDelete={vi.fn()} />)
+    expect(screen.getByTestId('unread-dot')).toBeInTheDocument()
+  })
+
+  it('hides unread dot for active thread', () => {
+    const threads = [makeThread({
+      id: 'thread-1',
+      title: 'Active Thread',
+      last_message: 'New message',
+      updated_at: new Date().toISOString(),
+    })]
+    render(<ThreadList threads={threads} loading={false} activeThreadId="thread-1" onDelete={vi.fn()} />)
+    expect(screen.queryByTestId('unread-dot')).not.toBeInTheDocument()
+  })
+
+  it('hides unread dot for threads with no messages', () => {
+    const threads = [makeThread({
+      id: 'thread-1',
+      title: 'Empty Thread',
+      last_message: null,
+      updated_at: new Date().toISOString(),
+    })]
+    render(<ThreadList threads={threads} loading={false} onDelete={vi.fn()} />)
+    expect(screen.queryByTestId('unread-dot')).not.toBeInTheDocument()
   })
 })

--- a/services/ui/src/app/chat/ThreadList.tsx
+++ b/services/ui/src/app/chat/ThreadList.tsx
@@ -1,10 +1,33 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import Link from 'next/link'
 import { Users, Trash2 } from 'lucide-react'
 import type { ChatThread } from './ChatLayout'
 import AgentAvatar from '@/components/AgentAvatar'
+
+const SEEN_KEY = 'hill90:thread-seen'
+
+function getSeenMap(): Record<string, string> {
+  try {
+    return JSON.parse(localStorage.getItem(SEEN_KEY) || '{}')
+  } catch {
+    return {}
+  }
+}
+
+function markSeen(threadId: string) {
+  const map = getSeenMap()
+  map[threadId] = new Date().toISOString()
+  localStorage.setItem(SEEN_KEY, JSON.stringify(map))
+}
+
+function isUnread(thread: ChatThread, seenMap: Record<string, string>): boolean {
+  if (!thread.last_message) return false
+  const lastSeen = seenMap[thread.id]
+  if (!lastSeen) return true
+  return (thread.updated_at || thread.created_at) > lastSeen
+}
 
 interface Props {
   threads: ChatThread[]
@@ -33,6 +56,20 @@ function truncate(text: string, maxLen: number): string {
 
 export default function ThreadList({ threads, loading, activeThreadId, onDelete }: Props) {
   const [confirmId, setConfirmId] = useState<string | null>(null)
+  const [seenMap, setSeenMap] = useState<Record<string, string>>({})
+
+  // Load seen map on mount
+  useEffect(() => {
+    setSeenMap(getSeenMap())
+  }, [])
+
+  // Mark active thread as seen whenever it changes
+  useEffect(() => {
+    if (activeThreadId) {
+      markSeen(activeThreadId)
+      setSeenMap(getSeenMap())
+    }
+  }, [activeThreadId])
 
   if (loading) {
     return (
@@ -61,6 +98,7 @@ export default function ThreadList({ threads, loading, activeThreadId, onDelete 
           ? truncate(thread.last_message, 60)
           : 'No messages yet'
         const time = timeAgo(thread.updated_at || thread.created_at)
+        const unread = !isActive && isUnread(thread, seenMap)
 
         return (
           <div key={thread.id} className="group relative">
@@ -91,6 +129,9 @@ export default function ThreadList({ threads, loading, activeThreadId, onDelete 
                     </span>
                     {!isGroup && thread.agent?.status === 'running' && (
                       <span className="w-1.5 h-1.5 rounded-full bg-brand-400 flex-shrink-0" />
+                    )}
+                    {unread && (
+                      <span className="w-2 h-2 rounded-full bg-blue-500 flex-shrink-0" data-testid="unread-dot" />
                     )}
                   </div>
                   {isGroup && thread.agents && thread.agents.length > 0 && (


### PR DESCRIPTION
## Summary
- Add blue unread indicator dot to thread list items
- localStorage-based seen tracking (`hill90:thread-seen` key): stores last-viewed timestamp per thread
- Active thread is automatically marked as seen on selection
- Unread logic: thread has `last_message` AND `updated_at` is newer than last seen time
- No dot shown for: active thread, threads with no messages, already-seen threads
- Message preview (truncated to 60 chars) and relative timestamps were already present — no changes needed

## Test Plan
- [x] 9 ThreadList tests pass (6 existing + 3 new unread tests)
- [ ] Visual: new thread with messages shows blue dot
- [ ] Visual: clicking thread clears its blue dot
- [ ] Visual: thread with no messages has no dot

🤖 Generated with [Claude Code](https://claude.com/claude-code)