### PR TITLE
feat: add skill dependency graph endpoint and UI

### DIFF
--- a/docs/site/openapi.yaml
+++ b/docs/site/openapi.yaml
@@ -3440,6 +3440,36 @@ paths:
       responses:
         "200":
           description: Nodes and edges
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  nodes:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                        name:
+                          type: string
+                        type:
+                          type: string
+                          enum: [skill, tool]
+                        scope:
+                          type: string
+                        is_platform:
+                          type: boolean
+                  edges:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        source:
+                          type: string
+                        target:
+                          type: string
 
   /skills/{id}:
     parameters:

--- a/services/api/src/openapi/openapi.yaml
+++ b/services/api/src/openapi/openapi.yaml
@@ -3440,6 +3440,36 @@ paths:
       responses:
         "200":
           description: Nodes and edges
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  nodes:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                        name:
+                          type: string
+                        type:
+                          type: string
+                          enum: [skill, tool]
+                        scope:
+                          type: string
+                        is_platform:
+                          type: boolean
+                  edges:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        source:
+                          type: string
+                        target:
+                          type: string
 
   /skills/{id}:
     parameters:

--- a/services/api/src/routes/skills.ts
+++ b/services/api/src/routes/skills.ts
@@ -89,6 +89,50 @@ router.get('/', requireRole('user'), async (_req: Request, res: Response) => {
   }
 });
 
