### PR TITLE
chore: disable the vault-sync schedule and write up the reinit path (JON-46)

### DIFF
--- a/.github/workflows/vault-sync-to-sops.yml
+++ b/.github/workflows/vault-sync-to-sops.yml
@@ -2,8 +2,39 @@ name: Vault Sync to SOPS
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: '0 6 * * 1'  # Weekly Monday 6am UTC
+
+  # SCHEDULE DISABLED 2026-07-26 (JON-46).
+  #
+  # This ran every Monday 06:00 UTC and failed every Monday from 2026-06-01
+  # onward. It cannot currently succeed, and an alert that always fires carries
+  # no information — it just trains you to ignore it.
+  #
+  # Two separate reasons it fails, in order:
+  #
+  #   1. Until 2026-07-26 it died at `Verify SSH connectivity`, never reaching
+  #      the vault. That is now resolved.
+  #   2. It now dies later, at `Renew sync token`, with 403 permission denied.
+  #      VAULT_SYNC_TOKEN in SOPS was minted against the vault destroyed in the
+  #      June 14 rebuild and does not exist in the one initialized on
+  #      2026-07-26.
+  #
+  # Minting a replacement needs a root token. The root token was revoked right
+  # after init, and on OpenBao >= 2.5.3 `bao operator generate-root` returns 403
+  # (the unauthenticated root-generation endpoints are disabled by default), so
+  # there is no way back to root on the current vault.
+  #
+  # BEFORE RE-ENABLING, all of these must be true:
+  #   - the vault has been reinitialized (see docs/decisions/vault-vs-sops.md)
+  #   - `vault.sh setup` and `vault.sh seed` have run, so it holds something
+  #   - `vault.sh setup-sync-token` has minted a token that exists in the
+  #     CURRENT vault, and the updated SOPS file is merged
+  #   - a manual `workflow_dispatch` run has gone green
+  #
+  # Re-enable by restoring:
+  #   schedule:
+  #     - cron: '0 6 * * 1'  # Weekly Monday 6am UTC
+  #
+  # workflow_dispatch is deliberately kept so it can still be run by hand.
 
 permissions:
   contents: write

--- a/docs/decisions/vault-vs-sops.md
+++ b/docs/decisions/vault-vs-sops.md
@@ -4,6 +4,24 @@
 Jon's.
 **Raised:** 2026-07-26 (JON-45)
 
