### PR TITLE
docs: record SOPS as the active secrets path (JON-45)

### DIFF
--- a/docs/architecture/secrets-model.md
+++ b/docs/architecture/secrets-model.md
@@ -1,5 +1,24 @@
 # Secrets Architecture
 
+> **Status as of 2026-07-26: SOPS is the active path. No vault is deployed.**
+>
+> There has been no `openbao` container, and no vault volume, since the June 14
+> rebuild. Every secret in use has been served by SOPS + age for six weeks,
+> without incident, and nothing noticed the vault was gone.
+>
+> The vault-first machinery below is **implemented and dormant**, not running.
+> `deploy.sh` still tries vault first and falls back to SOPS when it is absent
+> (`_common.sh:vault_available`), which is why deploys have kept working. The
+> design described in this document is therefore the *intended* model, not a
+> description of what is live.
+>
+> Whether to bring the vault back is an open question — see
+> [Vault vs SOPS](../decisions/vault-vs-sops.md). Until that is settled, read
+> this document as "how vault works here if enabled", and treat SOPS as the
+> system of record.
+
+## Intended model
+
 OpenBao is the runtime source of truth for secrets. SOPS is the bootstrap and disaster-recovery backup. Deploy is vault-first with SOPS fallback.
 
 ## Architecture Overview

--- a/docs/decisions/vault-vs-sops.md
+++ b/docs/decisions/vault-vs-sops.md
@@ -1,0 +1,103 @@
+# Vault vs SOPS: which is the secrets path?
+
+**Status:** open — this records the evidence and a recommendation. The call is
+Jon's.
+**Raised:** 2026-07-26 (JON-45)
+
+## What is actually true today
+
+- No `openbao` container has existed, running or stopped, since the June 14
+  rebuild. No vault volume, no `/opt/hill90/secrets/openbao-unseal.key`, and no
+  `OPENBAO_UNSEAL_KEY` in SOPS.
+- Every secret in use has been served by SOPS + age for six weeks. Nothing
+  broke, and nothing noticed.
+- `deploy.sh` is vault-first with a SOPS fallback. With no vault present,
+  `vault_available()` returns non-zero and every deploy silently takes the SOPS
+  path (`scripts/_common.sh:102-106`). That fallback is why the absence went
+  unremarked.
+- `hill90-vault-unseal.service` is enabled and active. It exits cleanly when the
+  container is absent, so it has been a no-op since June.
+- The weekly `vault-sync-to-sops` workflow has failed every run since
+  2026-06-01. It does not fail for want of a vault — it never gets that far; it
+  fails at `Verify SSH connectivity`. See JON-46.
+- SOPS still holds seven AppRole credential pairs (`VAULT_DB_*`, `VAULT_API_*`,
+  `VAULT_AI_*`, `VAULT_AUTH_*`, `VAULT_UI_*`, `VAULT_MCP_*`, `VAULT_MINIO_*`)
+  for services deleted in JON-27/28. They are dead weight whichever way this
+  goes.
+
+## What is actually being protected
+
+After the application strip, the live stacks are `infra` and `observability`.
+Between them the secrets are roughly:
+
+| Secret | Consumer | Shape |
+|---|---|---|
+| `TRAEFIK_ADMIN_PASSWORD_HASH` | Traefik dashboard | static, a bcrypt hash |
+| `HOSTINGER_API_KEY` | dns-manager | static, long-lived |
+| `GRAFANA_ADMIN_PASSWORD` | Grafana | static |
+| `ACME_EMAIL` | Traefik | not really a secret |
+
+All static. All read once, at deploy time. None rotated automatically today.
+
+## The case for each
+
+**Keep vault-first.** It is already written and it works. Per-service AppRoles
+give scoped access, there is an audit log, and revocation is possible. If the
+homelab grows something that needs dynamic credentials — a database, an
+application with per-environment secrets — the machinery is there rather than
+being a migration.
+
+**Make SOPS the documented path.** Three arguments, in increasing order of
+weight:
+
+1. *Nothing exercises what vault is for.* Four static values read at deploy
+   time use none of leasing, dynamic credentials, or revocation. The audit log
+   records a single AppRole login per deploy.
+
+2. *The operational burden is not small.* An unseal key that must exist in two
+   places and be backed up, a systemd unit with boot-order sensitivity, AppRole
+   bootstrap, root-token handling, a weekly sync job, and a volume that needs
+   its own backup. Each is a thing that can be wrong at 3am.
+
+3. *Vault's own disaster-recovery backup is SOPS.* This is the decisive one.
+   The unseal key lives in SOPS; the sync job exists to copy vault's contents
+   back into SOPS. So SOPS is already the root of trust and the recovery path.
+   Vault is a layer above something that must remain authoritative anyway — and
+   the job that keeps the two in step has never once succeeded.
+
+## Recommendation
+
+**Document SOPS as the active path. Keep the vault code, dormant.**
+
+Not "remove vault" — the implementation is decent and deleting it would be
+throwing away working code for no gain. But stop asserting a model that is not
+running, which is what
+[secrets-model.md](../architecture/secrets-model.md) did until this change.
+
+Reintroduce vault when there is a concrete consumer that needs something SOPS
+cannot do: dynamic credentials, short-lived leases, per-service revocation, or
+a real audit requirement. "It is good practice" is not that reason at this
+scale; six weeks of uneventful SOPS operation is evidence, not an accident.
+
+One legitimate counter-argument: this is a homelab, and running OpenBao for the
+experience of running OpenBao is a perfectly good reason. If that is the reason,
+it is worth making it explicitly — a deliberate "I want to operate a vault"
+rather than a default the documentation asserts on the reader's behalf.
+
+## If SOPS is chosen
+
+- Prune the seven stale AppRole pairs from SOPS.
+- Disable or delete the `vault-sync-to-sops` schedule. It has alerted failure
+  weekly since June; the alert has stopped carrying information.
+- Keep `scripts/vault.sh`, the compose file and the policies. Leave the
+  vault-first fallback in `deploy.sh` — it costs one failed `docker exec` per
+  deploy and means enabling vault later needs no code change.
+
+## If vault is chosen
+
+- JON-46 must be fixed first: CI cannot currently reach the VPS at all, so
+  neither the deploy nor the sync can run.
+- `vault.sh init` needed fixing before it was safe to run — it printed the
+  unseal key and root token. Done in PR #499.
+- There is still no non-SSH path to run `init`. Either add an init workflow or
+  accept a one-off manual initialization.


