### PR TITLE
fix: Ed25519 PEM key decoding — agents missing AKM and model-router tokens

### DIFF
--- a/services/api/src/services/akm-token.ts
+++ b/services/api/src/services/akm-token.ts
@@ -18,7 +18,7 @@ function getPrivateKey(): crypto.KeyObject {
   if (!AKM_SIGNING_PRIVATE_KEY) {
     throw new Error('AKM_SIGNING_PRIVATE_KEY not configured');
   }
-  cachedPrivateKey = crypto.createPrivateKey(AKM_SIGNING_PRIVATE_KEY);
+  cachedPrivateKey = crypto.createPrivateKey(AKM_SIGNING_PRIVATE_KEY.replace(/\\n/g, '\n'));
   return cachedPrivateKey;
 }
 

--- a/services/api/src/services/model-router-token.ts
+++ b/services/api/src/services/model-router-token.ts
@@ -18,7 +18,7 @@ function getPrivateKey(): crypto.KeyObject {
   if (!MODEL_ROUTER_SIGNING_PRIVATE_KEY) {
     throw new Error('MODEL_ROUTER_SIGNING_PRIVATE_KEY not configured');
   }
-  cachedPrivateKey = crypto.createPrivateKey(MODEL_ROUTER_SIGNING_PRIVATE_KEY);
+  cachedPrivateKey = crypto.createPrivateKey(MODEL_ROUTER_SIGNING_PRIVATE_KEY.replace(/\\n/g, '\n'));
   return cachedPrivateKey;
 }
 


### PR DESCRIPTION
## Summary
- Ed25519 private keys from SOPS/vault have literal `\n` strings instead of real newlines
- `crypto.createPrivateKey()` fails with `DECODER routines::unsupported`
- Agents start without AKM_TOKEN or MODEL_ROUTER_TOKEN — knowledge tools and model-router auth broken
- Fix: `.replace(/\\n/g, '\n')` before passing to createPrivateKey

## Plan
1. Fix akm-token.ts getPrivateKey to handle escaped newlines
2. Fix model-router-token.ts getPrivateKey same way

## Risks
- None: only affects key parsing, no functional change if key already has real newlines

## Rollback
- Revert the two-line change

## Validation Evidence
- Confirmed key decodes successfully after newline fix via `docker exec api node -e` test
- Ed25519 key type and asymmetricKeyType confirmed correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)