### PR TITLE
fix: browser screenshot cross-loop deadlock

### DIFF
--- a/services/agentbox/app/server.py
+++ b/services/agentbox/app/server.py
@@ -131,28 +131,25 @@ def create_app(
         )
 
     async def screenshot_endpoint(request: Request):
-        """Return a live Playwright screenshot as base64 PNG + current URL."""
+        """Return cached Playwright screenshot as base64 PNG + current URL.
+
+        The browser runs on a different event loop (created via asyncio.run()
+        in the chat handler thread). Calling page.screenshot() from uvicorn's
+        loop deadlocks. Instead, _execute_browser caches a screenshot after
+        every state-changing action, and this endpoint serves the cached bytes.
+        """
         import app.tools as _tools
 
-        if _tools._browser_page is None:
+        if _tools._browser_last_screenshot is None:
             return JSONResponse(
                 {"screenshot": None, "url": None, "error": "Browser not active"},
                 status_code=404,
             )
 
-        try:
-            page = _tools._browser_page
-            png_bytes = await page.screenshot(full_page=False)
-            return JSONResponse({
-                "screenshot": base64.b64encode(png_bytes).decode("ascii"),
-                "url": page.url,
-            })
-        except Exception as exc:
-            logger.error("Screenshot failed: %s", exc, exc_info=True)
-            return JSONResponse(
-                {"screenshot": None, "url": None, "error": str(exc)[:200]},
-                status_code=500,
-            )
+        return JSONResponse({
+            "screenshot": base64.b64encode(_tools._browser_last_screenshot).decode("ascii"),
+            "url": _tools._browser_last_url,
+        })
 
     async def files_endpoint(request: Request):
         """List files in the agent workspace directory."""

--- a/services/agentbox/app/tools.py
+++ b/services/agentbox/app/tools.py
@@ -326,6 +326,8 @@ async def _execute_tmux(args: dict) -> str:
 _browser_context: object | None = None  # playwright BrowserContext
 _browser_page: object | None = None     # playwright Page
 _playwright_instance: object | None = None
+_browser_last_screenshot: bytes | None = None  # cached PNG for cross-loop screenshot endpoint
+_browser_last_url: str | None = None           # URL at time of last screenshot
 
 MAX_TEXT_LENGTH = 4000
 SCREENSHOT_DIR = "/workspace/screenshots"
@@ -356,6 +358,23 @@ async def _get_browser_page():
     return _browser_page
 
 
+async def _capture_live_screenshot(page) -> None:
+    """Capture screenshot on the browser's owning loop and cache it.
+
+    The screenshot endpoint runs on uvicorn's event loop, which differs from
+    the loop that owns the Playwright browser (created via asyncio.run() in
+    the chat handler thread). Calling page.screenshot() cross-loop deadlocks.
+    We cache screenshot bytes after every state-changing browser action so the
+    endpoint can serve them without touching Playwright.
+    """
+    global _browser_last_screenshot, _browser_last_url
+    try:
+        _browser_last_screenshot = await page.screenshot(full_page=False)
+        _browser_last_url = page.url
+    except Exception:
+        pass  # Non-blocking — stale screenshot is better than none
+
+
 async def _execute_browser(args: dict) -> str:
     """Execute a browser action via Playwright. Returns JSON result."""
     action = args.get("action", "")
@@ -369,6 +388,7 @@ async def _execute_browser(args: dict) -> str:
                 return json.dumps({"success": False, "error": "url is required"})
             resp = await page.goto(url, wait_until="domcontentloaded", timeout=30000)
             title = await page.title()
+            await _capture_live_screenshot(page)
             return json.dumps({
                 "success": True,
                 "title": title,
@@ -382,6 +402,7 @@ async def _execute_browser(args: dict) -> str:
             filename = f"screenshot-{int(time.time())}.png"
             path = f"{SCREENSHOT_DIR}/{filename}"
             await page.screenshot(path=path, full_page=full_page)
+            await _capture_live_screenshot(page)
             return json.dumps({
                 "success": True,
                 "path": path,
@@ -394,6 +415,7 @@ async def _execute_browser(args: dict) -> str:
                 return json.dumps({"success": False, "error": "selector is required"})
             await page.click(selector, timeout=10000)
             await page.wait_for_load_state("domcontentloaded", timeout=10000)
+            await _capture_live_screenshot(page)
             return json.dumps({
                 "success": True,
                 "url": page.url,
@@ -416,6 +438,7 @@ async def _execute_browser(args: dict) -> str:
             text = json.dumps(result, default=str)
             if len(text) > MAX_TEXT_LENGTH:
                 text = text[:MAX_TEXT_LENGTH] + "...(truncated)"
+            await _capture_live_screenshot(page)
             return json.dumps({"success": True, "result": text})
 
         else:


### PR DESCRIPTION
## Summary
- Browser is created via `asyncio.run()` in the chat handler thread (temporary event loop)
- Screenshot endpoint runs on uvicorn's main event loop
- `await page.screenshot()` from uvicorn's loop deadlocks — Playwright page objects are bound to their creating loop
- **Fix**: Cache screenshot PNG bytes after every state-changing browser action (`navigate`, `click`, `evaluate`, `screenshot`) on the browser's owning loop. Screenshot endpoint serves cached bytes instantly.

Closes AI-177.

## Plan
1. Add `_browser_last_screenshot` and `_browser_last_url` module-level cache vars in `tools.py`
2. Add `_capture_live_screenshot()` helper called after navigate/click/evaluate/screenshot actions
3. Change `screenshot_endpoint` in `server.py` to serve cached bytes instead of calling Playwright

## Risks
- Screenshot is slightly stale (captured at end of last browser action, not live). Acceptable — polling UI updates on next action.
- `_capture_live_screenshot` failure is non-blocking (silent catch). Stale screenshot is better than deadlock.

## Rollback
Revert this commit. Screenshot endpoint will return 404 (browser not active) instead of deadlocking.

## Validation Evidence
- Root cause confirmed via live VPS test: health endpoint responds instantly, screenshot endpoint hangs indefinitely
- `asyncio.run()` at `chat.py:805` creates temporary event loop per tool call — confirmed via code trace
- Agentbox logs show `POST /work 200` completing but `GET /screenshot` never returning

## Test plan
- [ ] Send browser navigate message, screenshot endpoint returns cached PNG
- [ ] Navigate to second URL, screenshot updates to new page
- [ ] Browser tab in UI shows screenshot after agent navigates
- [ ] Screenshot endpoint returns 404 before any browser action (no cached data)
- [ ] Health endpoint unaffected
