### PR TITLE
feat: add search_shared_knowledge tool to agentbox

### DIFF
--- a/services/agentbox/app/tools.py
+++ b/services/agentbox/app/tools.py
@@ -273,6 +273,33 @@ SEARCH_KNOWLEDGE_TOOL = {
 }
 
 
+SEARCH_SHARED_KNOWLEDGE_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "search_shared_knowledge",
+        "description": (
+            "Search the shared knowledge library for information across all collections "
+            "you have access to. Returns relevant text chunks with source citations. "
+            "Use this to find documentation, research, or shared notes from the team."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "Search query (e.g. 'deployment process', 'API authentication')",
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Max results to return (default 10, max 50)",
+                    "default": 10,
+                },
+            },
+            "required": ["query"],
+        },
+    },
+}
+
 def build_tool_definitions(tools_config: ToolsConfig) -> list[dict]:
     """Build the tools array for the LLM request based on agent config."""
     definitions: list[dict] = []
@@ -294,6 +321,7 @@ def build_tool_definitions(tools_config: ToolsConfig) -> list[dict]:
     if os.environ.get("AKM_TOKEN") and os.environ.get("AKM_SERVICE_URL"):
         definitions.append(SAVE_KNOWLEDGE_TOOL)
         definitions.append(SEARCH_KNOWLEDGE_TOOL)
+        definitions.append(SEARCH_SHARED_KNOWLEDGE_TOOL)
     return definitions
 
 
