### PR TITLE
feat: add theme context and toggle infrastructure

### DIFF
--- a/services/ui/src/components/Providers.tsx
+++ b/services/ui/src/components/Providers.tsx
@@ -1,7 +1,12 @@
 'use client'
 
 import { SessionProvider } from "next-auth/react"
+import { ThemeProvider } from "@/contexts/ThemeContext"
 
 export default function Providers({ children }: { children: React.ReactNode }) {
-  return <SessionProvider>{children}</SessionProvider>
+  return (
+    <SessionProvider>
+      <ThemeProvider>{children}</ThemeProvider>
+    </SessionProvider>
+  )
 }

--- a/services/ui/src/components/ThemeToggle.tsx
+++ b/services/ui/src/components/ThemeToggle.tsx
@@ -1,0 +1,19 @@
+'use client'
+
+import { Sun, Moon } from 'lucide-react'
+import { useTheme } from '@/contexts/ThemeContext'
+
+export default function ThemeToggle() {
+  const { theme, toggleTheme } = useTheme()
+
+  return (
+    <button
+      onClick={toggleTheme}
+      className="p-1.5 text-mountain-400 hover:text-white transition-colors rounded-md hover:bg-navy-700"
+      aria-label={`Switch to ${theme === 'dark' ? 'light' : 'dark'} mode`}
+      data-testid="theme-toggle"
+    >
+      {theme === 'dark' ? <Sun size={20} /> : <Moon size={20} />}
+    </button>
+  )
+}

--- a/services/ui/src/components/TopBar.tsx
+++ b/services/ui/src/components/TopBar.tsx
@@ -6,6 +6,7 @@ import { useSession } from 'next-auth/react'
 import { Menu, Bell, Bot, CheckCircle, AlertCircle, Play } from 'lucide-react'
 import HillLogo from '@/components/HillLogo'
 import AuthButtons from '@/components/AuthButtons'
+import ThemeToggle from '@/components/ThemeToggle'
 import MobileDrawer from '@/components/MobileDrawer'
 
 interface Notification {
@@ -228,6 +229,7 @@ export default function TopBar({ navExtra }: TopBarProps) {
               )}
             </div>
           )}
+          <ThemeToggle />
           <AuthButtons />
         </div>
       </header>

--- a/services/ui/src/contexts/ThemeContext.tsx
+++ b/services/ui/src/contexts/ThemeContext.tsx
@@ -1,0 +1,54 @@
+'use client'
+
+import { createContext, useContext, useState, useEffect, useCallback } from 'react'
+
+type Theme = 'dark' | 'light'
+
+interface ThemeContextValue {
+  theme: Theme
+  toggleTheme: () => void
+}
+
+const ThemeContext = createContext<ThemeContextValue>({
+  theme: 'dark',
+  toggleTheme: () => {},
+})
+
+const STORAGE_KEY = 'hill90-theme'
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setTheme] = useState<Theme>('dark')
+
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY)
+      if (stored === 'light' || stored === 'dark') {
+        setTheme(stored)
+      }
+    } catch {
+      // localStorage unavailable
+    }
+  }, [])
+
+  const toggleTheme = useCallback(() => {
+    setTheme(prev => {
+      const next: Theme = prev === 'dark' ? 'light' : 'dark'
+      try {
+        localStorage.setItem(STORAGE_KEY, next)
+      } catch {
+        // localStorage unavailable
+      }
+      return next
+    })
+  }, [])
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  )
+}
+
+export function useTheme() {
+  return useContext(ThemeContext)
+}


### PR DESCRIPTION
## Summary
- Add `ThemeContext` (`contexts/ThemeContext.tsx`) with `ThemeProvider` and `useTheme` hook
- Stores theme preference (`dark`/`light`) in localStorage key `hill90-theme`, defaults to `dark`
- Add `ThemeToggle` component (`components/ThemeToggle.tsx`) — sun/moon icon button
- Wire `ThemeProvider` into `Providers.tsx` (wraps app alongside SessionProvider)
- Place `ThemeToggle` in TopBar between notification bell and auth buttons
- Infrastructure only — dark mode is the only functional theme for now

## Test plan
- [ ] Verify sun icon appears in TopBar (dark mode default)
- [ ] Click toggle — icon switches to moon, localStorage key `hill90-theme` set to `light`
- [ ] Click again — icon switches back to sun, localStorage set to `dark`
- [ ] Refresh page — preference persists from localStorage
- [ ] Verify no visual changes (only dark mode is styled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)