### PR TITLE
feat: add Knowledge tab to agent detail page

### DIFF
--- a/services/ui/src/__tests__/AgentKnowledge.test.tsx
+++ b/services/ui/src/__tests__/AgentKnowledge.test.tsx
@@ -1,0 +1,139 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+
+const mockFetch = vi.fn()
+vi.stubGlobal('fetch', mockFetch)
+
+import AgentKnowledge from '@/app/agents/[id]/AgentKnowledge'
+
+const MOCK_COLLECTIONS = [
+  { id: 'col-1', name: 'Platform Docs', description: 'Internal documentation', visibility: 'shared', created_at: '2026-01-01T00:00:00Z' },
+  { id: 'col-2', name: 'Research Notes', description: null, visibility: 'private', created_at: '2026-02-01T00:00:00Z' },
+]
+
+const MOCK_RESULTS = {
+  results: [
+    {
+      chunk_id: 'ch-1',
+      content: 'Deployment uses Docker Compose on VPS.',
+      headline: '<b>Deployment</b> uses Docker Compose on VPS.',
+      rank: 0.8,
+      source_title: 'deployment.md',
+      collection_name: 'Platform Docs',
+    },
+  ],
+}
+
+describe('AgentKnowledge', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockFetch.mockImplementation((...args: any[]) => {
+      const url = typeof args[0] === 'string' ? args[0] : ''
+      if (url.includes('/api/shared-knowledge/collections')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_COLLECTIONS) })
+      }
+      if (url.includes('/api/shared-knowledge/search')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_RESULTS) })
+      }
+      return Promise.resolve({ ok: false })
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('renders search input and collections heading', async () => {
+    render(<AgentKnowledge agentName="TestBot" />)
+
+    expect(screen.getByText('Search Knowledge')).toBeInTheDocument()
+    expect(screen.getByTestId('knowledge-search-input')).toBeInTheDocument()
+
+    await waitFor(() => {
+      expect(screen.getByText('Available Collections')).toBeInTheDocument()
+    })
+  })
+
+  it('fetches and displays collections', async () => {
+    render(<AgentKnowledge agentName="TestBot" />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('collections-list')).toBeInTheDocument()
+      expect(screen.getByText('Platform Docs')).toBeInTheDocument()
+      expect(screen.getByText('Research Notes')).toBeInTheDocument()
+    })
+  })
+
+  it('shows visibility badges', async () => {
+    render(<AgentKnowledge agentName="TestBot" />)
+
+    await waitFor(() => {
+      expect(screen.getByText('shared')).toBeInTheDocument()
+      expect(screen.getByText('private')).toBeInTheDocument()
+    })
+  })
+
+  it('shows empty state when no collections', async () => {
+    mockFetch.mockImplementation(() =>
+      Promise.resolve({ ok: true, json: () => Promise.resolve([]) })
+    )
+
+    render(<AgentKnowledge agentName="TestBot" />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('no-collections')).toBeInTheDocument()
+    })
+  })
+
+  it('searches and displays results', async () => {
+    render(<AgentKnowledge agentName="TestBot" />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Platform Docs')).toBeInTheDocument()
+    })
+
+    const input = screen.getByTestId('knowledge-search-input')
+    fireEvent.change(input, { target: { value: 'deployment' } })
+    fireEvent.submit(input.closest('form')!)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('search-results')).toBeInTheDocument()
+      expect(screen.getByText('deployment.md')).toBeInTheDocument()
+    })
+  })
+
+  it('shows no results message on empty search', async () => {
+    mockFetch.mockImplementation((...args: any[]) => {
+      const url = typeof args[0] === 'string' ? args[0] : ''
+      if (url.includes('/api/shared-knowledge/collections')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_COLLECTIONS) })
+      }
+      if (url.includes('/api/shared-knowledge/search')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ results: [] }) })
+      }
+      return Promise.resolve({ ok: false })
+    })
+
+    render(<AgentKnowledge agentName="TestBot" />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Platform Docs')).toBeInTheDocument()
+    })
+
+    const input = screen.getByTestId('knowledge-search-input')
+    fireEvent.change(input, { target: { value: 'nonexistent' } })
+    fireEvent.submit(input.closest('form')!)
+
+    await waitFor(() => {
+      expect(screen.getByText('No results found.')).toBeInTheDocument()
+    })
+  })
+
+  it('includes agent name in description', async () => {
+    render(<AgentKnowledge agentName="ResearchBot" />)
+
+    expect(screen.getByText(/ResearchBot/)).toBeInTheDocument()
+  })
+})

