### PR TITLE
feat(vault): add a sanctioned workflow to initialize a fresh vault (JON-45)

### DIFF
--- a/.github/workflows/vault-init.yml
+++ b/.github/workflows/vault-init.yml
@@ -1,0 +1,223 @@
+name: Vault Initialize (Prod)
+
+# One-shot initialization of a FRESH OpenBao. Mints a new unseal key and root
+# token, so it destroys nothing but it cannot be undone either — an already
+# initialized vault must never be run through this.
+#
+# It exists because there was previously no sanctioned way to initialize:
+# deploy-vault.yml runs `deploy.sh vault`, which calls auto-unseal and never
+# init, so the only route was hand-running SSH. This is the workflow_dispatch
+# equivalent.
+#
+# Safe to run in CI only because `vault.sh init` no longer prints the unseal key
+# or the root token (see PR #499). Before that fix, running this would have put
+# both credentials in the Actions log permanently.
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: 'Type "initialize" to confirm. This mints a NEW unseal key and root token.'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: deploy-prod
+  cancel-in-progress: false
+
+jobs:
+  init:
+    name: Initialize OpenBao
+    runs-on: ubuntu-latest
+    environment: production
+
+    steps:
+      - name: Check confirmation
+        run: |
+          if [ "${{ inputs.confirm }}" != "initialize" ]; then
+            echo "::error::Confirmation phrase not matched. Type exactly: initialize"
+            exit 1
+          fi
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Tailscale
+        uses: tailscale/github-action@v2
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:github-actions
+
+      - name: Setup SSH key
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.VPS_SSH_PRIVATE_KEY }}" > ~/.ssh/vps_key
+          chmod 600 ~/.ssh/vps_key
+
+      - name: Setup SOPS/age for secrets
+        env:
+          SOPS_VERSION: "3.9.4"
+        run: |
+          SOPS_URL="https://github.com/getsops/sops/releases/download/v${SOPS_VERSION}/sops-v${SOPS_VERSION}.linux.amd64"
+          curl -fsSL -o /tmp/sops "$SOPS_URL"
+          if file /tmp/sops | grep -q "HTML"; then
+            echo "::error::SOPS download returned HTML instead of binary — check URL: $SOPS_URL"
+            exit 1
+          fi
+          chmod +x /tmp/sops
+          sudo mv /tmp/sops /usr/local/bin/sops
+          mkdir -p ~/.config/sops/age
+          echo "${{ secrets.SOPS_AGE_KEY }}" > ~/.config/sops/age/keys.txt
+          chmod 600 ~/.config/sops/age/keys.txt
+
+      - name: Get Tailscale IP from secrets
+        id: get-ip
+        run: |
+          TAILSCALE_IP=$(sops -d --extract '["TAILSCALE_IP"]' infra/secrets/prod.enc.env)
+          echo "::add-mask::$TAILSCALE_IP"
+          echo "tailscale_ip=$TAILSCALE_IP" >> $GITHUB_OUTPUT
+
+      - name: Verify SSH connectivity
+        run: |
+          ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no -o ConnectTimeout=10 \
+            deploy@${{ steps.get-ip.outputs.tailscale_ip }} 'echo "SSH connection successful"'
+
+      # Refuse loudly rather than relying on vault.sh's own guard, so an
+      # accidental dispatch against a live vault stops here.
+      - name: Refuse if already initialized
+        run: |
+          INITIALIZED=$(ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
+            deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
+            'docker exec -e BAO_ADDR=http://127.0.0.1:8200 openbao bao status -format=json 2>/dev/null | grep -o "\"initialized\":[a-z]*" | cut -d: -f2')
+          echo "initialized=$INITIALIZED"
+          if [ "$INITIALIZED" != "false" ]; then
+            echo "::error::OpenBao reports initialized=$INITIALIZED. This workflow only initializes a FRESH vault. To unseal an existing one use vault.sh unseal."
+            exit 1
+          fi
+
+      - name: Sync host checkout to main
+        run: |
+          ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
+            deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
+            'cd /opt/hill90/app && git fetch origin && git reset --hard origin/main'
+
+      # Writes the unseal key and root token to 0600 files owned by deploy.
+      # Prints neither.
+      - name: Initialize
+        run: |
+          ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
+            deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
+            'cd /opt/hill90/app && bash scripts/vault.sh init'
+
+      - name: Verify key file ownership and mode
+        run: |
+          OUT=$(ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
+            deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
+            'stat -c "%a %U:%G" /opt/hill90/secrets/openbao-unseal.key')
+          echo "unseal key: $OUT"
+          if [ "$OUT" != "600 deploy:deploy" ]; then
+            echo "::error::Unseal key must be 600 deploy:deploy — the auto-unseal systemd unit runs as deploy. Got: $OUT"
+            exit 1
+          fi
+
+      - name: Unseal
+        run: |
+          ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
+            deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
+            'cd /opt/hill90/app && bash scripts/vault.sh unseal'
+
+      # The key must survive loss of the host, so it also goes into SOPS. The
+      # value is read and written inside vault.sh and never interpolated here.
+      - name: Store unseal key in SOPS on the host
+        run: |
+          ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
+            deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
+            'cd /opt/hill90/app && export SOPS_AGE_KEY_FILE=/opt/hill90/secrets/keys/keys.txt && bash scripts/vault.sh store-unseal-key'
+
+      - name: Copy updated SOPS back
+        run: |
+          scp -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
+            deploy@${{ steps.get-ip.outputs.tailscale_ip }}:/opt/hill90/app/infra/secrets/prod.enc.env \
+            infra/secrets/prod.enc.env
+          # Confirm locally that the key decrypts, without printing it.
+          LEN=$(sops -d --extract '["OPENBAO_UNSEAL_KEY"]' infra/secrets/prod.enc.env | wc -c)
+          echo "OPENBAO_UNSEAL_KEY decrypts to $LEN bytes"
+          [ "$LEN" -gt 0 ] || { echo "::error::OPENBAO_UNSEAL_KEY missing after copy-back"; exit 1; }
+
+      - name: Restore host checkout
+        if: always()
+        run: |
+          ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
+            deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
+            'cd /opt/hill90/app && git checkout -- infra/secrets/prod.enc.env && rm -f infra/secrets/prod.enc.env.backup.*' || true
+
+      # Do this BEFORE proving restart survival, so the root token is dead as
+      # early as possible. Auto-unseal does not need it.
+      - name: Revoke root token
+        run: |
+          ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
+            deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
+            'cd /opt/hill90/app && bash scripts/vault.sh revoke-root'
+
+      - name: Prove auto-unseal survives a container restart
+        run: |
+          IP=${{ steps.get-ip.outputs.tailscale_ip }}
+          ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no deploy@$IP 'docker restart openbao >/dev/null && sleep 8'
+
+          SEALED=$(ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no deploy@$IP \
+            'docker exec -e BAO_ADDR=http://127.0.0.1:8200 openbao bao status >/dev/null 2>&1; echo $?')
+          echo "after restart, bao status exit: $SEALED (expect 2 = sealed)"
+          [ "$SEALED" = "2" ] || { echo "::error::Expected sealed (2) after restart, got $SEALED"; exit 1; }
+
+          ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no deploy@$IP \
+            'cd /opt/hill90/app && bash scripts/vault.sh auto-unseal'
+
+          UNSEALED=$(ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no deploy@$IP \
+            'docker exec -e BAO_ADDR=http://127.0.0.1:8200 openbao bao status >/dev/null 2>&1; echo $?')
+          echo "after auto-unseal, bao status exit: $UNSEALED (expect 0 = unsealed)"
+          [ "$UNSEALED" = "0" ] || { echo "::error::Auto-unseal did not unseal after restart (exit $UNSEALED)"; exit 1; }
+
+      # The real test: the systemd unit is what runs at boot, so exercise it
+      # rather than only the script it calls.
+      - name: Prove the systemd unit unseals it too
+        run: |
+          IP=${{ steps.get-ip.outputs.tailscale_ip }}
+          ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no deploy@$IP 'docker restart openbao >/dev/null && sleep 8'
+          ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no deploy@$IP 'sudo systemctl restart hill90-vault-unseal'
+          sleep 5
+          RC=$(ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no deploy@$IP \
+            'docker exec -e BAO_ADDR=http://127.0.0.1:8200 openbao bao status >/dev/null 2>&1; echo $?')
+          echo "after systemd unit run, bao status exit: $RC (expect 0)"
+          [ "$RC" = "0" ] || { echo "::error::hill90-vault-unseal.service did not unseal the vault (exit $RC)"; exit 1; }
+
+      - name: Confirm root token is gone
+        run: |
+          GONE=$(ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
+            deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
+            'test -f /opt/hill90/secrets/openbao-root.token && echo present || echo absent')
+          echo "root token file: $GONE"
+          [ "$GONE" = "absent" ] || { echo "::error::Root token file still on disk"; exit 1; }
+
+      - name: Open PR with the unseal key in SOPS
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if git diff --quiet infra/secrets/prod.enc.env; then
+            echo "::error::prod.enc.env unchanged — the unseal key was not stored."
+            exit 1
+          fi
+          BRANCH="vault/store-unseal-key-$(date +%Y%m%d%H%M)"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add infra/secrets/prod.enc.env
+          git commit -m "chore: store OPENBAO_UNSEAL_KEY in SOPS after vault init"
+          git push -u origin "$BRANCH"
+          gh pr create \
+            --title "chore: store OPENBAO_UNSEAL_KEY in SOPS after vault init" \
+            --body "Adds \`OPENBAO_UNSEAL_KEY\` to the encrypted secrets file, so the unseal key survives loss of the host. Only the encrypted file changes; the value never left the VPS in plaintext and was never printed. Generated by the \`vault-init\` workflow."

