### PR TITLE
feat: auto-name chat threads from first user message

### DIFF
--- a/services/api/src/routes/chat.ts
+++ b/services/api/src/routes/chat.ts
@@ -1528,9 +1528,17 @@ export async function chatCallbackHandler(req: Request, res: Response): Promise<
 
   console.info(`[chat-callback] Updated message ${message_id}: status=${finalStatus}`);
 
-  // Update thread timestamp
+  // Update thread timestamp + auto-name untitled threads from first user message
   await pool.query(
-    `UPDATE chat_threads SET updated_at = NOW()
+    `UPDATE chat_threads SET updated_at = NOW(),
+       title = CASE
+         WHEN title IS NULL THEN (
+           SELECT LEFT(content, 50) FROM chat_messages
+           WHERE thread_id = chat_threads.id AND author_type = 'human'
+           ORDER BY created_at ASC LIMIT 1
+         )
+         ELSE title
+       END
      WHERE id = (SELECT thread_id FROM chat_messages WHERE id = $1)`,
     [message_id]
   );


### PR DESCRIPTION
## Summary
- When an agent's first response completes on an untitled thread (`title IS NULL`), automatically sets the thread title to the first 50 characters of the user's original message
- Merged into the existing thread timestamp UPDATE query — zero extra database calls
- Uses `CASE WHEN title IS NULL` so already-named threads (via PUT /chat/threads/:id) are never overwritten

## Implementation
Single SQL change in `chatCallbackHandler` — the thread timestamp UPDATE now also conditionally sets the title via a correlated subquery:
```sql
UPDATE chat_threads SET updated_at = NOW(),
  title = CASE
    WHEN title IS NULL THEN (
      SELECT LEFT(content, 50) FROM chat_messages
      WHERE thread_id = chat_threads.id AND author_type = 'human'
      ORDER BY created_at ASC LIMIT 1
    )
    ELSE title
  END
WHERE id = (SELECT thread_id FROM chat_messages WHERE id = $1)
```

## Test plan
- [x] `npx jest --testPathPattern=routes-chat` — 82/82 tests pass (zero regressions)
- [x] TypeScript compiles cleanly
- [ ] Create a new chat thread without a title, send a message, verify thread list shows the user's message as the thread name

🤖 Generated with [Claude Code](https://claude.com/claude-code)