### PR TITLE
fix: remove the dns sync zone-wipe hazard and clear residual drift (JON-47)

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -96,8 +96,16 @@ HTTPS_PORT=8443
 # with, or be mistaken for, anything else. Production leaves all three unset and
 # keeps its historical names exactly.
 #
+# The prefix must not collide with anything else on the machine. "hill90local"
+# was the first choice and turned out to collide with an older Hill90 app stack
+# already running here, which attaches to hill90local_edge and
+# hill90local_internal — sharing those silently, and letting a teardown remove a
+# network the other stack still needs. local.sh now refuses to start if a target
+# network is owned by a different compose project, so if you hit that, change
+# this prefix rather than working around it.
+#
 # Production defaults: CONTAINER_PREFIX="" NETWORK_PREFIX=hill90 VOLUME_PREFIX=prod
-CONTAINER_PREFIX=hill90local-
-NETWORK_PREFIX=hill90local
-VOLUME_PREFIX=hill90local
-VOLUME_PREFIX_BARE=hill90local-
+CONTAINER_PREFIX=hill90dev-
+NETWORK_PREFIX=hill90dev
+VOLUME_PREFIX=hill90dev
+VOLUME_PREFIX_BARE=hill90dev-

--- a/docs/reference/secrets.md
+++ b/docs/reference/secrets.md
@@ -4,7 +4,7 @@
 
 ## Age Key Locations
 
-- **Local (project):** `infra/secrets/keys/age-prod.key` (tracked in repo, used by scripts)
+- **Local (project):** `infra/secrets/keys/age-prod.key` — **gitignored, never committed** (`.gitignore` excludes `infra/secrets/keys/*.key` and `*.key`). Only the public `age-prod.pub` is tracked. Restore it from your password manager or the VPS.
 - **VPS:** `/opt/hill90/secrets/keys/keys.txt`
 - **Symlinked on VPS:** `/opt/hill90/app/infra/secrets/keys/age-prod.key` → `/opt/hill90/secrets/keys/keys.txt`
 

--- a/docs/runbooks/local-development.md
+++ b/docs/runbooks/local-development.md
@@ -3,6 +3,14 @@
 Run the Hill90 infrastructure stack on a Mac, using the same compose files
 production uses.
 
+## Before you start
+
+Docker Desktop must be running. Nothing else is required — no SOPS, no age key,
+no Tailscale, no VPS access, no secrets of any kind.
+
+`.env.local` is created for you from `.env.local.example` on first run; you do
+not need to copy it yourself. It is gitignored.
+
 ## One command
 
 ```bash
@@ -22,7 +30,29 @@ bash scripts/local.sh down       # remove containers and networks, keep data
 bash scripts/local.sh reset      # also delete the local volumes (prompts)
 ```
 
-Cold start takes roughly a minute, most of it Grafana installing plugins.
+Cold start takes roughly a minute, most of it Grafana installing plugins. From a
+completely clean machine — no containers, no volumes, no `.env.local` — the
+measured time is 65 seconds.
+
+Verify it worked:
+
+```bash
+bash scripts/local.sh health
+```
+
+```
+Routed surfaces
+  ✓ Traefik dashboard — HTTP 200
+  ✓ Portainer — HTTP 200
+  ✓ Grafana — HTTP 200
+
+Observability internals
+  ✓ Prometheus ready
+  ✓ Loki ready
+  ✓ Grafana health
+
+✓ All local checks passed.
+```
 
 ## URLs
 
@@ -76,6 +106,11 @@ and no path to Let's Encrypt. Each difference is one variable:
 | No basic-auth secret | `TRAEFIK_MIDDLEWARES=compress@file` | `auth@file,tailscale-only@file` |
 | Port 80 already in use | `HTTP_PORT=8080` | `80` |
 | Coexist with other stacks | `CONTAINER_PREFIX`, `NETWORK_PREFIX`, `VOLUME_PREFIX` | unset / `hill90` / `prod` |
+
+If `up` reports that a network belongs to another compose project, change
+`NETWORK_PREFIX` in `.env.local`. The default is `hill90dev`; an earlier default
+of `hill90local` collided with a separate Hill90 app stack on the reference
+machine, which is why that check exists.
 
 ### The one file that is genuinely duplicated
 