+// Skill-tool dependency graph
+router.get('/graph', requireRole('user'), async (_req: Request, res: Response) => {
+  try {
+    const [skillResult, edgeResult] = await Promise.all([
+      getPool().query(
+        `SELECT s.id, s.name, s.scope, s.is_platform,
+                COALESCE(json_agg(json_build_object('id', t.id, 'name', t.name))
+                  FILTER (WHERE t.id IS NOT NULL), '[]') AS tools
+         FROM skills s
+         LEFT JOIN skill_tools st ON st.skill_id = s.id
+         LEFT JOIN tools t ON t.id = st.tool_id
+         GROUP BY s.id
+         ORDER BY s.name ASC`
+      ),
+      getPool().query(
+        `SELECT st.skill_id AS source, st.tool_id AS target FROM skill_tools st`
+      ),
+    ]);
+
+    const skillNodes = skillResult.rows.map((s: any) => ({
+      id: s.id, name: s.name, type: 'skill' as const, scope: s.scope, is_platform: s.is_platform,
+    }));
+
+    const toolMap = new Map<string, string>();
+    for (const row of skillResult.rows) {
+      for (const t of row.tools) {
+        if (t.id) toolMap.set(t.id, t.name);
+      }
+    }
+
+    const toolNodes = Array.from(toolMap.entries()).map(([id, name]) => ({
+      id, name, type: 'tool' as const,
+    }));
+
+    res.json({
+      nodes: [...skillNodes, ...toolNodes],
+      edges: edgeResult.rows.map((e: any) => ({ source: e.source, target: e.target })),
+    });
+  } catch (err) {
+    console.error('[skills] Graph error:', err);
+    res.status(500).json({ error: 'Failed to build skill graph' });
+  }
+});
+
 // Get single skill
 router.get('/:id', requireRole('user'), async (req: Request, res: Response) => {
   try {

--- a/services/ui/src/app/harness/skills/SkillsClient.tsx
+++ b/services/ui/src/app/harness/skills/SkillsClient.tsx
@@ -60,6 +60,9 @@ export default function SkillsClient() {
   const [formError, setFormError] = useState('')
   const [searchQuery, setSearchQuery] = useState('')
   const [expandedInstructions, setExpandedInstructions] = useState<Set<string>>(new Set())
+  const [showGraph, setShowGraph] = useState(false)
+  const [graphData, setGraphData] = useState<{ nodes: any[]; edges: any[] } | null>(null)
+  const [graphLoading, setGraphLoading] = useState(false)
 
   const filteredSkills = useMemo(() => {
     if (!searchQuery.trim()) return skills
@@ -88,6 +91,22 @@ export default function SkillsClient() {
       .then(data => setAllTools(data))
       .catch(() => {})
   }, [fetchSkills])
+
+  const fetchGraph = useCallback(async () => {
+    setGraphLoading(true)
+    try {
+      const res = await fetch('/api/skills/graph')
+      if (res.ok) setGraphData(await res.json())
+    } catch {
+      // graph unavailable
+    } finally {
+      setGraphLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (showGraph && !graphData) fetchGraph()
+  }, [showGraph, graphData, fetchGraph])
 
   const resetForm = () => {
     setFormData({
@@ -495,6 +514,77 @@ export default function SkillsClient() {
           })}
         </div>
       )}
+
+      {/* Dependency Graph Toggle */}
+      <div className="mt-8">
+        <button
+          onClick={() => setShowGraph(!showGraph)}
+          className="flex items-center gap-2 text-sm text-mountain-400 hover:text-white transition-colors cursor-pointer"
+        >
+          {showGraph ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+          Tool Dependencies
+        </button>
+
+        {showGraph && (
+          <div className="mt-3 rounded-lg border border-navy-700 bg-navy-800 overflow-hidden">
+            {graphLoading ? (
+              <div className="flex items-center justify-center py-8">
+                <div className="h-6 w-6 rounded-full border-2 border-brand-500 border-t-transparent animate-spin" />
+              </div>
+            ) : graphData ? (
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-navy-700">
+                    <th className="text-left px-4 py-2 text-mountain-400 font-medium">Skill</th>
+                    <th className="text-left px-4 py-2 text-mountain-400 font-medium">Scope</th>
+                    <th className="text-left px-4 py-2 text-mountain-400 font-medium">Tools</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {graphData.nodes
+                    .filter(n => n.type === 'skill')
+                    .map(skill => {
+                      const toolIds = graphData.edges
+                        .filter(e => e.source === skill.id)
+                        .map(e => e.target)
+                      const tools = graphData.nodes.filter(n => n.type === 'tool' && toolIds.includes(n.id))
+                      return (
+                        <tr key={skill.id} className="border-b border-navy-700/50 hover:bg-navy-700/30">
+                          <td className="px-4 py-2 text-white">
+                            {skill.name}
+                            {skill.is_platform && (
+                              <Lock size={10} className="inline ml-1 text-mountain-500" />
+                            )}
+                          </td>
+                          <td className="px-4 py-2">
+                            <span className={`inline-flex items-center px-2 py-0.5 text-xs rounded-md ${scopeBadge(skill.scope).colorClasses}`}>
+                              {scopeBadge(skill.scope).label}
+                            </span>
+                          </td>
+                          <td className="px-4 py-2">
+                            {tools.length > 0 ? (
+                              <div className="flex flex-wrap gap-1">
+                                {tools.map(t => (
+                                  <span key={t.id} className="px-2 py-0.5 text-xs rounded-md bg-navy-900 text-brand-400 border border-navy-700 font-mono">
+                                    {t.name}
+                                  </span>
+                                ))}
+                              </div>
+                            ) : (
+                              <span className="text-mountain-500">None</span>
+                            )}
+                          </td>
+                        </tr>
+                      )
+                    })}
+                </tbody>
+              </table>
+            ) : (
+              <p className="px-4 py-4 text-sm text-mountain-500">Failed to load dependency graph</p>
+            )}
+          </div>
+        )}
+      </div>
     </>
   )
 }

--- a/services/ui/src/app/harness/skills/SkillsClient.tsx
+++ b/services/ui/src/app/harness/skills/SkillsClient.tsx
@@ -522,7 +522,7 @@ export default function SkillsClient() {
           className="flex items-center gap-2 text-sm text-mountain-400 hover:text-white transition-colors cursor-pointer"
         >
           {showGraph ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
-          Tool Dependencies
+          Dependency Graph
         </button>
 
         {showGraph && (


### PR DESCRIPTION
## Summary
- **API**: New `GET /skills/graph` route returns `{nodes, edges}` — nodes are skills (with scope/is_platform) and tools, edges are skill→tool dependencies
- **UI**: Collapsible "Tool Dependencies" table at the bottom of the Skills page showing each skill's scope and tool dependencies
- **OpenAPI**: Response schema added for `/skills/graph` (was a stub)
- **docs/site**: `openapi.yaml` synced
- **No changes** to AgentDetailClient.tsx or agent files

## Test plan
- [x] TypeScript compiles cleanly
- [x] `npx jest --testPathPattern="routes-skills|docs"` — 58/58 tests pass
- [x] `/skills/graph` already in EXPECTED_PATHS and OpenAPI
- [ ] Deploy API, verify `GET /skills/graph` returns nodes + edges
- [ ] Visit Skills page, click "Tool Dependencies", verify table renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)