--- a/services/ui/src/app/agents/[id]/AgentDetailClient.tsx
+++ b/services/ui/src/app/agents/[id]/AgentDetailClient.tsx
@@ -10,6 +10,7 @@ import AgentMemory from './AgentMemory'
 import AgentNotebook from './AgentNotebook'
 import AgentProgression from './AgentProgression'
 import WorkspaceBrowser from './WorkspaceBrowser'
+import AgentKnowledge from './AgentKnowledge'
 import AgentAvatar from '@/components/AgentAvatar'
 
 interface Agent {
@@ -74,7 +75,7 @@ function scopeBadge(scope: string): { label: string; colorClasses: string } {
   }
 }
 
-type TabId = 'overview' | 'configuration' | 'model-access' | 'memory' | 'notebook' | 'workspace' | 'activity'
+type TabId = 'overview' | 'configuration' | 'model-access' | 'memory' | 'notebook' | 'workspace' | 'knowledge' | 'activity'
 
 export default function AgentDetailClient({
   agentId,
@@ -389,6 +390,7 @@ export default function AgentDetailClient({
     { id: 'memory', label: 'Memory' },
     { id: 'notebook', label: 'Notebook' },
     { id: 'workspace', label: 'Workspace' },
+    { id: 'knowledge', label: 'Knowledge' },
     { id: 'activity', label: 'Activity' },
   ]
 
@@ -951,6 +953,10 @@ export default function AgentDetailClient({
 
       {activeTab === 'workspace' && agent && (
         <WorkspaceBrowser agentId={agent.agent_id} />
+      )}
+
+      {activeTab === 'knowledge' && agent && (
+        <AgentKnowledge agentName={agent.name} />
       )}
 
       {activeTab === 'activity' && (

--- a/services/ui/src/app/agents/[id]/AgentKnowledge.tsx
+++ b/services/ui/src/app/agents/[id]/AgentKnowledge.tsx
@@ -1,0 +1,161 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+import { Search, BookOpen, FileText } from 'lucide-react'
+
+interface Collection {
+  id: string
+  name: string
+  description: string | null
+  visibility: string
+  source_count?: number
+  created_at: string
+}
+
+interface SearchResult {
+  chunk_id: string
+  content: string
+  headline: string
+  rank: number
+  source_title: string
+  collection_name: string
+}
+
+export default function AgentKnowledge({ agentName }: { agentName: string }) {
+  const [collections, setCollections] = useState<Collection[]>([])
+  const [loading, setLoading] = useState(true)
+  const [query, setQuery] = useState('')
+  const [searching, setSearching] = useState(false)
+  const [results, setResults] = useState<SearchResult[]>([])
+  const [searched, setSearched] = useState(false)
+
+  const fetchCollections = useCallback(async () => {
+    try {
+      const res = await fetch('/api/shared-knowledge/collections')
+      if (res.ok) {
+        setCollections(await res.json())
+      }
+    } catch {
+      // silent
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    fetchCollections()
+  }, [fetchCollections])
+
+  const handleSearch = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!query.trim()) return
+
+    setSearching(true)
+    setSearched(true)
+    try {
+      const params = new URLSearchParams({ q: query.trim() })
+      const res = await fetch(`/api/shared-knowledge/search?${params}`)
+      if (res.ok) {
+        const data = await res.json()
+        setResults(data.results || [])
+      }
+    } catch {
+      // silent
+    } finally {
+      setSearching(false)
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Search */}
+      <div className="rounded-lg border border-navy-700 bg-navy-800 p-5">
+        <h2 className="text-lg font-semibold text-white mb-3">Search Knowledge</h2>
+        <p className="text-xs text-mountain-500 mb-3">
+          Search across shared knowledge collections available to {agentName}.
+        </p>
+        <form onSubmit={handleSearch} className="flex gap-2">
+          <div className="relative flex-1">
+            <Search size={14} className="absolute left-3 top-1/2 -translate-y-1/2 text-mountain-500" />
+            <input
+              type="text"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Search shared knowledge..."
+              className="w-full pl-9 pr-3 py-2 rounded-md border border-navy-600 bg-navy-900 text-sm text-white placeholder-mountain-500 focus:border-brand-500 focus:outline-none"
+              data-testid="knowledge-search-input"
+            />
+          </div>
+          <button
+            type="submit"
+            disabled={!query.trim() || searching}
+            className="px-4 py-2 text-sm font-medium rounded-lg bg-brand-600 hover:bg-brand-500 text-white transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {searching ? 'Searching...' : 'Search'}
+          </button>
+        </form>
+
+        {searched && !searching && (
+          <div className="mt-4" data-testid="search-results">
+            {results.length === 0 ? (
+              <p className="text-sm text-mountain-500">No results found.</p>
+            ) : (
+              <div className="space-y-3">
+                {results.map((r) => (
+                  <div key={r.chunk_id} className="rounded-md border border-navy-700 bg-navy-900 p-3">
+                    <div className="flex items-center gap-2 mb-1">
+                      <FileText size={12} className="text-mountain-400" />
+                      <span className="text-xs font-medium text-mountain-400">{r.collection_name}</span>
+                      <span className="text-xs text-mountain-500">{r.source_title}</span>
+                    </div>
+                    <p
+                      className="text-sm text-gray-200"
+                      dangerouslySetInnerHTML={{ __html: r.headline || r.content.slice(0, 200) }}
+                    />
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* Collections */}
+      <div className="rounded-lg border border-navy-700 bg-navy-800 p-5">
+        <h2 className="text-lg font-semibold text-white mb-3">Available Collections</h2>
+        {loading ? (
+          <div className="flex items-center justify-center py-6">
+            <div className="h-5 w-5 rounded-full border-2 border-brand-500 border-t-transparent animate-spin" />
+          </div>
+        ) : collections.length === 0 ? (
+          <p className="text-sm text-mountain-500" data-testid="no-collections">
+            No shared knowledge collections available.
+          </p>
+        ) : (
+          <div className="space-y-2" data-testid="collections-list">
+            {collections.map((col) => (
+              <div key={col.id} className="flex items-start gap-3 rounded-md border border-navy-700 bg-navy-900 p-3">
+                <BookOpen size={16} className="text-brand-400 mt-0.5 flex-shrink-0" />
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-2">
+                    <span className="text-sm font-medium text-white">{col.name}</span>
+                    <span className={`text-[10px] px-1.5 py-0.5 rounded border ${
+                      col.visibility === 'shared'
+                        ? 'bg-brand-900/50 text-brand-400 border-brand-700'
+                        : 'bg-navy-700 text-mountain-400 border-navy-600'
+                    }`}>
+                      {col.visibility}
+                    </span>
+                  </div>
+                  {col.description && (
+                    <p className="text-xs text-mountain-500 mt-0.5">{col.description}</p>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Add Knowledge tab to agent detail page tab bar (between Workspace and Activity)
- **Collections list**: fetches `GET /api/shared-knowledge/collections`, shows name, description, visibility badge (shared/private)
- **Search**: text input queries `GET /api/shared-knowledge/search?q=...`, displays results with highlighted snippets, source title, and collection name
- Read-only — no create/edit/delete, just browse what knowledge is available to the agent
- 7 new Vitest tests covering: render, collections fetch, visibility badges, empty state, search with results, no results, agent name in description

## Test Plan
- [x] 7 AgentKnowledge tests pass
- [ ] Visual: click Knowledge tab on agent detail — see collections list
- [ ] Visual: type query and search — see results with highlighted text

🤖 Generated with [Claude Code](https://claude.com/claude-code)