### PR TITLE
enhance: show session tabs in chat header bar

### DIFF
--- a/services/ui/src/__tests__/ChatLayout.test.tsx
+++ b/services/ui/src/__tests__/ChatLayout.test.tsx
@@ -459,7 +459,7 @@ describe('ChatView via ChatLayout', () => {
     )
 
     await waitFor(() => {
-      expect(screen.getByTestId('session-toggle')).toBeInTheDocument()
+      expect(screen.getByTestId('session-tabs')).toBeInTheDocument()
     })
   })
 

--- a/services/ui/src/__tests__/ChatView.test.tsx
+++ b/services/ui/src/__tests__/ChatView.test.tsx
@@ -21,6 +21,9 @@ vi.mock('lucide-react', () => ({
   Paperclip: (props: any) => <span data-testid="icon-paperclip" {...props} />,
   Search: (props: any) => <span data-testid="icon-search" {...props} />,
   X: (props: any) => <span data-testid="icon-x" {...props} />,
+  Globe: (props: any) => <span data-testid="icon-globe" {...props} />,
+  Monitor: (props: any) => <span data-testid="icon-monitor" {...props} />,
+  Activity: (props: any) => <span data-testid="icon-activity" {...props} />,
 }))
 
 vi.mock('@/app/chat/ChatMessage', () => ({

--- a/services/ui/src/app/chat/ChatView.tsx
+++ b/services/ui/src/app/chat/ChatView.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useRef, useCallback } from 'react'
 import { useRouter } from 'next/navigation'
-import { ArrowLeft, Send, Terminal, Users, Paperclip, Search, X } from 'lucide-react'
+import { ArrowLeft, Send, Monitor, Terminal, Activity, Globe, Users, Paperclip, Search, X } from 'lucide-react'
 import type { Session } from 'next-auth'
 import type { ChatThread } from './ChatLayout'
 import ChatMessage from './ChatMessage'
@@ -48,6 +48,7 @@ export default function ChatView({ threadId, session, thread, onBack, onThreadUp
   const [error, setError] = useState<string | null>(null)
   const [fileToast, setFileToast] = useState(false)
   const [sessionPaneOpen, setSessionPaneOpen] = useState(false)
+  const [activeSessionTab, setActiveSessionTab] = useState<'terminal' | 'events' | 'browser'>('terminal')
   const [participantPanelOpen, setParticipantPanelOpen] = useState(false)
   const [searchOpen, setSearchOpen] = useState(false)
   const [searchQuery, setSearchQuery] = useState('')
@@ -191,7 +192,7 @@ export default function ChatView({ threadId, session, thread, onBack, onThreadUp
       {/* Terminal (main stage) — shown when Live Session is open */}
       {sessionPaneOpen && (
         <div className="flex-1 flex flex-col min-w-0 min-h-0 overflow-hidden border-r border-[#292e42] bg-[#1a1b26]">
-          <SessionPane threadId={threadId} />
+          <SessionPane threadId={threadId} initialTab={activeSessionTab} />
         </div>
       )}
 
@@ -267,18 +268,34 @@ export default function ChatView({ threadId, session, thread, onBack, onThreadUp
             >
               <Users size={18} />
             </button>
-            <button
-              onClick={() => setSessionPaneOpen(prev => !prev)}
-              className={`p-1.5 rounded transition-colors ${
-                sessionPaneOpen
-                  ? 'bg-brand-600/20 text-brand-400'
-                  : 'text-mountain-400 hover:text-gray-200 hover:bg-navy-700'
-              }`}
-              title="Toggle Live Session"
-              data-testid="session-toggle"
-            >
-              <Terminal size={18} />
-            </button>
+            <div className="flex items-center border-l border-navy-700 ml-1 pl-1 gap-0.5" data-testid="session-tabs">
+              {([
+                { key: 'terminal' as const, icon: Terminal, label: 'Terminal' },
+                { key: 'browser' as const, icon: Globe, label: 'Browser' },
+                { key: 'events' as const, icon: Activity, label: 'Events' },
+              ]).map(({ key, icon: Icon, label }) => (
+                <button
+                  key={key}
+                  onClick={() => {
+                    if (activeSessionTab === key && sessionPaneOpen) {
+                      setSessionPaneOpen(false)
+                    } else {
+                      setActiveSessionTab(key)
+                      setSessionPaneOpen(true)
+                    }
+                  }}
+                  className={`p-1.5 rounded transition-colors ${
+                    sessionPaneOpen && activeSessionTab === key
+                      ? 'bg-brand-600/20 text-brand-400'
+                      : 'text-mountain-400 hover:text-gray-200 hover:bg-navy-700'
+                  }`}
+                  title={label}
+                  data-testid={`session-tab-${key}`}
+                >
+                  <Icon size={16} />
+                </button>
+              ))}
+            </div>
           </div>
         </div>
 

--- a/services/ui/src/app/chat/SessionPane.tsx
+++ b/services/ui/src/app/chat/SessionPane.tsx
@@ -14,6 +14,7 @@ type ViewMode = 'events' | 'terminal' | 'browser'
 
 interface Props {
   threadId: string
+  initialTab?: ViewMode
 }
 
 function TerminalBlock({ lines }: { lines: string[] }) {
@@ -171,8 +172,13 @@ function BrowserView({ threadId, active }: { threadId: string; active: boolean }
   )
 }
 
-export default function SessionPane({ threadId }: Props) {
-  const [viewMode, setViewMode] = useState<ViewMode>('terminal')
+export default function SessionPane({ threadId, initialTab }: Props) {
+  const [viewMode, setViewMode] = useState<ViewMode>(initialTab || 'terminal')
+
+  useEffect(() => {
+    if (initialTab) setViewMode(initialTab)
+  }, [initialTab])
+
   const [events, setEvents] = useState<AgentEvent[]>([])
   const [filter, setFilter] = useState<ToolFilter>('All')
   const [autoScroll, setAutoScroll] = useState(true)


### PR DESCRIPTION
## Summary
- Move Terminal/Browser/Events tabs from inside the session pane to the chat header bar
- Tabs are always visible when an agent is in the thread — no need to click a toggle first
- Clicking a tab opens that view in the left pane; clicking the active tab collapses it
- Session pane syncs view via new `initialTab` prop

## Changes
- **ChatView.tsx**: Replace single Terminal toggle with 3 tab buttons (Terminal, Browser, Events) separated by a divider. Add `activeSessionTab` state. Pass `initialTab` to SessionPane.
- **SessionPane.tsx**: Accept `initialTab` prop, sync `viewMode` when it changes from parent.

## Test plan
- [ ] Terminal, Browser, Events icons visible in header bar
- [ ] Click Terminal tab — session pane opens with terminal view
- [ ] Click Browser tab — session pane switches to browser view
- [ ] Click Events tab — session pane switches to events view
- [ ] Click active tab again — session pane collapses
- [ ] Tab icons inside session pane still work for switching views
- [ ] Search, Participants, Cancel buttons unaffected
