### PR TITLE
fix(vault): stop init printing the unseal key and root token (JON-45)

### DIFF
--- a/docs/runbooks/vault-unseal.md
+++ b/docs/runbooks/vault-unseal.md
@@ -2,6 +2,23 @@
 
 OpenBao (vault) starts sealed after every container restart. This runbook covers the auto-unseal mechanisms and manual fallback.
 
+> **Fresh initialization (2026-07-26).** `vault.sh init` no longer prints the
+> unseal key or root token. It writes both to `0600` files owned by whoever
+> runs it — on the host that is `deploy`, which is what the auto-unseal systemd
+> unit runs as. The previous instructions said to `sudo tee` the unseal key,
+> which produced a **root-owned** file the unit could not read, so auto-unseal
+> would have failed on the first reboot. Do not reintroduce `sudo` there.
+>
+> After `setup` and `seed`, run `bash scripts/vault.sh revoke-root`. It revokes
+> the root token, verifies independently that it is dead (`bao token revoke
+> -self` reports success even for a token that never existed), and removes the
+> file.
+>
+> The unseal key must also reach SOPS as `OPENBAO_UNSEAL_KEY`. The host
+> checkout is `git reset --hard` on every deploy, so a SOPS edit made on the
+> host is discarded — it has to be committed from a workstation.
+
+
 ## How Auto-Unseal Works
 
 The `vault.sh auto-unseal` command:

--- a/scripts/vault.sh
+++ b/scripts/vault.sh
@@ -7,8 +7,12 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/_common.sh"
 
-CONTAINER_NAME="openbao"
-UNSEAL_KEY_PATH="/opt/hill90/secrets/openbao-unseal.key"
+CONTAINER_NAME="${VAULT_CONTAINER:-openbao}"
+UNSEAL_KEY_PATH="${VAULT_UNSEAL_KEY_PATH:-/opt/hill90/secrets/openbao-unseal.key}"
+# The root token is written to a file rather than printed. It is deliberately
+# short-lived: revoke it with `vault.sh revoke-root` as soon as setup and seed
+# are done.
+ROOT_TOKEN_PATH="${VAULT_ROOT_TOKEN_PATH:-/opt/hill90/secrets/openbao-root.token}"
 SECRETS_FILE="${PROJECT_ROOT}/infra/secrets/prod.enc.env"
 POLICY_DIR="${PROJECT_ROOT}/platform/vault/policies"
 
@@ -26,7 +30,8 @@ Vault CLI — OpenBao secrets management lifecycle
 Usage: vault.sh <command>
 
 Commands:
-  init          Initialize OpenBao (generates unseal key + root token)
+  init          Initialize OpenBao (writes unseal key + root token to 0600 files)
+  revoke-root   Revoke the root token and remove it from disk
   unseal        Unseal OpenBao using host key file or SOPS fallback
   status        Show OpenBao seal/init status
   setup         Enable KV v2, AppRole, audit, apply policies, create roles
