### PR TITLE
feat: chat message search with PostgreSQL FTS

### DIFF
--- a/docs/site/openapi.yaml
+++ b/docs/site/openapi.yaml
@@ -4330,6 +4330,42 @@ paths:
       responses:
         "200":
           description: Matching messages
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  results:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                          format: uuid
+                        seq:
+                          type: integer
+                        author_id:
+                          type: string
+                        author_type:
+                          type: string
+                          enum: [human, agent]
+                        content:
+                          type: string
+                        headline:
+                          type: string
+                          description: FTS headline with **highlights**
+                        created_at:
+                          type: string
+                          format: date-time
+                  query:
+                    type: string
+                  total:
+                    type: integer
+        "400":
+          description: Missing q parameter
+        "404":
+          description: Thread not found
 
   # Task management
   /tasks:

--- a/services/api/src/openapi/openapi.yaml
+++ b/services/api/src/openapi/openapi.yaml
@@ -4330,6 +4330,42 @@ paths:
       responses:
         "200":
           description: Matching messages
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  results:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                          format: uuid
+                        seq:
+                          type: integer
+                        author_id:
+                          type: string
+                        author_type:
+                          type: string
+                          enum: [human, agent]
+                        content:
+                          type: string
+                        headline:
+                          type: string
+                          description: FTS headline with **highlights**
+                        created_at:
+                          type: string
+                          format: date-time
+                  query:
+                    type: string
+                  total:
+                    type: integer
+        "400":
+          description: Missing q parameter
+        "404":
+          description: Thread not found
 
   # Task management
   /tasks:

--- a/services/api/src/routes/chat.ts
+++ b/services/api/src/routes/chat.ts
@@ -1363,6 +1363,55 @@ router.get('/threads/:id/screenshot', requireRole('user'), async (req: Request, 
 });
 
 // ───────────────────────────────────────────────────────────────────
+// GET /chat/threads/:id/search — full-text search messages
+// ───────────────────────────────────────────────────────────────────
+
+router.get('/threads/:id/search', requireRole('user'), async (req: Request, res: Response) => {
+  try {
+    const user = (req as any).user;
+    const admin = isAdmin(req);
+    const threadId = req.params.id;
+
+    if (!(await isParticipant(threadId, user.sub, admin))) {
+      res.status(404).json({ error: 'Thread not found' });
+      return;
+    }
+
+    const q = typeof req.query.q === 'string' ? req.query.q.trim() : '';
+    if (!q) {
+      res.status(400).json({ error: 'q query parameter is required' });
+      return;
+    }
+
+    const pool = getPool();
+
+    // Use plainto_tsquery for safe user input (no special syntax needed)
+    const { rows } = await pool.query(
+      `SELECT id, seq, author_id, author_type, role, content, status,
+              reply_to, target_agents,
+              chain_id, chain_hop, triggered_by,
+              model, input_tokens, output_tokens, duration_ms,
+              error_message, created_at,
+              ts_headline('english', content, plainto_tsquery('english', $2),
+                'StartSel=**,StopSel=**,MaxFragments=3,MaxWords=40,MinWords=20') AS headline
+       FROM chat_messages
+       WHERE thread_id = $1
+         AND status IN ('complete', 'thinking')
+         AND content != ''
+         AND to_tsvector('english', content) @@ plainto_tsquery('english', $2)
+       ORDER BY ts_rank(to_tsvector('english', content), plainto_tsquery('english', $2)) DESC
+       LIMIT 50`,
+      [threadId, q]
+    );
+
+    res.json({ results: rows, query: q, total: rows.length });
+  } catch (err) {
+    console.error('[chat] Search error:', err);
+    res.status(500).json({ error: 'Search failed' });
+  }
+});
+
+// ───────────────────────────────────────────────────────────────────
 // Internal callback handler (separate router, no Keycloak auth)
 // ───────────────────────────────────────────────────────────────────
 

