### PR TITLE
feat: add agent workspace file listing

### DIFF
--- a/docs/site/openapi.yaml
+++ b/docs/site/openapi.yaml
@@ -1752,6 +1752,53 @@ paths:
         "404":
           description: Agent not running
 
+  /agents/{id}/workspace:
+    get:
+      summary: List agent workspace files
+      tags: [Agents]
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: path
+          in: query
+          schema:
+            type: string
+          description: Directory path to list (default /home/agentuser)
+      responses:
+        "200":
+          description: Directory listing
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  path:
+                    type: string
+                  entries:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        type:
+                          type: string
+                          enum: [file, directory, unknown]
+                        size:
+                          type: integer
+        "404":
+          description: Agent not found
+        "409":
+          description: Agent is not running
+        "502":
+          description: Agentbox unreachable
+
   /agents/{id}/events/export:
     get:
       summary: Export agent events as CSV

--- a/services/agentbox/app/server.py
+++ b/services/agentbox/app/server.py
@@ -154,12 +154,39 @@ def create_app(
                 status_code=500,
             )
 
+    async def files_endpoint(request: Request):
+        """List files in the agent workspace directory."""
+        path = request.query_params.get("path", "/home/agentuser")
+        # Restrict to safe roots
+        real = os.path.realpath(path)
+        if not (real.startswith("/home/agentuser") or real.startswith("/workspace")):
+            return JSONResponse({"error": "Path not allowed"}, status_code=403)
+        try:
+            entries = []
+            for name in sorted(os.listdir(real)):
+                full = os.path.join(real, name)
+                try:
+                    st = os.stat(full)
+                    entries.append({
+                        "name": name,
+                        "type": "directory" if os.path.isdir(full) else "file",
+                        "size": st.st_size,
+                    })
+                except OSError:
+                    entries.append({"name": name, "type": "unknown", "size": 0})
+            return JSONResponse({"path": path, "entries": entries})
+        except FileNotFoundError:
+            return JSONResponse({"error": f"Not found: {path}"}, status_code=404)
+        except PermissionError:
+            return JSONResponse({"error": f"Permission denied: {path}"}, status_code=403)
+
     async def terminal_ws_endpoint(websocket):
         await ws_terminal_handler(websocket, work_token)
 
     return Starlette(routes=[
         Route("/health", health_endpoint, methods=["GET"]),
         Route("/work", work_endpoint, methods=["POST"]),
+        Route("/files", files_endpoint, methods=["GET"]),
         Route("/screenshot", screenshot_endpoint, methods=["GET"]),
         Route("/terminal/stream", terminal_stream_endpoint, methods=["GET"]),
         WebSocketRoute("/terminal/ws", terminal_ws_endpoint),

--- a/services/api/src/__tests__/docs.test.ts
+++ b/services/api/src/__tests__/docs.test.ts
@@ -161,6 +161,7 @@ const EXPECTED_PATHS = [
   '/agents/{id}/webhooks/{webhookId}',
   '/agents/{id}/export',
   '/agents/{id}/runtime-metrics',
+  '/agents/{id}/workspace',
   '/agents/{id}/events/export',
   '/agents/{id}/schedule',
   '/model-policies',

--- a/services/api/src/openapi/openapi.yaml
+++ b/services/api/src/openapi/openapi.yaml
@@ -1752,6 +1752,53 @@ paths:
         "404":
           description: Agent not running
 
+  /agents/{id}/workspace:
+    get:
+      summary: List agent workspace files
+      tags: [Agents]
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: path
+          in: query
+          schema:
+            type: string
+          description: Directory path to list (default /home/agentuser)
+      responses:
+        "200":
+          description: Directory listing
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  path:
+                    type: string
+                  entries:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        type:
+                          type: string
+                          enum: [file, directory, unknown]
+                        size:
+                          type: integer
+        "404":
+          description: Agent not found
+        "409":
+          description: Agent is not running
+        "502":
+          description: Agentbox unreachable
+
   /agents/{id}/events/export:
     get:
       summary: Export agent events as CSV

--- a/services/api/src/routes/agents.ts
+++ b/services/api/src/routes/agents.ts
@@ -2445,6 +2445,41 @@ router.get('/:id/runtime-metrics', requireRole('user'), async (req: Request, res
   }
 });
 
+// Agent workspace file listing — proxied from agentbox container
+router.get('/:id/workspace', requireRole('user'), async (req: Request, res: Response) => {
+  try {
+    const scope = scopeToOwner(req);
+    const paramOffset = scope.params.length + 1;
+    const { rows } = await getPool().query(
+      `SELECT * FROM agents WHERE id = $${paramOffset}${scope.where !== '1=1' ? ` AND ${scope.where}` : ''}`,
+      [...scope.params, req.params.id],
+    );
+    if (rows.length === 0) {
+      res.status(404).json({ error: 'Agent not found' });
+      return;
+    }
+    const agent = rows[0];
+
+    if (agent.status !== 'running') {
+      res.status(409).json({ error: 'Agent is not running' });
+      return;
+    }
+
+    const path = (req.query.path as string) || '/home/agentuser';
+    const url = `http://agentbox-${agent.agent_id}:8054/files?path=${encodeURIComponent(path)}`;
+    const response = await fetch(url, { signal: AbortSignal.timeout(5000) });
+    const data = await response.json();
+    res.status(response.status).json(data);
+  } catch (err: any) {
+    if (err.name === 'TimeoutError' || err.code === 'UND_ERR_CONNECT_TIMEOUT') {
+      res.status(504).json({ error: 'Agentbox timed out' });
+      return;
+    }
+    console.error('[agents] Workspace listing error:', err);
+    res.status(502).json({ error: 'Failed to list workspace files' });
+  }
+});
+
 // ───────────────────────────────────────────────────────────────────
 // POST /agents/:id/clone — clone an agent with a new name and ID
 // ───────────────────────────────────────────────────────────────────

--- a/services/ui/src/app/agents/[id]/WorkspaceBrowser.tsx
+++ b/services/ui/src/app/agents/[id]/WorkspaceBrowser.tsx
@@ -1,51 +1,13 @@
 'use client'
 
-import { useState } from 'react'
-import { ChevronRight, ChevronDown, File, Folder, FolderOpen } from 'lucide-react'
+import { useState, useEffect, useCallback } from 'react'
+import { ChevronRight, ChevronDown, File, Folder, FolderOpen, RefreshCw, AlertCircle } from 'lucide-react'
 
-interface FileNode {
+interface FileEntry {
   name: string
-  type: 'file' | 'directory'
-  size?: number
-  children?: FileNode[]
+  type: 'file' | 'directory' | 'unknown'
+  size: number
 }
-
-// Mock workspace tree — will connect to real agent workspace API later
-const MOCK_WORKSPACE: FileNode[] = [
-  {
-    name: 'workspace',
-    type: 'directory',
-    children: [
-      {
-        name: 'plans',
-        type: 'directory',
-        children: [
-          { name: 'current-task.md', type: 'file', size: 2048 },
-          { name: 'backlog.md', type: 'file', size: 1024 },
-        ],
-      },
-      {
-        name: 'scratch',
-        type: 'directory',
-        children: [
-          { name: 'notes.txt', type: 'file', size: 512 },
-          { name: 'research.md', type: 'file', size: 3072 },
-        ],
-      },
-      {
-        name: 'output',
-        type: 'directory',
-        children: [
-          { name: 'report.md', type: 'file', size: 4096 },
-          { name: 'analysis.json', type: 'file', size: 1536 },
-        ],
-      },
-      { name: 'SOUL.md', type: 'file', size: 768 },
-      { name: 'RULES.md', type: 'file', size: 512 },
-      { name: '.env', type: 'file', size: 128 },
-    ],
-  },
-]
 
 function formatSize(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`
@@ -54,21 +16,64 @@ function formatSize(bytes: number): string {
   return `${(kb / 1024).toFixed(1)} MB`
 }
 
-function TreeNode({ node, depth = 0 }: { node: FileNode; depth?: number }) {
-  const [expanded, setExpanded] = useState(depth === 0)
+function FileRow({
+  entry,
+  depth,
+  agentId,
+}: {
+  entry: FileEntry
+  depth: number
+  agentId: string
+}) {
+  const [expanded, setExpanded] = useState(false)
+  const [children, setChildren] = useState<FileEntry[] | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [currentPath, setCurrentPath] = useState('')
 
-  const isDir = node.type === 'directory'
+  const isDir = entry.type === 'directory'
   const paddingLeft = depth * 16 + 8
+
+  const loadChildren = useCallback(async (dirPath: string) => {
+    setLoading(true)
+    try {
+      const res = await fetch(`/api/agents/${agentId}/workspace?path=${encodeURIComponent(dirPath)}`)
+      if (res.ok) {
+        const data = await res.json()
+        setChildren(data.entries || [])
+      }
+    } catch {
+      // ignore
+    } finally {
+      setLoading(false)
+    }
+  }, [agentId])
+
+  const handleToggle = () => {
+    if (!isDir) return
+    if (!expanded && children === null) {
+      loadChildren(currentPath)
+    }
+    setExpanded(!expanded)
+  }
+
+  // Set path from parent context
+  useEffect(() => {
+    if (entry.name && isDir) {
+      // Path will be set by parent via prop — for now derive from context
+    }
+  }, [entry.name, isDir])
 
   if (isDir) {
     return (
       <div>
         <button
-          onClick={() => setExpanded(!expanded)}
+          onClick={handleToggle}
           className="flex items-center gap-1.5 w-full py-1 px-2 text-sm text-mountain-300 hover:text-white hover:bg-navy-700/50 rounded transition-colors cursor-pointer"
           style={{ paddingLeft }}
         >
-          {expanded ? (
+          {loading ? (
+            <RefreshCw size={14} className="text-mountain-500 flex-shrink-0 animate-spin" />
+          ) : expanded ? (
             <ChevronDown size={14} className="text-mountain-500 flex-shrink-0" />
           ) : (
             <ChevronRight size={14} className="text-mountain-500 flex-shrink-0" />
@@ -78,20 +83,26 @@ function TreeNode({ node, depth = 0 }: { node: FileNode; depth?: number }) {
           ) : (
             <Folder size={16} className="text-yellow-400 flex-shrink-0" />
           )}
-          <span className="font-medium">{node.name}</span>
-          {node.children && (
-            <span className="text-xs text-mountain-600 ml-auto">{node.children.length} items</span>
+          <span className="font-medium">{entry.name}</span>
+          {children && (
+            <span className="text-xs text-mountain-600 ml-auto">{children.length} items</span>
           )}
         </button>
-        {expanded && node.children && (
+        {expanded && children && (
           <div>
-            {node.children
+            {children
               .sort((a, b) => {
                 if (a.type !== b.type) return a.type === 'directory' ? -1 : 1
                 return a.name.localeCompare(b.name)
               })
               .map((child) => (
-                <TreeNode key={child.name} node={child} depth={depth + 1} />
+                <FileRowWithPath
+                  key={child.name}
+                  entry={child}
+                  depth={depth + 1}
+                  agentId={agentId}
+                  parentPath={currentPath}
+                />
               ))}
           </div>
         )}
@@ -101,33 +112,206 @@ function TreeNode({ node, depth = 0 }: { node: FileNode; depth?: number }) {
 
   return (
     <div
-      className="flex items-center gap-1.5 py-1 px-2 text-sm text-mountain-400 hover:text-white hover:bg-navy-700/50 rounded transition-colors cursor-pointer"
+      className="flex items-center gap-1.5 py-1 px-2 text-sm text-mountain-400 hover:text-white hover:bg-navy-700/50 rounded transition-colors"
       style={{ paddingLeft: paddingLeft + 18 }}
     >
       <File size={14} className="text-mountain-500 flex-shrink-0" />
-      <span>{node.name}</span>
-      {node.size != null && (
-        <span className="text-xs text-mountain-600 ml-auto">{formatSize(node.size)}</span>
+      <span>{entry.name}</span>
+      {entry.size > 0 && (
+        <span className="text-xs text-mountain-600 ml-auto">{formatSize(entry.size)}</span>
+      )}
+    </div>
+  )
+}
+
+function FileRowWithPath({
+  entry,
+  depth,
+  agentId,
+  parentPath,
+}: {
+  entry: FileEntry
+  depth: number
+  agentId: string
+  parentPath: string
+}) {
+  const fullPath = parentPath ? `${parentPath}/${entry.name}` : entry.name
+
+  if (entry.type === 'directory') {
+    return <DirNode entry={entry} depth={depth} agentId={agentId} path={fullPath} />
+  }
+
+  const paddingLeft = depth * 16 + 8 + 18
+  return (
+    <div
+      className="flex items-center gap-1.5 py-1 px-2 text-sm text-mountain-400 hover:text-white hover:bg-navy-700/50 rounded transition-colors"
+      style={{ paddingLeft }}
+    >
+      <File size={14} className="text-mountain-500 flex-shrink-0" />
+      <span>{entry.name}</span>
+      {entry.size > 0 && (
+        <span className="text-xs text-mountain-600 ml-auto">{formatSize(entry.size)}</span>
+      )}
+    </div>
+  )
+}
+
+function DirNode({
+  entry,
+  depth,
+  agentId,
+  path,
+}: {
+  entry: FileEntry
+  depth: number
+  agentId: string
+  path: string
+}) {
+  const [expanded, setExpanded] = useState(false)
+  const [children, setChildren] = useState<FileEntry[] | null>(null)
+  const [loading, setLoading] = useState(false)
+
+  const paddingLeft = depth * 16 + 8
+
+  const handleToggle = async () => {
+    if (!expanded && children === null) {
+      setLoading(true)
+      try {
+        const res = await fetch(`/api/agents/${agentId}/workspace?path=${encodeURIComponent(path)}`)
+        if (res.ok) {
+          const data = await res.json()
+          setChildren(data.entries || [])
+        }
+      } catch {
+        // ignore
+      } finally {
+        setLoading(false)
+      }
+    }
+    setExpanded(!expanded)
+  }
+
+  return (
+    <div>
+      <button
+        onClick={handleToggle}
+        className="flex items-center gap-1.5 w-full py-1 px-2 text-sm text-mountain-300 hover:text-white hover:bg-navy-700/50 rounded transition-colors cursor-pointer"
+        style={{ paddingLeft }}
+      >
+        {loading ? (
+          <RefreshCw size={14} className="text-mountain-500 flex-shrink-0 animate-spin" />
+        ) : expanded ? (
+          <ChevronDown size={14} className="text-mountain-500 flex-shrink-0" />
+        ) : (
+          <ChevronRight size={14} className="text-mountain-500 flex-shrink-0" />
+        )}
+        {expanded ? (
+          <FolderOpen size={16} className="text-yellow-400 flex-shrink-0" />
+        ) : (
+          <Folder size={16} className="text-yellow-400 flex-shrink-0" />
+        )}
+        <span className="font-medium">{entry.name}</span>
+        {children && (
+          <span className="text-xs text-mountain-600 ml-auto">{children.length} items</span>
+        )}
+      </button>
+      {expanded && children && (
+        <div>
+          {children
+            .sort((a, b) => {
+              if (a.type !== b.type) return a.type === 'directory' ? -1 : 1
+              return a.name.localeCompare(b.name)
+            })
+            .map((child) => (
+              <FileRowWithPath
+                key={child.name}
+                entry={child}
+                depth={depth + 1}
+                agentId={agentId}
+                parentPath={path}
+              />
+            ))}
+        </div>
       )}
     </div>
   )
 }
 
 export default function WorkspaceBrowser({ agentId }: { agentId: string }) {
+  const [entries, setEntries] = useState<FileEntry[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const fetchRoot = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const res = await fetch(`/api/agents/${agentId}/workspace`)
+      if (res.status === 409) {
+        setError('Agent is not running. Start the agent to browse workspace files.')
+        return
+      }
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}))
+        setError(data.error || `Failed to load (${res.status})`)
+        return
+      }
+      const data = await res.json()
+      setEntries(data.entries || [])
+    } catch {
+      setError('Failed to connect to agent workspace')
+    } finally {
+      setLoading(false)
+    }
+  }, [agentId])
+
+  useEffect(() => {
+    fetchRoot()
+  }, [fetchRoot])
+
   return (
     <div className="rounded-lg border border-navy-700 bg-navy-800 p-4">
       <div className="flex items-center justify-between mb-3">
         <h2 className="text-sm font-semibold text-white">Workspace Files</h2>
-        <span className="text-xs text-mountain-500">Agent: {agentId}</span>
+        <button
+          onClick={fetchRoot}
+          disabled={loading}
+          className="p-1 text-mountain-400 hover:text-white rounded transition-colors disabled:opacity-50 cursor-pointer"
+          title="Refresh"
+        >
+          <RefreshCw size={14} className={loading ? 'animate-spin' : ''} />
+        </button>
       </div>
-      <div className="rounded-md border border-navy-700 bg-navy-900 p-2 max-h-[500px] overflow-y-auto">
-        {MOCK_WORKSPACE.map((node) => (
-          <TreeNode key={node.name} node={node} />
-        ))}
-      </div>
-      <p className="text-xs text-mountain-600 mt-3">
-        Static preview — will connect to agent workspace API in a future update.
-      </p>
+
+      {error ? (
+        <div className="flex items-center gap-2 py-6 justify-center text-mountain-500 text-sm">
+          <AlertCircle size={16} />
+          <span>{error}</span>
+        </div>
+      ) : loading ? (
+        <div className="flex items-center justify-center py-8">
+          <div className="h-6 w-6 rounded-full border-2 border-brand-500 border-t-transparent animate-spin" />
+        </div>
+      ) : entries.length === 0 ? (
+        <p className="text-sm text-mountain-500 text-center py-6">Workspace is empty</p>
+      ) : (
+        <div className="rounded-md border border-navy-700 bg-navy-900 p-2 max-h-[500px] overflow-y-auto">
+          {entries
+            .sort((a, b) => {
+              if (a.type !== b.type) return a.type === 'directory' ? -1 : 1
+              return a.name.localeCompare(b.name)
+            })
+            .map((entry) => (
+              <FileRowWithPath
+                key={entry.name}
+                entry={entry}
+                depth={0}
+                agentId={agentId}
+                parentPath="/home/agentuser"
+              />
+            ))}
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- **Agentbox**: New `GET /files?path=` endpoint lists directory contents with path restriction to `/home/agentuser` and `/workspace` (prevents traversal)
- **API**: New `GET /agents/:id/workspace?path=` proxies to agentbox when agent is running (409 if stopped, 502/504 on errors)
- **UI**: `WorkspaceBrowser` replaced static mock data with live tree view — lazy-loads subdirectories on click, shows file sizes, refresh button, error state for stopped agents
- **EXPECTED_PATHS** and **OpenAPI** updated, `docs/site` synced

## Test plan
- [x] TypeScript compiles cleanly
- [x] `npx jest --testPathPattern=docs` — 13/13 tests pass (including spec drift)
- [ ] Start agent, go to Detail > Workspace tab, verify file tree loads from ~/
- [ ] Click a directory to expand — verify lazy-load fetches children
- [ ] Stop agent, verify "Agent is not running" error state

🤖 Generated with [Claude Code](https://claude.com/claude-code)