### PR TITLE
feat: add agent environment variables UI

### DIFF
--- a/services/api/src/routes/agents.ts
+++ b/services/api/src/routes/agents.ts
@@ -492,7 +492,7 @@ router.get('/:id', requireRole('user'), async (req: Request, res: Response) => {
     const { rows } = await getPool().query(
       `SELECT a.id, a.agent_id, a.name, a.description, a.status, a.tools_config,
               cpus, mem_limit, pids_limit, soul_md, rules_md, container_id,
-              model_policy_id, a.autonomy_level, a.avatar_key, a.tags, a.container_profile_id,
+              model_policy_id, a.autonomy_level, a.avatar_key, a.tags, a.env_vars, a.container_profile_id,
               a.schedule_cron, a.schedule_enabled,
               cp.name AS cp_name, cp.docker_image AS cp_docker_image,
               COALESCE(mp.allowed_models, '[]'::jsonb) AS models,
@@ -751,7 +751,21 @@ router.put('/:id', requireRole('user'), async (req: Request, res: Response) => {
     }
 
     const user = (req as any).user;
-    const { name, description, tools_config, cpus, mem_limit, pids_limit, soul_md, rules_md, model_policy_id, model_names, skill_ids, container_profile_id, autonomy_level, tags } = req.body;
+    const { name, description, tools_config, cpus, mem_limit, pids_limit, soul_md, rules_md, model_policy_id, model_names, skill_ids, container_profile_id, autonomy_level, tags, env_vars } = req.body;
+
+    // Validate env_vars if provided
+    if (env_vars !== undefined) {
+      if (typeof env_vars !== 'object' || env_vars === null || Array.isArray(env_vars)) {
+        res.status(400).json({ error: 'env_vars must be an object with string key-value pairs' });
+        return;
+      }
+      for (const [k, v] of Object.entries(env_vars)) {
+        if (typeof v !== 'string') {
+          res.status(400).json({ error: `env_vars["${k}"] must be a string` });
+          return;
+        }
+      }
+    }
 
     // Validate tags if provided
     if (tags !== undefined) {
@@ -927,11 +941,12 @@ router.put('/:id', requireRole('user'), async (req: Request, res: Response) => {
         container_profile_id = CASE WHEN $11::boolean THEN $12::uuid ELSE container_profile_id END,
         autonomy_level = COALESCE($13, autonomy_level),
         tags = COALESCE($14, tags),
+        env_vars = COALESCE($15, env_vars),
         updated_at = NOW()
-       WHERE id = $15
+       WHERE id = $16
        RETURNING id, agent_id, name, description, status, tools_config,
                  cpus, mem_limit, pids_limit, soul_md, rules_md, container_id,
-                 model_policy_id, container_profile_id, autonomy_level, tags, error_message, created_at, updated_at, created_by`,
+                 model_policy_id, container_profile_id, autonomy_level, tags, env_vars, error_message, created_at, updated_at, created_by`,
       [
         name || null,
         description ?? null,
@@ -947,6 +962,7 @@ router.put('/:id', requireRole('user'), async (req: Request, res: Response) => {
         containerProfileProvided ? (container_profile_id ?? null) : null,
         autonomy_level || null,
         tags !== undefined ? JSON.stringify(tags) : null,
+        env_vars !== undefined ? JSON.stringify(env_vars) : null,
         req.params.id,
       ]
     );

--- a/services/ui/src/app/agents/[id]/AgentDetailClient.tsx
+++ b/services/ui/src/app/agents/[id]/AgentDetailClient.tsx
@@ -31,6 +31,7 @@ interface Agent {
   models: string[]
   skills: Array<{ id: string; name: string; scope: string; tools?: Array<{ id: string; name: string }>; instructions_md?: string }>
   tags: string[]
+  env_vars: Record<string, string>
   autonomy_level: string | null
   schedule_cron: string | null
   schedule_enabled: boolean
@@ -157,6 +158,11 @@ export default function AgentDetailClient({
   // Tags
   const [tagInput, setTagInput] = useState('')
   const [tagsSaving, setTagsSaving] = useState(false)
+
+  // Env vars
+  const [envKey, setEnvKey] = useState('')
+  const [envVal, setEnvVal] = useState('')
+  const [envSaving, setEnvSaving] = useState(false)
 
   // Avatar
   const avatarInputRef = useRef<HTMLInputElement>(null)
@@ -546,6 +552,55 @@ export default function AgentDetailClient({
       alert('Failed to save tags')
     } finally {
       setTagsSaving(false)
+    }
+  }
+
+  const handleAddEnvVar = async () => {
+    const key = envKey.trim()
+    if (!key) return
+    const updated = { ...(agent.env_vars || {}), [key]: envVal }
+    setEnvSaving(true)
+    try {
+      const res = await fetch(`/api/agents/${agentId}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ env_vars: updated }),
+      })
+      if (!res.ok) {
+        const data = await res.json()
+        alert(data.error || 'Failed to save environment variable')
+        return
+      }
+      setEnvKey('')
+      setEnvVal('')
+      await fetchAgent()
+    } catch {
+      alert('Failed to save environment variable')
+    } finally {
+      setEnvSaving(false)
+    }
+  }
+
+  const handleRemoveEnvVar = async (key: string) => {
+    const updated = { ...(agent.env_vars || {}) }
+    delete updated[key]
+    setEnvSaving(true)
+    try {
+      const res = await fetch(`/api/agents/${agentId}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ env_vars: updated }),
+      })
+      if (!res.ok) {
+        const data = await res.json()
+        alert(data.error || 'Failed to remove environment variable')
+        return
+      }
+      await fetchAgent()
+    } catch {
+      alert('Failed to remove environment variable')
+    } finally {
+      setEnvSaving(false)
     }
   }
 
@@ -1040,6 +1095,72 @@ export default function AgentDetailClient({
                   className="px-4 py-2 text-sm font-medium rounded-lg bg-brand-600 hover:bg-brand-500 text-white transition-colors disabled:opacity-50 cursor-pointer disabled:cursor-not-allowed"
                 >
                   {tagsSaving ? 'Saving...' : 'Add'}
+                </button>
+              </div>
+            )}
+          </div>
+
+          {/* Environment Variables */}
+          <div className="rounded-lg border border-navy-700 bg-navy-800 p-5">
+            <h2 className="text-lg font-semibold text-white mb-1">Environment Variables</h2>
+            <p className="text-sm text-mountain-400 mb-3">Key-value pairs injected into the agent container at startup.</p>
+            {Object.keys(agent.env_vars || {}).length > 0 ? (
+              <div className="rounded-md border border-navy-700 overflow-hidden mb-3">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b border-navy-700 bg-navy-900">
+                      <th className="text-left px-3 py-2 text-xs font-medium text-mountain-400 uppercase tracking-wide">Key</th>
+                      <th className="text-left px-3 py-2 text-xs font-medium text-mountain-400 uppercase tracking-wide">Value</th>
+                      {agent.status !== 'running' && <th className="w-10" />}
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {Object.entries(agent.env_vars || {}).sort(([a], [b]) => a.localeCompare(b)).map(([k, v]) => (
+                      <tr key={k} className="border-b border-navy-800 last:border-0">
+                        <td className="px-3 py-2 font-mono text-brand-400">{k}</td>
+                        <td className="px-3 py-2 font-mono text-white break-all">{v}</td>
+                        {agent.status !== 'running' && (
+                          <td className="px-3 py-2 text-center">
+                            <button
+                              onClick={() => handleRemoveEnvVar(k)}
+                              disabled={envSaving}
+                              className="text-mountain-500 hover:text-red-400 transition-colors cursor-pointer disabled:opacity-50"
+                            >
+                              &times;
+                            </button>
+                          </td>
+                        )}
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            ) : (
+              <p className="text-xs text-mountain-500 mb-3">No environment variables configured.</p>
+            )}
+            {agent.status !== 'running' && (
+              <div className="flex items-center gap-2">
+                <input
+                  type="text"
+                  value={envKey}
+                  onChange={(e) => setEnvKey(e.target.value.toUpperCase().replace(/[^A-Z0-9_]/g, ''))}
+                  placeholder="KEY"
+                  className="w-40 rounded-md border border-navy-600 bg-navy-900 px-3 py-2 text-sm font-mono text-white placeholder-mountain-500 focus:border-brand-500 focus:outline-none"
+                />
+                <input
+                  type="text"
+                  value={envVal}
+                  onChange={(e) => setEnvVal(e.target.value)}
+                  onKeyDown={(e) => e.key === 'Enter' && handleAddEnvVar()}
+                  placeholder="value"
+                  className="flex-1 rounded-md border border-navy-600 bg-navy-900 px-3 py-2 text-sm font-mono text-white placeholder-mountain-500 focus:border-brand-500 focus:outline-none"
+                />
+                <button
+                  onClick={handleAddEnvVar}
+                  disabled={envSaving || !envKey.trim()}
+                  className="px-4 py-2 text-sm font-medium rounded-lg bg-brand-600 hover:bg-brand-500 text-white transition-colors disabled:opacity-50 cursor-pointer disabled:cursor-not-allowed"
+                >
+                  {envSaving ? 'Saving...' : 'Add'}
                 </button>
               </div>
             )}


### PR DESCRIPTION
## Summary
- **API GET /agents/:id**: Now includes `env_vars` JSONB field in response
- **API PUT /agents/:id**: Accepts `env_vars` object with validation (must be string key-value pairs, rejects non-string values with specific error)
- **UI Configuration tab**: New "Environment Variables" section between Tags and Schedule with:
  - Sorted key-value table with monospace formatting
  - Add form with KEY input (auto-uppercased, restricted to `A-Z0-9_`) and value input
  - Remove button (×) per row
  - All editing disabled while agent is running
- Migration 052 (`env_vars JSONB DEFAULT '{}'`) already exists — this PR wires it up

## Test plan
- [ ] Open agent detail > Configuration tab — verify "Environment Variables" section appears
- [ ] Add env var (e.g. `API_KEY` = `test123`) — verify it saves and appears in table
- [ ] Add second var — verify table is sorted alphabetically
- [ ] Remove a var via × button — verify it disappears
- [ ] Start agent — verify add/remove controls are hidden
- [ ] `PUT /api/agents/:id` with `env_vars: {"not": 123}` — verify 400 error

🤖 Generated with [Claude Code](https://claude.com/claude-code)