### PR DESCRIPTION
`docs/architecture/secrets-model.md` opened with:

> OpenBao is the runtime source of truth for secrets.

That has been false since the June 14 rebuild. There is no vault container, no vault volume, no unseal key on the host, and no `OPENBAO_UNSEAL_KEY` in SOPS. Every secret in use has been served by SOPS + age for six weeks.

The reason nobody noticed: `deploy.sh` is vault-first with a SOPS fallback, so with no vault present `vault_available()` returns non-zero and every deploy quietly takes the SOPS path. Good engineering, bad documentation — the doc described the *intended* model as though it were the running one.

## What this changes

- **`secrets-model.md`** — a status banner stating what is actually live, and the existing content relabelled as the intended model rather than a description of production.
- **`docs/decisions/vault-vs-sops.md`** — the evidence, the case for each option, and a recommendation.

## Deliberately does not decide

Status is `open`. The recommendation is to document SOPS as the active path and keep the vault code dormant, but the call is yours — including the entirely legitimate option of running a vault *because operating one is the point of a homelab*. That reason is called out explicitly so it doesn't get argued away by the operational-burden case.

## The load-bearing argument, if you only read one thing

Vault's own disaster-recovery backup **is** SOPS. The unseal key lives in SOPS; the weekly sync job exists to copy vault's contents back into SOPS. So SOPS is already the root of trust and the recovery path, and vault sits as a layer above something that must stay authoritative regardless — while the job that keeps the two in step has never once succeeded.

Against that: after the application strip there are ~4 static secrets, read once at deploy time, exercising none of leasing, dynamic credentials, or revocation.

## Also noted

SOPS still holds seven AppRole credential pairs (`VAULT_DB_*`, `VAULT_API_*`, `VAULT_AI_*`, `VAULT_AUTH_*`, `VAULT_UI_*`, `VAULT_MCP_*`, `VAULT_MINIO_*`) for services deleted in JON-27/28. Dead weight whichever way this goes — not removed here, since that is a secrets change and deserves its own review.

Markdown link check passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)