### PR TITLE
feat: add chat thread archiving

### DIFF
--- a/services/api/src/db/migrations/052_add_chat_archived.sql
+++ b/services/api/src/db/migrations/052_add_chat_archived.sql
@@ -1,0 +1,3 @@
+-- Add archived flag to chat threads
+ALTER TABLE chat_threads ADD COLUMN IF NOT EXISTS archived BOOLEAN NOT NULL DEFAULT FALSE;
+CREATE INDEX IF NOT EXISTS idx_chat_threads_archived ON chat_threads (archived);

--- a/services/api/src/openapi/openapi.yaml
+++ b/services/api/src/openapi/openapi.yaml
@@ -3848,8 +3848,17 @@ paths:
       description: |
         Lists threads the caller participates in. Admin sees all threads.
         Returns last message preview (truncated to 100 chars).
+        Archived threads are excluded by default.
       security:
         - bearerAuth: []
+      parameters:
+        - name: include_archived
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: ["true", "false"]
+          description: Include archived threads in listing (default false)
       responses:
         "200":
           description: Thread list
@@ -3877,6 +3886,8 @@ paths:
                     last_author_type:
                       type: string
                       nullable: true
+                    archived:
+                      type: boolean
                     created_at:
                       type: string
                       format: date-time
@@ -4144,6 +4155,63 @@ paths:
                     description: Number of messages cancelled
         "404":
           description: Thread not found or not a participant
+
+  /chat/threads/{id}/archive:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+
+    post:
+      summary: Archive a thread
+      description: |
+        Marks the thread as archived. Archived threads are excluded from
+        listing by default. Owner or admin only.
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Thread archived
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  archived:
+                    type: boolean
+        "404":
+          description: Thread not found or not owner
+
+  /chat/threads/{id}/unarchive:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+
+    post:
+      summary: Unarchive a thread
+      description: |
+        Removes the archived flag from a thread. Owner or admin only.
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Thread unarchived
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  archived:
+                    type: boolean
+        "404":
+          description: Thread not found or not owner
 
   /chat/threads/{id}/stream:
     parameters:

--- a/services/api/src/routes/chat.ts
+++ b/services/api/src/routes/chat.ts
@@ -264,16 +264,19 @@ router.get('/threads', requireRole('user'), async (req: Request, res: Response) 
     let params: any[];
 
     if (admin) {
-      query = `SELECT t.id, t.type, t.title, t.created_by, t.created_at, t.updated_at,
+      const includeArchived = req.query.include_archived === 'true';
+      query = `SELECT t.id, t.type, t.title, t.created_by, t.created_at, t.updated_at, t.archived,
                       (SELECT content FROM chat_messages
                        WHERE thread_id = t.id ORDER BY seq DESC LIMIT 1) AS last_message,
                       (SELECT author_type FROM chat_messages
                        WHERE thread_id = t.id ORDER BY seq DESC LIMIT 1) AS last_author_type
                FROM chat_threads t
+               ${includeArchived ? '' : 'WHERE t.archived = FALSE'}
                ORDER BY t.updated_at DESC`;
       params = [];
     } else {
-      query = `SELECT t.id, t.type, t.title, t.created_by, t.created_at, t.updated_at,
+      const includeArchived = req.query.include_archived === 'true';
+      query = `SELECT t.id, t.type, t.title, t.created_by, t.created_at, t.updated_at, t.archived,
                       (SELECT content FROM chat_messages
                        WHERE thread_id = t.id ORDER BY seq DESC LIMIT 1) AS last_message,
                       (SELECT author_type FROM chat_messages
@@ -281,6 +284,7 @@ router.get('/threads', requireRole('user'), async (req: Request, res: Response) 
                FROM chat_threads t
                JOIN chat_participants cp ON cp.thread_id = t.id
                WHERE cp.participant_id = $1 AND cp.participant_type = 'human' AND cp.left_at IS NULL
+               ${includeArchived ? '' : 'AND t.archived = FALSE'}
                ORDER BY t.updated_at DESC`;
       params = [user.sub];
     }
@@ -649,6 +653,58 @@ router.delete('/threads/:id', requireRole('user'), async (req: Request, res: Res
   } catch (err) {
     console.error('[chat] Delete thread error:', err);
     res.status(500).json({ error: 'Failed to delete thread' });
+  }
+});
+
+// ───────────────────────────────────────────────────────────────────
+// POST /chat/threads/:id/archive — archive thread
+// ───────────────────────────────────────────────────────────────────
+
+router.post('/threads/:id/archive', requireRole('user'), async (req: Request, res: Response) => {
+  try {
+    const user = (req as any).user;
+    const admin = isAdmin(req);
+
+    if (!(await isThreadOwner(req.params.id, user.sub, admin))) {
+      res.status(404).json({ error: 'Thread not found' });
+      return;
+    }
+
+    await getPool().query(
+      `UPDATE chat_threads SET archived = TRUE, updated_at = NOW() WHERE id = $1`,
+      [req.params.id]
+    );
+
+    res.json({ archived: true });
+  } catch (err) {
+    console.error('[chat] Archive thread error:', err);
+    res.status(500).json({ error: 'Failed to archive thread' });
+  }
+});
+
+// ───────────────────────────────────────────────────────────────────
+// POST /chat/threads/:id/unarchive — unarchive thread
+// ───────────────────────────────────────────────────────────────────
+
+router.post('/threads/:id/unarchive', requireRole('user'), async (req: Request, res: Response) => {
+  try {
+    const user = (req as any).user;
+    const admin = isAdmin(req);
+
+    if (!(await isThreadOwner(req.params.id, user.sub, admin))) {
+      res.status(404).json({ error: 'Thread not found' });
+      return;
+    }
+
+    await getPool().query(
+      `UPDATE chat_threads SET archived = FALSE, updated_at = NOW() WHERE id = $1`,
+      [req.params.id]
+    );
+
+    res.json({ archived: false });
+  } catch (err) {
+    console.error('[chat] Unarchive thread error:', err);
+    res.status(500).json({ error: 'Failed to unarchive thread' });
   }
 });
 

