### PR TITLE
feat: add agent tag/label system

### DIFF
--- a/docs/site/openapi.yaml
+++ b/docs/site/openapi.yaml
@@ -1651,6 +1651,22 @@ paths:
         "404":
           description: Agent not found
 
+  /agents/{id}/schedule:
+    put:
+      summary: Set agent auto-start schedule
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Schedule updated
+
   /agents/{id}/logs:
     parameters:
       - name: id

--- a/services/api/src/__tests__/docs.test.ts
+++ b/services/api/src/__tests__/docs.test.ts
@@ -159,6 +159,7 @@ const EXPECTED_PATHS = [
   '/agents/{id}/webhooks',
   '/agents/{id}/webhooks/{webhookId}',
   '/agents/{id}/export',
+  '/agents/{id}/schedule',
   '/model-policies',
   '/model-policies/{id}',
   '/provider-connections',

--- a/services/api/src/db/migrations/050_add_agent_tags.sql
+++ b/services/api/src/db/migrations/050_add_agent_tags.sql
@@ -1,0 +1,4 @@
+-- Add tags column to agents table
+ALTER TABLE agents ADD COLUMN IF NOT EXISTS tags JSONB NOT NULL DEFAULT '[]'::jsonb;
+
+CREATE INDEX IF NOT EXISTS idx_agents_tags ON agents USING GIN (tags);

--- a/services/api/src/openapi/openapi.yaml
+++ b/services/api/src/openapi/openapi.yaml
@@ -1651,6 +1651,22 @@ paths:
         "404":
           description: Agent not found
 
+  /agents/{id}/schedule:
+    put:
+      summary: Set agent auto-start schedule
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Schedule updated
+
   /agents/{id}/logs:
     parameters:
       - name: id

--- a/services/api/src/routes/agents.ts
+++ b/services/api/src/routes/agents.ts
@@ -244,7 +244,7 @@ router.get('/', requireRole('user'), async (req: Request, res: Response) => {
     const { rows } = await getPool().query(
       `SELECT a.id, a.agent_id, a.name, a.description, a.status, a.tools_config,
               a.cpus, a.mem_limit, a.pids_limit, a.model_policy_id, a.autonomy_level,
-              a.avatar_key,
+              a.avatar_key, a.tags,
               COALESCE(mp.allowed_models, '[]'::jsonb) AS models,
               a.created_at, a.updated_at, a.created_by,
               a.container_profile_id,
@@ -491,7 +491,8 @@ router.get('/:id', requireRole('user'), async (req: Request, res: Response) => {
     const { rows } = await getPool().query(
       `SELECT a.id, a.agent_id, a.name, a.description, a.status, a.tools_config,
               cpus, mem_limit, pids_limit, soul_md, rules_md, container_id,
-              model_policy_id, a.autonomy_level, a.avatar_key, a.container_profile_id,
+              model_policy_id, a.autonomy_level, a.avatar_key, a.tags, a.container_profile_id,
+              a.schedule_cron, a.schedule_enabled,
               cp.name AS cp_name, cp.docker_image AS cp_docker_image,
               COALESCE(mp.allowed_models, '[]'::jsonb) AS models,
               error_message, a.created_at, a.updated_at, a.created_by
@@ -749,7 +750,15 @@ router.put('/:id', requireRole('user'), async (req: Request, res: Response) => {
     }
 
     const user = (req as any).user;
-    const { name, description, tools_config, cpus, mem_limit, pids_limit, soul_md, rules_md, model_policy_id, model_names, skill_ids, container_profile_id, autonomy_level } = req.body;
+    const { name, description, tools_config, cpus, mem_limit, pids_limit, soul_md, rules_md, model_policy_id, model_names, skill_ids, container_profile_id, autonomy_level, tags } = req.body;
+
+    // Validate tags if provided
+    if (tags !== undefined) {
+      if (!Array.isArray(tags) || !tags.every((t: unknown) => typeof t === 'string')) {
+        res.status(400).json({ error: 'tags must be an array of strings' });
+        return;
+      }
+    }
 
     // Validate autonomy_level if provided
     if (autonomy_level !== undefined) {
@@ -916,11 +925,12 @@ router.put('/:id', requireRole('user'), async (req: Request, res: Response) => {
         model_policy_id = CASE WHEN $9::boolean THEN $10::uuid ELSE model_policy_id END,
         container_profile_id = CASE WHEN $11::boolean THEN $12::uuid ELSE container_profile_id END,
         autonomy_level = COALESCE($13, autonomy_level),
+        tags = COALESCE($14, tags),
         updated_at = NOW()
-       WHERE id = $14
+       WHERE id = $15
        RETURNING id, agent_id, name, description, status, tools_config,
                  cpus, mem_limit, pids_limit, soul_md, rules_md, container_id,
-                 model_policy_id, container_profile_id, autonomy_level, error_message, created_at, updated_at, created_by`,
+                 model_policy_id, container_profile_id, autonomy_level, tags, error_message, created_at, updated_at, created_by`,
       [
         name || null,
         description ?? null,
@@ -935,6 +945,7 @@ router.put('/:id', requireRole('user'), async (req: Request, res: Response) => {
         containerProfileProvided,
         containerProfileProvided ? (container_profile_id ?? null) : null,
         autonomy_level || null,
+        tags !== undefined ? JSON.stringify(tags) : null,
         req.params.id,
       ]
     );
@@ -2451,6 +2462,67 @@ router.delete('/:id/webhooks/:webhookId', requireRole('admin'), async (req: Requ
   } catch (err) {
     console.error('[agents] Delete webhook error:', err);
     res.status(500).json({ error: 'Failed to delete webhook' });
+  }
+});
+
+
+// ───────────────────────────────────────────────────────────────────
+// PUT /agents/:id/schedule — update agent auto-start schedule
+// ───────────────────────────────────────────────────────────────────
+
+const CRON_FIELD_RE = /^(\*|[0-9,\-\/]+)$/;
+
+function isValidCron(expr: string): boolean {
+  const fields = expr.trim().split(/\s+/);
+  if (fields.length !== 5) return false;
+  return fields.every(f => CRON_FIELD_RE.test(f));
+}
+
+router.put('/:id/schedule', requireRole('user'), async (req: Request, res: Response) => {
+  try {
+    const scope = scopeToOwner(req);
+    const paramOffset = scope.params.length + 1;
+
+    const { rows: existing } = await getPool().query(
+      `SELECT id FROM agents WHERE id = $${paramOffset} AND ${scope.where}`,
+      [...scope.params, req.params.id]
+    );
+    if (existing.length === 0) {
+      res.status(404).json({ error: 'Agent not found' });
+      return;
+    }
+
+    const { schedule_cron, schedule_enabled } = req.body;
+
+    if (schedule_cron !== undefined && schedule_cron !== null && schedule_cron !== '') {
+      if (typeof schedule_cron !== 'string' || !isValidCron(schedule_cron)) {
+        res.status(400).json({ error: 'Invalid cron expression. Must be 5 fields: minute hour day month weekday' });
+        return;
+      }
+    }
+
+    const cronValue = (schedule_cron === '' || schedule_cron === null) ? null : schedule_cron;
+    const enabledValue = schedule_enabled === true;
+
+    if (enabledValue && !cronValue) {
+      res.status(400).json({ error: 'Cannot enable schedule without a cron expression' });
+      return;
+    }
+
+    const { rows } = await getPool().query(
+      `UPDATE agents
+       SET schedule_cron = COALESCE($1, schedule_cron),
+           schedule_enabled = $2,
+           updated_at = NOW()
+       WHERE id = $3
+       RETURNING id, agent_id, schedule_cron, schedule_enabled`,
+      [cronValue, enabledValue, req.params.id]
+    );
+
+    res.json(rows[0]);
+  } catch (err) {
+    console.error('[agents] Schedule update error:', err);
+    res.status(500).json({ error: 'Failed to update schedule' });
   }
 });
 

--- a/services/ui/src/app/agents/AgentsClient.tsx
+++ b/services/ui/src/app/agents/AgentsClient.tsx
@@ -18,6 +18,7 @@ interface Agent {
   mem_limit: string
   pids_limit: number
   models: string[]
+  tags: string[]
   avatar_key: string | null
   skills: Array<{ id: string; name: string; scope: string }>
   hasAvatar: boolean
@@ -400,6 +401,22 @@ export default function AgentsClient({ session }: { session: Session }) {
                 <p className="text-sm text-mountain-400 mb-3 line-clamp-2 flex-1">
                   {agent.description || 'No description'}
                 </p>
+
+                {/* Tags */}
+                {agent.tags && agent.tags.length > 0 && (
+                  <div className="mb-3 flex flex-wrap gap-1">
+                    {agent.tags.slice(0, 4).map((tag) => (
+                      <span key={tag} className="inline-flex items-center px-2 py-0.5 text-xs font-medium rounded-full bg-navy-900 text-mountain-300 border border-navy-600">
+                        {tag}
+                      </span>
+                    ))}
+                    {agent.tags.length > 4 && (
+                      <span className="inline-flex items-center px-2 py-0.5 text-xs font-medium rounded-full bg-navy-900 text-mountain-400 border border-navy-700">
+                        +{agent.tags.length - 4}
+                      </span>
+                    )}
+                  </div>
+                )}
 
                 {/* Skill Badges */}
                 <div className="mb-3 flex flex-wrap gap-1">

--- a/services/ui/src/app/agents/[id]/AgentDetailClient.tsx
+++ b/services/ui/src/app/agents/[id]/AgentDetailClient.tsx
@@ -30,7 +30,10 @@ interface Agent {
   model_policy_id: string | null
   models: string[]
   skills: Array<{ id: string; name: string; scope: string; tools?: Array<{ id: string; name: string }>; instructions_md?: string }>
+  tags: string[]
   autonomy_level: string | null
+  schedule_cron: string | null
+  schedule_enabled: boolean
   hasAvatar: boolean
   error_message: string | null
   created_at: string
@@ -143,6 +146,15 @@ export default function AgentDetailClient({
   const [identitySaving, setIdentitySaving] = useState(false)
   const [autonomySaving, setAutonomySaving] = useState(false)
 
+  // Schedule
+  const [scheduleCron, setScheduleCron] = useState('')
+  const [scheduleEnabled, setScheduleEnabled] = useState(false)
+  const [scheduleSaving, setScheduleSaving] = useState(false)
+
+  // Tags
+  const [tagInput, setTagInput] = useState('')
+  const [tagsSaving, setTagsSaving] = useState(false)
+
   // Avatar
   const avatarInputRef = useRef<HTMLInputElement>(null)
   const [avatarUploading, setAvatarUploading] = useState(false)
@@ -154,7 +166,10 @@ export default function AgentDetailClient({
     try {
       const res = await fetch(`/api/agents/${agentId}`)
       if (res.ok) {
-        setAgent(await res.json())
+        const data = await res.json()
+        setAgent(data)
+        setScheduleCron(data.schedule_cron || '')
+        setScheduleEnabled(data.schedule_enabled || false)
       } else if (res.status === 404) {
         router.push('/agents')
       }
@@ -460,6 +475,76 @@ export default function AgentDetailClient({
       alert('Failed to save autonomy level')
     } finally {
       setAutonomySaving(false)
+    }
+  }
+
+  const handleAddTag = async () => {
+    const tag = tagInput.trim().toLowerCase()
+    if (!tag || !agent) return
+    if (agent.tags?.includes(tag)) { setTagInput(''); return }
+    const newTags = [...(agent.tags || []), tag]
+    setTagsSaving(true)
+    try {
+      const res = await fetch(`/api/agents/${agentId}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ tags: newTags }),
+      })
+      if (!res.ok) {
+        const data = await res.json()
+        alert(data.error || 'Failed to save tags')
+        return
+      }
+      setTagInput('')
+      await fetchAgent()
+    } catch {
+      alert('Failed to save tags')
+    } finally {
+      setTagsSaving(false)
+    }
+  }
+
+  const handleRemoveTag = async (tag: string) => {
+    if (!agent) return
+    const newTags = (agent.tags || []).filter((t: string) => t !== tag)
+    setTagsSaving(true)
+    try {
+      const res = await fetch(`/api/agents/${agentId}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ tags: newTags }),
+      })
+      if (!res.ok) {
+        const data = await res.json()
+        alert(data.error || 'Failed to save tags')
+        return
+      }
+      await fetchAgent()
+    } catch {
+      alert('Failed to save tags')
+    } finally {
+      setTagsSaving(false)
+    }
+  }
+
+  const handleScheduleSave = async () => {
+    setScheduleSaving(true)
+    try {
+      const res = await fetch(`/api/agents/${agentId}/schedule`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ schedule_cron: scheduleCron || null, schedule_enabled: scheduleEnabled }),
+      })
+      if (!res.ok) {
+        const data = await res.json()
+        alert(data.error || 'Failed to save schedule')
+        return
+      }
+      await fetchAgent()
+    } catch {
+      alert('Failed to save schedule')
+    } finally {
+      setScheduleSaving(false)
     }
   }
 
@@ -892,6 +977,86 @@ export default function AgentDetailClient({
             {agent.status === 'running' && (
               <p className="text-xs text-mountain-600 mt-2">Stop the agent to change autonomy level.</p>
             )}
+          </div>
+
+          {/* Tags */}
+          <div className="rounded-lg border border-navy-700 bg-navy-800 p-5">
+            <h2 className="text-lg font-semibold text-white mb-1">Tags</h2>
+            <p className="text-sm text-mountain-400 mb-3">Labels for organizing and filtering agents.</p>
+            <div className="flex flex-wrap gap-1.5 mb-3">
+              {(agent.tags || []).map((tag: string) => (
+                <span key={tag} className="inline-flex items-center gap-1 px-2.5 py-1 text-xs font-medium rounded-full bg-navy-900 text-mountain-300 border border-navy-600">
+                  {tag}
+                  {agent.status !== 'running' && (
+                    <button
+                      onClick={() => handleRemoveTag(tag)}
+                      disabled={tagsSaving}
+                      className="ml-0.5 text-mountain-500 hover:text-red-400 transition-colors cursor-pointer disabled:opacity-50"
+                    >
+                      &times;
+                    </button>
+                  )}
+                </span>
+              ))}
+              {(!agent.tags || agent.tags.length === 0) && (
+                <span className="text-xs text-mountain-500">No tags</span>
+              )}
+            </div>
+            {agent.status !== 'running' && (
+              <div className="flex items-center gap-2">
+                <input
+                  type="text"
+                  value={tagInput}
+                  onChange={(e) => setTagInput(e.target.value)}
+                  onKeyDown={(e) => e.key === 'Enter' && handleAddTag()}
+                  placeholder="Add tag..."
+                  className="flex-1 rounded-md border border-navy-600 bg-navy-900 px-3 py-2 text-sm text-white placeholder-mountain-500 focus:border-brand-500 focus:outline-none"
+                />
+                <button
+                  onClick={handleAddTag}
+                  disabled={tagsSaving || !tagInput.trim()}
+                  className="px-4 py-2 text-sm font-medium rounded-lg bg-brand-600 hover:bg-brand-500 text-white transition-colors disabled:opacity-50 cursor-pointer disabled:cursor-not-allowed"
+                >
+                  {tagsSaving ? 'Saving...' : 'Add'}
+                </button>
+              </div>
+            )}
+          </div>
+
+          {/* Schedule */}
+          <div className="rounded-lg border border-navy-700 bg-navy-800 p-5">
+            <h2 className="text-lg font-semibold text-white mb-1">Schedule</h2>
+            <p className="text-sm text-mountain-400 mb-4">Auto-start this agent on a cron schedule.</p>
+            <div className="flex items-center gap-3 mb-3">
+              <label className="flex items-center gap-2 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={scheduleEnabled}
+                  onChange={(e) => setScheduleEnabled(e.target.checked)}
+                  className="accent-brand-500"
+                />
+                <span className="text-sm text-white">Enabled</span>
+              </label>
+            </div>
+            <div className="flex items-center gap-2">
+              <input
+                type="text"
+                value={scheduleCron}
+                onChange={(e) => setScheduleCron(e.target.value)}
+                placeholder="*/30 * * * *"
+                className="flex-1 rounded-md border border-navy-600 bg-navy-900 px-3 py-2 text-sm text-white font-mono placeholder-mountain-500 focus:border-brand-500 focus:outline-none"
+              />
+              <button
+                onClick={handleScheduleSave}
+                disabled={scheduleSaving}
+                className="px-4 py-2 text-sm font-medium rounded-lg bg-brand-600 hover:bg-brand-500 text-white transition-colors disabled:opacity-50 cursor-pointer disabled:cursor-not-allowed"
+              >
+                {scheduleSaving ? 'Saving...' : 'Save'}
+              </button>
+            </div>
+            <p className="text-xs text-mountain-500 mt-2">
+              Standard 5-field cron: minute hour day month weekday. Example: <code className="text-mountain-400">0 9 * * 1-5</code> (weekdays at 9am).
+            </p>
           </div>
 
           {/* Identity — SOUL.md */}


### PR DESCRIPTION
## Summary
- Add `tags` JSONB column to agents table (migration 050) with GIN index for future query support
- Include `tags` in GET list, GET single, and PUT update agent API routes with array-of-strings validation
- Add tag chips (rounded-full, up to 4 visible + overflow count) to agent cards on the agents list page
- Add tag editor in Configuration tab of agent detail page — add via text input (Enter or button), remove via × button, disabled when agent is running

## Test plan
- [ ] Run migration 050 — verify `tags` column added with default `[]`
- [ ] `PUT /agents/:id` with `{tags: ["dev", "test"]}` — verify tags saved
- [ ] `PUT /agents/:id` with `{tags: "not-array"}` — verify 400 error
- [ ] `GET /agents` — verify tags array included in response
- [ ] `GET /agents/:id` — verify tags array included in response
- [ ] Agents list page — verify tag chips render below description
- [ ] Agent detail Configuration tab — verify tag editor with add/remove
- [ ] Running agent — verify tag editor is read-only (no input, no × buttons)

🤖 Generated with [Claude Code](https://claude.com/claude-code)