### PR TITLE
fix: clear error message for duplicate agent ID

### DIFF
--- a/services/ui/src/app/agents/new/AgentFormClient.tsx
+++ b/services/ui/src/app/agents/new/AgentFormClient.tsx
@@ -93,6 +93,7 @@ export default function AgentFormClient({
   const [error, setError] = useState('')
   const [validationError, setValidationError] = useState('')
   const [touched, setTouched] = useState<Record<string, boolean>>({})
+  const [agentIdServerError, setAgentIdServerError] = useState('')
 
   const [agentId, setAgentId] = useState(initial?.agent_id || '')
   const [name, setName] = useState(initial?.name || '')
@@ -162,7 +163,9 @@ export default function AgentFormClient({
   }
 
   // Inline validation
-  const agentIdError = touched.agent_id && agentId.length > 0 && !AGENT_ID_REGEX.test(agentId)
+  const agentIdError = agentIdServerError
+    ? agentIdServerError
+    : touched.agent_id && agentId.length > 0 && !AGENT_ID_REGEX.test(agentId)
     ? 'Must be lowercase letters, numbers, and hyphens. Cannot start or end with a hyphen.'
     : touched.agent_id && agentId.length === 0
     ? 'Agent ID is required'
@@ -201,6 +204,7 @@ export default function AgentFormClient({
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     if (!validateForm()) return
+    setAgentIdServerError('')
 
     setSaving(true)
     setError('')
@@ -240,6 +244,10 @@ export default function AgentFormClient({
 
       if (!res.ok) {
         const data = await res.json()
+        if (res.status === 409 && data.error?.toLowerCase().includes('agent_id')) {
+          setAgentIdServerError(data.error)
+          return
+        }
         setError(data.error || `Failed to ${isEdit ? 'update' : 'create'} agent`)
         return
       }
@@ -287,7 +295,7 @@ export default function AgentFormClient({
             id="agent_id"
             type="text"
             value={agentId}
-            onChange={(e) => setAgentId(e.target.value.toLowerCase().replace(/[^a-z0-9-]/g, ''))}
+            onChange={(e) => { setAgentId(e.target.value.toLowerCase().replace(/[^a-z0-9-]/g, '')); setAgentIdServerError('') }}
             onBlur={() => setTouched(prev => ({ ...prev, agent_id: true }))}
             disabled={isEdit}
             required


### PR DESCRIPTION
## Summary
- **Inline duplicate error**: 409 responses from `POST /agents` now display inline on the Agent ID field instead of in the generic error banner
- **Auto-clear**: Server error clears when the user edits the Agent ID field
- **No API changes**: The API already returns `409 { error: "An agent with this agent_id already exists" }` — this is UI-only

## Test plan
- [ ] Create an agent with ID `test-agent`
- [ ] Try creating another agent with ID `test-agent` — verify red error appears below the Agent ID field (not in the top banner)
- [ ] Edit the Agent ID field — verify the error clears
- [ ] Submit with a different valid ID — verify agent creates successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)