@@ -88,31 +93,109 @@ cmd_init() {
         return 0
     fi
 
+    # Both secrets are written straight to 0600 files and never printed.
+    #
+    # This used to echo the unseal key and root token to stdout. Anywhere this
+    # runs — an SSH session, a CI job, a terminal with scrollback — that is a
+    # durable copy of the two credentials that together are complete control of
+    # the vault. There is no safe terminal to print them to, so they are not
+    # printed at all.
+    #
+    # Files are created by whoever runs this (the deploy user on the host), so
+    # they end up deploy:deploy. The previous instructions said to `sudo tee`
+    # the unseal key, which produced a root-owned file that the auto-unseal
+    # systemd unit — running as User=deploy — could not read. That would have
+    # meant a vault which never came back after a reboot.
+    local key_dir
+    key_dir="$(dirname "$UNSEAL_KEY_PATH")"
+    mkdir -p "$key_dir"
+
     echo "Initializing with 1 key share, 1 key threshold..."
+
+    # umask before creation: never let the file exist world-readable, even for
+    # the instant between creat() and chmod().
+    local old_umask
+    old_umask=$(umask)
+    umask 077
+
     local init_output
     init_output=$(bao_exec operator init -key-shares=1 -key-threshold=1 -format=json)
 
-    local unseal_key
-    unseal_key=$(echo "$init_output" | python3 -c "import sys,json; print(json.load(sys.stdin)['unseal_keys_b64'][0])")
-    local root_token
-    root_token=$(echo "$init_output" | python3 -c "import sys,json; print(json.load(sys.stdin)['root_token'])")
+    printf '%s' "$init_output" \
+        | python3 -c "import sys,json; sys.stdout.write(json.load(sys.stdin)['unseal_keys_b64'][0])" \
+        > "$UNSEAL_KEY_PATH"
+    printf '%s' "$init_output" \
+        | python3 -c "import sys,json; sys.stdout.write(json.load(sys.stdin)['root_token'])" \
+        > "$ROOT_TOKEN_PATH"
 
-    echo ""
-    echo "================================"
-    echo "SAVE THESE VALUES SECURELY"
-    echo "================================"
-    echo ""
-    echo "Unseal Key: ${unseal_key}"
-    echo "Root Token: ${root_token}"
+    unset init_output
+    umask "$old_umask"
+
+    chmod 600 "$UNSEAL_KEY_PATH" "$ROOT_TOKEN_PATH"
+
+    if [ ! -s "$UNSEAL_KEY_PATH" ] || [ ! -s "$ROOT_TOKEN_PATH" ]; then
+        die "Initialization produced an empty key or token file — refusing to continue. Vault is initialized but the credentials were not captured; recover from ${UNSEAL_KEY_PATH} manually before restarting."
+    fi
+
+    success "✓ Unseal key written to ${UNSEAL_KEY_PATH} (0600, $(stat -c '%U:%G' "$UNSEAL_KEY_PATH" 2>/dev/null || stat -f '%Su:%Sg' "$UNSEAL_KEY_PATH"))"
+    success "✓ Root token written to ${ROOT_TOKEN_PATH} (0600)"
     echo ""
     echo "Next steps:"
-    echo "  1. Store unseal key in SOPS: make secrets-update KEY=OPENBAO_UNSEAL_KEY VALUE=\"${unseal_key}\""
-    echo "  2. Copy to host: echo \"${unseal_key}\" | sudo tee ${UNSEAL_KEY_PATH} && sudo chmod 0600 ${UNSEAL_KEY_PATH}"
-    echo "  3. Unseal: bash scripts/vault.sh unseal"
-    echo "  4. Setup: export BAO_TOKEN=\"${root_token}\" && bash scripts/vault.sh setup"
-    echo "  5. Seed: bash scripts/vault.sh seed"
-    echo "  6. Revoke root token: docker exec openbao bao token revoke -self"
+    echo "  1. Unseal:        bash scripts/vault.sh unseal"
+    echo "  2. Setup:         BAO_TOKEN=\"\$(cat ${ROOT_TOKEN_PATH})\" bash scripts/vault.sh setup"
+    echo "  3. Seed:          BAO_TOKEN=\"\$(cat ${ROOT_TOKEN_PATH})\" bash scripts/vault.sh seed"
+    echo "  4. Revoke root:   bash scripts/vault.sh revoke-root"
     echo ""
+    echo "  The unseal key must ALSO be stored in SOPS as OPENBAO_UNSEAL_KEY, so"
+    echo "  it survives loss of this host. The host checkout is reset on every"
+    echo "  deploy, so that has to be committed from a workstation — see"
+    echo "  docs/runbooks/vault-unseal.md."
+    echo ""
+}
+
+# Revoke the root token and remove it from disk.
+#
+# A root token is unconstrained and does not expire. Once setup and seed have
+# run, nothing needs it — day-to-day access is by AppRole. Leaving it on the
+# filesystem is the single largest standing risk in this design.
+cmd_revoke_root() {
+    require_running
+
+    if [ ! -f "$ROOT_TOKEN_PATH" ]; then
+        warn "No root token file at ${ROOT_TOKEN_PATH} — nothing to revoke."
+        return 0
+    fi
+
+    local token
+    token=$(cat "$ROOT_TOKEN_PATH")
+    if [ -z "$token" ]; then
+        warn "Root token file is empty; removing it."
+        rm -f "$ROOT_TOKEN_PATH"
+        return 0
+    fi
+
+    echo "Revoking root token..."
+    docker exec -e "BAO_ADDR=http://127.0.0.1:8200" -e "BAO_TOKEN=${token}" \
+        "$CONTAINER_NAME" bao token revoke -self >/dev/null 2>&1 || true
+
+    # Verify independently. `token revoke -self` prints "Revoked token (if it
+    # existed)" and exits 0 regardless, so its exit code proves nothing.
+    if ! docker exec -e "BAO_ADDR=http://127.0.0.1:8200" -e "BAO_TOKEN=${token}" \
+            "$CONTAINER_NAME" bao token lookup >/dev/null 2>&1; then
+        success "✓ Root token revoked and confirmed dead"
+    else
+        unset token
+        die "Root token is STILL VALID after the revoke call. Do NOT leave this host until it is revoked — a live root token is unconstrained access to every secret."
+    fi
+    unset token
+
+    # Best-effort overwrite before unlinking.
+    if command -v shred >/dev/null 2>&1; then
+        shred -u "$ROOT_TOKEN_PATH" 2>/dev/null || rm -f "$ROOT_TOKEN_PATH"
+    else
+        rm -f "$ROOT_TOKEN_PATH"
+    fi
+    success "✓ Removed ${ROOT_TOKEN_PATH}"
 }
 
 cmd_unseal() {
@@ -132,6 +215,11 @@ cmd_unseal() {
 
     # Try host key file first
     if [ -f "$UNSEAL_KEY_PATH" ]; then
+        if [ ! -r "$UNSEAL_KEY_PATH" ]; then
+            # Almost always a root-owned file and a deploy-user caller. Say so,
+            # rather than dying inside a command substitution.
+            die "Unseal key at ${UNSEAL_KEY_PATH} exists but is not readable by $(id -un). It must be owned by deploy:deploy with mode 0600 — the auto-unseal systemd unit runs as deploy."
+        fi
         unseal_key=$(cat "$UNSEAL_KEY_PATH")
         info "Using unseal key from ${UNSEAL_KEY_PATH}"
     fi
@@ -636,6 +724,7 @@ main() {
 
     case "$cmd" in
         init)          cmd_init "$@" ;;
+        revoke-root)   cmd_revoke_root "$@" ;;
         unseal)        cmd_unseal "$@" ;;
         status)        cmd_status "$@" ;;
         setup)         cmd_setup "$@" ;;


