### PR TITLE
feat: add detailed health check endpoint

### DIFF
--- a/docs/site/openapi.yaml
+++ b/docs/site/openapi.yaml
@@ -955,6 +955,51 @@ paths:
                     type: string
                     example: api
 
+  /health/detailed:
+    get:
+      summary: Detailed health check
+      description: >
+        Returns service health with database connectivity, uptime, memory usage,
+        and Node.js version. Public — no authentication required.
+      security: []
+      responses:
+        "200":
+          description: Detailed health status
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    enum: [healthy, degraded]
+                  service:
+                    type: string
+                    example: api
+                  uptime_seconds:
+                    type: integer
+                  node_version:
+                    type: string
+                    example: v20.18.0
+                  database:
+                    type: object
+                    properties:
+                      status:
+                        type: string
+                        enum: [connected, error]
+                      latency_ms:
+                        type: integer
+                        nullable: true
+                  memory:
+                    type: object
+                    properties:
+                      rss_mb:
+                        type: integer
+                      heap_used_mb:
+                        type: integer
+                      heap_total_mb:
+                        type: integer
+
   /me:
     get:
       summary: Get current user claims

--- a/services/api/src/__tests__/docs.test.ts
+++ b/services/api/src/__tests__/docs.test.ts
@@ -141,6 +141,7 @@ describe('Root route non-regression', () => {
 // from drift enforcement. They are tested for auth/RBAC above, not contract coverage.
 const EXPECTED_PATHS = [
   '/health',
+  '/health/detailed',
   '/me',
   '/agents',
   '/agents/{id}',
@@ -285,7 +286,7 @@ describe('Spec contract enforcement', () => {
       for (const [method, operation] of Object.entries(pathItem)) {
         if (method === 'parameters') continue;
         const op = operation as any;
-        if (pathKey === '/health') {
+        if (pathKey === '/health' || pathKey === '/health/detailed') {
           expect(op.security).toEqual([]);
         } else {
           expect(op.security).toBeDefined();

--- a/services/api/src/app.ts
+++ b/services/api/src/app.ts
@@ -39,6 +39,37 @@ export function createApp(opts: AppOptions = {}): Application {
     res.json({ status: 'healthy', service: 'api' });
   });
 
+  // Detailed health — public, includes DB check + runtime stats
+  app.get('/health/detailed', async (_req, res) => {
+    const mem = process.memoryUsage();
+    let dbStatus: 'connected' | 'error' = 'error';
+    let dbLatencyMs: number | null = null;
+
+    try {
+      const { getPool } = await import('./db/pool');
+      const start = Date.now();
+      await getPool().query('SELECT 1');
+      dbLatencyMs = Date.now() - start;
+      dbStatus = 'connected';
+    } catch { /* db unreachable */ }
+
+    res.json({
+      status: dbStatus === 'connected' ? 'healthy' : 'degraded',
+      service: 'api',
+      uptime_seconds: Math.floor(process.uptime()),
+      node_version: process.version,
+      database: {
+        status: dbStatus,
+        latency_ms: dbLatencyMs,
+      },
+      memory: {
+        rss_mb: Math.round(mem.rss / 1024 / 1024),
+        heap_used_mb: Math.round(mem.heapUsed / 1024 / 1024),
+        heap_total_mb: Math.round(mem.heapTotal / 1024 / 1024),
+      },
+    });
+  });
+
   // Internal service-to-service endpoints (service-token auth, not Keycloak)
   app.post('/internal/delegation-token', delegationTokenHandler);
   app.post('/internal/chat/callback', chatCallbackHandler);

--- a/services/api/src/openapi/openapi.yaml
+++ b/services/api/src/openapi/openapi.yaml
@@ -955,6 +955,51 @@ paths:
                     type: string
                     example: api
 
+  /health/detailed:
+    get:
+      summary: Detailed health check
+      description: >
+        Returns service health with database connectivity, uptime, memory usage,
+        and Node.js version. Public — no authentication required.
+      security: []
+      responses:
+        "200":
+          description: Detailed health status
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    enum: [healthy, degraded]
+                  service:
+                    type: string
+                    example: api
+                  uptime_seconds:
+                    type: integer
+                  node_version:
+                    type: string
+                    example: v20.18.0
+                  database:
+                    type: object
+                    properties:
+                      status:
+                        type: string
+                        enum: [connected, error]
+                      latency_ms:
+                        type: integer
+                        nullable: true
+                  memory:
+                    type: object
+                    properties:
+                      rss_mb:
+                        type: integer
+                      heap_used_mb:
+                        type: integer
+                      heap_total_mb:
+                        type: integer
+
   /me:
     get:
       summary: Get current user claims


### PR DESCRIPTION
## Summary
- **`GET /health/detailed`** — public endpoint returning:
  - `status`: "healthy" or "degraded" (degraded when DB unreachable)
  - `uptime_seconds`: `process.uptime()`
  - `node_version`: `process.version`
  - `database.status` + `database.latency_ms`: SELECT 1 round-trip
  - `memory`: rss_mb, heap_used_mb, heap_total_mb
- OpenAPI spec documented with full schema
- Docs drift test updated: EXPECTED_PATHS + security exemption (public like /health)

## Test plan
- [x] All 13 docs drift tests pass
- [x] `spec documents all API routes` — /health/detailed present
- [x] `every registered Express route maps to EXPECTED_PATHS` — passes
- [x] `every path except /health has security defined` — exempts /health/detailed

🤖 Generated with [Claude Code](https://claude.com/claude-code)