### PR TITLE
enhance: add SOUL.md preview on agent list cards

### DIFF
--- a/services/ui/src/app/agents/AgentsClient.tsx
+++ b/services/ui/src/app/agents/AgentsClient.tsx
@@ -73,6 +73,7 @@ export default function AgentsClient({ session }: { session: Session }) {
   const [templatesLoading, setTemplatesLoading] = useState(false)
   const [creatingFromTemplate, setCreatingFromTemplate] = useState<string | null>(null)
   const [errorDetails, setErrorDetails] = useState<Record<string, string>>({})
+  const [soulPreviews, setSoulPreviews] = useState<Record<string, string | null>>({})
   const importInputRef = useRef<HTMLInputElement>(null)
   const router = useRouter()
 
@@ -279,6 +280,18 @@ export default function AgentsClient({ session }: { session: Session }) {
       if (importInputRef.current) importInputRef.current.value = ''
     }
   }
+
+  const fetchSoulPreview = useCallback(async (agentId: string) => {
+    if (soulPreviews[agentId] !== undefined) return
+    setSoulPreviews(prev => ({ ...prev, [agentId]: null }))
+    try {
+      const res = await fetch(`/api/agents/${agentId}`)
+      if (res.ok) {
+        const data = await res.json()
+        setSoulPreviews(prev => ({ ...prev, [agentId]: data.soul_md || '' }))
+      }
+    } catch { /* ignore */ }
+  }, [soulPreviews])
 
   const openTemplates = async () => {
     setShowTemplates(true)
@@ -492,6 +505,23 @@ export default function AgentsClient({ session }: { session: Session }) {
                 <p className="text-sm text-mountain-400 mb-3 line-clamp-2 flex-1">
                   {agent.description || 'No description'}
                 </p>
+
+                {/* SOUL.md preview */}
+                {soulPreviews[agent.id] ? (
+                  <div className="mb-3 px-2.5 py-2 rounded-md bg-navy-900 border border-navy-700">
+                    <p className="text-[10px] font-medium text-mountain-500 uppercase tracking-wide mb-1">SOUL.md</p>
+                    <p className="text-xs text-mountain-300 line-clamp-2 font-mono">
+                      {soulPreviews[agent.id]!.slice(0, 100)}{soulPreviews[agent.id]!.length > 100 ? '...' : ''}
+                    </p>
+                  </div>
+                ) : soulPreviews[agent.id] === undefined ? (
+                  <button
+                    onClick={() => fetchSoulPreview(agent.id)}
+                    className="mb-3 text-xs text-mountain-500 hover:text-mountain-300 transition-colors cursor-pointer"
+                  >
+                    Show SOUL.md preview
+                  </button>
+                ) : null}
 
                 {/* Error message */}
                 {agent.status === 'error' && (errorDetails[agent.id] || agent.error_message) && (


### PR DESCRIPTION
## Summary
- Adds a clickable "Show SOUL.md preview" link on each agent card in the list view
- On click, lazy-fetches the agent detail (which includes `soul_md`) and displays the first 100 chars in a monospace preview box
- Results are cached in `soulPreviews` state — no re-fetch on subsequent views
- Shows nothing if `soul_md` is empty
- Only modifies `AgentsClient.tsx` (1 file, 30 lines)

## Test plan
- [ ] Navigate to /agents — verify "Show SOUL.md preview" link appears on each card
- [ ] Click the link — verify preview box appears with first 100 chars of SOUL.md
- [ ] Click on a second agent — verify it fetches independently
- [ ] Agent with no SOUL.md — verify preview disappears (no empty box)
- [ ] Navigate away and back — verify cached previews persist during session

🤖 Generated with [Claude Code](https://claude.com/claude-code)