### PR TITLE
feat: add clone button to agent detail page

### DIFF
--- a/services/ui/src/app/agents/[id]/AgentDetailClient.tsx
+++ b/services/ui/src/app/agents/[id]/AgentDetailClient.tsx
@@ -288,6 +288,24 @@ export default function AgentDetailClient({
     }
   }
 
+  const handleClone = async () => {
+    setActionLoading(true)
+    try {
+      const res = await fetch(`/api/agents/${agentId}/clone`, { method: 'POST' })
+      if (res.ok) {
+        const cloned = await res.json()
+        router.push(`/agents/${cloned.id}`)
+      } else {
+        const data = await res.json()
+        alert(data.error || 'Failed to clone agent')
+      }
+    } catch (err) {
+      console.error('Failed to clone:', err)
+    } finally {
+      setActionLoading(false)
+    }
+  }
+
   const fetchLogs = async () => {
     try {
       const res = await fetch(`/api/agents/${agentId}/logs?tail=200`)
@@ -462,6 +480,13 @@ export default function AgentDetailClient({
               Edit
             </Link>
           )}
+          <button
+            onClick={handleClone}
+            disabled={actionLoading}
+            className="px-4 py-2 text-sm font-medium rounded-lg border border-navy-600 text-mountain-400 hover:text-white hover:border-navy-500 transition-colors disabled:opacity-50 cursor-pointer disabled:cursor-not-allowed"
+          >
+            Clone
+          </button>
           {isAdmin && (
             <button
               onClick={handleDelete}


### PR DESCRIPTION
## Summary
- Adds a **Clone** button to the agent detail page header (between Edit and Delete)
- Calls `POST /api/agents/:id/clone` (existing API endpoint)
- On success, redirects to the newly created agent's detail page
- Button is available to all users (not admin-gated), disabled while action is loading

## Test plan
- [ ] Open any agent's detail page — Clone button visible in header
- [ ] Click Clone — new agent created, redirected to its detail page
- [ ] Cloned agent has same config (tools, skills, model policy, container profile, SOUL/RULES)
- [ ] Cloned agent has a unique slug (`original-clone`, `original-clone-2`, etc.)
- [ ] Clone button disabled during loading state
- [ ] Clone of nonexistent agent returns 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)