### PR TITLE
enhance: add workspace file viewer with syntax display

### DIFF
--- a/services/agentbox/app/server.py
+++ b/services/agentbox/app/server.py
@@ -180,6 +180,27 @@ def create_app(
         except PermissionError:
             return JSONResponse({"error": f"Permission denied: {path}"}, status_code=403)
 
+
+    async def file_read_endpoint(request: Request):
+        """Read file contents from the agent workspace (max 512 KB)."""
+        path = request.query_params.get("path", "")
+        real = os.path.realpath(path)
+        if not (real.startswith("/home/agentuser") or real.startswith("/workspace")):
+            return JSONResponse({"error": "Path not allowed"}, status_code=403)
+        try:
+            size = os.path.getsize(real)
+            if size > 512 * 1024:
+                return JSONResponse({"error": f"File too large ({size} bytes, max 512 KB)"}, status_code=413)
+            with open(real, "r", errors="replace") as f:
+                content = f.read()
+            return JSONResponse({"path": path, "content": content, "size": size})
+        except IsADirectoryError:
+            return JSONResponse({"error": "Path is a directory"}, status_code=400)
+        except FileNotFoundError:
+            return JSONResponse({"error": f"Not found: {path}"}, status_code=404)
+        except PermissionError:
+            return JSONResponse({"error": f"Permission denied: {path}"}, status_code=403)
+
     async def terminal_ws_endpoint(websocket):
         await ws_terminal_handler(websocket, work_token)
 
@@ -187,6 +208,7 @@ def create_app(
         Route("/health", health_endpoint, methods=["GET"]),
         Route("/work", work_endpoint, methods=["POST"]),
         Route("/files", files_endpoint, methods=["GET"]),
+        Route("/file-read", file_read_endpoint, methods=["GET"]),
         Route("/screenshot", screenshot_endpoint, methods=["GET"]),
         Route("/terminal/stream", terminal_stream_endpoint, methods=["GET"]),
         WebSocketRoute("/terminal/ws", terminal_ws_endpoint),

--- a/services/api/src/routes/agents.ts
+++ b/services/api/src/routes/agents.ts
@@ -2466,7 +2466,9 @@ router.get('/:id/workspace', requireRole('user'), async (req: Request, res: Resp
     }
 
     const path = (req.query.path as string) || '/home/agentuser';
-    const url = `http://agentbox-${agent.agent_id}:8054/files?path=${encodeURIComponent(path)}`;
+    const read = req.query.read === 'true';
+    const endpoint = read ? 'file-read' : 'files';
+    const url = `http://agentbox-${agent.agent_id}:8054/${endpoint}?path=${encodeURIComponent(path)}`;
     const response = await fetch(url, { signal: AbortSignal.timeout(5000) });
     const data = await response.json();
     res.status(response.status).json(data);

--- a/services/ui/src/app/agents/[id]/AgentDetailClient.tsx
+++ b/services/ui/src/app/agents/[id]/AgentDetailClient.tsx
@@ -136,6 +136,12 @@ export default function AgentDetailClient({
   const [toolInstalls, setToolInstalls] = useState<ToolInstallStatus[]>([])
   const [toolInstallsLoading, setToolInstallsLoading] = useState(false)
 
+  // Workspace file viewer state
+  const [viewingFile, setViewingFile] = useState<{ path: string; name: string } | null>(null)
+  const [fileContent, setFileContent] = useState<string | null>(null)
+  const [fileLoading, setFileLoading] = useState(false)
+  const [fileError, setFileError] = useState<string | null>(null)
+
   // Activity sub-view state
   const [activityView, setActivityView] = useState<'timeline' | 'events' | 'logs'>('timeline')
 
@@ -1386,7 +1392,61 @@ export default function AgentDetailClient({
       )}
 
       {activeTab === 'workspace' && agent && (
-        <WorkspaceBrowser agentId={agent.agent_id} />
+        <div className="space-y-4">
+          <WorkspaceBrowser
+            agentId={agent.agent_id}
+            onFileClick={(path: string, name: string) => {
+              setViewingFile({ path, name })
+              setFileContent(null)
+              setFileError(null)
+              setFileLoading(true)
+              fetch(`/api/agents/${agentId}/workspace?path=${encodeURIComponent(path)}&read=true`)
+                .then(res => {
+                  if (!res.ok) throw new Error(`${res.status}`)
+                  return res.json()
+                })
+                .then(data => {
+                  if (data.content !== undefined) {
+                    setFileContent(data.content)
+                  } else {
+                    setFileError(data.error || 'Could not read file')
+                  }
+                })
+                .catch(() => setFileError('Failed to read file'))
+                .finally(() => setFileLoading(false))
+            }}
+          />
+
+          {viewingFile && (
+            <div className="rounded-lg border border-navy-700 bg-navy-800 overflow-hidden">
+              <div className="flex items-center justify-between px-4 py-2 border-b border-navy-700 bg-navy-900/50">
+                <div className="flex items-center gap-2 min-w-0">
+                  <span className="text-sm font-medium text-white truncate">{viewingFile.name}</span>
+                  <span className="text-xs text-mountain-500 truncate hidden sm:block">{viewingFile.path}</span>
+                </div>
+                <button
+                  onClick={() => { setViewingFile(null); setFileContent(null); setFileError(null) }}
+                  className="text-mountain-400 hover:text-white transition-colors text-sm px-2 cursor-pointer"
+                >
+                  Close
+                </button>
+              </div>
+              <div className="max-h-[500px] overflow-auto bg-[#0d1117]">
+                {fileLoading ? (
+                  <div className="flex items-center justify-center py-12">
+                    <div className="h-6 w-6 rounded-full border-2 border-brand-500 border-t-transparent animate-spin" />
+                  </div>
+                ) : fileError ? (
+                  <p className="text-sm text-mountain-500 px-4 py-6 text-center">{fileError}</p>
+                ) : fileContent !== null ? (
+                  <pre className="p-4 text-sm font-mono text-green-400 whitespace-pre-wrap break-words leading-relaxed">
+                    <code>{fileContent}</code>
+                  </pre>
+                ) : null}
+              </div>
+            </div>
+          )}
+        </div>
       )}
 
       {activeTab === 'knowledge' && agent && (

--- a/services/ui/src/app/agents/[id]/WorkspaceBrowser.tsx
+++ b/services/ui/src/app/agents/[id]/WorkspaceBrowser.tsx
@@ -129,22 +129,25 @@ function FileRowWithPath({
   depth,
   agentId,
   parentPath,
+  onFileClick,
 }: {
   entry: FileEntry
   depth: number
   agentId: string
   parentPath: string
+  onFileClick?: (path: string, name: string) => void
 }) {
   const fullPath = parentPath ? `${parentPath}/${entry.name}` : entry.name
 
   if (entry.type === 'directory') {
-    return <DirNode entry={entry} depth={depth} agentId={agentId} path={fullPath} />
+    return <DirNode entry={entry} depth={depth} agentId={agentId} path={fullPath} onFileClick={onFileClick} />
   }
 
   const paddingLeft = depth * 16 + 8 + 18
   return (
-    <div
-      className="flex items-center gap-1.5 py-1 px-2 text-sm text-mountain-400 hover:text-white hover:bg-navy-700/50 rounded transition-colors"
+    <button
+      onClick={() => onFileClick?.(fullPath, entry.name)}
+      className="flex items-center gap-1.5 w-full py-1 px-2 text-sm text-mountain-400 hover:text-white hover:bg-navy-700/50 rounded transition-colors cursor-pointer text-left"
       style={{ paddingLeft }}
     >
       <File size={14} className="text-mountain-500 flex-shrink-0" />
@@ -152,7 +155,7 @@ function FileRowWithPath({
       {entry.size > 0 && (
         <span className="text-xs text-mountain-600 ml-auto">{formatSize(entry.size)}</span>
       )}
-    </div>
+    </button>
   )
 }
 
@@ -161,11 +164,13 @@ function DirNode({
   depth,
   agentId,
   path,
+  onFileClick,
 }: {
   entry: FileEntry
   depth: number
   agentId: string
   path: string
+  onFileClick?: (path: string, name: string) => void
 }) {
   const [expanded, setExpanded] = useState(false)
   const [children, setChildren] = useState<FileEntry[] | null>(null)
@@ -229,6 +234,7 @@ function DirNode({
                 depth={depth + 1}
                 agentId={agentId}
                 parentPath={path}
+                onFileClick={onFileClick}
               />
             ))}
         </div>
@@ -237,7 +243,7 @@ function DirNode({
   )
 }
 
-export default function WorkspaceBrowser({ agentId }: { agentId: string }) {
+export default function WorkspaceBrowser({ agentId, onFileClick }: { agentId: string; onFileClick?: (path: string, name: string) => void }) {
   const [entries, setEntries] = useState<FileEntry[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -308,6 +314,7 @@ export default function WorkspaceBrowser({ agentId }: { agentId: string }) {
                 depth={0}
                 agentId={agentId}
                 parentPath="/home/agentuser"
+                onFileClick={onFileClick}
               />
             ))}
         </div>


### PR DESCRIPTION
## Summary
- **UI**: Click any file in the Workspace tab to view its contents in a code viewer panel below the file listing. Dark background (`#0d1117`), monospace green text, scrollable up to 500px. Close button to dismiss.
- **Agentbox**: New `GET /file-read?path=...` endpoint reads file contents (max 512 KB, restricted to `/home/agentuser` and `/workspace`, text mode with `errors='replace'`)
- **API**: Workspace proxy routes `?read=true` queries to the new `/file-read` endpoint
- **WorkspaceBrowser**: File rows are now clickable buttons with `onFileClick` callback prop

## Files changed
- `services/ui/src/app/agents/[id]/AgentDetailClient.tsx` — viewer state, panel UI, fetch logic
- `services/ui/src/app/agents/[id]/WorkspaceBrowser.tsx` — `onFileClick` prop threaded to file rows
- `services/api/src/routes/agents.ts` — workspace proxy `read=true` routing
- `services/agentbox/app/server.py` — `/file-read` endpoint

## Test plan
- [x] TypeScript compiles cleanly
- [x] `npx jest --testPathPattern=routes-agents` — 149/149 tests pass
- [ ] Start agent, open Workspace tab, click a file, verify contents appear in viewer

🤖 Generated with [Claude Code](https://claude.com/claude-code)