### PR TITLE
feat: add agent status history tracking

### DIFF
--- a/docs/site/openapi.yaml
+++ b/docs/site/openapi.yaml
@@ -1532,6 +1532,54 @@ paths:
         "404":
           description: Agent not found
 
+  /agents/{id}/status-history:
+    get:
+      summary: List agent status transitions
+      tags: [Agents]
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 50
+            maximum: 200
+      responses:
+        "200":
+          description: Status history entries ordered by changed_at desc
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                      format: uuid
+                    agent_id:
+                      type: string
+                      format: uuid
+                    old_status:
+                      type: string
+                    new_status:
+                      type: string
+                    changed_at:
+                      type: string
+                      format: date-time
+                    changed_by:
+                      type: string
+                      nullable: true
+        "404":
+          description: Agent not found
+
   /agents/{id}/clone:
     post:
       summary: Clone an agent

--- a/services/api/src/__tests__/docs.test.ts
+++ b/services/api/src/__tests__/docs.test.ts
@@ -156,6 +156,7 @@ const EXPECTED_PATHS = [
   '/agents/{id}/avatar',
   '/agents/{id}/logs',
   '/agents/{id}/clone',
+  '/agents/{id}/status-history',
   '/agents/{id}/webhooks',
   '/agents/{id}/webhooks/{webhookId}',
   '/agents/{id}/export',

--- a/services/api/src/db/migrations/051_create_agent_status_history.sql
+++ b/services/api/src/db/migrations/051_create_agent_status_history.sql
@@ -1,0 +1,12 @@
+-- Track agent status transitions for audit and debugging
+CREATE TABLE IF NOT EXISTS agent_status_history (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  agent_id UUID NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+  old_status TEXT NOT NULL,
+  new_status TEXT NOT NULL,
+  changed_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  changed_by TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_status_history_agent_id ON agent_status_history(agent_id);
+CREATE INDEX IF NOT EXISTS idx_agent_status_history_changed_at ON agent_status_history(changed_at);

--- a/services/api/src/openapi/openapi.yaml
+++ b/services/api/src/openapi/openapi.yaml
@@ -1532,6 +1532,54 @@ paths:
         "404":
           description: Agent not found
 
+  /agents/{id}/status-history:
+    get:
+      summary: List agent status transitions
+      tags: [Agents]
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 50
+            maximum: 200
+      responses:
+        "200":
+          description: Status history entries ordered by changed_at desc
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                      format: uuid
+                    agent_id:
+                      type: string
+                      format: uuid
+                    old_status:
+                      type: string
+                    new_status:
+                      type: string
+                    changed_at:
+                      type: string
+                      format: date-time
+                    changed_by:
+                      type: string
+                      nullable: true
+        "404":
+          description: Agent not found
+
   /agents/{id}/clone:
     post:
       summary: Clone an agent

--- a/services/api/src/routes/agents.ts
+++ b/services/api/src/routes/agents.ts
@@ -1304,6 +1304,16 @@ router.post('/:id/start', requireRole('admin'), async (req: Request, res: Respon
       [containerId, workToken, req.params.id]
     );
 
+    // Record status transition
+    try {
+      await getPool().query(
+        `INSERT INTO agent_status_history (agent_id, old_status, new_status, changed_by) VALUES ($1, $2, 'running', $3)`,
+        [agent.id, agent.status, user.sub]
+      );
+    } catch (err) {
+      console.error(`[agents] Status history insert failed for ${agent.agent_id}:`, err);
+    }
+
     // Track session for uptime progression
     try {
       await getPool().query(
@@ -1330,6 +1340,10 @@ router.post('/:id/start', requireRole('admin'), async (req: Request, res: Respon
       await getPool().query(
         `UPDATE agents SET status = 'error', error_message = $1, updated_at = NOW() WHERE id = $2`,
         [err.message, req.params.id]
+      );
+      await getPool().query(
+        `INSERT INTO agent_status_history (agent_id, old_status, new_status, changed_by) VALUES ($1, $2, 'error', $3)`,
+        [req.params.id, 'starting', (req as any).user?.sub]
       );
     } catch { /* best effort */ }
 
@@ -1407,6 +1421,16 @@ router.post('/:id/stop', requireRole('admin'), async (req: Request, res: Respons
       `UPDATE agents SET status = 'stopped', container_id = NULL, work_token = NULL, akm_jti = NULL, akm_exp = NULL, model_router_jti = NULL, model_router_exp = NULL, model_router_refresh_hash = NULL, error_message = NULL, updated_at = NOW() WHERE id = $1`,
       [req.params.id]
     );
+
+    // Record status transition
+    try {
+      await getPool().query(
+        `INSERT INTO agent_status_history (agent_id, old_status, new_status, changed_by) VALUES ($1, $2, 'stopped', $3)`,
+        [agent.id, agent.status, user.sub]
+      );
+    } catch (err) {
+      console.error(`[agents] Status history insert failed for ${agent.agent_id}:`, err);
+    }
 
     const stopCorrelationId = (req as any).correlationId;
     // AI-115: token_revoked audit events
@@ -2572,6 +2596,41 @@ router.put('/:id/schedule', requireRole('user'), async (req: Request, res: Respo
   } catch (err) {
     console.error('[agents] Schedule update error:', err);
     res.status(500).json({ error: 'Failed to update schedule' });
+  }
+});
+
+// ---------------------------------------------------------------
+// GET /agents/:id/status-history
+// ---------------------------------------------------------------
+
+router.get('/:id/status-history', requireRole('user'), async (req: Request, res: Response) => {
+  try {
+    const scope = scopeToOwner(req);
+    const paramOffset = scope.params.length + 1;
+
+    const { rows: agentRows } = await getPool().query(
+      `SELECT id FROM agents WHERE id = $${paramOffset} AND ${scope.where}`,
+      [...scope.params, req.params.id]
+    );
+    if (agentRows.length === 0) {
+      res.status(404).json({ error: 'Agent not found' });
+      return;
+    }
+
+    const limit = Math.min(parseInt(req.query.limit as string) || 50, 200);
+    const { rows } = await getPool().query(
+      `SELECT id, agent_id, old_status, new_status, changed_at, changed_by
+       FROM agent_status_history
+       WHERE agent_id = $1
+       ORDER BY changed_at DESC
+       LIMIT $2`,
+      [req.params.id, limit]
+    );
+
+    res.json(rows);
+  } catch (err) {
+    console.error('[agents] Status history error:', err);
+    res.status(500).json({ error: 'Failed to fetch status history' });
   }
 });
 


### PR DESCRIPTION
## Summary
- **Migration 051**: New `agent_status_history` table (id, agent_id, old_status, new_status, changed_at, changed_by) with indexes on agent_id and changed_at
- **Start route**: Records `old_status → running` transition after the agent status UPDATE, with `changed_by` set to the requesting user
- **Stop route**: Records `old_status → stopped` transition after the agent status UPDATE
- **Error catch**: Records `starting → error` transition (best-effort, inside existing catch block)
- **GET /agents/:id/status-history**: Returns status transitions for an agent, ordered by changed_at desc, with configurable limit (default 50, max 200). Owner-scoped via `scopeToOwner`.
- **EXPECTED_PATHS** and **OpenAPI spec** updated

## Test plan
- [ ] Start an agent — status_history row inserted with old_status=stopped, new_status=running
- [ ] Stop an agent — status_history row inserted with old_status=running, new_status=stopped
- [ ] Force a start error — status_history row inserted with new_status=error
- [ ] GET /agents/:id/status-history returns transitions in desc order
- [ ] Non-owner gets 404 on status-history endpoint
- [ ] `?limit=5` returns at most 5 rows
- [ ] OpenAPI spec validation passes (docs test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)