### PR TITLE
fix: agent stats query uses wrong column name (model → model_name)

### DIFF
--- a/services/api/src/routes/agents.ts
+++ b/services/api/src/routes/agents.ts
@@ -2225,7 +2225,7 @@ router.get('/:id/stats', requireRole('user'), async (req: Request, res: Response
         `SELECT COUNT(*) AS total_inferences,
                 COALESCE(SUM(input_tokens + output_tokens), 0) AS total_tokens,
                 COALESCE(SUM(cost_usd), 0) AS estimated_cost,
-                COUNT(DISTINCT model) AS distinct_models
+                COUNT(DISTINCT model_name) AS distinct_models
          FROM model_usage WHERE agent_id = $1`,
         [agent.agent_id],
       ),


### PR DESCRIPTION
## Summary
- `GET /agents/:id/stats` queried `COUNT(DISTINCT model)` but the `model_usage` table column is `model_name`
- This caused Postgres error 42703 (`errorMissingColumn`) on every stats request, visible in VPS API logs
- One-character fix: `model` → `model_name`

## VPS Health Check Results
- **22/22 containers**: All up and healthy, zero restarts
- **API**: Repeated `[agents] Stats error: column "model" does not exist` — **fixed in this PR**
- **UI**: `Failed to find Server Action` errors — expected stale-client cache after redeploy, not a bug
- **Terminal proxy**: `not found` for stopped agents — expected behavior, not a bug
- **All other services**: Clean logs, no errors

## Test plan
- [ ] Deploy API, hit `GET /agents/:id/stats` — should return stats instead of 500
- [ ] Verify `distinct_models` field is populated correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)