### PR TITLE
fix(local): let Traefik route the hill90-app stack

### DIFF
--- a/platform/edge/traefik.local.yml
+++ b/platform/edge/traefik.local.yml
@@ -76,8 +76,18 @@ providers:
     # still running. Production has no such neighbours, so it does not need
     # this and does not have it.
     # LabelRegexp is Traefik v3 only — on v2.11 it fails with
-    # "unsupported function: LabelRegexp" and every container is dropped.
-    constraints: "Label(`com.docker.compose.project`,`hill90-local-edge`) || Label(`com.docker.compose.project`,`hill90-local-observability`)"
+    # "unsupported function: LabelRegexp" and every container is dropped, so
+    # each project is listed explicitly.
+    #
+    # hill90-local is the app stack (github.com/jonhill90/hill90-app), which
+    # attaches to these networks via its compose/local.infra.yml overlay and
+    # carries its own Traefik labels. Without this clause its routers are
+    # dropped and every app hostname returns 404.
+    #
+    # These are literals rather than ${VAR} on purpose: Traefik v2.11 does no
+    # environment interpolation in the static config file, so a placeholder
+    # here is matched as the literal string and silently matches nothing.
+    constraints: "Label(`com.docker.compose.project`,`hill90-local-edge`) || Label(`com.docker.compose.project`,`hill90-local-observability`) || Label(`com.docker.compose.project`,`hill90-local`)"
 
   file:
     directory: /etc/traefik/dynamic


### PR DESCRIPTION
Replaces #506, which a branch-name collision left pointing at another lane's vault commit. Same change, unique branch. **Diff is one file, one behavioural line.**

## The problem

The local Docker provider constraint lists the two infra compose projects explicitly:

```
constraints: "Label(`com.docker.compose.project`,`hill90-local-edge`) || Label(`com.docker.compose.project`,`hill90-local-observability`)"
```

The app stack ([hill90-app](https://github.com/jonhill90/hill90-app)) runs as project `hill90-local`. Its `compose/local.infra.yml` overlay attaches it to `hill90local_edge` with its own Traefik labels, but every one of those routers is dropped — so all five app hostnames 404 while the infra surfaces work fine.

The existing comment says the constraint was added after observing "an older Hill90 app stack still running". That was this stack, before it had routable labels; it is now a deliberate tenant of these networks.

## The change

One additional clause for `hill90-local`. Nothing else.

**Why literals and not `${VAR:-default}`:** Traefik 2.11 does no environment interpolation in the static config file. I verified rather than assumed — with `constraints: "Label(...,\`${TEST_PROJECT}\`)"` and `TEST_PROJECT=substituted` in the environment, Traefik loaded the file without error and discovered **zero** routers from a container labelled `com.docker.compose.project=substituted`. The placeholder is matched as a literal string. The `${VAR:-prod_default}` pattern from #500 applies to the compose files, which Compose does interpolate; this file is not one of them.

`LabelRegexp` would collapse all three clauses into one pattern, but it is Traefik v3 only — the existing comment already records that it breaks on 2.11.

## Expected effect on the live VPS: none

- **No workflow triggers on this path.** The only two push-triggered workflows are `deploy.yml` (paths: `platform/observability/**`, `docker-compose.vault.yml`, `docker-compose.observability.yml`) and `tailscale.yml` (`policy.hujson`). `platform/edge/traefik.local.yml` matches neither, so merging deploys nothing.
- **The file is never mounted in production.** `docker-compose.infra.yml:60` mounts `platform/edge/${TRAEFIK_STATIC_CONFIG:-traefik.yml}`; only `.env.local` sets it to `traefik.local.yml`. Production keeps using `traefik.yml`, which this PR does not touch.
- Nothing under `deploy/`, no vault paths, no `platform/observability/**`. The uninitialized `openbao` container is untouched.

If a redeploy were triggered manually, it would restart Traefik with an unchanged production config.

## Verification

Both real stacks together on this branch — `scripts/local.sh up`, then the app with `--infra`:

```
SERVICE          URL                                            CODE
UI               http://app.localtest.me:8080/                  200
API health       http://api.localtest.me:8080/health            200
Keycloak realm   http://auth.localtest.me:8080/realms/hill90    200
MCP gateway      http://ai.localtest.me:8080/mcp/health         200
MinIO console    http://storage.localtest.me:8080/              200

infra own surfaces (must be unaffected):
  traefik      302
  grafana      302
  portainer    200

internal-only app services (must stay unrouted):
  ai.localtest.me/health         404
  knowledge.localtest.me/health  404
```

Plus a full browser login through Traefik ending on an authenticated dashboard. Before this change all five app rows were 404; the infra rows are unchanged either way, and `ai`/`knowledge` stay correctly unrouted because the app sets `traefik.enable=false` on them, matching production.

Local run of the checks CI runs — `check_md_links`, `check_volume_names`, `check_env_surface`, `check_secrets_schema`, `check_destructive_commands`, `shellcheck` — all pass, and `docker compose config` on the production infra file is still valid.

## Unrelated observation, not fixed here

The comment above `providers.docker` cites `scripts/checks/check_local_parity.py`, which does not exist in the tree. Left alone to keep this diff to one line of behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)