### PR DESCRIPTION
Relates to JON-45. **The vault is not initialized and I did not initialize it** — see "Why I stopped" below. This PR is the code fix that has to land before anyone runs `init` safely.

## The defect

`vault.sh init` printed the unseal key and the root token to stdout, then printed them again inside the next-steps block. Together those two values are complete control of the vault, and there is no safe terminal to print them to — an SSH session, a CI job log, or shell scrollback all keep a durable copy. If this had been run through a workflow, both would now be sitting in GitHub Actions logs.

They are now written straight to `0600` files and never printed.

## Three more on the same path

**The documented procedure would have broken auto-unseal on the first reboot.** Step 2 said to `sudo tee` the unseal key to `/opt/hill90/secrets/openbao-unseal.key`. That produces a **root-owned** file — and `hill90-vault-unseal.service` runs as `User=deploy`. The unit could not have read it. Worse, `cmd_unseal` did `unseal_key=$(cat "$UNSEAL_KEY_PATH")` under `set -e`, so it would have died inside a command substitution with no useful message. `init` now creates the files as the invoking user, and `unseal` fails with an explicit ownership error:

```
$ chmod 000 <unseal key>; bash scripts/vault.sh unseal
ERROR: Unseal key at .../openbao-unseal.key exists but is not readable by jon.
It must be owned by deploy:deploy with mode 0600 — the auto-unseal systemd unit runs as deploy.
```

**No way to revoke the root token.** Added `vault.sh revoke-root`. A root token is unconstrained and never expires; once `setup` and `seed` have run, nothing needs it.

