### PR TITLE
fix: reduce dashboard polling interval from 60s to 30s

### DIFF
--- a/services/ui/src/app/dashboard/DashboardClient.tsx
+++ b/services/ui/src/app/dashboard/DashboardClient.tsx
@@ -38,7 +38,7 @@ interface RecentThread {
   updated_at: string
 }
 
-const REFRESH_INTERVAL = 60_000
+const REFRESH_INTERVAL = 30_000
 
 function sevenDaysAgo(): string {
   const d = new Date()


### PR DESCRIPTION
## Summary
Changes `REFRESH_INTERVAL` from 60,000ms to 30,000ms in DashboardClient.tsx. The dashboard already polls all stats (running agents, chat threads, messages today, health checks, harness overview) on this interval — this just makes it more responsive.

## Test plan
- [x] One-line change, no logic changes
- [ ] Visit dashboard, verify stats refresh every ~30s

🤖 Generated with [Claude Code](https://claude.com/claude-code)