### PR TITLE
docs: note host-wide log ingestion and volume survival in the local runbook

### DIFF
--- a/docs/runbooks/local-development.md
+++ b/docs/runbooks/local-development.md
@@ -144,6 +144,9 @@ bash scripts/local.sh up       # rebuild to an identical result
 to type `reset` to confirm. It can only ever touch the local Docker daemon —
 `local.sh` contains no SSH and no VPS hostname, asserted by a test.
 
+Volumes survive `down`, so a rebuild comes back with its data. Verified: 7
+volumes before and after, and Grafana still has its 4 provisioned dashboards.
+
 On the VPS, the equivalent is:
 
 ```bash
@@ -167,6 +170,13 @@ exactly this reason; if you started Traefik another way, restart it.
 
 **Grafana 404 immediately after `up`.** It is still installing plugins.
 `local.sh up` waits for it; `docker compose up` on its own does not.
+
+**Loki shows logs from containers that are not Hill90's.** Expected. Promtail
+discovers containers through the Docker socket and ships everything on the host;
+on a developer Mac that includes whatever else you have running. On the VPS there
+are no neighbours, so the config is not narrowed — narrowing it locally would
+mean forking `promtail.yml`, which is exactly what this setup avoids. Filter in
+Grafana with `{container=~"hill90dev-.*"}`.
 
 **Routers from another project appear in the dashboard.** Traefik's Docker
 provider sees every container on the socket. The local static config constrains


### PR DESCRIPTION
Follow-up to proving `docs/runbooks/local-development.md` end to end on a clean
Mac, on merged `main` (`0732832`).

**The runbook worked exactly as written.** Two behaviours it did not explain
would have surprised a reader, so they are now documented:

- **Loki ingests logs from every container on the host**, not just Hill90's — 21
  of them on this machine, including an unrelated app stack. That is promtail
  doing its job through the Docker socket. On the VPS there are no neighbours, so
  `promtail.yml` is not narrowed; narrowing it locally would mean forking a
  config file, which is precisely what this setup exists to avoid. Documented
  with the Grafana filter to use instead: `{container=~"hill90dev-.*"}`.
- **Volumes survive `down`** — stated explicitly, with the verified numbers.

## Clean-room evidence

Wiped containers, volumes, networks, `.env.local` and the built image, then
followed the runbook literally.

```
PRE-CONDITIONS
  .env.local: absent   containers: 0   volumes: 0   networks: 0   image: 0

$ bash scripts/local.sh up        → 1:05.81 total
$ bash scripts/local.sh health
Routed surfaces
  ✓ Traefik dashboard — HTTP 200
  ✓ Portainer — HTTP 200
  ✓ Grafana — HTTP 200
Observability internals
  ✓ Prometheus ready
  ✓ Loki ready
  ✓ Grafana health
✓ All local checks passed.
```

Browser-reachable, following redirects, each serving its real UI:

```
http://traefik.localtest.me:8080/dashboard/   HTTP 200   <title>Traefik</title>
http://portainer.localtest.me:8080/           HTTP 200   <title>Portainer</title>
http://grafana.localtest.me:8080/             HTTP 200   <title>Grafana</title>  (→ /login)
```

Not just responding — actually working. Queried **through Grafana's own
datasource proxy**, which exercises browser → Traefik → Grafana → backend:

```
Prometheus, query 'up':  status=success  series=7
    cadvisor=1  grafana=1  loki=1  node-exporter=1  prometheus=1  tempo=1  traefik=1

Loki, query_range {container="hill90dev-traefik"}:  status=success  streams=2  loglines=5
    sample: {"level":"debug","middlewareName":"compress@file",...
```

That Loki sample is the `compress@file` middleware the local override sets — the
log line proves the local routing config is the one actually in effect.

Grafana login with the runbook's `admin / admin`: `{"message":"Logged in"}`.
3 datasources, 4 dashboards provisioned.

Teardown/rebuild cycle, also per the runbook:

```
$ bash scripts/local.sh down   → containers 0, volumes 7 (kept)
$ bash scripts/local.sh up     → 1:04.79, all health checks pass, 4 dashboards intact
```

## Checks

```
$ bats tests/scripts/                       201 tests, 0 failures
$ python3 -m pytest tests/checks/ -q        29 passed
$ shellcheck --severity=error scripts/*.sh  (clean)
$ check_env_surface / check_secrets_schema / check_volume_names / check_md_links / check_destructive_commands  (all clean)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)