### PR TITLE
feat: add agent log search and time filters

### DIFF
--- a/services/api/src/routes/agents.ts
+++ b/services/api/src/routes/agents.ts
@@ -1778,6 +1778,29 @@ router.get('/:id/events', requireRole('user'), async (req: Request, res: Respons
   }
 });
 
+// Filter log lines by search term and timestamp range.
+function filterLogLines(lines: string[], search?: string, since?: string, until?: string): string[] {
+  let filtered = lines;
+  if (since || until) {
+    const sinceMs = since ? new Date(since).getTime() : 0;
+    const untilMs = until ? new Date(until).getTime() : Infinity;
+    if (!isNaN(sinceMs) || !isNaN(untilMs)) {
+      filtered = filtered.filter((line) => {
+        const spaceIdx = line.indexOf(' ');
+        if (spaceIdx < 10) return true;
+        const ts = new Date(line.slice(0, spaceIdx)).getTime();
+        if (isNaN(ts)) return true;
+        return ts >= (isNaN(sinceMs) ? 0 : sinceMs) && ts <= (isNaN(untilMs) ? Infinity : untilMs);
+      });
+    }
+  }
+  if (search) {
+    const term = search.toLowerCase();
+    filtered = filtered.filter((line) => line.toLowerCase().includes(term));
+  }
+  return filtered;
+}
+
 // Get container logs
 router.get('/:id/logs', requireRole('admin'), async (req: Request, res: Response) => {
   try {
@@ -1790,6 +1813,9 @@ router.get('/:id/logs', requireRole('admin'), async (req: Request, res: Response
     const agent = rows[0];
     const tail = parseInt(req.query.tail as string) || 200;
     const follow = req.query.follow === 'true';
+    const search = (req.query.search as string) || undefined;
+    const since = (req.query.since as string) || undefined;
+    const until = (req.query.until as string) || undefined;
 
     if (follow) {
       // SSE streaming
@@ -1804,7 +1830,8 @@ router.get('/:id/logs', requireRole('admin'), async (req: Request, res: Response
         stream.on('data', (chunk: Buffer) => {
           // Docker stream has 8-byte header per frame; strip it
           const lines = stripDockerHeader(chunk);
-          for (const line of lines) {
+          const filtered = filterLogLines(lines, search, since, until);
+          for (const line of filtered) {
             res.write(`data: ${line}\n\n`);
           }
         });
@@ -1836,7 +1863,8 @@ router.get('/:id/logs', requireRole('admin'), async (req: Request, res: Response
     stream.on('end', () => {
       const raw = Buffer.concat(chunks);
       const lines = stripDockerHeader(raw);
-      res.json({ logs: lines.join('\n') });
+      const filtered = filterLogLines(lines, search, since, until);
+      res.json({ logs: filtered.join('\n') });
     });
     stream.on('error', (err: Error) => {
       res.status(500).json({ error: 'Failed to read logs', detail: err.message });

--- a/services/ui/src/app/agents/[id]/AgentDetailClient.tsx
+++ b/services/ui/src/app/agents/[id]/AgentDetailClient.tsx
@@ -118,6 +118,7 @@ export default function AgentDetailClient({
   // Logs
   const [logs, setLogs] = useState('')
   const [showLogs, setShowLogs] = useState(false)
+  const [logSearch, setLogSearch] = useState('')
   const logsEndRef = useRef<HTMLDivElement>(null)
   const eventSourceRef = useRef<EventSource | null>(null)
 
@@ -250,7 +251,9 @@ export default function AgentDetailClient({
       return
     }
 
-    const es = new EventSource(`/api/agents/${agentId}/logs?follow=true&tail=100`)
+    const sseParams = new URLSearchParams({ follow: 'true', tail: '100' })
+    if (logSearch) sseParams.set('search', logSearch)
+    const es = new EventSource(`/api/agents/${agentId}/logs?${sseParams}`)
     eventSourceRef.current = es
 
     es.onmessage = (event) => {
@@ -262,7 +265,7 @@ export default function AgentDetailClient({
     es.addEventListener('error', () => { es.close() })
 
     return () => { es.close() }
-  }, [showLogs, isAdmin, agent?.status, agentId])
+  }, [showLogs, isAdmin, agent?.status, agentId, logSearch])
 
   const handleAction = async (action: 'start' | 'stop') => {
     setActionLoading(true)
@@ -335,7 +338,9 @@ export default function AgentDetailClient({
 
   const fetchLogs = async () => {
     try {
-      const res = await fetch(`/api/agents/${agentId}/logs?tail=200`)
+      const params = new URLSearchParams({ tail: '500' })
+      if (logSearch) params.set('search', logSearch)
+      const res = await fetch(`/api/agents/${agentId}/logs?${params}`)
       if (res.ok) {
         const data = await res.json()
         setLogs(data.logs || '')
@@ -1134,6 +1139,13 @@ export default function AgentDetailClient({
               <div className="flex items-center justify-between mb-3">
                 <h2 className="text-lg font-semibold text-white">Logs</h2>
                 <div className="flex items-center gap-2">
+                  <input
+                    type="text"
+                    value={logSearch}
+                    onChange={(e) => setLogSearch(e.target.value)}
+                    placeholder="Search logs..."
+                    className="px-3 py-1.5 text-xs rounded-md bg-navy-900 border border-navy-600 text-white placeholder-mountain-500 focus:border-brand-500 focus:outline-none w-48"
+                  />
                   {agent.status === 'running' && (
                     <button
                       onClick={() => setShowLogs(!showLogs)}


### PR DESCRIPTION
## Summary
- Add `search`, `since`, and `until` query parameters to `GET /agents/:id/logs` for server-side log filtering
- Filter applies to both SSE streaming and non-streaming log responses (case-insensitive text match, ISO timestamp range)
- Add search input to the Activity tab logs panel in the agent detail UI
- Increase default non-streaming tail from 200 to 500 lines

## Test plan
- [ ] Verify logs load without search term (baseline)
- [ ] Enter search term and confirm only matching lines are returned
- [ ] Verify SSE streaming respects the search filter
- [ ] Confirm `since` and `until` params filter by timestamp range via API
- [ ] Check that lines without parseable timestamps are included (not dropped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)