### PR TITLE
fix: add missing env_vars migration breaking agent detail page

### DIFF
--- a/services/api/src/db/migrations/052_add_agent_env_vars.sql
+++ b/services/api/src/db/migrations/052_add_agent_env_vars.sql
@@ -1,0 +1,1 @@
+ALTER TABLE agents ADD COLUMN IF NOT EXISTS env_vars JSONB DEFAULT '{}'::jsonb;


### PR DESCRIPTION
## Summary
- **Root cause**: PR #440 merged agent env vars code (JSONB column in SELECT queries, UI form, validation) but the migration file `052_add_agent_env_vars.sql` was never committed
- **Impact**: The agent detail page (`/agents/{id}`) returns 500 because `SELECT ... a.env_vars ...` fails when the column doesn't exist in the database. The page renders blank.
- **Fix**: Commits the existing migration file `ALTER TABLE agents ADD COLUMN IF NOT EXISTS env_vars JSONB DEFAULT '{}'::jsonb`

## Verification
- Playwright E2E confirmed: agents list page loads (doesn't SELECT env_vars), but agent detail page is blank (500 from missing column)
- After merge and automated CI/CD pipeline, the Configuration tab's "Environment Variables" section will render correctly

## Test plan
- [x] Migration file uses `IF NOT EXISTS` — safe to run on any DB state
- [x] Confirmed `env_vars` is referenced in GET single agent (line 495), PUT (line 944), and UI Configuration tab
- [ ] After merge, verify agent detail page loads and shows Environment Variables section

🤖 Generated with [Claude Code](https://claude.com/claude-code)