@@ -135,7 +170,7 @@ exactly this reason; if you started Traefik another way, restart it.
 
 **Routers from another project appear in the dashboard.** Traefik's Docker
 provider sees every container on the socket. The local static config constrains
-it to the `hill90-local-*` compose projects; production has no such neighbours
+it to the `hill90-local-edge` / `hill90-local-observability` compose projects; production has no such neighbours
 and does not need the constraint.
 
 ## See Also

--- a/infra/dns/hill90.com.json
+++ b/infra/dns/hill90.com.json
@@ -9,6 +9,20 @@
     },
     {
       "type": "A",
+      "name": "remote",
+      "content": "${TAILSCALE_IP}",
+      "ttl": 3600,
+      "priority": null
+    },
+    {
+      "type": "A",
+      "name": "vps",
+      "content": "${TAILSCALE_IP}",
+      "ttl": 3600,
+      "priority": null
+    },
+    {
+      "type": "A",
       "name": "portainer",
       "content": "${TAILSCALE_IP}",
       "ttl": 3600,
@@ -17,6 +31,13 @@
     {
       "type": "A",
       "name": "traefik",
+      "content": "${TAILSCALE_IP}",
+      "ttl": 3600,
+      "priority": null
+    },
+    {
+      "type": "A",
+      "name": "grafana",
       "content": "${TAILSCALE_IP}",
       "ttl": 3600,
       "priority": null

--- a/platform/edge/traefik.local.yml
+++ b/platform/edge/traefik.local.yml
@@ -69,7 +69,7 @@ providers:
   docker:
     endpoint: "unix:///var/run/docker.sock"
     exposedByDefault: false
-    network: hill90local_edge
+    network: hill90dev_edge
     # LOCAL-ONLY. The Docker provider sees every container on the socket, not
     # just this project's. On a developer Mac that can mean picking up routers
     # from an unrelated stack — observed here with an older Hill90 app stack

--- a/scripts/hostinger.sh
+++ b/scripts/hostinger.sh
@@ -353,7 +353,7 @@ dns_sync() {
     current_records=$(api_call GET "/api/dns/v1/zones/$DOMAIN")
 
     local needs_update=false
-    for pair in "@:$vps_ip" "admin:$tailscale_ip" "portainer:$tailscale_ip" "traefik:$tailscale_ip" "grafana:$tailscale_ip" "vault:$tailscale_ip"; do
+    for pair in "@:$vps_ip" "remote:$tailscale_ip" "vps:$tailscale_ip" "portainer:$tailscale_ip" "traefik:$tailscale_ip" "grafana:$tailscale_ip" "vault:$tailscale_ip"; do
         local name="${pair%%:*}"
         local expected="${pair##*:}"
         local current
@@ -373,6 +373,15 @@ dns_sync() {
         return 0
     fi
 
+    # NO "overwrite: true". The Hostinger PUT upserts the records it is given
+    # and leaves the rest of the zone alone; with overwrite it REPLACES the
+    # whole zone with whatever is in this payload. The zone has 33 record
+    # groups and this payload has 7, so overwrite would have destroyed the
+    # remote A record (the only SSH path to the VPS), every mail record — MX,
+    # SPF, DKIM, DMARC, autoconfig, autodiscover — plus www, docs and a
+    # minecraft SRV. Verified empirically: a targeted update without the flag
+    # left all 33 groups intact and changed exactly one record.
+    #
     # Build and validate payload
     local payload
     payload=$(jq -n \
@@ -380,10 +389,10 @@ dns_sync() {
         --arg ts "$tailscale_ip" \
         '{
             domain: "hill90.com",
-            overwrite: true,
             zone: [
                 {name: "@",         type: "A", ttl: 3600, records: [{content: $vps}]},
-                {name: "admin",     type: "A", ttl: 3600, records: [{content: $ts}]},
+                {name: "remote",    type: "A", ttl: 3600, records: [{content: $ts}]},
+                {name: "vps",       type: "A", ttl: 3600, records: [{content: $ts}]},
                 {name: "portainer", type: "A", ttl: 3600, records: [{content: $ts}]},
                 {name: "traefik",   type: "A", ttl: 3600, records: [{content: $ts}]},
                 {name: "grafana",   type: "A", ttl: 3600, records: [{content: $ts}]},
@@ -449,7 +458,7 @@ dns_verify() {
     if [[ -n "$tailscale_ip" ]]; then
         echo "" >&2
         echo -e "${BLUE}Verifying Tailscale-only DNS (expected: $tailscale_ip)...${NC}" >&2
-        for host in "portainer.$DOMAIN" "traefik.$DOMAIN" "grafana.$DOMAIN" "vault.$DOMAIN"; do
+        for host in "remote.$DOMAIN" "vps.$DOMAIN" "portainer.$DOMAIN" "traefik.$DOMAIN" "grafana.$DOMAIN" "vault.$DOMAIN"; do
             local resolved
             resolved=$(dig +short "$host" 2>/dev/null | head -n1)
             if [[ "$resolved" == "$tailscale_ip" ]]; then

--- a/scripts/local.sh
+++ b/scripts/local.sh
@@ -118,11 +118,26 @@ cmd_up() {
     info "Building and starting the edge stack (traefik, dns-manager, portainer)..."
     compose_edge up -d --build --force-recreate || die "Edge stack failed to start"
 
+    # Refuse to share networks with an unrelated project. Docker will happily
+    # let two stacks attach to the same network name, and then a teardown here
+    # removes something the other stack still needs — observed on this machine
+    # with an older Hill90 app stack.
+    local netpfx_pre; netpfx_pre=$(env_get NETWORK_PREFIX hill90dev)
+    for net in edge internal agent_internal; do
+        local owner
+        owner=$(docker network inspect "${netpfx_pre}_${net}" \
+                --format '{{index .Labels "com.docker.compose.project"}}' 2>/dev/null || true)
+        if [ -n "$owner" ] && [ "$owner" != "$EDGE_PROJECT" ] && [ "$owner" != "$OBS_PROJECT" ]; then
+            die "Network ${netpfx_pre}_${net} already exists and belongs to compose project '${owner}'.
+    Change NETWORK_PREFIX in .env.local to something unused, then retry."
+        fi
+    done
+
     # The edge compose declares hill90_internal and hill90_agent_internal but no
     # edge service attaches to them, so compose never creates them. Production
     # has the same gap and scripts/deploy.sh cmd_infra creates them explicitly
     # after the edge stack; do exactly the same here rather than diverging.
-    local netpfx; netpfx=$(env_get NETWORK_PREFIX hill90)
+    local netpfx; netpfx=$(env_get NETWORK_PREFIX hill90dev)
     for net in internal agent_internal; do
         if ! docker network inspect "${netpfx}_${net}" >/dev/null 2>&1; then
             docker network create --driver bridge --internal "${netpfx}_${net}" >/dev/null
@@ -178,10 +193,21 @@ cmd_down() {
     info "Stopping the edge stack..."
     compose_edge down --remove-orphans 2>/dev/null || true
 
-    # Created by hand in cmd_up, so removed by hand here.
-    local netpfx; netpfx=$(env_get NETWORK_PREFIX hill90)
+    # Created by hand in cmd_up, so removed by hand here — but only when empty.
+    # Docker refuses to remove an in-use network, and swallowing that error made
+    # it look deliberate; be explicit instead so a shared network is reported
+    # rather than silently left behind.
+    local netpfx; netpfx=$(env_get NETWORK_PREFIX hill90dev)
     for net in internal agent_internal; do
-        docker network rm "${netpfx}_${net}" >/dev/null 2>&1 && info "Removed ${netpfx}_${net}" || true
+        local attached
+        attached=$(docker network inspect "${netpfx}_${net}" --format '{{len .Containers}}' 2>/dev/null || echo "")
+        if [ -z "$attached" ]; then
+            continue
+        elif [ "$attached" = "0" ]; then
+            docker network rm "${netpfx}_${net}" >/dev/null 2>&1 && info "Removed ${netpfx}_${net}"
+        else
+            warn "Left ${netpfx}_${net} in place — ${attached} container(s) from another project are attached"
+        fi
     done
 
     success "Local stack is down. Volumes were kept — use 'reset' to delete them."

--- a/tests/scripts/hostinger.bats
+++ b/tests/scripts/hostinger.bats
@@ -66,3 +66,36 @@
   [ "$status" -eq 1 ]
   [[ "$output" == *"Unknown"* ]]
 }
+
+# --- DNS record-set parity and the overwrite hazard (JON-47) ----------------
+
+@test "dns_sync never posts overwrite:true" {
+  # overwrite:true replaces the ENTIRE zone with the payload. The payload holds
+  # 7 record groups; the live zone holds 33, including the remote A record that
+  # is the only SSH path to the VPS, and every mail record.
+  run bash -c 'sed -n "/^dns_sync/,/^}$/p" scripts/hostinger.sh | grep -v "^ *#" | grep "overwrite"'
+  [ "$status" -eq 1 ]
+}
+
+@test "dns_sync payload and infra/dns/hill90.com.json describe the same records" {
+  run bash -c '
+    payload=$(grep -oE "\{name: \"[a-z@]+\"" scripts/hostinger.sh | grep -oE "\"[a-z@]+\"" | tr -d "\"" | sort -u)
+    declared=$(python3 -c "
+import json
+print(chr(10).join(sorted(r[chr(39)+chr(39)] if False else r[\"name\"] for r in json.load(open(\"infra/dns/hill90.com.json\"))[\"records\"])))")
+    [ "$payload" = "$declared" ]'
+  [ "$status" -eq 0 ]
+}
+
+@test "dns_sync manages the remote record that SSH depends on" {
+  run bash -c 'sed -n "/^dns_sync/,/^}$/p" scripts/hostinger.sh | grep -c "name: \"remote\""'
+  [ "$output" = "1" ]
+}
+
+@test "infra/dns/hill90.com.json has no app-era hostnames" {
+  run python3 -c "
+import json,sys
+names={r['name'] for r in json.load(open('infra/dns/hill90.com.json'))['records']}
+sys.exit(1 if names & {'api','ai','auth','storage','litellm','openclaw','admin'} else 0)"
+  [ "$status" -eq 0 ]
+}

--- a/tests/scripts/local.bats
+++ b/tests/scripts/local.bats
@@ -73,7 +73,7 @@
         -f deploy/compose/overrides/local.infra.yml config
   [ "$status" -eq 0 ]
   [[ "$output" == *"traefik.localtest.me"* ]]
-  [[ "$output" == *"hill90local_edge"* ]]
+  [[ "$output" == *"hill90dev_edge"* ]]
   [[ "$output" != *"tailscale-only@file"* ]]
 }
 


### PR DESCRIPTION
Started as the residual-drift cleanup in JON-47 and turned up something bigger
than drift.

## The serious one: `dns sync` would have wiped the zone

`dns_sync` posted `overwrite: true` with **7 record groups against a 33-group
zone**. `overwrite` replaces the entire zone with the payload. Running
`hostinger.sh dns sync` would have destroyed 25 record groups:

| Lost | Consequence |
|---|---|
| `remote` A | **the only SSH path to the VPS** |
| `@` MX, `@` TXT (SPF), 3× DKIM CNAME, `_dmarc`, autoconfig, autodiscover | email stops working |
| `www` CNAME | the apex site |
| `docs` CNAME | docs.hill90.com |
| `_minecraft._tcp` SRV | Jon's minecraft server |
| `api`, `ai`, `auth`, `litellm`, `storage`, `openclaw` + their ACME TXT | app-era, but not this command's call to make |

Recovering SSH after that means the Hostinger web console.

The flag is removed. I verified the semantics empirically rather than trusting
the API docs — a targeted update **without** `overwrite` left all 33 groups
intact and changed exactly one record:

```
$ bash scripts/hostinger.sh dns update /tmp/vps-fix.json
{ "message": "Request accepted" }

record groups before=33 after=33
  CHANGED: vps A: ['100.69.23.114'] -> ['100.88.29.112']
no other differences
```

## Record sets reconciled

`infra/dns/hill90.com.json` and the `dns_sync` payload disagreed — `admin` and
`grafana` were in one and not the other, and **`remote` was in neither**, despite
being the record SSH depends on. A sync would therefore have deleted it.

Both files now declare the same seven: `@`, `remote`, `vps`, `portainer`,
`traefik`, `grafana`, `vault`. App-era `admin` dropped.

Four bats tests lock it down — including one that fails if the two files diverge,
and one that fails if an app-era hostname comes back. Both proven by injecting
the fault:

```
$ # after adding "admin" back to the json
not ok 12 dns_sync payload and infra/dns/hill90.com.json describe the same records
not ok 14 infra/dns/hill90.com.json has no app-era hostnames
```

## Live DNS

`vps.hill90.com` → `100.88.29.112`, done via the targeted update path (validated
first, full-zone diff after), confirmed resolving through 1.1.1.1.

**`openclaw.hill90.com` deliberately left alone.** It still points at the dead
address. Deleting a hostname from a live zone is not reversible without the
snapshot, and the ticket said it "probably" goes — that is Jon's call, not one to
make while he is asleep.

## `secrets.md` was wrong about the age key

`docs/reference/secrets.md:7` said the private key is *"tracked in repo"*. It is
not: `.gitignore` excludes `infra/secrets/keys/*.key` and `*.key`, and only the
`.pub` files are tracked. The Step 4 docs rewrite did not catch it. Corrected — a
doc telling a reader a private key belongs in git is worse than no doc.

## A defect in my own merged work (#500)

Following the runbook from a clean machine, as asked, found one: `NETWORK_PREFIX`
defaulted to `hill90local`, which **collides with the older Hill90 app stack
already running on this Mac**. Both attach to `hill90local_edge` and
`hill90local_internal`; they were silently sharing networks, and `local.sh down`
had already removed one the other stack still needed.

Fixed three ways: default is now `hill90dev`; `up` refuses to start if a target
network belongs to another compose project; and teardown leaves a network in
place with a warning when foreign containers are attached.

## Clean-room runbook verification

Wiped everything — containers, volumes, networks, `.env.local`, the built image —
and followed `docs/runbooks/local-development.md` exactly as a new reader.

```
PRE-CONDITIONS
  .env.local:  absent      containers: 0      volumes: 0      networks: 0

$ bash scripts/local.sh up          → 1:05.53 total
$ bash scripts/local.sh health
Routed surfaces
  ✓ Traefik dashboard — HTTP 200
  ✓ Portainer — HTTP 200
  ✓ Grafana — HTTP 200
Observability internals
  ✓ Prometheus ready
  ✓ Loki ready
  ✓ Grafana health
✓ All local checks passed.
```

Browser-reachable, following redirects:

```
http://traefik.localtest.me:8080/dashboard/   HTTP 200  → <title>Traefik</title>
http://portainer.localtest.me:8080/           HTTP 200
http://grafana.localtest.me:8080/             HTTP 200  final=…/login  → <title>Grafana</title>
```

Grafana login with the runbook's `admin / admin`: `{"message":"Logged in"}`.
Prometheus: 7 targets, all `up`. Grafana: 3 datasources, 4 dashboards. Loki
returning real label sets, so promtail→loki is genuinely shipping.

**Three runbook gaps closed** — it never said Docker Desktop must be running,
never said `.env.local` is created for you, and had no verification step. Added,
with the measured 65-second cold start.

## Checks

```
$ bats tests/scripts/                       201 tests, 0 failures
$ python3 -m pytest tests/checks/ -q        29 passed
$ shellcheck --severity=error scripts/*.sh  (clean)
$ check_env_surface.py    Configuration surface consistent: 21 variable(s)
$ check_secrets_schema.py Secrets schema validation: all checks passed
$ check_md_links.py       no missing local links
$ check_destructive_commands.sh / check_volume_names.py / validate.sh traefik  (clean)
```

Jon's six untracked screenshots in the main checkout are untouched — verified
present before and after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)