### PR TITLE
feat: multi-agent collaborative group chat dispatch (AI-212)

### DIFF
--- a/services/agentbox/app/chat.py
+++ b/services/agentbox/app/chat.py
@@ -130,7 +130,28 @@ def handle_chat(
     # Append group context if this is a group thread
     thread_type = payload.get("thread_type")
     participants = payload.get("participants")
-    if thread_type == "group" and participants and isinstance(participants, list):
+    is_lead = payload.get("is_lead", False)
+    collaborators = payload.get("collaborators")
+
+    if is_lead and collaborators and isinstance(collaborators, list):
+        # Collaborative mode: lead agent with queryable collaborators
+        collab_lines = "\n".join(
+            f"- @{c['agent_id']} ({c.get('name', c['agent_id'])})"
+            for c in collaborators if isinstance(c, dict) and "agent_id" in c
+        )
+        collab_block = (
+            "\n\n## Collaborative Group Thread — You Are the Lead Agent\n"
+            "You are the lead agent in this group thread. The user's message is directed to you.\n"
+            "You have these collaborator agents available:\n"
+            f"{collab_lines}\n\n"
+            "As the lead, you should:\n"
+            "1. Produce the primary response to the user.\n"
+            "2. If you need specialized input, mention a collaborator with @slug.\n"
+            "3. Synthesize collaborator input into a coherent answer.\n"
+            "You produce the primary response — collaborators provide input to help you."
+        )
+        system_content = f"{system_content}{collab_block}" if system_content else collab_block
+    elif thread_type == "group" and participants and isinstance(participants, list):
         agent_lines = "\n".join(
             f"- @{p['agent_id']}" for p in participants if isinstance(p, dict) and "agent_id" in p
         )

--- a/services/api/src/__tests__/routes-chat.test.ts
+++ b/services/api/src/__tests__/routes-chat.test.ts
@@ -475,7 +475,7 @@ describe('Chat multi-agent dispatch', () => {
   it('POST /chat/threads/:id/messages dispatches to all agents in group (I8, I11)', async () => {
     mockQuery
       .mockResolvedValueOnce({ rows: [{ id: 1 }] })  // isParticipant
-      .mockResolvedValueOnce({ rows: [{ type: 'group' }] })  // getThreadType
+      .mockResolvedValueOnce({ rows: [{ type: 'group', lead_agent_id: null }] })  // getThreadType
       .mockResolvedValueOnce({  // getThreadAgents
         rows: [{ participant_id: 'agent-1' }, { participant_id: 'agent-2' }],
       })
@@ -494,6 +494,9 @@ describe('Chat multi-agent dispatch', () => {
       .mockResolvedValueOnce({ rows: [{ id: 'user-msg', seq: 10 }] })  // INSERT user message
       .mockResolvedValueOnce({ rows: [] })  // UPDATE thread timestamp
       .mockResolvedValueOnce({ rows: [{ role: 'user', content: 'prev' }] })  // message history
+      // getAgentForDispatch for participant list (group threads)
+      .mockResolvedValueOnce({ rows: [{ id: 'agent-1', agent_id: 'alpha', name: 'Alpha', status: 'running', work_token: 'wt-1', models: ['gpt-4o-mini'] }] })
+      .mockResolvedValueOnce({ rows: [{ id: 'agent-2', agent_id: 'beta', name: 'Beta', status: 'running', work_token: 'wt-2', models: ['gpt-4o'] }] })
       .mockResolvedValueOnce({ rows: [{ id: 'ph-1' }] })  // placeholder agent 1
       .mockResolvedValueOnce({ rows: [{ id: 'ph-2' }] });  // placeholder agent 2
 
@@ -514,7 +517,7 @@ describe('Chat multi-agent dispatch', () => {
   it('POST /chat/threads/:id/messages @-mention routes to single agent (I9)', async () => {
     mockQuery
       .mockResolvedValueOnce({ rows: [{ id: 1 }] })  // isParticipant
-      .mockResolvedValueOnce({ rows: [{ type: 'group' }] })  // getThreadType
+      .mockResolvedValueOnce({ rows: [{ type: 'group', lead_agent_id: null }] })  // getThreadType
       .mockResolvedValueOnce({  // getThreadAgents
         rows: [{ participant_id: 'agent-1' }, { participant_id: 'agent-2' }],
       })
@@ -531,6 +534,9 @@ describe('Chat multi-agent dispatch', () => {
       .mockResolvedValueOnce({ rows: [{ id: 'user-msg', seq: 10 }] })  // INSERT user message
       .mockResolvedValueOnce({ rows: [] })  // UPDATE thread timestamp
       .mockResolvedValueOnce({ rows: [{ role: 'user', content: 'prev' }] })  // message history
+      // getAgentForDispatch for participant list (group threads)
+      .mockResolvedValueOnce({ rows: [{ id: 'agent-1', agent_id: 'alpha', name: 'Alpha', status: 'running', work_token: 'wt-1', models: ['gpt-4o-mini'] }] })
+      .mockResolvedValueOnce({ rows: [{ id: 'agent-2', agent_id: 'beta', name: 'Beta', status: 'running', work_token: 'wt-2', models: ['gpt-4o'] }] })
       .mockResolvedValueOnce({ rows: [{ id: 'ph-1' }] });  // placeholder
 
     const res = await request(app)
@@ -547,7 +553,7 @@ describe('Chat multi-agent dispatch', () => {
   it('POST /chat/threads/:id/messages returns 400 for unknown @-mention (I10)', async () => {
     mockQuery
       .mockResolvedValueOnce({ rows: [{ id: 1 }] })  // isParticipant
-      .mockResolvedValueOnce({ rows: [{ type: 'group' }] })  // getThreadType
+      .mockResolvedValueOnce({ rows: [{ type: 'group', lead_agent_id: null }] })  // getThreadType
       .mockResolvedValueOnce({  // getThreadAgents
         rows: [{ participant_id: 'agent-1' }],
       })
@@ -566,7 +572,7 @@ describe('Chat multi-agent dispatch', () => {
   it('POST /chat/threads/:id/messages skips agent with pending, dispatches others (I12)', async () => {
     mockQuery
       .mockResolvedValueOnce({ rows: [{ id: 1 }] })  // isParticipant
-      .mockResolvedValueOnce({ rows: [{ type: 'group' }] })  // getThreadType
+      .mockResolvedValueOnce({ rows: [{ type: 'group', lead_agent_id: null }] })  // getThreadType
       .mockResolvedValueOnce({  // getThreadAgents
         rows: [{ participant_id: 'agent-1' }, { participant_id: 'agent-2' }],
       })
@@ -583,6 +589,9 @@ describe('Chat multi-agent dispatch', () => {
       .mockResolvedValueOnce({ rows: [{ id: 'user-msg', seq: 10 }] })  // INSERT user message
       .mockResolvedValueOnce({ rows: [] })  // UPDATE thread timestamp
       .mockResolvedValueOnce({ rows: [{ role: 'user', content: 'prev' }] })  // message history
+      // getAgentForDispatch for participant list (group threads)
+      .mockResolvedValueOnce({ rows: [{ id: 'agent-1', agent_id: 'alpha', name: 'Alpha', status: 'running', work_token: 'wt-1', models: ['gpt-4o-mini'] }] })
+      .mockResolvedValueOnce({ rows: [{ id: 'agent-2', agent_id: 'beta', name: 'Beta', status: 'running', work_token: 'wt-2', models: ['gpt-4o'] }] })
       .mockResolvedValueOnce({ rows: [{ id: 'ph-2' }] });  // placeholder for agent 2
 
     const res = await request(app)
@@ -601,7 +610,7 @@ describe('Chat multi-agent dispatch', () => {
   it('POST /chat/threads/:id/messages strict elevated deny for group (I13)', async () => {
     mockQuery
       .mockResolvedValueOnce({ rows: [{ id: 1 }] })  // isParticipant
-      .mockResolvedValueOnce({ rows: [{ type: 'group' }] })  // getThreadType
+      .mockResolvedValueOnce({ rows: [{ type: 'group', lead_agent_id: null }] })  // getThreadType
       .mockResolvedValueOnce({  // getThreadAgents
         rows: [{ participant_id: 'agent-1' }, { participant_id: 'agent-2' }],
       })
@@ -628,7 +637,7 @@ describe('Chat multi-agent dispatch', () => {
   it('POST /chat/threads/:id/messages sets reply_to on placeholders (I15)', async () => {
     mockQuery
       .mockResolvedValueOnce({ rows: [{ id: 1 }] })  // isParticipant
-      .mockResolvedValueOnce({ rows: [{ type: 'group' }] })  // getThreadType
+      .mockResolvedValueOnce({ rows: [{ type: 'group', lead_agent_id: null }] })  // getThreadType
       .mockResolvedValueOnce({  // getThreadAgents
         rows: [{ participant_id: 'agent-1' }],
       })
@@ -640,6 +649,8 @@ describe('Chat multi-agent dispatch', () => {
       .mockResolvedValueOnce({ rows: [{ id: 'user-msg-123', seq: 10 }] })  // INSERT user message
       .mockResolvedValueOnce({ rows: [] })  // UPDATE thread timestamp
       .mockResolvedValueOnce({ rows: [] })  // message history
+      // getAgentForDispatch for participant list (group threads)
+      .mockResolvedValueOnce({ rows: [{ id: 'agent-1', agent_id: 'alpha', name: 'Alpha', status: 'running', work_token: 'wt', models: ['gpt-4o-mini'] }] })
       .mockResolvedValueOnce({ rows: [{ id: 'ph-1' }] });  // placeholder
 
     await request(app)
@@ -659,7 +670,7 @@ describe('Chat multi-agent dispatch', () => {
   it('POST /chat/threads/:id/messages stores target_agents for @-mentions (I16)', async () => {
     mockQuery
       .mockResolvedValueOnce({ rows: [{ id: 1 }] })
-      .mockResolvedValueOnce({ rows: [{ type: 'group' }] })
+      .mockResolvedValueOnce({ rows: [{ type: 'group', lead_agent_id: null }] })
       .mockResolvedValueOnce({ rows: [{ participant_id: 'agent-1' }] })
       .mockResolvedValueOnce({ rows: [{ slug: 'alpha', participant_id: 'agent-1' }] })  // resolveAgentSlugs
       .mockResolvedValueOnce({
@@ -670,6 +681,8 @@ describe('Chat multi-agent dispatch', () => {
       .mockResolvedValueOnce({ rows: [{ id: 'user-msg', seq: 10 }] })  // INSERT user message
       .mockResolvedValueOnce({ rows: [] })  // UPDATE thread timestamp
       .mockResolvedValueOnce({ rows: [] })  // message history
+      // getAgentForDispatch for participant list (group threads)
+      .mockResolvedValueOnce({ rows: [{ id: 'agent-1', agent_id: 'alpha', name: 'Alpha', status: 'running', work_token: 'wt', models: ['gpt-4o-mini'] }] })
       .mockResolvedValueOnce({ rows: [{ id: 'ph-1' }] });
 
     await request(app)
@@ -719,7 +732,7 @@ describe('Chat multi-agent dispatch', () => {
 
     mockQuery
       .mockResolvedValueOnce({ rows: [{ id: 1 }] })  // isParticipant
-      .mockResolvedValueOnce({ rows: [{ type: 'group' }] })  // getThreadType
+      .mockResolvedValueOnce({ rows: [{ type: 'group', lead_agent_id: null }] })  // getThreadType
       .mockResolvedValueOnce({ rows: [{ participant_id: 'agent-1' }] })  // getThreadAgents
       .mockResolvedValueOnce({
         rows: [{ id: 'agent-1', agent_id: 'alpha', name: 'Alpha', status: 'running', work_token: 'wt', models: ['gpt-4o-mini'] }],
@@ -729,6 +742,8 @@ describe('Chat multi-agent dispatch', () => {
       .mockResolvedValueOnce({ rows: [{ id: 'user-msg', seq: 10 }] })  // INSERT user message
       .mockResolvedValueOnce({ rows: [] })  // UPDATE thread timestamp
       .mockResolvedValueOnce({ rows: [] })  // message history
+      // getAgentForDispatch for participant list (group threads)
+      .mockResolvedValueOnce({ rows: [{ id: 'agent-1', agent_id: 'alpha', name: 'Alpha', status: 'running', work_token: 'wt', models: ['gpt-4o-mini'] }] })
       .mockResolvedValueOnce({ rows: [{ id: 'ph-1' }] })  // placeholder
       .mockResolvedValueOnce({ rowCount: 1 });  // UPDATE placeholder to error
 
@@ -1745,7 +1760,7 @@ describe('Group broadcast dispatch', () => {
 
     mockQuery
       .mockResolvedValueOnce({ rows: [{ id: 1 }] })  // isParticipant
-      .mockResolvedValueOnce({ rows: [{ type: 'group' }] })  // getThreadType
+      .mockResolvedValueOnce({ rows: [{ type: 'group', lead_agent_id: null }] })  // getThreadType
       .mockResolvedValueOnce({  // getThreadAgents
         rows: [{ participant_id: 'a1' }, { participant_id: 'a2' }, { participant_id: 'a3' }],
       })
@@ -1761,6 +1776,10 @@ describe('Group broadcast dispatch', () => {
       .mockResolvedValueOnce({ rows: [{ id: 'user-msg', seq: 10 }] })  // INSERT user message
       .mockResolvedValueOnce({ rows: [] })  // UPDATE thread timestamp
       .mockResolvedValueOnce({ rows: [{ role: 'user', content: 'prev' }] })  // history
+      // getAgentForDispatch for participant list (group threads)
+      .mockResolvedValueOnce({ rows: [{ id: 'a1', agent_id: 'alpha', name: 'Alpha', status: 'running', work_token: 'wt1', models: ['gpt-4o'] }] })
+      .mockResolvedValueOnce({ rows: [{ id: 'a2', agent_id: 'beta', name: 'Beta', status: 'running', work_token: 'wt2', models: ['gpt-4o'] }] })
+      .mockResolvedValueOnce({ rows: [{ id: 'a3', agent_id: 'gamma', name: 'Gamma', status: 'running', work_token: 'wt3', models: ['gpt-4o'] }] })
       .mockResolvedValueOnce({ rows: [{ id: 'ph-1' }] })  // placeholder a1
       .mockResolvedValueOnce({ rows: [{ id: 'ph-2' }] })  // placeholder a2
       .mockResolvedValueOnce({ rows: [{ id: 'ph-3' }] });  // placeholder a3
@@ -1785,7 +1804,7 @@ describe('Group broadcast dispatch', () => {
 
     mockQuery
       .mockResolvedValueOnce({ rows: [{ id: 1 }] })  // isParticipant
-      .mockResolvedValueOnce({ rows: [{ type: 'group' }] })  // getThreadType
+      .mockResolvedValueOnce({ rows: [{ type: 'group', lead_agent_id: null }] })  // getThreadType
       .mockResolvedValueOnce({  // getThreadAgents
         rows: [{ participant_id: 'a1' }, { participant_id: 'a2' }, { participant_id: 'a3' }],
       })
@@ -1801,6 +1820,10 @@ describe('Group broadcast dispatch', () => {
       .mockResolvedValueOnce({ rows: [{ id: 'user-msg', seq: 10 }] })  // INSERT user message
       .mockResolvedValueOnce({ rows: [] })  // UPDATE thread timestamp
       .mockResolvedValueOnce({ rows: [{ role: 'user', content: 'prev' }] })  // history
+      // getAgentForDispatch for participant list (group threads)
+      .mockResolvedValueOnce({ rows: [{ id: 'a1', agent_id: 'alpha', name: 'Alpha', status: 'running', work_token: 'wt1', models: [] }] })
+      .mockResolvedValueOnce({ rows: [{ id: 'a2', agent_id: 'beta', name: 'Beta', status: 'running', work_token: 'wt2', models: [] }] })
+      .mockResolvedValueOnce({ rows: [{ id: 'a3', agent_id: 'gamma', name: 'Gamma', status: 'running', work_token: 'wt3', models: [] }] })
       .mockResolvedValueOnce({ rows: [{ id: 'ph-1' }] })  // placeholder a1
       .mockResolvedValueOnce({ rows: [{ id: 'ph-2' }] })  // placeholder a2
       .mockResolvedValueOnce({ rows: [{ id: 'ph-3' }] })  // placeholder a3
@@ -1820,7 +1843,7 @@ describe('Group broadcast dispatch', () => {
   it('group dispatch payload includes thread_type and participants (T3)', async () => {
     mockQuery
       .mockResolvedValueOnce({ rows: [{ id: 1 }] })  // isParticipant
-      .mockResolvedValueOnce({ rows: [{ type: 'group' }] })  // getThreadType
+      .mockResolvedValueOnce({ rows: [{ type: 'group', lead_agent_id: null }] })  // getThreadType
       .mockResolvedValueOnce({  // getThreadAgents
         rows: [{ participant_id: 'a1' }, { participant_id: 'a2' }],
       })
@@ -1833,6 +1856,9 @@ describe('Group broadcast dispatch', () => {
       .mockResolvedValueOnce({ rows: [{ id: 'user-msg', seq: 10 }] })  // INSERT user message
       .mockResolvedValueOnce({ rows: [] })  // UPDATE thread timestamp
       .mockResolvedValueOnce({ rows: [{ role: 'user', content: 'prev' }] })  // history
+      // getAgentForDispatch for participant list (group threads)
+      .mockResolvedValueOnce({ rows: [{ id: 'a1', agent_id: 'alpha', name: 'Alpha', status: 'running', work_token: 'wt1', models: [] }] })
+      .mockResolvedValueOnce({ rows: [{ id: 'a2', agent_id: 'beta', name: 'Beta', status: 'running', work_token: 'wt2', models: [] }] })
       .mockResolvedValueOnce({ rows: [{ id: 'ph-1' }] })  // placeholder a1
       .mockResolvedValueOnce({ rows: [{ id: 'ph-2' }] });  // placeholder a2
 

--- a/services/api/src/db/migrations/053_add_lead_agent_id.sql
+++ b/services/api/src/db/migrations/053_add_lead_agent_id.sql
@@ -1,0 +1,10 @@
+-- Migration 053: Add lead_agent_id to chat_threads for collaborative group chat.
+--
+-- In a collaborative group thread, the lead agent is the primary responder.
+-- Other agents serve as collaborators the lead can query for input.
+-- NULL means classic broadcast dispatch (all agents respond independently).
+
+ALTER TABLE chat_threads ADD COLUMN lead_agent_id UUID DEFAULT NULL
+  REFERENCES agents(id) ON DELETE SET NULL;
+
+CREATE INDEX idx_chat_threads_lead ON chat_threads(lead_agent_id) WHERE lead_agent_id IS NOT NULL;

--- a/services/api/src/routes/chat.ts
+++ b/services/api/src/routes/chat.ts
@@ -111,13 +111,13 @@ async function getThreadAgents(threadId: string): Promise<string[]> {
   return rows.map((r: any) => r.participant_id);
 }
 
-/** Get thread type. */
-async function getThreadType(threadId: string): Promise<string | null> {
+/** Get thread type and lead_agent_id. */
+async function getThreadType(threadId: string): Promise<{ type: string; lead_agent_id: string | null } | null> {
   const { rows } = await getPool().query(
-    `SELECT type FROM chat_threads WHERE id = $1`,
+    `SELECT type, lead_agent_id FROM chat_threads WHERE id = $1`,
     [threadId]
   );
-  return rows.length > 0 ? rows[0].type : null;
+  return rows.length > 0 ? { type: rows[0].type, lead_agent_id: rows[0].lead_agent_id } : null;
 }
 
 /**
@@ -174,6 +174,7 @@ async function dispatchToAgents(opts: {
   triggeredBy?: string | null;
   threadType?: string;
   participants?: { agent_id: string; name: string }[];
+  leadAgentId?: string | null;
 }): Promise<{
   dispatched: { agent_id: string; message_id: string }[];
   failed: { agent_id: string; message_id: string; reason: string }[];
@@ -206,6 +207,14 @@ async function dispatchToAgents(opts: {
   }
 
   // Phase 2: Dispatch all work items in parallel
+  // In collaborative mode (leadAgentId set), the lead agent gets collaborator
+  // context so it knows which agents are available for consultation.
+  const collaboratorList = opts.leadAgentId
+    ? opts.agents
+        .filter(a => a.id !== opts.leadAgentId)
+        .map(a => ({ agent_id: a.agent_id, name: a.name || a.agent_id }))
+    : undefined;
+
   const results = await Promise.allSettled(
     placeholders.map(({ agent, placeholderId, model }) =>
       dispatchChatWork({
@@ -218,6 +227,8 @@ async function dispatchToAgents(opts: {
         callbackUrl,
         threadType: opts.threadType,
         participants: opts.participants,
+        isLead: opts.leadAgentId ? agent.id === opts.leadAgentId : undefined,
+        collaborators: opts.leadAgentId && agent.id === opts.leadAgentId ? collaboratorList : undefined,
       })
     )
   );
@@ -264,7 +275,7 @@ router.get('/threads', requireRole('user'), async (req: Request, res: Response) 
     let params: any[];
 
     if (admin) {
-      query = `SELECT t.id, t.type, t.title, t.created_by, t.created_at, t.updated_at,
+      query = `SELECT t.id, t.type, t.title, t.created_by, t.lead_agent_id, t.created_at, t.updated_at,
                       (SELECT content FROM chat_messages
                        WHERE thread_id = t.id ORDER BY seq DESC LIMIT 1) AS last_message,
                       (SELECT author_type FROM chat_messages
@@ -273,7 +284,7 @@ router.get('/threads', requireRole('user'), async (req: Request, res: Response) 
                ORDER BY t.updated_at DESC`;
       params = [];
     } else {
-      query = `SELECT t.id, t.type, t.title, t.created_by, t.created_at, t.updated_at,
+      query = `SELECT t.id, t.type, t.title, t.created_by, t.lead_agent_id, t.created_at, t.updated_at,
                       (SELECT content FROM chat_messages
                        WHERE thread_id = t.id ORDER BY seq DESC LIMIT 1) AS last_message,
                       (SELECT author_type FROM chat_messages
@@ -346,7 +357,7 @@ router.post('/threads', requireRole('user'), async (req: Request, res: Response)
   try {
     const user = (req as any).user;
     const admin = isAdmin(req);
-    const { agent_id, agent_ids, message, title, idempotency_key } = req.body;
+    const { agent_id, agent_ids, message, title, idempotency_key, lead_agent_id } = req.body;
 
     // Resolve agent UUIDs: support both single agent_id and array agent_ids
     let agentUuids: string[];
@@ -373,6 +384,23 @@ router.post('/threads', requireRole('user'), async (req: Request, res: Response)
       return;
     }
 
+    // Validate lead_agent_id for collaborative mode
+    const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+    if (lead_agent_id) {
+      if (typeof lead_agent_id !== 'string' || !UUID_RE.test(lead_agent_id)) {
+        res.status(400).json({ error: 'lead_agent_id must be a valid UUID' });
+        return;
+      }
+      if (threadType !== 'group') {
+        res.status(400).json({ error: 'lead_agent_id is only valid for group threads (requires agent_ids with 2+ agents)' });
+        return;
+      }
+      if (!agentUuids.includes(lead_agent_id)) {
+        res.status(400).json({ error: 'lead_agent_id must be one of the agent_ids' });
+        return;
+      }
+    }
+
     // Look up all agents
     const agents: Awaited<ReturnType<typeof getAgentForDispatch>>[] = [];
     for (const uuid of agentUuids) {
@@ -396,10 +424,32 @@ router.post('/threads', requireRole('user'), async (req: Request, res: Response)
       }
     }
 
+    // Classify agents for dispatch (before DB writes to avoid orphans)
+    const dispatchableAgents: NonNullable<Awaited<ReturnType<typeof getAgentForDispatch>>>[] = [];
+    const skipped: { agent_id: string; reason: string }[] = [];
+
+    for (const agent of agents) {
+      if (agent!.status !== 'running' || !agent!.work_token) {
+        skipped.push({ agent_id: agent!.id, reason: 'not_running' });
+      } else {
+        dispatchableAgents.push(agent!);
+      }
+    }
+
     // Pre-flight: at least one agent must be running
-    const runningAgents = agents.filter(a => a!.status === 'running' && a!.work_token);
-    if (runningAgents.length === 0) {
+    if (dispatchableAgents.length === 0) {
       res.status(400).json({ error: 'No available agents — all selected agents are not running' });
+      return;
+    }
+
+    // In collaborative mode, only dispatch to the lead agent (others are collaborators)
+    const agentsToDispatch = lead_agent_id
+      ? dispatchableAgents.filter(a => a.id === lead_agent_id)
+      : dispatchableAgents;
+
+    if (lead_agent_id && agentsToDispatch.length === 0) {
+      // Lead agent isn't running — reject before creating thread
+      res.status(409).json({ error: 'Lead agent is not running' });
       return;
     }
 
@@ -407,10 +457,10 @@ router.post('/threads', requireRole('user'), async (req: Request, res: Response)
 
     // Create thread
     const { rows: [thread] } = await pool.query(
-      `INSERT INTO chat_threads (type, title, created_by)
-       VALUES ($1, $2, $3)
-       RETURNING id, type, title, created_by, created_at, updated_at`,
-      [threadType, title || null, user.sub]
+      `INSERT INTO chat_threads (type, title, created_by, lead_agent_id)
+       VALUES ($1, $2, $3, $4)
+       RETURNING id, type, title, created_by, lead_agent_id, created_at, updated_at`,
+      [threadType, title || null, user.sub, lead_agent_id || null]
     );
 
     // Add participants: human owner + all agents
@@ -437,19 +487,7 @@ router.post('/threads', requireRole('user'), async (req: Request, res: Response)
       [thread.id, user.sub, message.trim(), idempotency_key || null]
     );
 
-    // Classify agents for dispatch
-    const dispatchableAgents: NonNullable<Awaited<ReturnType<typeof getAgentForDispatch>>>[] = [];
-    const skipped: { agent_id: string; reason: string }[] = [];
-
-    for (const agent of agents) {
-      if (agent!.status !== 'running' || !agent!.work_token) {
-        skipped.push({ agent_id: agent!.id, reason: 'not_running' });
-      } else {
-        dispatchableAgents.push(agent!);
-      }
-    }
-
-    // Build participant list for group context
+    // Build participant list for group context (all agents, not just dispatch targets)
     const participantList = threadType === 'group'
       ? agents.map(a => ({ agent_id: a!.agent_id, name: a!.name || a!.agent_id }))
       : undefined;
@@ -458,11 +496,12 @@ router.post('/threads', requireRole('user'), async (req: Request, res: Response)
     const historyMessages = [{ role: 'user', content: message.trim() }];
     const { dispatched, failed } = await dispatchToAgents({
       threadId: thread.id,
-      agents: dispatchableAgents,
+      agents: agentsToDispatch,
       replyTo: userMsg.id,
       historyMessages,
       threadType: threadType || undefined,
       participants: participantList,
+      leadAgentId: lead_agent_id || null,
     });
 
     // Direct thread backward compat response
@@ -513,7 +552,7 @@ router.get('/threads/:id', requireRole('user'), async (req: Request, res: Respon
 
     // Get thread
     const { rows: threadRows } = await pool.query(
-      `SELECT id, type, title, created_by, created_at, updated_at
+      `SELECT id, type, title, created_by, lead_agent_id, created_at, updated_at
        FROM chat_threads WHERE id = $1`,
       [req.params.id]
     );
@@ -591,17 +630,49 @@ router.put('/threads/:id', requireRole('user'), async (req: Request, res: Respon
       return;
     }
 
-    const { title } = req.body;
+    const { title, lead_agent_id } = req.body;
     if (title !== undefined && title !== null && typeof title !== 'string') {
       res.status(400).json({ error: 'title must be a string or null' });
       return;
     }
 
+    // Validate lead_agent_id if provided
+    if (lead_agent_id !== undefined && lead_agent_id !== null) {
+      const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+      if (typeof lead_agent_id !== 'string' || !UUID_RE.test(lead_agent_id)) {
+        res.status(400).json({ error: 'lead_agent_id must be a valid UUID or null' });
+        return;
+      }
+      // Verify it's an active agent participant in this thread
+      const agentUuids = await getThreadAgents(req.params.id);
+      if (!agentUuids.includes(lead_agent_id)) {
+        res.status(400).json({ error: 'lead_agent_id must be an active agent participant in the thread' });
+        return;
+      }
+    }
+
+    // Build dynamic SET clause
+    const setClauses = ['updated_at = NOW()'];
+    const params: any[] = [];
+    let idx = 1;
+
+    if (title !== undefined) {
+      setClauses.push(`title = $${idx}`);
+      params.push(title ?? null);
+      idx++;
+    }
+    if (lead_agent_id !== undefined) {
+      setClauses.push(`lead_agent_id = $${idx}`);
+      params.push(lead_agent_id ?? null);
+      idx++;
+    }
+
+    params.push(req.params.id);
     const { rows } = await getPool().query(
-      `UPDATE chat_threads SET title = $1, updated_at = NOW()
-       WHERE id = $2
-       RETURNING id, type, title, created_by, created_at, updated_at`,
-      [title ?? null, req.params.id]
+      `UPDATE chat_threads SET ${setClauses.join(', ')}
+       WHERE id = $${idx}
+       RETURNING id, type, title, created_by, lead_agent_id, created_at, updated_at`,
+      params
     );
 
     if (rows.length === 0) {
@@ -772,11 +843,13 @@ router.post('/threads/:id/messages', requireRole('user'), async (req: Request, r
       return;
     }
 
-    const threadType = await getThreadType(threadId);
-    if (!threadType) {
+    const threadInfo = await getThreadType(threadId);
+    if (!threadInfo) {
       res.status(404).json({ error: 'Thread not found' });
       return;
     }
+    const threadType = threadInfo.type;
+    const leadAgentId = threadInfo.lead_agent_id;
 
     // Parse @-mentions
     const { slugs, cleanContent } = parseMentions(message.trim());
@@ -897,19 +970,34 @@ router.post('/threads/:id/messages', requireRole('user'), async (req: Request, r
     );
     const historyMessages = history.reverse();
 
-    // Build participant list for group context
-    const participantList = threadType === 'group'
-      ? targetAgents.map(a => ({ agent_id: a.agent_id, name: a.name || a.agent_id }))
-      : undefined;
+    // Build participant list for group context (all thread agents, not just targets)
+    let participantList: { agent_id: string; name: string }[] | undefined;
+    if (threadType === 'group') {
+      const allAgentInfos = await Promise.all(allAgentUuids.map(getAgentForDispatch));
+      participantList = allAgentInfos
+        .filter((a): a is NonNullable<typeof a> => a !== null)
+        .map(a => ({ agent_id: a.agent_id, name: a.name || a.agent_id }));
+    }
+
+    // In collaborative mode, only dispatch to the lead agent
+    const agentsToDispatch = leadAgentId
+      ? dispatchable.filter(a => a.id === leadAgentId)
+      : dispatchable;
+
+    if (leadAgentId && agentsToDispatch.length === 0) {
+      res.status(409).json({ error: 'Lead agent is not running or has a pending response' });
+      return;
+    }
 
     // Dispatch to each dispatchable agent via shared helper
     const { dispatched, failed: failedArr } = await dispatchToAgents({
       threadId,
-      agents: dispatchable,
+      agents: agentsToDispatch,
       replyTo: userMsg.id,
       historyMessages,
       threadType: threadType || undefined,
       participants: participantList,
+      leadAgentId,
     });
 
     // Direct thread backward compat response

--- a/services/api/src/services/chat-dispatch.ts
+++ b/services/api/src/services/chat-dispatch.ts
@@ -15,6 +15,8 @@ interface ChatDispatchParams {
   callbackUrl: string;
   threadType?: string;   // 'direct' | 'group' — omitted for backward compat
   participants?: Array<{ agent_id: string; name: string }>;  // group thread participant list
+  isLead?: boolean;      // true when this agent is the lead in collaborative mode
+  collaborators?: Array<{ agent_id: string; name: string }>;  // other agents the lead can query
 }
 
 interface DispatchResult {
@@ -24,11 +26,11 @@ interface DispatchResult {
 }
 
 export async function dispatchChatWork(params: ChatDispatchParams): Promise<DispatchResult> {
-  const { agentId, workToken, threadId, messageId, messages, model, callbackUrl, threadType, participants } = params;
+  const { agentId, workToken, threadId, messageId, messages, model, callbackUrl, threadType, participants, isLead, collaborators } = params;
 
   const url = `http://agentbox-${agentId}:8054/work`;
 
-  console.log(`[chat-dispatch] Dispatching to ${agentId}: thread_id=${threadId} message_id=${messageId} model=${model}`);
+  console.log(`[chat-dispatch] Dispatching to ${agentId}: thread_id=${threadId} message_id=${messageId} model=${model} lead=${!!isLead}`);
 
   const payload: Record<string, unknown> = {
     thread_id: threadId,
@@ -39,6 +41,8 @@ export async function dispatchChatWork(params: ChatDispatchParams): Promise<Disp
   };
   if (threadType) payload.thread_type = threadType;
   if (participants && participants.length > 0) payload.participants = participants;
+  if (isLead) payload.is_lead = true;
+  if (collaborators && collaborators.length > 0) payload.collaborators = collaborators;
 
   const body = {
     type: 'chat',


### PR DESCRIPTION
## Summary
- Adds `lead_agent_id` column to `chat_threads` (migration 053) to designate a lead agent for collaborative group threads
- When `lead_agent_id` is set, only the lead agent receives dispatch — other agents serve as queryable collaborators via a future internal tool
- Lead agent gets a dedicated collaborative system prompt with collaborator list and instructions to synthesize a single combined response
- All validation happens before DB writes to prevent orphaned threads on error
- PUT `/threads/:id` supports setting/clearing `lead_agent_id` to toggle collaborative mode

## Files Changed
- `services/api/src/db/migrations/053_add_lead_agent_id.sql` — new column with FK + partial index
- `services/api/src/routes/chat.ts` — collaborative dispatch in POST/PUT/GET handlers
- `services/api/src/services/chat-dispatch.ts` — `isLead` + `collaborators` payload fields
- `services/agentbox/app/chat.py` — collaborative system prompt block for lead agents
- `services/api/src/openapi/openapi.yaml` — document `lead_agent_id` field

## Test plan
- [ ] Create group thread without `lead_agent_id` — broadcast dispatch (backward compat)
- [ ] Create group thread with `lead_agent_id` — only lead receives dispatch
- [ ] Verify lead agent payload includes `is_lead: true` and `collaborators` array
- [ ] `PUT /threads/:id` with `lead_agent_id` — sets collaborative mode
- [ ] `PUT /threads/:id` with `lead_agent_id: null` — reverts to broadcast
- [ ] Invalid UUID for `lead_agent_id` returns 400
- [ ] `lead_agent_id` not in `agent_ids` returns 400
- [ ] Lead agent not running returns 409 (no orphaned thread created)
- [ ] Direct thread with `lead_agent_id` returns 400
- [ ] GET endpoints include `lead_agent_id` in response

🤖 Generated with [Claude Code](https://claude.com/claude-code)