### PR TITLE
fix(vault): do not revoke root before the vault is configured (JON-46)

### DIFF
--- a/.github/workflows/vault-init.yml
+++ b/.github/workflows/vault-init.yml
@@ -20,6 +20,11 @@ on:
         description: 'Type "initialize" to confirm. This mints a NEW unseal key and root token.'
         required: true
         type: string
+      revoke_root:
+        description: 'Revoke the root token at the end. Leave FALSE until setup/seed/setup-sync-token have run — see below.'
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: write
@@ -161,13 +166,31 @@ jobs:
             deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
             'cd /opt/hill90/app && git checkout -- infra/secrets/prod.enc.env && rm -f infra/secrets/prod.enc.env.backup.*' || true
 
-      # Do this BEFORE proving restart survival, so the root token is dead as
-      # early as possible. Auto-unseal does not need it.
+      # ONE-WAY DOOR — off by default, and this is why.
+      #
+      # On OpenBao >= 2.5.3 the unauthenticated root-generation endpoints are
+      # disabled by default, so `bao operator generate-root` returns 403
+      # (verified against 2.6.1). With no other sudo-capable token, revoking
+      # root means the vault can never be configured again without
+      # reinitializing it.
+      #
+      # Revoking immediately after init — which this workflow used to do
+      # unconditionally — therefore produced a vault that was up, healthy, and
+      # permanently unconfigurable. Run setup, seed and setup-sync-token first,
+      # then revoke.
       - name: Revoke root token
+        if: ${{ inputs.revoke_root }}
         run: |
           ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
             deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
             'cd /opt/hill90/app && bash scripts/vault.sh revoke-root'
+
+      - name: Report where the root token is
+        if: ${{ !inputs.revoke_root }}
+        run: |
+          echo "Root token left at /opt/hill90/secrets/openbao-root.token (0600 deploy:deploy)."
+          echo "Run setup / seed / setup-sync-token, then revoke it with:"
+          echo "  bash scripts/vault.sh revoke-root"
 
       - name: Prove auto-unseal survives a container restart
         run: |
@@ -201,6 +224,7 @@ jobs:
           [ "$RC" = "0" ] || { echo "::error::hill90-vault-unseal.service did not unseal the vault (exit $RC)"; exit 1; }
 
       - name: Confirm root token is gone
