### PR TITLE
feat: add agent metrics endpoint

### DIFF
--- a/docs/site/openapi.yaml
+++ b/docs/site/openapi.yaml
@@ -1494,6 +1494,25 @@ paths:
         "404":
           description: Agent not found
 
+  /agents/{id}/metrics:
+    get:
+      summary: Get agent operational metrics
+      tags: [Agents]
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Computed operational metrics for the agent
+        "404":
+          description: Agent not found
+
   /agents/{id}/artifacts:
     get:
       summary: Get agent artifacts (badges)

--- a/services/api/src/__tests__/docs.test.ts
+++ b/services/api/src/__tests__/docs.test.ts
@@ -195,6 +195,7 @@ const EXPECTED_PATHS = [
   '/agents/{id}/skills',
   '/agents/{id}/skills/{skillId}',
   '/agents/{id}/stats',
+  '/agents/{id}/metrics',
   '/agents/{id}/artifacts',
   '/chat/threads',
   '/chat/threads/{id}',

--- a/services/api/src/openapi/openapi.yaml
+++ b/services/api/src/openapi/openapi.yaml
@@ -1494,6 +1494,25 @@ paths:
         "404":
           description: Agent not found
 
+  /agents/{id}/metrics:
+    get:
+      summary: Get agent operational metrics
+      tags: [Agents]
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Computed operational metrics for the agent
+        "404":
+          description: Agent not found
+
   /agents/{id}/artifacts:
     get:
       summary: Get agent artifacts (badges)

--- a/services/api/src/routes/agents.ts
+++ b/services/api/src/routes/agents.ts
@@ -2146,6 +2146,55 @@ router.get('/:id/stats', requireRole('user'), async (req: Request, res: Response
   }
 });
 
+// Agent metrics — computed operational metrics
+router.get('/:id/metrics', requireRole('user'), async (req: Request, res: Response) => {
+  try {
+    const scope = scopeToOwner(req);
+    const paramOffset = scope.params.length + 1;
+    const { rows } = await getPool().query(
+      `SELECT * FROM agents WHERE id = $${paramOffset}${scope.where !== '1=1' ? ` AND ${scope.where}` : ''}`,
+      [...scope.params, req.params.id],
+    );
+    if (rows.length === 0) {
+      res.status(404).json({ error: 'Agent not found' });
+      return;
+    }
+    const agent = rows[0];
+
+    const [messagesResult, eventsResult, lastActiveResult] = await Promise.all([
+      getPool().query(
+        `SELECT COUNT(*) AS total_messages
+         FROM chat_messages WHERE author_id = $1 AND author_type = 'agent'`,
+        [agent.id],
+      ),
+      getPool().query(
+        `SELECT COUNT(*) AS total_events
+         FROM model_usage WHERE agent_id = $1`,
+        [agent.agent_id],
+      ),
+      getPool().query(
+        `SELECT MAX(created_at) AS last_active FROM (
+           SELECT created_at FROM agent_sessions WHERE agent_id = $1
+           UNION ALL
+           SELECT created_at FROM chat_messages WHERE author_id = $1 AND author_type = 'agent'
+           UNION ALL
+           SELECT created_at FROM model_usage WHERE agent_id = $2
+         ) AS events`,
+        [agent.id, agent.agent_id],
+      ),
+    ]);
+
+    res.json({
+      total_messages: Number(messagesResult.rows[0].total_messages),
+      total_events: Number(eventsResult.rows[0].total_events),
+      last_active: lastActiveResult.rows[0].last_active || null,
+    });
+  } catch (err: any) {
+    console.error('[agents] Metrics error:', err);
+    res.status(500).json({ error: 'Failed to compute metrics' });
+  }
+});
+
 // Agent progression — artifacts (computed on-demand from stats)
 const ARTIFACT_CATALOG = [
   { id: 'first_light', name: 'First Light', icon: '⚡', description: 'Completed first model inference', check: (s: any) => s.total_inferences >= 1 },


### PR DESCRIPTION
## Summary
- Add `GET /agents/:id/metrics` endpoint returning computed operational metrics
- **total_messages**: count of agent-authored messages from `chat_messages`
- **total_events**: count of model usage records from `model_usage`
- **last_active**: most recent timestamp across `agent_sessions`, `chat_messages`, and `model_usage`
- Queries existing tables only — no new migrations needed
- Owner-scoped via `scopeToOwner` (same pattern as `/stats`)

## Files changed
- `services/api/src/routes/agents.ts` — new metrics route
- `services/api/src/__tests__/docs.test.ts` — EXPECTED_PATHS entry
- `services/api/src/openapi/openapi.yaml` — OpenAPI spec
- `docs/site/openapi.yaml` — docs site sync

## Test plan
- [ ] Call `GET /agents/:id/metrics` for an agent with chat history — verify `total_messages` count
- [ ] Verify `total_events` reflects model_usage rows for the agent
- [ ] Verify `last_active` returns the most recent timestamp or null for a fresh agent
- [ ] Verify 404 for nonexistent agent ID
- [ ] Verify non-owner user cannot access another user's agent metrics
- [ ] Run docs contract test (`docs.test.ts`) — verify EXPECTED_PATHS passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)