--- a/scripts/vault.sh
+++ b/scripts/vault.sh
@@ -13,7 +13,7 @@ UNSEAL_KEY_PATH="${VAULT_UNSEAL_KEY_PATH:-/opt/hill90/secrets/openbao-unseal.key
 # short-lived: revoke it with `vault.sh revoke-root` as soon as setup and seed
 # are done.
 ROOT_TOKEN_PATH="${VAULT_ROOT_TOKEN_PATH:-/opt/hill90/secrets/openbao-root.token}"
-SECRETS_FILE="${PROJECT_ROOT}/infra/secrets/prod.enc.env"
+SECRETS_FILE="${VAULT_SECRETS_FILE:-${PROJECT_ROOT}/infra/secrets/prod.enc.env}"
 POLICY_DIR="${PROJECT_ROOT}/platform/vault/policies"
 
 # Services that get their own AppRole
@@ -32,6 +32,7 @@ Usage: vault.sh <command>
 Commands:
   init          Initialize OpenBao (writes unseal key + root token to 0600 files)
   revoke-root   Revoke the root token and remove it from disk
+  store-unseal-key  Copy the host unseal key into SOPS as OPENBAO_UNSEAL_KEY
   unseal        Unseal OpenBao using host key file or SOPS fallback
   status        Show OpenBao seal/init status
   setup         Enable KV v2, AppRole, audit, apply policies, create roles
