### PR TITLE
enhance: clarify chat thread delete confirmation

### DIFF
--- a/services/ui/src/app/chat/ThreadList.tsx
+++ b/services/ui/src/app/chat/ThreadList.tsx
@@ -167,7 +167,7 @@ export default function ThreadList({ threads, loading, activeThreadId, onDelete 
                 className="absolute inset-0 z-10 flex items-center justify-center bg-navy-900/95 border-b border-navy-800 px-3"
                 data-testid={`confirm-delete-${thread.id}`}
               >
-                <span className="text-xs text-gray-300 mr-2">Delete this thread?</span>
+                <span className="text-xs text-gray-300 mr-2">Delete? Cannot be undone.</span>
                 <button
                   onClick={() => {
                     onDelete(thread.id)


### PR DESCRIPTION
## Summary
The chat thread delete confirmation overlay already existed in `ThreadList.tsx` — the trash icon sets `confirmId` which shows an inline overlay with Delete/Cancel buttons. This PR updates the confirmation message to clarify the action is permanent.

**Before:** "Delete this thread?"
**After:** "Delete? Cannot be undone."

## Existing behavior (unchanged)
1. Trash icon appears on hover (line 148)
2. Click sets `confirmId` → shows inline overlay (line 165)
3. "Delete" button fires `onDelete(thread.id)` (line 173)
4. "Cancel" button clears `confirmId` (line 182)

## Test plan
- [ ] Hover over a thread — verify trash icon appears
- [ ] Click trash — verify overlay shows "Delete? Cannot be undone." with Delete/Cancel
- [ ] Click Cancel — overlay disappears, thread intact
- [ ] Click Delete — thread is removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)