### PR TITLE
fix: wrap save_knowledge content with YAML frontmatter

### DIFF
--- a/services/agentbox/app/tools.py
+++ b/services/agentbox/app/tools.py
@@ -398,6 +398,11 @@ async def _execute_save_knowledge(args: dict) -> str:
     if not akm_url or not akm_token:
         return json.dumps({"success": False, "error": "AKM not configured"})
 
+    # AKM requires YAML frontmatter — wrap content if not already present
+    if not content.startswith("---"):
+        entry_type = path.split("/")[0] if "/" in path else "note"
+        content = f"---\ntype: {entry_type}\n---\n{content}"
+
     try:
         async with httpx.AsyncClient(timeout=15) as client:
             res = await client.post(


### PR DESCRIPTION
## Summary
The `save_knowledge` tool in agentbox sends content to the AKM service, but AKM requires every entry to begin with YAML frontmatter (`---\n...\n---`). Without it, `parse_frontmatter()` raises `FrontmatterError: content must begin with frontmatter (---)` and AKM returns 500.

**Fix**: If content doesn't already start with `---`, wrap it with frontmatter automatically, deriving `type` from the path prefix (e.g., `notes/foo.md` → `type: notes`).

## Root cause evidence
```
agentbox log: HTTP Request: POST http://knowledge:8002/api/v1/entries "HTTP/1.1 500 Internal Server Error"
knowledge log: FrontmatterError: content must begin with frontmatter (---)
```

## Test plan
- [ ] Rebuild agentbox image, restart agent
- [ ] Chat: "save a note at notes/test.md with content: '# Test'"
- [ ] Verify AKM returns 201 (not 500)
- [ ] Check `/harness/knowledge` — entry appears
- [ ] Chat: "search_knowledge for 'Test'" — verify it finds the entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)