+## What has been done, and what is still open
+
+**Done (2026-07-26):** the `vault-sync-to-sops` schedule is disabled. It had
+failed every Monday since 2026-06-01 and could not succeed; a weekly alert that
+always fires carries no information. `workflow_dispatch` is kept, so it can
+still be run by hand. Reversible with a one-line commit — the re-enable
+conditions are written at the schedule block in the workflow.
+
+**Still open — this is the decision for you:** whether the vault should hold
+secrets at all. Nothing below has been actioned. Disabling a broken alert is
+housekeeping, not a strategic choice, and it was deliberately kept separate
+from the question this document exists to answer.
+
+**Not done, deliberately:** the vault has not been reinitialized. That means
+destroying a volume and invalidating an unseal key already merged into SOPS,
+which is not something to do unattended. The procedure is in
+[Reinitializing the vault](#reinitializing-the-vault) below.
+
 ## What is actually true today
 
 **Updated 2026-07-26, after JON-45.** The vault now exists again — but it is
@@ -111,11 +129,88 @@ rather than a default the documentation asserts on the reader's behalf.
   vault-first fallback in `deploy.sh` — it costs one failed `docker exec` per
   deploy and means enabling vault later needs no code change.
 
-## If vault is chosen
+## If vault is chosen: reinitializing the vault
 
-- JON-46 must be fixed first: CI cannot currently reach the VPS at all, so
-  neither the deploy nor the sync can run.
-- `vault.sh init` needed fixing before it was safe to run — it printed the
-  unseal key and root token. Done in PR #499.
-- There is still no non-SSH path to run `init`. Either add an init workflow or
-  accept a one-off manual initialization.
+<a id="reinitializing-the-vault"></a>
+
+The vault running today is **inert** — empty, and unconfigurable because its
+root token was revoked and OpenBao 2.6.1 cannot mint a new one (403 from
+`bao operator generate-root`; the unauthenticated root-generation endpoints are
+disabled by default since 2.5.3). The only route to a working vault is to start
+it over.
+
+### What it costs
+
+- **The `openbao-data` volume is destroyed.** It contains nothing — no policies,
+  no AppRoles, no KV data — so nothing of value is lost. But it is a volume
+  deletion on the live host, and it is irreversible.
+- **The current unseal key stops working.** A fresh `init` mints a new one, so
+  `OPENBAO_UNSEAL_KEY` in SOPS is wrong the moment the old vault is wiped. This
+  needs **a second PR** to land the new key, and until it merges the key exists
+  only on the host at `/opt/hill90/secrets/openbao-unseal.key`.
+- Roughly 20 minutes, most of it waiting on workflow runs and one merge.
+
+### The steps, in order
+
+Order matters. Revoking root before `setup-sync-token` is what produced the
+current inert vault.
+
+1. **Wipe the volume.** On the host, stop the stack and remove it:
+   `docker compose -p hill90-prod-platform -f deploy/compose/prod/docker-compose.vault.yml down -v`
+   (or `docker volume rm openbao-data` once the container is gone).
+2. **Redeploy** — `gh workflow run deploy-vault.yml`. It will go red at
+   `Verify readiness`, because an uninitialized OpenBao returns 501 from
+   `/v1/sys/health`. That is expected at this point, not a fault.
+3. **Initialize** — `gh workflow run vault-init.yml -f confirm=initialize`.
+   Leave `revoke_root` at its default of **false**. The workflow asserts the
+   unseal key is `600 deploy:deploy`, stores it in SOPS, proves auto-unseal
+   survives a container restart including through the systemd unit, and opens a
+   PR with the new key.
+4. **Merge that PR.** Nothing after this works from CI until the new
+   `OPENBAO_UNSEAL_KEY` is on `main`.
+5. **Configure it** — `vault.sh setup` then `vault.sh seed`, with
+   `BAO_TOKEN=$(cat /opt/hill90/secrets/openbao-root.token)`. This creates the
+   KV engine, the policies and the per-service AppRoles, and populates
+   `secret/infra/traefik`, `secret/infra/dns-manager` and
+   `secret/observability/grafana`. There is no workflow for these yet; one
+   would need writing, in the shape of `vault-init.yml`.
+6. **Mint the sync token** — `vault.sh setup-sync-token`. It writes
+   `VAULT_SYNC_TOKEN` into SOPS. That needs another PR to land.
+7. **Revoke root** — `vault.sh revoke-root`. Only now. After this the vault
+   cannot be reconfigured without repeating this whole procedure.
+8. **Re-enable the sync schedule** — restore the `cron` block in
+   `.github/workflows/vault-sync-to-sops.yml`, but only after a manual
+   `workflow_dispatch` run has gone green.
+
+### If you would rather not
+
+Then nothing needs doing. SOPS is already the operative store, the schedule is
+off, and the inert vault costs a few hundred MB and one container. Removing it
+entirely is a separate, easy change whenever you want.
+
+## Known future break: the `file` storage backend
+
+Independent of which option you pick.
+
+OpenBao logs this on every start of the live vault:
+
+```
+[WARN] storage.file: the file physical backend is deprecated;
+use bao operator migrate to move to a supported storage backend by v2.7.0
+```
+
+`platform/vault/config.hcl` uses `storage "file"`. It is **removed in v2.7.0**,
+and the compose file pins `ghcr.io/openbao/openbao:2` — a floating major tag —
+so this breaks on a routine image pull, not on a deliberate upgrade.
+
+Three ways out, in increasing order of effort:
+
+1. **Pin the image** to a 2.6.x tag. Buys time; does not fix it.
+2. **Migrate** to a supported backend with `bao operator migrate`. The obvious
+   target is `raft` (integrated storage), which is single-node friendly.
+3. **Retire the vault**, if the decision above goes that way, and the question
+   disappears.
+
+Worth deciding before v2.7.0 lands rather than discovering it when a pull
+breaks the stack. If the vault is reinitialized anyway, switching to `raft` at
+the same time costs almost nothing extra — the volume is being wiped regardless.


### PR DESCRIPTION
Takes option 2. Nothing was reinitialized and no volume was touched.

## The schedule is off

`vault-sync-to-sops` ran every Monday 06:00 UTC and failed every Monday from 2026-06-01. It cannot currently succeed, and an alert that always fires carries no information.

`workflow_dispatch` is kept, so it can still be run by hand. The comment at the schedule block records:

- both failure causes in order — SSH connectivity until 2026-07-26, then 403 on `Renew sync token` because `VAULT_SYNC_TOKEN` belongs to the vault destroyed in June
- why it cannot be fixed without root, which OpenBao 2.6.1 will not mint
- the four conditions that must all hold before re-enabling
- the exact `cron` line to restore

Reversible with a one-line commit.

## The strategic call is still yours

The doc now separates these explicitly. Disabling a broken alert is housekeeping; whether the vault should hold secrets is the open question, and I did not want a disabled schedule to quietly imply an answer.

## The reinitialize path is written up

`vault-vs-sops.md` now carries it as an ordered runbook you can follow without reconstructing tonight:

1. wipe `openbao-data`
2. redeploy — **expect red** at `Verify readiness`; an uninitialized OpenBao returns 501 from `/v1/sys/health`, which is expected at that point, not a fault
3. `vault-init` with `revoke_root` left **false**
4. merge the new unseal-key PR — nothing after this works from CI until it is on `main`
5. `setup` then `seed` (no workflow for these yet; one would need writing)
6. `setup-sync-token`, then merge that PR too
7. `revoke-root` **last**
8. re-enable the schedule only after a manual green run

Ordering is the whole point — revoking root early is exactly what produced the current inert vault.

**Cost, stated plainly:** a volume deletion on the live host (empty, but irreversible), and a second PR because a fresh init invalidates the unseal key merged in #505. Until that merges the key exists only on the host. Roughly 20 minutes, mostly waiting.

And a short "if you would rather not" — nothing needs doing; SOPS is already operative and the inert vault costs a container.

## Known future break, recorded because it applies either way

The live vault logs this on every start:

```
[WARN] storage.file: the file physical backend is deprecated;
use bao operator migrate to move to a supported storage backend by v2.7.0
```

`platform/vault/config.hcl` uses `storage "file"`, and `docker-compose.vault.yml` pins `ghcr.io/openbao/openbao:2` — a floating major tag. So this breaks on a **routine image pull**, not a deliberate upgrade. Both verified in the tree, not assumed.

Options given: pin to 2.6.x (buys time), migrate to `raft`, or retire the vault. Noted that if it gets reinitialized anyway, switching to `raft` then costs almost nothing — the volume is being wiped regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)