### PR TITLE
feat: add http_request tool for external API calls (AI-217)

### DIFF
--- a/services/agentbox/app/tools.py
+++ b/services/agentbox/app/tools.py
@@ -300,6 +300,42 @@ SEARCH_SHARED_KNOWLEDGE_TOOL = {
     },
 }
 
+HTTP_REQUEST_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "http_request",
+        "description": (
+            "Make an HTTP request to an external API. Supports GET and POST. "
+            "Blocked: internal IPs, loopback, RFC1918, Tailscale/CGNAT ranges. "
+            "Max response 1MB, 30s timeout. Use for calling public REST APIs."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "enum": ["GET", "POST"],
+                    "description": "HTTP method",
+                },
+                "url": {
+                    "type": "string",
+                    "description": "Full URL (must be https:// or http://)",
+                },
+                "headers": {
+                    "type": "object",
+                    "description": "Optional request headers (e.g. {\"Authorization\": \"Bearer ...\"})",
+                },
+                "body": {
+                    "type": "string",
+                    "description": "Request body for POST (JSON string)",
+                },
+            },
+            "required": ["method", "url"],
+        },
+    },
+}
+
+
 def build_tool_definitions(tools_config: ToolsConfig) -> list[dict]:
     """Build the tools array for the LLM request based on agent config."""
     definitions: list[dict] = []
@@ -316,6 +352,9 @@ def build_tool_definitions(tools_config: ToolsConfig) -> list[dict]:
     # browser is available when shell is enabled (chromium is pre-installed)
     if tools_config.shell.enabled:
         definitions.append(BROWSER_TOOL)
+    # http_request available when shell is enabled
+    if tools_config.shell.enabled:
+        definitions.append(HTTP_REQUEST_TOOL)
     # knowledge tools available when AKM is configured
     import os
     if os.environ.get("AKM_TOKEN") and os.environ.get("AKM_SERVICE_URL"):
