### PR TITLE
feat: inject ANTHROPIC_API_KEY into agent containers (AI-185)

### DIFF
--- a/deploy/compose/prod/docker-compose.api.yml
+++ b/deploy/compose/prod/docker-compose.api.yml
@@ -121,6 +121,7 @@ services:
       - PROVIDER_KEY_ENCRYPTION_KEY=${PROVIDER_KEY_ENCRYPTION_KEY}
       - MODEL_ROUTER_URL=http://ai:8000
       - CHAT_CALLBACK_TOKEN=${CHAT_CALLBACK_TOKEN}
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
     healthcheck:
       test: ["CMD", "node", "-e", "require('http').get('http://localhost:3000/health', (r) => {process.exit(r.statusCode === 200 ? 0 : 1)})"]
       interval: 30s

--- a/platform/vault/secrets-schema.yaml
+++ b/platform/vault/secrets-schema.yaml
@@ -115,6 +115,12 @@ runtime_secrets:
     compose_refs:
       - docker-compose.api.yml
 
+  # --- secret/shared/anthropic ---
+  - key: ANTHROPIC_API_KEY
+    vault_path: secret/shared/anthropic
+    compose_refs:
+      - docker-compose.api.yml
+
   # --- secret/auth/config ---
   - key: KC_ADMIN_USERNAME
     vault_path: secret/auth/config

--- a/platform/vault/secrets-schema.yaml
+++ b/platform/vault/secrets-schema.yaml
@@ -80,6 +80,7 @@ runtime_secrets:
     vault_path: secret/ai/config
     compose_refs:
       - docker-compose.ai.yml
+      - docker-compose.api.yml
 
   - key: OPENAI_API_KEY
     vault_path: secret/ai/config
@@ -112,12 +113,6 @@ runtime_secrets:
   # --- secret/shared/chat ---
   - key: CHAT_CALLBACK_TOKEN
     vault_path: secret/shared/chat
-    compose_refs:
-      - docker-compose.api.yml
-
-  # --- secret/shared/anthropic ---
-  - key: ANTHROPIC_API_KEY
-    vault_path: secret/shared/anthropic
     compose_refs:
       - docker-compose.api.yml
 

--- a/services/api/src/routes/agents.ts
+++ b/services/api/src/routes/agents.ts
@@ -1248,6 +1248,10 @@ router.post('/:id/start', requireRole('admin'), async (req: Request, res: Respon
     if (process.env.CHAT_CALLBACK_TOKEN) {
       chatEnv.push(`CHAT_CALLBACK_TOKEN=${process.env.CHAT_CALLBACK_TOKEN}`);
     }
+    // Claude Code CLI credential handoff (AI-185)
+    if (process.env.ANTHROPIC_API_KEY) {
+      chatEnv.push(`ANTHROPIC_API_KEY=${process.env.ANTHROPIC_API_KEY}`);
+    }
 
     // Resolve agent scope for network assignment
     const effectiveScope = await getAgentEffectiveScope(agent.id);


### PR DESCRIPTION
## Summary
- Inject ANTHROPIC_API_KEY into agent containers at start time so Claude Code CLI works inside agentbox
- Key sourced from existing vault path `secret/ai/config` (already in SOPS)
- Added compose ref to secrets schema for docker-compose.api.yml

## Plan
1. Add ANTHROPIC_API_KEY to API container env in docker-compose.api.yml
2. Pass it through to agentbox containers in agents.ts start flow
3. Update secrets schema to include api compose ref

## Risks
- Low: key already exists in vault/SOPS, just passing through to a new container
- If key is missing, agent starts without it — Claude Code won't work but agent functions normally

## Rollback
- Remove the env var from docker-compose.api.yml and agents.ts
- Redeploy API service

## Validation Evidence
- Secrets schema check passes (compose_refs aligned)
- Agent start flow unchanged — just one additional env var
- Claude Code --bare mode confirmed to accept ANTHROPIC_API_KEY in research phase

## Test plan
- [ ] Agent starts with ANTHROPIC_API_KEY in container env
- [ ] Claude Code CLI works inside agent container

🤖 Generated with [Claude Code](https://claude.com/claude-code)