@@ -196,6 +197,50 @@ cmd_revoke_root() {
         rm -f "$ROOT_TOKEN_PATH"
     fi
     success "✓ Removed ${ROOT_TOKEN_PATH}"
+}
+
+# Copy the unseal key from the host key file into SOPS.
+#
+# The key has to exist in two places: on the host so auto-unseal works without
+# decrypting anything at boot, and in SOPS so it survives loss of the host.
+# This is the second half.
+#
+# The value is read and written entirely inside this function — it is never an
+# argument, never interpolated into a caller's shell, and never printed. That
+# matters because the obvious alternative (`make secrets-update KEY=... VALUE=...`)
+# puts the unseal key in the process table and in shell history.
+cmd_store_unseal_key() {
+    require_file "$UNSEAL_KEY_PATH" "Unseal key"
+    require_file "$SECRETS_FILE" "Secrets file"
+    require_command sops
+    require_command jq
+
+    if [ ! -r "$UNSEAL_KEY_PATH" ]; then
+        die "Unseal key at ${UNSEAL_KEY_PATH} is not readable by $(id -un)."
+    fi
+
+    local key
+    key=$(cat "$UNSEAL_KEY_PATH")
+    [ -n "$key" ] || die "Unseal key file is empty."
+
+    # jq -Rs quotes it correctly whatever it contains.
+    local escaped
+    escaped=$(printf '%s' "$key" | jq -Rs .)
+    unset key
+
+    if sops --set "[\"OPENBAO_UNSEAL_KEY\"] ${escaped}" "$SECRETS_FILE"; then
+        unset escaped
+        success "✓ OPENBAO_UNSEAL_KEY written to $(basename "$SECRETS_FILE")"
+    else
+        unset escaped
+        die "Failed to write OPENBAO_UNSEAL_KEY into ${SECRETS_FILE}"
+    fi
+
+    # Confirm it round-trips, without revealing it.
+    local stored_len
+    stored_len=$(sops -d --extract '["OPENBAO_UNSEAL_KEY"]' "$SECRETS_FILE" 2>/dev/null | wc -c | tr -d ' ')
+    [ "$stored_len" -gt 0 ] || die "OPENBAO_UNSEAL_KEY did not round-trip after writing."
+    success "✓ Verified: OPENBAO_UNSEAL_KEY decrypts to ${stored_len} bytes"
 }
 
 cmd_unseal() {
@@ -725,6 +770,7 @@ main() {
     case "$cmd" in
         init)          cmd_init "$@" ;;
         revoke-root)   cmd_revoke_root "$@" ;;
