### PR TITLE
feat: start agents in home directory instead of /workspace

### DIFF
--- a/services/agentbox/app/config.py
+++ b/services/agentbox/app/config.py
@@ -18,7 +18,7 @@ class ShellConfig(BaseModel):
 class FilesystemConfig(BaseModel):
     enabled: bool = False
     read_only: bool = False
-    allowed_paths: list[str] = Field(default_factory=lambda: ["/workspace"])
+    allowed_paths: list[str] = Field(default_factory=lambda: ["/home/agentuser", "/workspace"])
     denied_paths: list[str] = Field(
         default_factory=lambda: ["/etc/shadow", "/etc/passwd", "/root"]
     )

--- a/services/agentbox/app/policy.py
+++ b/services/agentbox/app/policy.py
@@ -67,7 +67,7 @@ class CommandPolicy:
 
         return True, "ok"
 
-    def build_argv_and_env(self, command: str, cwd: str = "/workspace") -> tuple[list[str], dict[str, str]] | tuple[None, str]:
+    def build_argv_and_env(self, command: str, cwd: str = "/home/agentuser") -> tuple[list[str], dict[str, str]] | tuple[None, str]:
         """Validate command and return (argv, env) or (None, error_reason)."""
         allowed, reason = self.check(command)
         if not allowed:
@@ -82,7 +82,7 @@ class CommandPolicy:
         }
         return (argv, safe_env), ""
 
-    def execute(self, command: str, timeout: int = 30, cwd: str = "/workspace") -> dict:
+    def execute(self, command: str, timeout: int = 30, cwd: str = "/home/agentuser") -> dict:
         """Execute command with shell=False, explicit argv, restricted env, pinned cwd."""
         allowed, reason = self.check(command)
         if not allowed:
@@ -124,7 +124,7 @@ class CommandPolicy:
         self,
         command: str,
         timeout: int = 30,
-        cwd: str = "/workspace",
+        cwd: str = "/home/agentuser",
         on_output: Callable[[str], None] | None = None,
         max_line_len: int = 4096,
         max_lines: int = 1000,

--- a/services/agentbox/app/pty_shell.py
+++ b/services/agentbox/app/pty_shell.py
@@ -34,7 +34,7 @@ class PtyResult:
 def execute_streaming(
     argv: list[str],
     env: dict[str, str],
-    cwd: str = "/workspace",
+    cwd: str = os.path.expanduser("~"),
     timeout: int = 300,
 ) -> Generator[bytes, None, PtyResult]:
     """Execute command in a PTY, yielding output chunks as they arrive.

--- a/services/agentbox/app/shell.py
+++ b/services/agentbox/app/shell.py
@@ -7,6 +7,7 @@ Any process inside the container can import and use these functions directly.
 from __future__ import annotations
 
 import json
+import os
 import time
 
 from app.config import ShellConfig
@@ -144,7 +145,7 @@ async def execute_command_pty(
         command=command,
         argv=argv,
         env=env,
-        cwd="/workspace",
+        cwd=os.path.expanduser("~"),
         timeout=timeout,
         command_id=cmd_id,
         emitter=_emitter,

--- a/services/agentbox/app/ws_terminal.py
+++ b/services/agentbox/app/ws_terminal.py
@@ -92,7 +92,7 @@ async def ws_terminal_handler(websocket: WebSocket, work_token: str | None) -> N
             os.close(slave_fd)
 
             try:
-                os.chdir("/workspace")
+                os.chdir(os.path.expanduser("~"))
             except OSError:
                 pass
 

--- a/services/agentbox/tests/test_config.py
+++ b/services/agentbox/tests/test_config.py
@@ -99,5 +99,5 @@ class TestFilesystemConfig:
         config = FilesystemConfig()
         assert config.enabled is False
         assert config.read_only is False
-        assert config.allowed_paths == ["/workspace"]
+        assert config.allowed_paths == ["/home/agentuser", "/workspace"]
         assert "/etc/shadow" in config.denied_paths


### PR DESCRIPTION
## Summary
Agents now start in `/home/agentuser` (~) instead of `/workspace`, making terminal sessions feel like a normal user shell.

**Changes:**
- **ws_terminal.py**: `os.chdir` uses `~` instead of `/workspace` for WebSocket terminal sessions
- **shell.py**: Shell command execution defaults to `~` as working directory
- **pty_shell.py**: PTY streaming execution defaults to `~`
- **policy.py**: All 3 `cwd` default parameters changed from `/workspace` to `/home/agentuser`
- **config.py**: Filesystem `allowed_paths` now includes `/home/agentuser` alongside `/workspace`

**What stays the same:**
- `/workspace` volume mount is unchanged (persistent agent data)
- `~/workspace` symlink still works (created by zshrc)
- Screenshot dir remains `/workspace/screenshots`
- The zshrc `cd ~` line now actually matters (was previously overridden by `/workspace` chdir)

Closes AI-204

## Test plan
- [ ] Rebuild agentbox image on VPS (`docker build --no-cache`)
- [ ] Start an agent, open terminal — should show `~` prompt, not `/workspace`
- [ ] Run `pwd` — should show `/home/agentuser`
- [ ] Run `ls workspace/` — symlink to `/workspace` should work
- [ ] Send chat message with shell command — verify it executes from home dir

🤖 Generated with [Claude Code](https://claude.com/claude-code)