### PR TITLE
fix: add file upload and delete to storage page

### DIFF
--- a/docs/site/openapi.yaml
+++ b/docs/site/openapi.yaml
@@ -3980,6 +3980,44 @@ paths:
         "409":
           description: No running agents in thread
 
+  /chat/threads/{id}/screenshot:
+    get:
+      summary: Latest browser screenshot for thread agent
+      description: >
+        Returns the latest Playwright browser screenshot from the running agent
+        in this thread. Proxied from agentbox. Used by the Browser tab for live viewing.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Screenshot data
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  screenshot:
+                    type: string
+                    description: Base64-encoded PNG screenshot
+                  url:
+                    type: string
+                    nullable: true
+                    description: Current page URL
+                  timestamp:
+                    type: string
+                    format: date-time
+        "404":
+          description: No running agent or no browser active
+        "409":
+          description: No running agents in thread
+
   # Task management
   /tasks:
     get:
@@ -4153,6 +4191,53 @@ paths:
           description: Transitioned task
         "404":
           description: Task not found
+  /storage/buckets/{name}/upload:
+    post:
+      summary: Upload file to bucket
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: name
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                file:
+                  type: string
+                  format: binary
+      responses:
+        "200":
+          description: Upload successful
+        "400":
+          description: No file provided
+        "502":
+          description: Storage service unavailable
+
+  /storage/buckets/{name}/objects/*:
+    delete:
+      summary: Delete object from bucket
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: name
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Object deleted
+        "404":
+          description: Bucket or object not found
+        "502":
+          description: Storage service unavailable
+
   # ── Admin: Secrets Vault Inventory (AI-147) ──
 
   /admin/secrets:
@@ -4244,6 +4329,60 @@ paths:
           description: Not authenticated
         "403":
           description: Requires admin role
+
+  /admin/secrets/kv:
+    put:
+      summary: Create or update a vault secret
+      description: Write a key-value pair to vault. Admin only.
+      security:
+        - bearerAuth: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [path, key, value]
+              properties:
+                path:
+                  type: string
+                key:
+                  type: string
+                value:
+                  type: string
+      responses:
+        "200":
+          description: Secret written
+        "401":
+          description: Not authenticated
+        "403":
+          description: Requires admin role
+        "502":
+          description: Vault unavailable
+    delete:
+      summary: Delete a vault secret key
+      description: Remove a key from a vault path. Admin only.
+      security:
+        - bearerAuth: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [path, key]
+              properties:
+                path:
+                  type: string
+                key:
+                  type: string
+      responses:
+        "200":
+          description: Secret deleted
+        "401":
+          description: Not authenticated
+        "403":
+          description: Requires admin role
+        "502":
+          description: Vault unavailable
 
   # ── Storage (MinIO) ──────────────────────────────────────────────
 

--- a/services/api/src/__tests__/docs.test.ts
+++ b/services/api/src/__tests__/docs.test.ts
@@ -195,13 +195,17 @@ const EXPECTED_PATHS = [
   '/chat/threads/{id}/cancel',
   '/chat/threads/{id}/stream',
   '/chat/threads/{id}/events',
+  '/chat/threads/{id}/screenshot',
   '/tasks',
   '/tasks/{id}',
   '/tasks/{id}/transition',
   '/storage/buckets',
   '/storage/buckets/{name}/objects',
+  '/storage/buckets/{name}/upload',
+  '/storage/buckets/{name}/objects/*',
   '/admin/secrets',
   '/admin/secrets/status',
+  '/admin/secrets/kv',
 ];
 
 const INFRA_PATHS = ['/docs', '/openapi.json', '/internal/delegation-token', '/internal/chat/callback', '/internal/model-router/refresh-token'];

--- a/services/api/src/openapi/openapi.yaml
+++ b/services/api/src/openapi/openapi.yaml
@@ -3980,6 +3980,44 @@ paths:
         "409":
           description: No running agents in thread
 
+  /chat/threads/{id}/screenshot:
+    get:
+      summary: Latest browser screenshot for thread agent
+      description: >
+        Returns the latest Playwright browser screenshot from the running agent
+        in this thread. Proxied from agentbox. Used by the Browser tab for live viewing.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Screenshot data
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  screenshot:
+                    type: string
+                    description: Base64-encoded PNG screenshot
+                  url:
+                    type: string
+                    nullable: true
+                    description: Current page URL
+                  timestamp:
+                    type: string
+                    format: date-time
+        "404":
+          description: No running agent or no browser active
+        "409":
+          description: No running agents in thread
+
   # Task management
   /tasks:
     get:
@@ -4153,6 +4191,53 @@ paths:
           description: Transitioned task
         "404":
           description: Task not found
+  /storage/buckets/{name}/upload:
+    post:
+      summary: Upload file to bucket
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: name
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                file:
+                  type: string
+                  format: binary
+      responses:
+        "200":
+          description: Upload successful
+        "400":
+          description: No file provided
+        "502":
+          description: Storage service unavailable
+
+  /storage/buckets/{name}/objects/*:
+    delete:
+      summary: Delete object from bucket
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: name
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Object deleted
+        "404":
+          description: Bucket or object not found
+        "502":
+          description: Storage service unavailable
+
   # ── Admin: Secrets Vault Inventory (AI-147) ──
 
   /admin/secrets:
@@ -4244,6 +4329,60 @@ paths:
           description: Not authenticated
         "403":
           description: Requires admin role
+
+  /admin/secrets/kv:
+    put:
+      summary: Create or update a vault secret
+      description: Write a key-value pair to vault. Admin only.
+      security:
+        - bearerAuth: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [path, key, value]
+              properties:
+                path:
+                  type: string
+                key:
+                  type: string
+                value:
+                  type: string
+      responses:
+        "200":
+          description: Secret written
+        "401":
+          description: Not authenticated
+        "403":
+          description: Requires admin role
+        "502":
+          description: Vault unavailable
+    delete:
+      summary: Delete a vault secret key
+      description: Remove a key from a vault path. Admin only.
+      security:
+        - bearerAuth: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [path, key]
+              properties:
+                path:
+                  type: string
+                key:
+                  type: string
+      responses:
+        "200":
+          description: Secret deleted
+        "401":
+          description: Not authenticated
+        "403":
+          description: Requires admin role
+        "502":
+          description: Vault unavailable
 
   # ── Storage (MinIO) ──────────────────────────────────────────────
 

--- a/services/api/src/routes/storage.ts
+++ b/services/api/src/routes/storage.ts
@@ -1,12 +1,20 @@
 import { Router, Request, Response } from 'express';
+import multer from 'multer';
 import {
   ListBucketsCommand,
   ListObjectsV2Command,
+  PutObjectCommand,
+  DeleteObjectCommand,
 } from '@aws-sdk/client-s3';
 import { getS3Client } from '../services/s3';
 import { requireRole } from '../middleware/role';
 
 const router = Router();
+
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: 50 * 1024 * 1024 }, // 50MB
+});
 
 // All storage routes require admin role
 router.use(requireRole('admin'));
@@ -69,6 +77,69 @@ router.get('/buckets/:name/objects', async (req: Request, res: Response) => {
     }
     console.error(`[storage] Failed to list objects in ${name}:`, err);
     res.status(502).json({ error: 'Failed to list objects from storage service' });
+  }
+});
+
+// POST /storage/buckets/:name/upload — upload a file to a bucket
+router.post('/buckets/:name/upload', upload.single('file'), async (req: Request, res: Response) => {
+  const { name } = req.params;
+  const file = (req as any).file as Express.Multer.File | undefined;
+  const key = (req.body?.key as string) || file?.originalname;
+
+  if (!file) {
+    res.status(400).json({ error: 'No file provided' });
+    return;
+  }
+  if (!key) {
+    res.status(400).json({ error: 'No key provided' });
+    return;
+  }
+
+  try {
+    const s3 = getS3Client();
+    await s3.send(new PutObjectCommand({
+      Bucket: name,
+      Key: key,
+      Body: file.buffer,
+      ContentType: file.mimetype,
+    }));
+
+    res.json({ key, size: file.size, content_type: file.mimetype });
+  } catch (err: any) {
+    if (err.name === 'NoSuchBucket' || err.$metadata?.httpStatusCode === 404) {
+      res.status(404).json({ error: `Bucket '${name}' not found` });
+      return;
+    }
+    console.error(`[storage] Failed to upload to ${name}:`, err);
+    res.status(502).json({ error: 'Failed to upload to storage service' });
+  }
+});
+
+// DELETE /storage/buckets/:name/objects/* — delete an object from a bucket
+router.delete('/buckets/:name/objects/*', async (req: Request, res: Response) => {
+  const { name } = req.params;
+  const key = (req.params as any)[0] as string;
+
+  if (!key) {
+    res.status(400).json({ error: 'No object key provided' });
+    return;
+  }
+
+  try {
+    const s3 = getS3Client();
+    await s3.send(new DeleteObjectCommand({
+      Bucket: name,
+      Key: key,
+    }));
+
+    res.json({ deleted: key });
+  } catch (err: any) {
+    if (err.name === 'NoSuchBucket' || err.$metadata?.httpStatusCode === 404) {
+      res.status(404).json({ error: `Bucket '${name}' not found` });
+      return;
+    }
+    console.error(`[storage] Failed to delete ${key} from ${name}:`, err);
+    res.status(502).json({ error: 'Failed to delete object from storage service' });
   }
 });
 

--- a/services/ui/src/app/api/storage/[...path]/route.ts
+++ b/services/ui/src/app/api/storage/[...path]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest } from 'next/server'
 import { proxyToApi } from '@/utils/api-proxy'
+import { proxyMultipartToApi } from '@/utils/api-proxy-multipart'
 
 async function proxyRequest(req: NextRequest, { params }: { params: Promise<{ path: string[] }> }) {
   const { path } = await params
@@ -7,4 +8,12 @@ async function proxyRequest(req: NextRequest, { params }: { params: Promise<{ pa
   return proxyToApi(req, `/storage/${pathStr}`, { label: 'storage-proxy' })
 }
 
+async function proxyUpload(req: NextRequest, { params }: { params: Promise<{ path: string[] }> }) {
+  const { path } = await params
+  const pathStr = path.join('/')
+  return proxyMultipartToApi(req, `/storage/${pathStr}`, { label: 'storage-proxy-upload' })
+}
+
 export const GET = proxyRequest
+export const POST = proxyUpload
+export const DELETE = proxyRequest

--- a/services/ui/src/app/harness/storage/StorageClient.tsx
+++ b/services/ui/src/app/harness/storage/StorageClient.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import { useState, useEffect, useCallback } from 'react'
-import { HardDrive, FolderOpen, File, ChevronRight, ArrowLeft, RefreshCw } from 'lucide-react'
+import { useState, useEffect, useCallback, useRef } from 'react'
+import { HardDrive, FolderOpen, File, ChevronRight, ArrowLeft, RefreshCw, Upload, Trash2 } from 'lucide-react'
 
 interface Bucket {
   name: string
@@ -54,6 +54,9 @@ export default function StorageClient() {
   const [prefixes, setPrefixes] = useState<string[]>([])
   const [objectsLoading, setObjectsLoading] = useState(false)
   const [objectsError, setObjectsError] = useState<string | null>(null)
+  const [uploading, setUploading] = useState(false)
+  const [deleting, setDeleting] = useState<string | null>(null)
+  const fileInputRef = useRef<HTMLInputElement>(null)
 
   const fetchBuckets = useCallback(async () => {
     setLoading(true)
@@ -94,6 +97,56 @@ export default function StorageClient() {
       setObjectsLoading(false)
     }
   }, [])
+
+  const handleUpload = useCallback(async (files: FileList) => {
+    if (!activeBucket || files.length === 0) return
+    setUploading(true)
+    setObjectsError(null)
+    try {
+      for (const file of Array.from(files)) {
+        const formData = new FormData()
+        formData.append('file', file)
+        const key = prefix + file.name
+        formData.append('key', key)
+        const res = await fetch(`/api/storage/buckets/${activeBucket}/upload`, {
+          method: 'POST',
+          body: formData,
+        })
+        if (!res.ok) {
+          const data = await res.json().catch(() => ({}))
+          throw new Error(data.error || `Failed to upload ${file.name} (${res.status})`)
+        }
+      }
+      fetchObjects(activeBucket, prefix)
+    } catch (err) {
+      setObjectsError(err instanceof Error ? err.message : 'Upload failed')
+    } finally {
+      setUploading(false)
+      if (fileInputRef.current) fileInputRef.current.value = ''
+    }
+  }, [activeBucket, prefix, fetchObjects])
+
+  const handleDelete = useCallback(async (key: string) => {
+    if (!activeBucket) return
+    const fileName = key.replace(prefix, '')
+    if (!confirm(`Delete "${fileName}"?`)) return
+    setDeleting(key)
+    setObjectsError(null)
+    try {
+      const res = await fetch(`/api/storage/buckets/${activeBucket}/objects/${encodeURIComponent(key)}`, {
+        method: 'DELETE',
+      })
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}))
+        throw new Error(data.error || `Failed to delete (${res.status})`)
+      }
+      fetchObjects(activeBucket, prefix)
+    } catch (err) {
+      setObjectsError(err instanceof Error ? err.message : 'Delete failed')
+    } finally {
+      setDeleting(null)
+    }
+  }, [activeBucket, prefix, fetchObjects])
 
   useEffect(() => {
     fetchBuckets()
@@ -165,13 +218,30 @@ export default function StorageClient() {
           </button>
           <HardDrive className="h-6 w-6 text-brand-400" />
           <h1 className="text-2xl font-bold text-white">{activeBucket}</h1>
-          <button
-            onClick={() => fetchObjects(activeBucket, prefix)}
-            className="ml-auto p-1.5 rounded-md text-mountain-400 hover:text-white hover:bg-navy-700 transition-colors cursor-pointer"
-            title="Refresh"
-          >
-            <RefreshCw className="h-4 w-4" />
-          </button>
+          <div className="ml-auto flex items-center gap-2">
+            <input
+              ref={fileInputRef}
+              type="file"
+              multiple
+              className="hidden"
+              onChange={(e) => e.target.files && handleUpload(e.target.files)}
+            />
+            <button
+              onClick={() => fileInputRef.current?.click()}
+              disabled={uploading}
+              className="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm font-medium bg-brand-600 text-white hover:bg-brand-500 disabled:opacity-50 disabled:cursor-not-allowed transition-colors cursor-pointer"
+            >
+              <Upload className="h-3.5 w-3.5" />
+              {uploading ? 'Uploading...' : 'Upload'}
+            </button>
+            <button
+              onClick={() => fetchObjects(activeBucket, prefix)}
+              className="p-1.5 rounded-md text-mountain-400 hover:text-white hover:bg-navy-700 transition-colors cursor-pointer"
+              title="Refresh"
+            >
+              <RefreshCw className="h-4 w-4" />
+            </button>
+          </div>
         </div>
 
         {/* Breadcrumbs */}