+        store-unseal-key) cmd_store_unseal_key "$@" ;;
         unseal)        cmd_unseal "$@" ;;
         status)        cmd_status "$@" ;;
         setup)         cmd_setup "$@" ;;


### PR DESCRIPTION
The vault stack is now **deployed** on the VPS via `gh workflow run deploy-vault.yml` — container up, `Initialized false`, `Sealed true`, volume `openbao-data` created. It cannot go further without `init`, and there was no sanctioned way to run it.

`deploy-vault.yml` runs `deploy.sh vault` → `auto-unseal`, never `init`. The only route was hand-running SSH, which is precisely what we don't want for the step that mints a new unseal key and root token. This adds the `workflow_dispatch` equivalent.

**This is only safe to run in CI because #499 landed.** Before that fix, `vault.sh init` printed the unseal key and the root token — running it through a workflow would have put both in the Actions log permanently.

## What the workflow does

1. Refuses unless you type `initialize`, and again if the vault reports `initialized != false`
2. `git reset --hard origin/main` on the host so it runs the fixed script
3. `vault.sh init` — writes both credentials to `0600` files, prints neither
4. **Asserts the unseal key is `600 deploy:deploy`** — `hill90-vault-unseal.service` runs as `User=deploy`, so a root-owned file would silently break every reboot. That was the original bug; this makes it impossible to reintroduce unnoticed.
5. `vault.sh unseal`
6. `vault.sh store-unseal-key` → copies the key into SOPS on the host, copies the encrypted file back, opens a PR
7. `vault.sh revoke-root` — done *before* the restart tests, so the root token is dead as early as possible
8. **Proves recovery twice**: auto-unseal after a container restart, and then `systemctl restart hill90-vault-unseal` — because the unit is what runs at boot, and testing only the script it calls wouldn't prove the unit works
9. Asserts the root token file is gone

## `vault.sh store-unseal-key`

The key has to live in two places: on the host so auto-unseal needs no decryption at boot, and in SOPS so it survives loss of the host.

The value is read and written entirely inside the function — never an argument, never interpolated into the workflow's shell, never printed. The obvious alternative (`make secrets-update KEY=... VALUE=...`) would put the unseal key in the process table and in shell history.

Verified against a scratch copy of `prod.enc.env`:

```
✓ OPENBAO_UNSEAL_KEY written to scratch.enc.env
✓ Verified: OPENBAO_UNSEAL_KEY decrypts to 45 bytes
  ✓ round-trip exact (value not printed)
  occurrences of the value in output: 0
  key count now: 64  (was 63, expect 64)
```

## Note on JON-46

`gh workflow run deploy-vault.yml` just now **passed** `Verify SSH connectivity`. That contradicts what I inferred last night from the sync workflow's failures — CI can reach the VPS today. I'll re-check JON-46 against fresh run logs rather than carry the old conclusion forward.

## To run

Merge, then dispatch `Vault Initialize (Prod)` with `initialize`. I'd rather you pull the trigger on a one-way operation than have me do it unattended — but say the word and I'll run it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)