+        if: ${{ inputs.revoke_root }}
         run: |
           GONE=$(ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
             deploy@${{ steps.get-ip.outputs.tailscale_ip }} \

--- a/docs/decisions/vault-vs-sops.md
+++ b/docs/decisions/vault-vs-sops.md
@@ -17,6 +17,12 @@ because it was never about whether a vault *could* run.
 - **It holds no policies, no AppRoles and no KV data.** `setup` and `seed` have
   not been run. Every deploy still falls back to SOPS, which the green
   `deploy-vault` run logged explicitly.
+- **And it cannot currently be configured.** The root token was revoked right
+  after init, and on OpenBao 2.6.1 `bao operator generate-root` returns 403 —
+  the unauthenticated root-generation endpoints are disabled by default since
+  2.5.3. With no other sudo-capable token, the only route back to root is
+  reinitializing. So the running vault is not just empty, it is inert until
+  someone decides to reinitialize it.
 - Between the June 14 rebuild and 2026-07-26 there was no vault at all, and
   nothing noticed.
 - Every secret in use has been served by SOPS + age for six weeks. Nothing

--- a/docs/runbooks/vault-unseal.md
+++ b/docs/runbooks/vault-unseal.md
@@ -2,6 +2,22 @@
 
 OpenBao (vault) starts sealed after every container restart. This runbook covers the auto-unseal mechanisms and manual fallback.
 
+> **Do not revoke the root token before the vault is configured (2026-07-26).**
+> On OpenBao >= 2.5.3 the unauthenticated root-generation endpoints are disabled
+> by default, so `bao operator generate-root` returns **403** — verified against
+> 2.6.1, both before and after revocation, with the flag set at listener and at
+> top level. With no other sudo-capable token, there is then no supported way
+> back to root, and the vault cannot be configured at all.
+>
+> Correct order: `init` -> `unseal` -> `setup` -> `seed` -> `setup-sync-token`
+> -> `revoke-root`. The `vault-init` workflow now leaves the root token in place
+> by default (`revoke_root: false`) for exactly this reason.
+>
+> This is what happened on 2026-07-26: root was revoked immediately after init,
+> which left a healthy but permanently unconfigurable vault. Recovering means
+> reinitializing.
+
+
 > **Fresh initialization (2026-07-26).** `vault.sh init` no longer prints the
 > unseal key or root token. It writes both to `0600` files owned by whoever
 > runs it — on the host that is `deploy`, which is what the auto-unseal systemd

--- a/scripts/vault.sh
+++ b/scripts/vault.sh
@@ -159,8 +159,23 @@ cmd_init() {
 # A root token is unconstrained and does not expire. Once setup and seed have
 # run, nothing needs it — day-to-day access is by AppRole. Leaving it on the
 # filesystem is the single largest standing risk in this design.
+#
+# ONE-WAY DOOR. On OpenBao >= 2.5.3 the unauthenticated root-generation
+# endpoints are disabled by default (disable_unauthed_generate_root_endpoints
+# defaults to true), so `bao operator generate-root` returns 403 — verified
+# against 2.6.1, both before and after revocation, with the flag set at
+# listener and top level. Regaining root then requires an existing
+# sudo-capable token, and if none exists the only route back is
+# reinitializing the vault.
+#
+# So: run `setup`, `seed` and `setup-sync-token` BEFORE this. Revoking first
+# leaves a vault that cannot be configured.
 cmd_revoke_root() {
     require_running
+
+    warn "Revoking root is IRREVERSIBLE on OpenBao >= 2.5.3 unless another"
+    warn "sudo-capable token exists. generate-root is disabled by default."
+    warn "Ensure setup/seed/setup-sync-token have already run."
 
     if [ ! -f "$ROOT_TOKEN_PATH" ]; then
         warn "No root token file at ${ROOT_TOKEN_PATH} — nothing to revoke."
@@ -568,10 +583,13 @@ cmd_setup_sync_token() {
         die "Failed to store VAULT_SYNC_TOKEN in SOPS"
     fi
 
+    unset sync_token escaped_token
+
     echo ""
     success "Sync token created and stored in SOPS!"
     echo ""
-    echo "Token: ${sync_token}" >&2
+    # Deliberately NOT printed. This runs in CI, and a printed token would be
+    # a durable copy in the Actions log — the same defect init had.
     echo ""
     echo "IMPORTANT: Commit and push the updated SOPS file so GitHub Actions can read it:"
     echo "  git add infra/secrets/prod.enc.env"


### PR DESCRIPTION
**JON-46 cannot be completed as written, and I stopped rather than force it.** Minting a sync token needs root; root is gone and cannot be regenerated on this OpenBao version.

## What I found

`bao operator generate-root` returns **403** on OpenBao 2.6.1. Since 2.5.3 the unauthenticated root-generation endpoints are disabled by default (`disable_unauthed_generate_root_endpoints` defaults true).

Verified on a throwaway instance — 403 in every configuration I could construct:

| Condition | Result |
|---|---|
| Root token still valid | 403 |
| After revoking root | 403 |
| Flag set inside `listener` block | 403 |
| Flag set at top level | 403 |
| `/v1/sys/seal-status` (control) | 200 — so the listener is fine |

Confirmed identically against the live vault: `generate-root` → `Code: 403`, root token file absent.

With no other sudo-capable token, there is no supported way back to root. The only route is reinitializing.

## This is my bug

The `vault-init` workflow I wrote revoked root unconditionally, immediately after init. On HashiCorp Vault that is correct practice. On OpenBao ≥2.5.3 it is a **one-way door**: it left the vault up, healthy, unsealed — and permanently unconfigurable. No `setup`, no `seed`, no AppRoles, no sync token, ever.

I should have ordered it init → unseal → setup → seed → setup-sync-token → revoke-root.

## What this PR changes

- `vault-init.yml` gains a `revoke_root` input, **defaulting to false**, with the ordering documented at the step.
- `revoke-root` warns that it is irreversible on OpenBao ≥2.5.3.
- `setup-sync-token` no longer prints the token — it echoed it to stderr, the same defect `init` had, and it is meant to run in CI.
- Runbook and decision doc record the constraint.

**It does not reinitialize the live vault.** That is destructive and would invalidate the unseal key you just merged in #505, so it is your call.

## Your options for JON-46

1. **Reinitialize.** The vault is empty, so nothing is lost but the current unseal key. Wipe the `openbao-data` volume, re-run `vault-init` with `revoke_root: false`, then `setup` → `seed` → `setup-sync-token` → `revoke-root`. Needs a new SOPS PR for the new unseal key. I can drive all of it through workflows.
2. **Leave the vault inert and disable the sync schedule.** Consistent with the `vault-vs-sops` recommendation — SOPS is the operative store, the vault holds nothing, and the weekly alert has been noise since June.

Option 2 is less work and matches where the evidence points; option 1 is right if you want vault to actually hold secrets.

Separately worth noting: OpenBao warns the `file` storage backend is deprecated and removed in v2.7.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)