@@ -228,6 +298,7 @@ export default function StorageClient() {
                   <th className="px-4 py-3 font-medium">Name</th>
                   <th className="px-4 py-3 font-medium w-28 text-right">Size</th>
                   <th className="px-4 py-3 font-medium w-48 text-right">Last Modified</th>
+                  <th className="px-4 py-3 font-medium w-12"></th>
                 </tr>
               </thead>
               <tbody>
@@ -237,7 +308,7 @@ export default function StorageClient() {
                     className="border-b border-navy-700/50 hover:bg-navy-700/30 cursor-pointer transition-colors"
                     onClick={navigateUp}
                   >
-                    <td className="px-4 py-2.5" colSpan={3}>
+                    <td className="px-4 py-2.5" colSpan={4}>
                       <span className="flex items-center gap-2 text-mountain-400 hover:text-white">
                         <FolderOpen className="h-4 w-4 text-mountain-500" />
                         ..
@@ -263,6 +334,7 @@ export default function StorageClient() {
                       </td>
                       <td className="px-4 py-2.5 text-right text-mountain-500">--</td>
                       <td className="px-4 py-2.5 text-right text-mountain-500">--</td>
+                      <td></td>
                     </tr>
                   )
                 })}
@@ -273,7 +345,7 @@ export default function StorageClient() {
                   return (
                     <tr
                       key={obj.key}
-                      className="border-b border-navy-700/50 hover:bg-navy-700/30 transition-colors"
+                      className="border-b border-navy-700/50 hover:bg-navy-700/30 transition-colors group"
                     >
                       <td className="px-4 py-2.5">
                         <span className="flex items-center gap-2 text-white">
@@ -286,6 +358,16 @@ export default function StorageClient() {
                       </td>
                       <td className="px-4 py-2.5 text-right text-mountain-400">
                         {formatDate(obj.last_modified)}
+                      </td>
+                      <td className="px-4 py-2.5 text-center">
+                        <button
+                          onClick={() => handleDelete(obj.key)}
+                          disabled={deleting === obj.key}
+                          className="p-1 rounded text-mountain-500 opacity-0 group-hover:opacity-100 hover:text-red-400 hover:bg-red-900/20 disabled:opacity-50 transition-all cursor-pointer"
+                          title={`Delete ${fileName}`}
+                        >
+                          <Trash2 className="h-3.5 w-3.5" />
+                        </button>
                       </td>
                     </tr>
                   )

--- a/services/ui/src/utils/api-proxy-multipart.ts
+++ b/services/ui/src/utils/api-proxy-multipart.ts
@@ -1,0 +1,45 @@
+import { auth } from '@/auth'
+import { NextRequest, NextResponse } from 'next/server'
+
+const API_URL = process.env.API_URL || 'http://localhost:3000'
+
+/**
+ * Proxy a multipart/form-data request to the backend API service.
+ * Passes the raw body and content-type (with boundary) through unchanged.
+ */
+export async function proxyMultipartToApi(
+  req: NextRequest,
+  backendPath: string,
+  { label = 'proxy-multipart' }: { label?: string } = {}
+) {
+  const session = await auth()
+  if (!session?.accessToken) {
+    return NextResponse.json({ error: 'Not authenticated' }, { status: 401 })
+  }
+
+  const url = new URL(`${API_URL}${backendPath}`)
+
+  req.nextUrl.searchParams.forEach((value, key) => {
+    url.searchParams.set(key, value)
+  })
+
+  const contentType = req.headers.get('content-type') || ''
+
+  try {
+    const res = await fetch(url.toString(), {
+      method: req.method,
+      headers: {
+        'Authorization': `Bearer ${session.accessToken}`,
+        'Content-Type': contentType,
+      },
+      body: await req.arrayBuffer(),
+      signal: AbortSignal.timeout(60000),
+    })
+
+    const data = await res.json()
+    return NextResponse.json(data, { status: res.status })
+  } catch (err) {
+    console.error(`[${label}] Error:`, err)
+    return NextResponse.json({ error: 'API request failed' }, { status: 502 })
+  }
+}


### PR DESCRIPTION
## Summary
- Add `POST /storage/buckets/:name/upload` route using multer for multipart file upload to MinIO
- Add `DELETE /storage/buckets/:name/objects/*` route for object deletion
- Add multipart proxy utility (`api-proxy-multipart.ts`) to forward FormData with boundary intact through Next.js
- Wire POST/DELETE handlers in the UI storage proxy route
- Add Upload button and per-object Delete button (hover-reveal) to StorageClient UI

## Test plan
- [ ] Navigate to /harness/storage, verify buckets list loads
- [ ] Click into a bucket, click Upload, select a file — verify it appears in the list
- [ ] Hover over an uploaded file, click the trash icon — confirm deletion dialog, verify file is removed
- [ ] Upload to a prefixed path (navigate into a folder first) — verify key includes prefix
- [ ] Verify 502 errors no longer occur when MinIO is reachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)