### PR TITLE
feat: add create entry form to agent Knowledge tab

### DIFF
--- a/services/api/src/routes/knowledge.ts
+++ b/services/api/src/routes/knowledge.ts
@@ -108,6 +108,28 @@ router.get('/entries/:agentId/:path(*)', requireRole('user'), async (req: Reques
   }
 });
 
+// Create entry
+router.post('/entries', requireRole('user'), async (req: Request, res: Response) => {
+  try {
+    const { agent_id, path, content } = req.body;
+    if (!agent_id || !path || !content) {
+      res.status(400).json({ error: 'agent_id, path, and content are required' });
+      return;
+    }
+
+    if (!await isAgentOwned(req, agent_id)) {
+      res.status(403).json({ error: 'Not authorized to create entries for this agent' });
+      return;
+    }
+
+    const result = await akmProxy.createEntry(agent_id, path, content);
+    res.status(result.status).json(result.data);
+  } catch (err) {
+    console.error('[knowledge] Create entry error:', err);
+    res.status(500).json({ error: 'Failed to create knowledge entry' });
+  }
+});
+
 // Search entries
 router.get('/search', requireRole('user'), async (req: Request, res: Response) => {
   try {

--- a/services/api/src/services/akm-proxy.ts
+++ b/services/api/src/services/akm-proxy.ts
@@ -60,6 +60,31 @@ export async function searchEntries(q: string, agentId?: string): Promise<ProxyR
   return proxyGet('/internal/admin/search', params);
 }
 
+export async function createEntry(agentId: string, path: string, content: string): Promise<ProxyResponse> {
+  if (!AKM_INTERNAL_SERVICE_TOKEN) {
+    return { status: 503, data: { error: 'Knowledge service not configured' } };
+  }
+
+  const url = `${AKM_SERVICE_URL}/internal/admin/entries/${encodeURIComponent(agentId)}`;
+
+  let resp: Response;
+  try {
+    resp = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${AKM_INTERNAL_SERVICE_TOKEN}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ path, content }),
+    });
+  } catch {
+    return { status: 502, data: { error: 'Knowledge service unavailable' } };
+  }
+
+  const data = await resp.json();
+  return { status: resp.status, data };
+}
+
 export async function appendJournal(agentId: string, content: string): Promise<ProxyResponse> {
   if (!AKM_INTERNAL_SERVICE_TOKEN) {
     return { status: 503, data: { error: 'Knowledge service not configured' } };

--- a/services/knowledge/app/routes/internal_admin.py
+++ b/services/knowledge/app/routes/internal_admin.py
@@ -180,6 +180,33 @@ class _ServiceClaims:
     sub: str
 
 
+class EntryCreateBody(BaseModel):
+    path: str
+    content: str
+
+
+@router.post("/entries/{agent_id}", status_code=201)
+async def create_entry(
+    agent_id: str,
+    body: EntryCreateBody,
+    request: Request,
+) -> dict[str, Any]:
+    """Create a knowledge entry for an agent (service-to-service)."""
+    _verify_service_token(request)
+    pool = request.app.state.pool
+    data_dir = request.app.state.settings.data_dir
+
+    claims = _ServiceClaims(sub=agent_id)
+    try:
+        entry = await knowledge_store.create_entry(
+            pool, data_dir, claims, body.path, body.content
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    return _serialize(entry)
+
+
 class JournalAppendBody(BaseModel):
     content: str
 

--- a/services/ui/src/__tests__/AgentKnowledge.test.tsx
+++ b/services/ui/src/__tests__/AgentKnowledge.test.tsx
@@ -46,7 +46,7 @@ describe('AgentKnowledge', () => {
   })
 
   it('renders search input and collections heading', async () => {
-    render(<AgentKnowledge agentName="TestBot" />)
+    render(<AgentKnowledge agentName="TestBot" agentId="test-bot" />)
 
     expect(screen.getByText('Search Knowledge')).toBeInTheDocument()
     expect(screen.getByTestId('knowledge-search-input')).toBeInTheDocument()
@@ -57,7 +57,7 @@ describe('AgentKnowledge', () => {
   })
 
   it('fetches and displays collections', async () => {
-    render(<AgentKnowledge agentName="TestBot" />)
+    render(<AgentKnowledge agentName="TestBot" agentId="test-bot" />)
 
     await waitFor(() => {
       expect(screen.getByTestId('collections-list')).toBeInTheDocument()
@@ -67,7 +67,7 @@ describe('AgentKnowledge', () => {
   })
 
   it('shows visibility badges', async () => {
-    render(<AgentKnowledge agentName="TestBot" />)
+    render(<AgentKnowledge agentName="TestBot" agentId="test-bot" />)
 
     await waitFor(() => {
       expect(screen.getByText('shared')).toBeInTheDocument()
@@ -80,7 +80,7 @@ describe('AgentKnowledge', () => {
       Promise.resolve({ ok: true, json: () => Promise.resolve([]) })
     )
 
-    render(<AgentKnowledge agentName="TestBot" />)
+    render(<AgentKnowledge agentName="TestBot" agentId="test-bot" />)
 
     await waitFor(() => {
       expect(screen.getByTestId('no-collections')).toBeInTheDocument()
@@ -88,7 +88,7 @@ describe('AgentKnowledge', () => {
   })
 
   it('searches and displays results', async () => {
-    render(<AgentKnowledge agentName="TestBot" />)
+    render(<AgentKnowledge agentName="TestBot" agentId="test-bot" />)
 
     await waitFor(() => {
       expect(screen.getByText('Platform Docs')).toBeInTheDocument()
@@ -116,7 +116,7 @@ describe('AgentKnowledge', () => {
       return Promise.resolve({ ok: false })
     })
 
-    render(<AgentKnowledge agentName="TestBot" />)
+    render(<AgentKnowledge agentName="TestBot" agentId="test-bot" />)
 
     await waitFor(() => {
       expect(screen.getByText('Platform Docs')).toBeInTheDocument()
@@ -132,7 +132,7 @@ describe('AgentKnowledge', () => {
   })
 
   it('includes agent name in description', async () => {
-    render(<AgentKnowledge agentName="ResearchBot" />)
+    render(<AgentKnowledge agentName="ResearchBot" agentId="research-bot" />)
 
     expect(screen.getByText(/ResearchBot/)).toBeInTheDocument()
   })

--- a/services/ui/src/app/agents/[id]/AgentDetailClient.tsx
+++ b/services/ui/src/app/agents/[id]/AgentDetailClient.tsx
@@ -1450,7 +1450,7 @@ export default function AgentDetailClient({
       )}
 
       {activeTab === 'knowledge' && agent && (
-        <AgentKnowledge agentName={agent.name} />
+        <AgentKnowledge agentName={agent.name} agentId={agent.agent_id} />
       )}
 
       {activeTab === 'activity' && (

--- a/services/ui/src/app/agents/[id]/AgentKnowledge.tsx
+++ b/services/ui/src/app/agents/[id]/AgentKnowledge.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useEffect, useCallback } from 'react'
-import { Search, BookOpen, FileText } from 'lucide-react'
+import { Search, BookOpen, FileText, Plus, X } from 'lucide-react'
 
 interface Collection {
   id: string
@@ -21,13 +21,18 @@ interface SearchResult {
   collection_name: string
 }
 
-export default function AgentKnowledge({ agentName }: { agentName: string }) {
+export default function AgentKnowledge({ agentName, agentId }: { agentName: string; agentId: string }) {
   const [collections, setCollections] = useState<Collection[]>([])
   const [loading, setLoading] = useState(true)
   const [query, setQuery] = useState('')
   const [searching, setSearching] = useState(false)
   const [results, setResults] = useState<SearchResult[]>([])
   const [searched, setSearched] = useState(false)
+  const [showCreate, setShowCreate] = useState(false)
+  const [newPath, setNewPath] = useState('')
+  const [newContent, setNewContent] = useState('')
+  const [creating, setCreating] = useState(false)
+  const [createError, setCreateError] = useState<string | null>(null)
 
   const fetchCollections = useCallback(async () => {
     try {
@@ -66,8 +71,88 @@ export default function AgentKnowledge({ agentName }: { agentName: string }) {
     }
   }
 
+  const handleCreate = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!newPath.trim() || !newContent.trim()) return
+
+    setCreating(true)
+    setCreateError(null)
+    try {
+      const res = await fetch('/api/knowledge/entries', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ agent_id: agentId, path: newPath.trim(), content: newContent.trim() }),
+      })
+      if (res.ok) {
+        setShowCreate(false)
+        setNewPath('')
+        setNewContent('')
+      } else {
+        const data = await res.json()
+        setCreateError(data.error || data.detail || 'Failed to create entry')
+      }
+    } catch {
+      setCreateError('Failed to create entry')
+    } finally {
+      setCreating(false)
+    }
+  }
+
   return (
     <div className="space-y-6">
+      {/* Create entry toggle */}
+      <div className="flex justify-end">
+        <button
+          onClick={() => setShowCreate(prev => !prev)}
+          className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md bg-brand-600 hover:bg-brand-500 text-white transition-colors cursor-pointer"
+        >
+          {showCreate ? <X size={14} /> : <Plus size={14} />}
+          {showCreate ? 'Cancel' : 'New Entry'}
+        </button>
+      </div>
+
+      {/* Create entry form */}
+      {showCreate && (
+        <div className="rounded-lg border border-navy-700 bg-navy-800 p-5">
+          <h2 className="text-lg font-semibold text-white mb-3">Create Knowledge Entry</h2>
+          <form onSubmit={handleCreate} className="space-y-3">
+            <div>
+              <label className="block text-xs text-mountain-400 mb-1">Path</label>
+              <input
+                type="text"
+                value={newPath}
+                onChange={(e) => setNewPath(e.target.value)}
+                placeholder="notes/my-entry.md"
+                className="w-full rounded-md border border-navy-600 bg-navy-900 px-3 py-2 text-sm text-white placeholder-mountain-500 focus:border-brand-500 focus:outline-none"
+                data-testid="create-path-input"
+              />
+            </div>
+            <div>
+              <label className="block text-xs text-mountain-400 mb-1">Content</label>
+              <textarea
+                value={newContent}
+                onChange={(e) => setNewContent(e.target.value)}
+                placeholder={"---\ntitle: My Entry\ntype: note\n---\n\nEntry content here..."}
+                rows={8}
+                className="w-full rounded-md border border-navy-600 bg-navy-900 px-3 py-2 text-sm text-white placeholder-mountain-500 focus:border-brand-500 focus:outline-none font-mono resize-y"
+                data-testid="create-content-input"
+              />
+              <p className="text-xs text-mountain-500 mt-1">Include YAML frontmatter with title, type (note/plan/decision/journal/research), and optional tags.</p>
+            </div>
+            {createError && (
+              <p className="text-sm text-red-400">{createError}</p>
+            )}
+            <button
+              type="submit"
+              disabled={!newPath.trim() || !newContent.trim() || creating}
+              className="px-4 py-2 text-sm font-medium rounded-lg bg-brand-600 hover:bg-brand-500 text-white transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {creating ? 'Creating...' : 'Create Entry'}
+            </button>
+          </form>
+        </div>
+      )}
+
       {/* Search */}
       <div className="rounded-lg border border-navy-700 bg-navy-800 p-5">
         <h2 className="text-lg font-semibold text-white mb-3">Search Knowledge</h2>


### PR DESCRIPTION
## Summary
- Adds a **New Entry** button to the agent Knowledge tab that opens an inline form
- Form has **path** (e.g. `notes/my-entry.md`) and **content** fields (supports YAML frontmatter)
- New `POST /knowledge/entries` API route with ownership check
- New `createEntry` function in `akm-proxy.ts`
- New `POST /internal/admin/entries/{agent_id}` endpoint on knowledge service
- Updated test mocks to include new `agentId` prop

## Files changed
- `services/ui/src/app/agents/[id]/AgentKnowledge.tsx` — form UI, create handler
- `services/ui/src/app/agents/[id]/AgentDetailClient.tsx` — pass `agentId` prop
- `services/ui/src/__tests__/AgentKnowledge.test.tsx` — add `agentId` to test renders
- `services/api/src/routes/knowledge.ts` — POST /entries route
- `services/api/src/services/akm-proxy.ts` — createEntry proxy function
- `services/knowledge/app/routes/internal_admin.py` — POST /entries/{agent_id} endpoint

## Test plan
- [ ] Open agent detail → Knowledge tab → click New Entry
- [ ] Fill path and content with frontmatter → submit → entry created
- [ ] Missing fields → button disabled
- [ ] Non-owned agent → 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)