@@ -379,6 +418,9 @@ async def execute_tool_call(
 
     if name == "search_shared_knowledge":
         return await _execute_search_shared_knowledge(arguments)
+
+    if name == "http_request":
+        return await _execute_http_request(arguments)
 
     return json.dumps({"success": False, "error": f"Unknown tool: {name}"})
 
@@ -817,5 +859,95 @@ async def _execute_browser(args: dict) -> str:
         else:
             return json.dumps({"success": False, "error": f"Unknown browser action: {action}"})
 
+    except Exception as exc:
+        return json.dumps({"success": False, "error": str(exc)[:300]})
+
+
+# ── HTTP Request tool ────────────────────────────────────────────────
+
+_MAX_RESPONSE_BYTES = 1024 * 1024  # 1 MB
+_HTTP_TIMEOUT = 30.0
+
+
+def _is_blocked_ip(host: str) -> bool:
+    """Check if a hostname resolves to a blocked IP range (SSRF protection).
+
+    Blocks: loopback, RFC1918 (10/8, 172.16/12, 192.168/16), link-local,
+    reserved, Tailscale/CGNAT (100.64.0.0/10), IPv6 private/loopback.
+    """
+    import ipaddress
+    import socket
+
+    try:
+        addrs = socket.getaddrinfo(host, None, socket.AF_UNSPEC, socket.SOCK_STREAM)
+    except socket.gaierror:
+        return False  # DNS failure handled by httpx
+
+    for _family, _, _, _, sockaddr in addrs:
+        try:
+            addr = ipaddress.ip_address(sockaddr[0])
+        except ValueError:
+            continue
+        if addr.is_loopback or addr.is_private or addr.is_link_local or addr.is_reserved:
+            return True
+        if isinstance(addr, ipaddress.IPv4Address):
+            if addr in ipaddress.ip_network("100.64.0.0/10"):
+                return True
+    return False
+
+
+async def _execute_http_request(args: dict) -> str:
+    """Make an HTTP GET/POST request to an external API with safety checks."""
+    import httpx
+    from urllib.parse import urlparse
+
+    method = args.get("method", "GET").upper()
+    url = args.get("url", "")
+    headers = args.get("headers") or {}
+    body = args.get("body", "")
+
+    if method not in ("GET", "POST"):
+        return json.dumps({"success": False, "error": "method must be GET or POST"})
+    if not url:
+        return json.dumps({"success": False, "error": "url is required"})
+
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        return json.dumps({"success": False, "error": "url must use http:// or https://"})
+    if not parsed.hostname:
+        return json.dumps({"success": False, "error": "url has no hostname"})
+    if _is_blocked_ip(parsed.hostname):
+        return json.dumps({"success": False, "error": "blocked: internal/private IP address"})
+
+    # Sanitize headers
+    safe_headers = {}
+    for k, v in headers.items():
+        if k.lower() not in ("host", "transfer-encoding"):
+            safe_headers[k] = str(v)
+
+    try:
+        async with httpx.AsyncClient(
+            timeout=_HTTP_TIMEOUT,
+            follow_redirects=True,
+            max_redirects=5,
+        ) as client:
+            if method == "GET":
+                resp = await client.get(url, headers=safe_headers)
+            else:
+                resp = await client.post(url, headers=safe_headers, content=body)
+
+            resp_body = resp.text
+            if len(resp_body) > _MAX_RESPONSE_BYTES:
+                resp_body = resp_body[:_MAX_RESPONSE_BYTES] + "\n...(truncated at 1MB)"
+
+            return json.dumps({
+                "success": True,
+                "status": resp.status_code,
+                "headers": dict(list(resp.headers.items())[:20]),
+                "body": resp_body,
+                "url": str(resp.url),
+            })
+    except httpx.TimeoutException:
+        return json.dumps({"success": False, "error": f"Request timed out after {_HTTP_TIMEOUT}s"})
     except Exception as exc:
         return json.dumps({"success": False, "error": str(exc)[:300]})

--- a/services/ui/src/app/agents/[id]/AgentDetailClient.tsx
+++ b/services/ui/src/app/agents/[id]/AgentDetailClient.tsx
@@ -142,6 +142,13 @@ export default function AgentDetailClient({
   const [fileLoading, setFileLoading] = useState(false)
   const [fileError, setFileError] = useState<string | null>(null)
 
+  // Summary stats
+  const [summaryStats, setSummaryStats] = useState<{
+    total_inferences: number; total_tokens: number; estimated_cost: number;
+    chat_messages: number; knowledge_entries: number; total_uptime_seconds: number;
+    skills_assigned: number; distinct_models: number;
+  } | null>(null)
+
   // Activity sub-view state
   const [activityView, setActivityView] = useState<'timeline' | 'events' | 'logs'>('timeline')
 
@@ -252,6 +259,15 @@ export default function AgentDetailClient({
     const interval = setInterval(fetchAgent, 10000)
     return () => clearInterval(interval)
   }, [agent?.status, fetchAgent])
+
+  // Fetch summary stats for overview tab
+  useEffect(() => {
+    if (activeTab !== 'overview' || !agent) return
+    fetch(`/api/agents/${agentId}/stats`)
+      .then(res => res.ok ? res.json() : null)
+      .then(data => { if (data) setSummaryStats(data) })
+      .catch(() => {})
+  }, [activeTab, agent, agentId])
 
   // Fetch model policy name
   useEffect(() => {
@@ -788,6 +804,53 @@ export default function AgentDetailClient({
               </div>
             )}
           </div>
+
+          {/* Activity Summary */}
+          {summaryStats && (
+            <div className="rounded-lg border border-navy-700 bg-navy-800 p-5">
+              <h2 className="text-lg font-semibold text-white mb-3">Activity Summary</h2>
+              <dl className="grid grid-cols-2 sm:grid-cols-4 gap-4 text-sm">
+                <div>
+                  <dt className="text-mountain-400">Messages</dt>
+                  <dd className="text-white mt-1 text-lg font-mono">{summaryStats.chat_messages.toLocaleString()}</dd>
+                </div>
+                <div>
+                  <dt className="text-mountain-400">Inferences</dt>
+                  <dd className="text-white mt-1 text-lg font-mono">{summaryStats.total_inferences.toLocaleString()}</dd>
+                </div>
+                <div>
+                  <dt className="text-mountain-400">Tokens Used</dt>
+                  <dd className="text-white mt-1 text-lg font-mono">{summaryStats.total_tokens.toLocaleString()}</dd>
+                </div>
+                <div>
+                  <dt className="text-mountain-400">Est. Cost</dt>
+                  <dd className="text-white mt-1 text-lg font-mono">${summaryStats.estimated_cost.toFixed(2)}</dd>
+                </div>
+                <div>
+                  <dt className="text-mountain-400">Knowledge Entries</dt>
+                  <dd className="text-white mt-1 text-lg font-mono">{summaryStats.knowledge_entries}</dd>
+                </div>
+                <div>
+                  <dt className="text-mountain-400">Skills</dt>
+                  <dd className="text-white mt-1 text-lg font-mono">{summaryStats.skills_assigned}</dd>
+                </div>
+                <div>
+                  <dt className="text-mountain-400">Models Used</dt>
+                  <dd className="text-white mt-1 text-lg font-mono">{summaryStats.distinct_models}</dd>
+                </div>
+                <div>
+                  <dt className="text-mountain-400">Total Uptime</dt>
+                  <dd className="text-white mt-1 text-lg font-mono">
+                    {summaryStats.total_uptime_seconds >= 86400
+                      ? `${Math.floor(summaryStats.total_uptime_seconds / 86400)}d ${Math.floor((summaryStats.total_uptime_seconds % 86400) / 3600)}h`
+                      : summaryStats.total_uptime_seconds >= 3600
+                        ? `${Math.floor(summaryStats.total_uptime_seconds / 3600)}h ${Math.floor((summaryStats.total_uptime_seconds % 3600) / 60)}m`
+                        : `${Math.floor(summaryStats.total_uptime_seconds / 60)}m`}
+                  </dd>
+                </div>
+              </dl>
+            </div>
+          )}
 
           {/* Description */}
           {agent.description && (


### PR DESCRIPTION
## Summary
Adds an `http_request` tool to agentbox that lets agents make HTTP GET/POST requests to external APIs with built-in safety.

## Safety measures
| Protection | Implementation |
|-----------|---------------|
| SSRF blocking | DNS pre-check blocks loopback, RFC1918, link-local, reserved, Tailscale/CGNAT (100.64.0.0/10) |
| Response size | Max 1MB, truncated with warning |
| Timeout | 30 seconds |
| Redirects | Max 5 hops |
| Header sanitization | Strips `Host` and `Transfer-Encoding` |
| Methods | GET and POST only |

## Tool definition
```json
{
  "name": "http_request",
  "parameters": {
    "method": "GET|POST",
    "url": "https://api.example.com/data",
    "headers": {"Authorization": "Bearer ..."},
    "body": "{\"key\": \"value\"}"
  }
}
```

## Response format
```json
{
  "success": true,
  "status": 200,
  "headers": {"content-type": "application/json", ...},
  "body": "...",
  "url": "https://api.example.com/data"
}
```

## Availability
Enabled when `tools_config.shell.enabled` is true (same gate as browser/tmux).

## Test plan
- [ ] Rebuild agentbox, start agent
- [ ] Chat: "Use http_request to GET https://httpbin.org/get" — verify 200 response
- [ ] Chat: "Use http_request to POST https://httpbin.org/post with body {\"test\": true}" — verify echo
- [ ] Chat: "Use http_request to GET http://127.0.0.1:8080" — verify blocked
- [ ] Chat: "Use http_request to GET http://169.254.169.254" — verify blocked (link-local)

🤖 Generated with [Claude Code](https://claude.com/claude-code)