### PR TITLE
fix: add missing agent schedule columns migration

### DIFF
--- a/services/api/src/db/migrations/054_add_agent_schedule.sql
+++ b/services/api/src/db/migrations/054_add_agent_schedule.sql
@@ -1,0 +1,4 @@
+-- Add schedule columns to agents table for auto-start cron scheduling.
+-- Referenced by PUT /agents/:id/schedule and GET /agents/:id responses.
+ALTER TABLE agents ADD COLUMN IF NOT EXISTS schedule_cron VARCHAR(128);
+ALTER TABLE agents ADD COLUMN IF NOT EXISTS schedule_enabled BOOLEAN NOT NULL DEFAULT false;


### PR DESCRIPTION
## Summary
- **Root cause**: `schedule_cron` and `schedule_enabled` columns are referenced by `GET /agents/:id` (line 496) and `PUT /agents/:id/schedule` (line 2739) but no migration ever created them
- **Impact**: Schedule section in agent detail UI silently fails — cron values are never persisted
- **Fix**: Migration 054 adds both columns with `IF NOT EXISTS` for idempotency

## Verification
```sql
-- Before: columns missing
SELECT column_name FROM information_schema.columns 
WHERE table_name = 'agents' AND column_name LIKE 'schedule%';
-- (0 rows)

-- After: columns present
-- schedule_cron VARCHAR(128) nullable
-- schedule_enabled BOOLEAN NOT NULL DEFAULT false
```

## Also verified (all present)
- `agent_status_history` table — exists with proper FK
- `agent_webhooks` table — exists with proper FK  
- `avatar_key` column — present
- `tags` column — present
- `env_vars` column — present
- `lead_agent_id` on `chat_threads` — present

## Test plan
- [ ] Merge and verify API startup logs show migration applied
- [ ] Open agent detail > Configuration > Schedule — set a cron, verify it saves
- [ ] Toggle schedule enabled/disabled — verify persistence across page reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)