### PR TITLE
feat: add agent runtime metrics endpoint (AI-229)

### DIFF
--- a/services/api/src/routes/agents.ts
+++ b/services/api/src/routes/agents.ts
@@ -13,6 +13,7 @@ import {
   createAndStartContainer,
   stopAndRemoveContainer,
   inspectContainer,
+  getContainerStats,
   getContainerLogs,
   execInContainer,
   removeAgentVolumes,
@@ -2398,6 +2399,33 @@ router.get('/:id/artifacts', requireRole('user'), async (req: Request, res: Resp
   } catch (err: any) {
     console.error('[agents] Artifacts error:', err);
     res.status(500).json({ error: 'Failed to compute artifacts' });
+  }
+});
+
+// Agent runtime metrics — live CPU/memory from Docker container stats
+router.get('/:id/runtime-metrics', requireRole('user'), async (req: Request, res: Response) => {
+  try {
+    const scope = scopeToOwner(req);
+    const paramOffset = scope.params.length + 1;
+    const { rows } = await getPool().query(
+      `SELECT agent_id FROM agents WHERE id = $${paramOffset}${scope.where !== '1=1' ? ` AND ${scope.where}` : ''}`,
+      [...scope.params, req.params.id],
+    );
+    if (rows.length === 0) {
+      res.status(404).json({ error: 'Agent not found' });
+      return;
+    }
+
+    const stats = await getContainerStats(rows[0].agent_id);
+    if (!stats) {
+      res.status(404).json({ error: 'Agent not running' });
+      return;
+    }
+
+    res.json(stats);
+  } catch (err: any) {
+    console.error('[agents] Runtime metrics error:', err);
+    res.status(500).json({ error: 'Failed to fetch runtime metrics' });
   }
 });
 

--- a/services/api/src/services/docker.ts
+++ b/services/api/src/services/docker.ts
@@ -186,6 +186,61 @@ export async function inspectContainer(agentId: string): Promise<{
   }
 }
 
+export async function getContainerStats(agentId: string): Promise<{
+  cpu_percent: number;
+  memory_usage_mb: number;
+  memory_limit_mb: number;
+  memory_percent: number;
+  pids: number;
+  net_rx_mb: number;
+  net_tx_mb: number;
+} | null> {
+  const containerName = `${CONTAINER_PREFIX}${agentId}`;
+  assertAgentboxName(containerName);
+
+  try {
+    const container = docker.getContainer(containerName);
+    const info = await container.inspect();
+    assertManagedLabel(info.Config.Labels);
+    if (info.State.Status !== 'running') return null;
+
+    const stats: any = await container.stats({ stream: false });
+
+    // CPU percentage: delta usage / delta system * num CPUs * 100
+    const cpuDelta = stats.cpu_stats.cpu_usage.total_usage - (stats.precpu_stats.cpu_usage?.total_usage || 0);
+    const systemDelta = stats.cpu_stats.system_cpu_usage - (stats.precpu_stats.system_cpu_usage || 0);
+    const numCpus = stats.cpu_stats.online_cpus || stats.cpu_stats.cpu_usage.percpu_usage?.length || 1;
+    const cpuPercent = systemDelta > 0 ? (cpuDelta / systemDelta) * numCpus * 100 : 0;
+
+    // Memory
+    const memUsage = stats.memory_stats.usage - (stats.memory_stats.stats?.cache || 0);
+    const memLimit = stats.memory_stats.limit;
+
+    // Network (sum all interfaces)
+    let netRx = 0;
+    let netTx = 0;
+    if (stats.networks) {
+      for (const iface of Object.values(stats.networks) as any[]) {
+        netRx += iface.rx_bytes || 0;
+        netTx += iface.tx_bytes || 0;
+      }
+    }
+
+    return {
+      cpu_percent: Math.round(cpuPercent * 100) / 100,
+      memory_usage_mb: Math.round((memUsage / 1048576) * 100) / 100,
+      memory_limit_mb: Math.round((memLimit / 1048576) * 100) / 100,
+      memory_percent: memLimit > 0 ? Math.round((memUsage / memLimit) * 10000) / 100 : 0,
+      pids: stats.pids_stats?.current || 0,
+      net_rx_mb: Math.round((netRx / 1048576) * 100) / 100,
+      net_tx_mb: Math.round((netTx / 1048576) * 100) / 100,
+    };
+  } catch (err: any) {
+    if (err.statusCode === 404) return null;
+    throw err;
+  }
+}
+
 export async function getContainerLogs(
   agentId: string,
   opts: { tail?: number; follow?: boolean } = {}


### PR DESCRIPTION
## Summary
- **New `getContainerStats()`** in `docker.ts` — reads live Docker container stats via dockerode `container.stats()` API, computes CPU%, memory usage/limit/%, PIDs, and network I/O
- **New `GET /agents/:id/runtime-metrics`** route — proxies Docker stats for a running agent's container, returns 404 if agent not running, respects ownership scoping
- OpenAPI spec and `EXPECTED_PATHS` docs test already included this route — this PR implements the handler

## Response format
```json
{
  "cpu_percent": 12.34,
  "memory_usage_mb": 256.00,
  "memory_limit_mb": 1024.00,
  "memory_percent": 25.00,
  "pids": 15,
  "net_rx_mb": 1.23,
  "net_tx_mb": 0.45
}
```

## Test plan
- [ ] Start an agent, hit `GET /api/agents/:id/runtime-metrics` — verify JSON response with CPU/memory stats
- [ ] Stop the agent — verify 404 with `"Agent not running"`
- [ ] Hit with non-existent agent ID — verify 404 with `"Agent not found"`
- [ ] Verify ownership scoping (non-admin cannot see other users' agent metrics)
- [ ] `npm run build` passes in `services/api/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)