--- a/services/ui/src/__tests__/ChatView.test.tsx
+++ b/services/ui/src/__tests__/ChatView.test.tsx
@@ -19,6 +19,8 @@ vi.mock('lucide-react', () => ({
   Terminal: (props: any) => <span data-testid="icon-terminal" {...props} />,
   Users: (props: any) => <span data-testid="icon-users" {...props} />,
   Paperclip: (props: any) => <span data-testid="icon-paperclip" {...props} />,
+  Search: (props: any) => <span data-testid="icon-search" {...props} />,
+  X: (props: any) => <span data-testid="icon-x" {...props} />,
 }))
 
 vi.mock('@/app/chat/ChatMessage', () => ({

--- a/services/ui/src/app/chat/ChatView.tsx
+++ b/services/ui/src/app/chat/ChatView.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useRef, useCallback } from 'react'
 import { useRouter } from 'next/navigation'
-import { ArrowLeft, Send, Terminal, Users, Paperclip } from 'lucide-react'
+import { ArrowLeft, Send, Terminal, Users, Paperclip, Search, X } from 'lucide-react'
 import type { Session } from 'next-auth'
 import type { ChatThread } from './ChatLayout'
 import ChatMessage from './ChatMessage'
@@ -49,6 +49,11 @@ export default function ChatView({ threadId, session, thread, onBack, onThreadUp
   const [fileToast, setFileToast] = useState(false)
   const [sessionPaneOpen, setSessionPaneOpen] = useState(false)
   const [participantPanelOpen, setParticipantPanelOpen] = useState(false)
+  const [searchOpen, setSearchOpen] = useState(false)
+  const [searchQuery, setSearchQuery] = useState('')
+  const [searchResults, setSearchResults] = useState<(Message & { headline?: string })[]>([])
+  const [searching, setSearching] = useState(false)
+  const searchInputRef = useRef<HTMLInputElement>(null)
   const messagesEndRef = useRef<HTMLDivElement>(null)
   const eventSourceRef = useRef<EventSource | null>(null)
   const refocusTimer = useRef<number | null>(null)
@@ -103,6 +108,36 @@ export default function ChatView({ threadId, session, thread, onBack, onThreadUp
       if (refocusTimer.current) clearTimeout(refocusTimer.current)
     }
   }, [threadId])
+
+  // Search handler with debounce
+  const searchTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  useEffect(() => {
+    if (!searchOpen || !searchQuery.trim()) {
+      setSearchResults([])
+      return
+    }
+    if (searchTimer.current) clearTimeout(searchTimer.current)
+    searchTimer.current = setTimeout(async () => {
+      setSearching(true)
+      try {
+        const res = await fetch(`/api/chat/${threadId}/search?q=${encodeURIComponent(searchQuery.trim())}`)
+        if (res.ok) {
+          const data = await res.json()
+          setSearchResults(data.results || [])
+        }
+      } catch {
+        // ignore
+      } finally {
+        setSearching(false)
+      }
+    }, 300)
+    return () => { if (searchTimer.current) clearTimeout(searchTimer.current) }
+  }, [searchQuery, searchOpen, threadId])
+
+  // Focus search input when opened
+  useEffect(() => {
+    if (searchOpen) searchInputRef.current?.focus()
+  }, [searchOpen])
 
   const handleSend = async () => {
     const text = input.trim()
@@ -209,6 +244,18 @@ export default function ChatView({ threadId, session, thread, onBack, onThreadUp
               onCancelled={onThreadUpdated}
             />
             <button
+              onClick={() => { setSearchOpen(prev => !prev); if (searchOpen) { setSearchQuery(''); setSearchResults([]) } }}
+              className={`p-1.5 rounded transition-colors ${
+                searchOpen
+                  ? 'bg-brand-600/20 text-brand-400'
+                  : 'text-mountain-400 hover:text-gray-200 hover:bg-navy-700'
+              }`}
+              title="Search messages"
+              data-testid="search-toggle"
+            >
+              <Search size={18} />
+            </button>
+            <button
               onClick={() => setParticipantPanelOpen(prev => !prev)}
               className={`p-1.5 rounded transition-colors ${
                 participantPanelOpen
@@ -234,6 +281,67 @@ export default function ChatView({ threadId, session, thread, onBack, onThreadUp
             </button>
           </div>
         </div>
+
+        {/* Search bar */}
+        {searchOpen && (
+          <div className="px-4 py-2 border-b border-navy-700 bg-navy-800/50" data-testid="search-bar">
+            <div className="flex items-center gap-2">
+              <Search size={14} className="text-mountain-500 flex-shrink-0" />
+              <input
+                ref={searchInputRef}
+                type="text"
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                placeholder="Search messages..."
+                className="flex-1 bg-transparent text-sm text-white placeholder-mountain-500 focus:outline-none"
+                data-testid="search-input"
+              />
+              {searching && (
+                <div className="h-4 w-4 rounded-full border-2 border-brand-500 border-t-transparent animate-spin flex-shrink-0" />
+              )}
+              <button
+                onClick={() => { setSearchOpen(false); setSearchQuery(''); setSearchResults([]) }}
+                className="text-mountain-400 hover:text-white transition-colors"
+              >
+                <X size={14} />
+              </button>
+            </div>
+            {searchResults.length > 0 && (
+              <div className="mt-2 max-h-64 overflow-y-auto space-y-1" data-testid="search-results">
+                {searchResults.map(r => (
+                  <button
+                    key={r.id}
+                    onClick={() => {
+                      const el = document.getElementById(`msg-${r.id}`)
+                      if (el) {
+                        el.scrollIntoView({ behavior: 'smooth', block: 'center' })
+                        el.classList.add('ring-2', 'ring-brand-500/50')
+                        setTimeout(() => el.classList.remove('ring-2', 'ring-brand-500/50'), 2000)
+                      }
+                    }}
+                    className="w-full text-left px-3 py-2 rounded bg-navy-900/50 hover:bg-navy-700 transition-colors"
+                  >
+                    <div className="flex items-center gap-2 mb-0.5">
+                      <span className="text-[10px] font-medium text-mountain-500">
+                        {r.author_type === 'human' ? 'You' : agents.find(a => a.id === r.author_id)?.name || 'Agent'}
+                      </span>
+                      <span className="text-[10px] text-mountain-600">
+                        {new Date(r.created_at).toLocaleString()}
+                      </span>
+                    </div>
+                    <p
+                      className="text-xs text-mountain-300 line-clamp-2"
+                      dangerouslySetInnerHTML={{ __html: (r.headline || r.content.slice(0, 120)).replace(/\*\*([^*]+)\*\*/g, '<mark class="bg-brand-600/30 text-brand-300 rounded px-0.5">$1</mark>') }}
+                    />
+                  </button>
+                ))}
+              </div>
+            )}
+            {searchQuery.trim() && !searching && searchResults.length === 0 && (
+              <p className="mt-2 text-xs text-mountain-500">No results found</p>
+            )}
+          </div>
+        )}
 
         {/* Agent stopped warning */}
         {!anyAgentRunning && agents.length > 0 && (
@@ -263,14 +371,15 @@ export default function ChatView({ threadId, session, thread, onBack, onThreadUp
               }
             }
             return (
-              <ChatMessage
-                key={msg.id}
-                message={msg}
-                isOwnMessage={msg.author_id === userId}
-                isGroup={isGroup}
-                agents={agents}
-                triggerAgentName={triggerAgentName}
-              />
+              <div key={msg.id} id={`msg-${msg.id}`} className="transition-all duration-300 rounded">
+                <ChatMessage
+                  message={msg}
+                  isOwnMessage={msg.author_id === userId}
+                  isGroup={isGroup}
+                  agents={agents}
+                  triggerAgentName={triggerAgentName}
+                />
+              </div>
             )
           })}
           <div ref={messagesEndRef} />


### PR DESCRIPTION
## Summary
- Implements `GET /chat/threads/:id/search?q=term` using PostgreSQL `to_tsvector`/`plainto_tsquery` for full-text search within a thread
- Returns up to 50 matching messages ranked by `ts_rank` relevance, with `ts_headline` snippets using `**bold**` markers
- Only searches `complete` and `thinking` messages with non-empty content
- ChatView header adds a search icon (magnifying glass) that toggles a search bar
- 300ms debounced search queries with loading spinner
- Click a result to scroll to and briefly highlight the matching message in the conversation
- Headline text renders with `<mark>` highlights for matched terms
- OpenAPI spec enriched with full response schema (results array, query, total)
- `docs/site/openapi.yaml` synced

## Files Changed
- `services/api/src/routes/chat.ts` — new search endpoint
- `services/ui/src/app/chat/ChatView.tsx` — search UI (icon, bar, results, scroll-to)
- `services/api/src/openapi/openapi.yaml` — enriched search response schema
- `docs/site/openapi.yaml` — synced

## Test plan
- [ ] Open a chat thread with messages → click search icon → type a term
- [ ] Verify results appear with highlighted snippets
- [ ] Click a result → conversation scrolls to that message with brief ring highlight
- [ ] Search with no matches → "No results found" shown
- [ ] Empty query → no API call, results cleared
- [ ] Close search → state resets
- [ ] Non-participant gets 404
- [ ] Missing `q` param returns 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)