--- a/services/ui/src/app/chat/ChatLayout.tsx
+++ b/services/ui/src/app/chat/ChatLayout.tsx
@@ -27,6 +27,7 @@ export interface ChatThread {
   agents?: ChatAgent[]
   // Backward compat: single agent for direct threads
   agent?: ChatAgent
+  archived?: boolean
 }
 
 interface Props {
@@ -41,10 +42,12 @@ export default function ChatLayout({ session, activeThreadId }: Props) {
   const [showNewThread, setShowNewThread] = useState(false)
   const [sidebarOpen, setSidebarOpen] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const [showArchived, setShowArchived] = useState(false)
 
   const fetchThreads = useCallback(async () => {
     try {
-      const res = await fetch('/api/chat')
+      const url = showArchived ? '/api/chat?include_archived=true' : '/api/chat'
+      const res = await fetch(url)
       if (res.ok) {
         const data = await res.json()
         setThreads(data)
@@ -54,7 +57,7 @@ export default function ChatLayout({ session, activeThreadId }: Props) {
     } finally {
       setLoading(false)
     }
-  }, [])
+  }, [showArchived])
 
   useEffect(() => {
     fetchThreads()
@@ -82,6 +85,24 @@ export default function ChatLayout({ session, activeThreadId }: Props) {
     } catch (err) {
       console.error('Failed to delete thread:', err)
       setError('Failed to delete thread')
+    }
+  }
+
+  const handleArchive = async (threadId: string) => {
+    try {
+      const res = await fetch(`/api/chat/${threadId}/archive`, { method: 'POST' })
+      if (res.ok) await fetchThreads()
+    } catch (err) {
+      console.error('Failed to archive thread:', err)
+    }
+  }
+
+  const handleUnarchive = async (threadId: string) => {
+    try {
+      const res = await fetch(`/api/chat/${threadId}/unarchive`, { method: 'POST' })
+      if (res.ok) await fetchThreads()
+    } catch (err) {
+      console.error('Failed to unarchive thread:', err)
     }
   }
 
@@ -139,6 +160,10 @@ export default function ChatLayout({ session, activeThreadId }: Props) {
             loading={loading}
             activeThreadId={activeThreadId}
             onDelete={handleDeleteThread}
+            onArchive={handleArchive}
+            onUnarchive={handleUnarchive}
+            showArchived={showArchived}
+            onToggleArchived={() => setShowArchived(!showArchived)}
           />
         </div>
       </div>

--- a/services/ui/src/app/chat/ThreadList.tsx
+++ b/services/ui/src/app/chat/ThreadList.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useCallback } from 'react'
 import Link from 'next/link'
-import { Users, Trash2 } from 'lucide-react'
+import { Users, Trash2, Archive, ArchiveRestore } from 'lucide-react'
 import type { ChatThread } from './ChatLayout'
 import AgentAvatar from '@/components/AgentAvatar'
 
@@ -34,6 +34,10 @@ interface Props {
   loading: boolean
   activeThreadId?: string
   onDelete: (threadId: string) => void
+  onArchive: (threadId: string) => void
+  onUnarchive: (threadId: string) => void
+  showArchived: boolean
+  onToggleArchived: () => void
 }
 
 function timeAgo(dateStr: string): string {
@@ -54,7 +58,7 @@ function truncate(text: string, maxLen: number): string {
   return text.slice(0, maxLen) + '...'
 }
 
-export default function ThreadList({ threads, loading, activeThreadId, onDelete }: Props) {
+export default function ThreadList({ threads, loading, activeThreadId, onDelete, onArchive, onUnarchive, showArchived, onToggleArchived }: Props) {
   const [confirmId, setConfirmId] = useState<string | null>(null)
   const [seenMap, setSeenMap] = useState<Record<string, string>>({})
 
@@ -88,7 +92,21 @@ export default function ThreadList({ threads, loading, activeThreadId, onDelete 
   }
 
   return (
-    <div className="flex-1 overflow-y-auto">
+    <div className="flex flex-col flex-1 min-h-0">
+      <div className="flex items-center justify-between px-3 py-2 border-b border-navy-800">
+        <span className="text-xs text-mountain-500">{threads.length} thread{threads.length !== 1 ? 's' : ''}</span>
+        <button
+          onClick={onToggleArchived}
+          className={`text-xs px-2 py-0.5 rounded transition-colors cursor-pointer ${
+            showArchived
+              ? 'bg-brand-600 text-white'
+              : 'text-mountain-400 hover:text-white'
+          }`}
+        >
+          {showArchived ? 'Hide Archived' : 'Show Archived'}
+        </button>
+      </div>
+      <div className="flex-1 overflow-y-auto">
       {threads.map(thread => {
         const isActive = thread.id === activeThreadId
         const isGroup = thread.type === 'group'
@@ -106,7 +124,7 @@ export default function ThreadList({ threads, loading, activeThreadId, onDelete 
               href={`/chat/${thread.id}`}
               className={`block px-3 py-2.5 border-b border-navy-800 hover:bg-navy-800 transition-colors ${
                 isActive ? 'bg-navy-800 border-l-2 border-l-brand-500' : ''
-              }`}
+              } ${thread.archived ? 'opacity-50' : ''}`}
             >
               <div className="flex items-start gap-2">
                 {/* Agent avatar */}
@@ -145,6 +163,21 @@ export default function ThreadList({ threads, loading, activeThreadId, onDelete 
                 </div>
                 <div className="flex items-start gap-1 flex-shrink-0 mt-0.5">
                   <span className="text-xs text-mountain-500">{time}</span>
+                  <button
+                    onClick={(e) => {
+                      e.preventDefault()
+                      e.stopPropagation()
+                      if (thread.archived) {
+                        onUnarchive(thread.id)
+                      } else {
+                        onArchive(thread.id)
+                      }
+                    }}
+                    className="p-0.5 text-mountain-500 hover:text-brand-400 opacity-0 group-hover:opacity-100 transition-opacity"
+                    aria-label={thread.archived ? `Unarchive thread ${displayTitle}` : `Archive thread ${displayTitle}`}
+                  >
+                    {thread.archived ? <ArchiveRestore size={12} /> : <Archive size={12} />}
+                  </button>
                   <button
                     onClick={(e) => {
                       e.preventDefault()
@@ -190,6 +223,7 @@ export default function ThreadList({ threads, loading, activeThreadId, onDelete 
           </div>
         )
       })}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Add `archived` boolean column to `chat_threads` table (migration 052) with index
- Add `POST /chat/threads/:id/archive` and `POST /chat/threads/:id/unarchive` API endpoints with owner/admin authorization
- Update `GET /chat/threads` to exclude archived threads by default; `include_archived=true` query param includes them
- Add archive/unarchive buttons (Archive/ArchiveRestore icons) to ThreadList with dimmed styling for archived threads
- Add "Show Archived" / "Hide Archived" toggle in thread list header
- Update OpenAPI spec with new endpoints and `archived` field on thread listing

## Test plan
- [ ] Migration 052 applies cleanly on fresh and existing databases
- [ ] `POST /threads/:id/archive` sets `archived = TRUE`, returns `{ archived: true }`
- [ ] `POST /threads/:id/unarchive` sets `archived = FALSE`, returns `{ archived: false }`
- [ ] Non-owner/non-admin gets 404 on archive/unarchive
- [ ] `GET /threads` excludes archived threads by default
- [ ] `GET /threads?include_archived=true` includes archived threads
- [ ] Archive button appears on hover, toggles to ArchiveRestore for archived threads
- [ ] Archived threads render with `opacity-50` styling
- [ ] "Show Archived" toggle fetches and displays archived threads
- [ ] OpenAPI spec validates without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)