### PR TITLE
fix: add required title field to save_knowledge frontmatter

### DIFF
--- a/services/agentbox/app/tools.py
+++ b/services/agentbox/app/tools.py
@@ -398,10 +398,15 @@ async def _execute_save_knowledge(args: dict) -> str:
     if not akm_url or not akm_token:
         return json.dumps({"success": False, "error": "AKM not configured"})
 
-    # AKM requires YAML frontmatter — wrap content if not already present
+    # AKM requires YAML frontmatter with title + type — wrap if not present
     if not content.startswith("---"):
-        entry_type = path.split("/")[0] if "/" in path else "note"
-        content = f"---\ntype: {entry_type}\n---\n{content}"
+        valid_types = {"plan", "decision", "journal", "research", "context", "note", "notebook"}
+        path_prefix = path.split("/")[0].rstrip("s") if "/" in path else "note"
+        entry_type = path_prefix if path_prefix in valid_types else "note"
+        # Derive title from filename
+        filename = path.rsplit("/", 1)[-1].rsplit(".", 1)[0] if "/" in path else path.rsplit(".", 1)[0]
+        title = filename.replace("-", " ").replace("_", " ").title()
+        content = f"---\ntitle: {title}\ntype: {entry_type}\n---\n{content}"
 
     try:
         async with httpx.AsyncClient(timeout=15) as client:


### PR DESCRIPTION
## Summary
Follow-up to PR #472. AKM requires both `title` and `type` in frontmatter (`REQUIRED_FIELDS = ("title", "type")`). PR #472 only added `type`, so entries still failed with `FrontmatterError: required frontmatter field missing: title`.

**Fix**: Derives title from the filename (e.g., `notes/browser-features.md` → `Browser Features`). Also validates type against AKM's `VALID_TYPES` set and strips trailing 's' from path prefix (`notes/` → `note`).

## Test plan
- [ ] Rebuild agentbox, restart agent
- [ ] Chat: "save_knowledge at notes/test-note.md with content: '# Test'"
- [ ] Verify AKM returns 201
- [ ] Check `/harness/knowledge` — entry appears with title "Test Note"

🤖 Generated with [Claude Code](https://claude.com/claude-code)