@@ -348,6 +376,9 @@ async def execute_tool_call(
 
     if name == "search_knowledge":
         return await _execute_search_knowledge(arguments)
+
+    if name == "search_shared_knowledge":
+        return await _execute_search_shared_knowledge(arguments)
 
     return json.dumps({"success": False, "error": f"Unknown tool: {name}"})
 
@@ -416,6 +447,59 @@ async def _execute_search_knowledge(args: dict) -> str:
             if res.status_code == 200:
                 data = res.json()
                 return json.dumps({"success": True, **data})
+            else:
+                return json.dumps({"success": False, "error": f"Search failed: {res.status_code}"})
+    except Exception as exc:
+        return json.dumps({"success": False, "error": str(exc)[:200]})
+
+
+async def _execute_search_shared_knowledge(args: dict) -> str:
+    """Search shared knowledge library via the knowledge service."""
+    import os
+    import httpx
+
+    query = args.get("query", "")
+    if not query:
+        return json.dumps({"success": False, "error": "query is required"})
+
+    limit = args.get("limit", 10)
+    if not isinstance(limit, int):
+        try:
+            limit = int(limit)
+        except (TypeError, ValueError):
+            limit = 10
+    limit = max(1, min(limit, 50))
+
+    akm_url = os.environ.get("AKM_SERVICE_URL", "")
+    akm_token = os.environ.get("AKM_TOKEN", "")
+    if not akm_url or not akm_token:
+        return json.dumps({"success": False, "error": "Knowledge service not configured"})
+
+    try:
+        async with httpx.AsyncClient(timeout=15) as client:
+            res = await client.get(
+                f"{akm_url}/api/v1/shared/search",
+                params={"q": query, "limit": limit},
+                headers={"Authorization": f"Bearer {akm_token}"},
+            )
+            if res.status_code == 200:
+                data = res.json()
+                results = data.get("results", [])
+                formatted = []
+                for r in results:
+                    formatted.append({
+                        "content": r.get("content", ""),
+                        "headline": r.get("headline", ""),
+                        "source_title": r.get("source_title", ""),
+                        "collection_name": r.get("collection_name", ""),
+                        "rank": r.get("rank"),
+                    })
+                return json.dumps({
+                    "success": True,
+                    "query": query,
+                    "count": len(formatted),
+                    "results": formatted,
+                })
             else:
                 return json.dumps({"success": False, "error": f"Search failed: {res.status_code}"})
     except Exception as exc:

--- a/services/agentbox/poetry.lock
+++ b/services/agentbox/poetry.lock
@@ -18,7 +18,7 @@ version = "4.12.1"
 description = "High-level concurrency and networking framework on top of asyncio or Trio"
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "dev"]
+groups = ["main"]
 files = [
     {file = "anyio-4.12.1-py3-none-any.whl", hash = "sha256:d405828884fc140aa80a3c667b8beed277f1dfedec42ba031bd6ac3db606ab6c"},
     {file = "anyio-4.12.1.tar.gz", hash = "sha256:41cfcc3a4c85d3f05c932da7c26d0201ac36f72abd4435ba90d0464a3ffed703"},
@@ -37,7 +37,7 @@ version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
-groups = ["main", "dev"]
+groups = ["main"]
 files = [
     {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
     {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
@@ -386,7 +386,7 @@ version = "0.16.0"
 description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "dev"]
+groups = ["main"]
 files = [
     {file = "h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86"},
     {file = "h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1"},
@@ -398,7 +398,7 @@ version = "1.0.9"
 description = "A minimal low-level HTTP client."
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main"]
 files = [
     {file = "httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55"},
     {file = "httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8"},
@@ -420,7 +420,7 @@ version = "0.28.1"
 description = "The next generation HTTP client."
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main"]
 files = [
     {file = "httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad"},
     {file = "httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc"},
@@ -445,7 +445,7 @@ version = "3.11"
 description = "Internationalized Domain Names in Applications (IDNA)"
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "dev"]
+groups = ["main"]
 files = [
     {file = "idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea"},
     {file = "idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902"},
@@ -906,12 +906,11 @@ version = "4.15.0"
 description = "Backported and Experimental Type Hints for Python 3.9+"
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "dev"]
+groups = ["main"]
 files = [
     {file = "typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"},
     {file = "typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466"},
 ]
-markers = {dev = "python_version == \"3.12\""}
 
 [[package]]
 name = "typing-inspection"
@@ -1039,4 +1038,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "0210f99ba2ceacd2dc3558b047d7ae1346dedf186ae61ea787c76b91362a3feb"
+content-hash = "f306e68cac6a9a2385cd8ed57ea604083a7b1fa744ad15a2cf26f58dcccf5054"

--- a/services/agentbox/pyproject.toml
+++ b/services/agentbox/pyproject.toml
@@ -14,6 +14,7 @@ pyyaml = "^6.0"
 requests = "^2.31.0"
 websockets = ">=12.0"
 playwright = "^1.52"
+httpx = ">=0.27.0"
 
 
 [tool.poetry.group.dev.dependencies]
@@ -21,7 +22,6 @@ pytest = "^7.4.0"
 pytest-asyncio = "^0.23.0"
 pytest-cov = "^4.1.0"
 ruff = "^0.1.0"
-httpx = ">=0.27.0"
 
 [tool.ruff]
 line-length = 100


### PR DESCRIPTION
## Summary
- **New tool**: `search_shared_knowledge` — lets agents search the shared knowledge library (collections, sources, documents) via full-text search. Returns content chunks with source titles and collection names.
- **Endpoint**: Calls knowledge service `GET /api/v1/shared/search?q=...&limit=...` with AKM JWT auth
- **Bug fix**: Moved `httpx` from dev to main dependencies in `pyproject.toml` — it was missing from production builds, which broke all existing knowledge tools (`save_knowledge`, `search_knowledge`) at runtime

## Changes
- `services/agentbox/app/tools.py`:
  - Added `SEARCH_SHARED_KNOWLEDGE_TOOL` definition
  - Added `_execute_search_shared_knowledge()` handler with result formatting
  - Registered in `build_tool_definitions()` (when AKM configured)
  - Registered in `execute_tool_call()` dispatch
- `services/agentbox/pyproject.toml`: moved httpx to main deps

## Test plan
- [x] Agentbox unit tests: 58/58 pass (pre-existing)
- [ ] Rebuild agentbox, start agent, verify tool appears in LLM tool list
- [ ] Send "search shared knowledge for deployment" and verify results

🤖 Generated with [Claude Code](https://claude.com/claude-code)