### PR TITLE
docs: vault is running again, but SOPS is still the operative store (JON-45)

### DIFF
--- a/docs/architecture/secrets-model.md
+++ b/docs/architecture/secrets-model.md
@@ -1,21 +1,33 @@
 # Secrets Architecture
 
-> **Status as of 2026-07-26: SOPS is the active path. No vault is deployed.**
+> **Status as of 2026-07-26: the vault is running. SOPS is still the path
+> deploys use.**
 >
-> There has been no `openbao` container, and no vault volume, since the June 14
-> rebuild. Every secret in use has been served by SOPS + age for six weeks,
-> without incident, and nothing noticed the vault was gone.
+> Both statements are true and the distinction matters.
 >
-> The vault-first machinery below is **implemented and dormant**, not running.
-> `deploy.sh` still tries vault first and falls back to SOPS when it is absent
-> (`_common.sh:vault_available`), which is why deploys have kept working. The
-> design described in this document is therefore the *intended* model, not a
-> description of what is live.
+> OpenBao was reinitialized on 2026-07-26 (JON-45) after being absent since the
+> June 14 rebuild. It is up, healthy, initialized and unsealed, auto-unseal is
+> proven to survive a container restart — including through
+> `hill90-vault-unseal.service`, which is what runs at boot — and
+> `deploy-vault.yml` is green.
 >
-> Whether to bring the vault back is an open question — see
-> [Vault vs SOPS](../decisions/vault-vs-sops.md). Until that is settled, read
-> this document as "how vault works here if enabled", and treat SOPS as the
-> system of record.
+> **But the vault holds nothing.** `vault.sh setup` and `vault.sh seed` have
+> not been run, so there are no policies, no AppRoles and no KV data. Every
+> deploy therefore still reads its secrets from SOPS. That is not a guess; the
+> green vault deploy logged it:
+>
+> ```
+> WARNING: OpenBao available but login failed for vault, falling back to SOPS
+> ```
+>
+> So: vault is **available** infrastructure, SOPS is the **operative** store.
+> Nothing reads a secret out of the vault today.
+>
+> Filling it is a deliberate next step, not an oversight — it depends on the
+> open question in [Vault vs SOPS](../decisions/vault-vs-sops.md), which is
+> still Jon's call. Running `setup` and `seed` also needs a root token, and the
+> one minted at init was revoked immediately by design; a new one comes from
+> `bao operator generate-root` using the unseal key.
 
 ## Intended model
 

--- a/docs/decisions/vault-vs-sops.md
+++ b/docs/decisions/vault-vs-sops.md
@@ -6,9 +6,19 @@ Jon's.
 
 ## What is actually true today
 
-- No `openbao` container has existed, running or stopped, since the June 14
-  rebuild. No vault volume, no `/opt/hill90/secrets/openbao-unseal.key`, and no
-  `OPENBAO_UNSEAL_KEY` in SOPS.
+**Updated 2026-07-26, after JON-45.** The vault now exists again — but it is
+empty, and nothing reads from it. The argument below is unchanged by that,
+because it was never about whether a vault *could* run.
+
+- OpenBao is deployed, initialized, unsealed and healthy as of 2026-07-26.
+  Auto-unseal survives a container restart, verified through the systemd unit.
+  `OPENBAO_UNSEAL_KEY` is now in SOPS and at `/opt/hill90/secrets/openbao-unseal.key`
+  (`600 deploy:deploy`). The root token was revoked immediately.
+- **It holds no policies, no AppRoles and no KV data.** `setup` and `seed` have
+  not been run. Every deploy still falls back to SOPS, which the green
+  `deploy-vault` run logged explicitly.
+- Between the June 14 rebuild and 2026-07-26 there was no vault at all, and
+  nothing noticed.
 - Every secret in use has been served by SOPS + age for six weeks. Nothing
   broke, and nothing noticed.
 - `deploy.sh` is vault-first with a SOPS fallback. With no vault present,
@@ -17,9 +27,11 @@ Jon's.
   unremarked.
 - `hill90-vault-unseal.service` is enabled and active. It exits cleanly when the
   container is absent, so it has been a no-op since June.
-- The weekly `vault-sync-to-sops` workflow has failed every run since
-  2026-06-01. It does not fail for want of a vault — it never gets that far; it
-  fails at `Verify SSH connectivity`. See JON-46.
+- The weekly `vault-sync-to-sops` workflow failed every run from 2026-06-01 to
+  2026-07-20 at `Verify SSH connectivity` — it never reached the vault. That
+  has since resolved: as of 2026-07-26 it gets past SSH and fails later, at
+  `Renew sync token`, with `403 permission denied`, because `VAULT_SYNC_TOKEN`
+  in SOPS belongs to the vault that was destroyed in June. See JON-46.
 - SOPS still holds seven AppRole credential pairs (`VAULT_DB_*`, `VAULT_API_*`,
   `VAULT_AI_*`, `VAULT_AUTH_*`, `VAULT_UI_*`, `VAULT_MCP_*`, `VAULT_MINIO_*`)
   for services deleted in JON-27/28. They are dead weight whichever way this


### PR DESCRIPTION
Follow-up to #501, which said "SOPS is the active path, no vault is deployed." The second half is now out of date — but the fix is **not** "both are live," because that would overstate it.

## What changed

OpenBao is back: initialized, unsealed, healthy, auto-unseal proven through `hill90-vault-unseal.service`, `deploy-vault.yml` green.

## What did not change

**The vault holds nothing.** `setup` and `seed` have not been run — no policies, no AppRoles, no KV data. Every deploy still reads from SOPS. Not inferred; the green vault deploy logged it:

```
WARNING: OpenBao available but login failed for vault, falling back to SOPS
```

So the doc now says: vault is **available** infrastructure, SOPS is the **operative** store, and nothing reads a secret out of the vault today. Filling it is a deliberate next step gated on your call in `vault-vs-sops.md` — and it needs a root token, which was revoked at init by design (a new one comes from `bao operator generate-root` using the unseal key).

## JON-46 correction

The decision doc previously said the sync workflow fails at `Verify SSH connectivity`. That was true for every run from 2026-06-01 to 2026-07-20 — and it is now **resolved**: the workflow gets past SSH today. It fails later, at `Renew sync token`:

```
Error renewing token: 403. Errors: permission denied
```

`VAULT_SYNC_TOKEN` in SOPS belongs to the vault destroyed in June. So the original diagnosis ("no vault to sync from") was wrong about the *mechanism* but right that it needs a vault — and it now needs a **new sync token**, which needs `setup`, which needs a root token.

The recommendation itself is untouched. It was never an argument about whether a vault could run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)