### PR TITLE
fix(vault): parse bao status with jq, not grep (JON-45)

### DIFF
--- a/.github/workflows/vault-init.yml
+++ b/.github/workflows/vault-init.yml
@@ -91,9 +91,14 @@ jobs:
       # accidental dispatch against a live vault stops here.
       - name: Refuse if already initialized
         run: |
+          # Parse with jq, not grep. `bao status -format=json` emits
+          # '"initialized": false' WITH a space after the colon, so a
+          # grep -o '"initialized":[a-z]*' matches only the key and yields an
+          # empty string — which then fails this guard on a genuinely fresh
+          # vault. It failed safe, but it failed.
           INITIALIZED=$(ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
             deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
-            'docker exec -e BAO_ADDR=http://127.0.0.1:8200 openbao bao status -format=json 2>/dev/null | grep -o "\"initialized\":[a-z]*" | cut -d: -f2')
+            'docker exec -e BAO_ADDR=http://127.0.0.1:8200 openbao bao status -format=json 2>/dev/null | jq -r ".initialized"')
           echo "initialized=$INITIALIZED"
           if [ "$INITIALIZED" != "false" ]; then
             echo "::error::OpenBao reports initialized=$INITIALIZED. This workflow only initializes a FRESH vault. To unseal an existing one use vault.sh unseal."


### PR DESCRIPTION
The init workflow's "refuse if already initialized" guard is broken, and blocked tonight's initialization.

It read state with `grep -o '"initialized":[a-z]*'`. But `bao status -format=json` emits:

```
  "initialized": false,
  "sealed": true,
```

— with a **space** after the colon. So the pattern matched only `"initialized":`, `cut -d: -f2` returned empty, and the guard rejected a genuinely fresh vault:

```
initialized=
##[error]OpenBao reports initialized=. This workflow only initializes a FRESH vault.
```

It failed *safe* — it refused to initialize rather than initializing something it shouldn't — which is the right direction for a guard. But it was still wrong.

Fixed with `jq -r '.initialized'`, verified against the live vault:

```
jq: /usr/bin/jq
parsed with jq: false
sealed: true
```

`jq` is installed on the host by bootstrap playbook 01, so this adds no dependency.

Note `vault.sh cmd_init`'s own equivalent check is *not* affected — it greps the whole line then `tr -d ' ,"'`, which strips the space.

🤖 Generated with [Claude Code](https://claude.com/claude-code)