**Revocation verification was wrong — in my own first draft.** `bao token revoke -self` prints `Success! Revoked token (if it existed)` and exits 0 regardless, so its exit code proves nothing. I wrote a verification step using `bao token lookup -self` — and `-self` is not a valid flag, so that command *always* fails, which would have reported a live root token as revoked. I only caught it because the check fired "already invalid" on a token that then revoked successfully. It is `bao token lookup` with no argument.

## Verified against a real OpenBao 2 container, locally — not on the VPS

```
1. init                      -> 0 secret values printed
2. sealed after init         -> bao status exit 2  (2=sealed)
3. after unseal              -> bao status exit 0  (0=unsealed)
4. after container restart   -> bao status exit 2  (2=sealed)
5. after auto-unseal         -> bao status exit 0  (0=unsealed, survived restart)
6. health endpoint           -> HTTP 200
7. root token before revoke  -> lookup exit 0  (0=valid)
   ✓ Root token revoked and confirmed dead
8. root token after revoke   -> lookup exit 2  (2=dead)
9. vault still unsealed      -> bao status exit 0
```

Step 5 is the restart-survival proof. Steps 7→8 are the revocation proof with the *corrected* check — note step 7 confirms the token was genuinely live first, which is what made the earlier false positive visible.

Container name and both credential paths are overridable by env var so this is testable against a throwaway vault. Production defaults unchanged.

## Why I stopped before initializing

Three blockers, each independently sufficient:

**1. There is no non-SSH way to run `init`.** `deploy-vault.yml` runs `deploy.sh vault`, which calls `auto-unseal` — never `init`. No workflow initializes a vault. Initializing requires `bao operator init` on the host, which is a VPS-mutating command over SSH, which I was told not to run.

**2. The authorized deploy cannot succeed before init.** An uninitialized OpenBao returns **501** from `/v1/sys/health`, so the compose healthcheck fails and the container reports unhealthy. Measured, not assumed:

```
=== UNINITIALIZED vault ===
  health endpoint HTTP code: 501
  compose healthcheck (wget -q -O /dev/null) exit: 1
  bao status exit code: 2
```

`deploy.sh verify vault` polls docker health 30 times, so `gh workflow run deploy-vault.yml` would go red and leave an unhealthy container running. Running it would have been pointless mutation plus a false failure alert overnight.

**3. CI probably cannot reach the VPS at all.** See the JON-46 note below.

## Ground truth (read-only SSH, confirmed)

- No `openbao` container, running or stopped. No vault volume.
- `/opt/hill90` unchanged since the June 14 rebuild; no `openbao-unseal.key`.
- `hill90-vault-unseal.service` is enabled and active — it no-ops cleanly when the container is absent.
- No `OPENBAO_UNSEAL_KEY` in SOPS. Fresh init confirmed, not a restore.
- SOPS still holds **7 stale AppRole credential pairs** for services deleted in JON-27/28 (DB, API, AI, AUTH, UI, MCP, MINIO). Worth pruning.

## JON-46 — the stated cause is wrong

The weekly sync has **not** been failing because there is no vault. It never gets that far:

```
success   Setup Tailscale
success   Get Tailscale IP from secrets
failure   Verify SSH connectivity      <-- ssh: connect to host *** port 22: Connection timed out
skipped   Read sync token from SOPS
skipped   Run sync on VPS
```

And it has failed every week since **2026-06-01** — a fortnight *before* the June 14 rebuild, so the missing vault cannot explain the earlier failures either.

`TAILSCALE_IP` in SOPS is `100.88.29.112`, which matches the host's actual tailnet address, so it is not a stale-address problem. The runner simply cannot reach the host over Tailscale. No deploy workflow has run since **February 2026**, so there is no recent evidence that CI→VPS connectivity works at all — and `deploy-vault.yml` uses the same `reusable-deploy-service.yml` SSH path.

**So fixing JON-45 will not fix JON-46, and JON-46 likely blocks JON-45's deploy step.** My guess is the tailnet ACL for `tag:github-actions` → `tag:vps`, or the OAuth client, changed around the start of June — but that is a guess, and it is in the Tailscale admin console, not this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
