### PR TITLE
docs(local): record the app project in the Traefik constraint list

### DIFF
--- a/docs/runbooks/local-development.md
+++ b/docs/runbooks/local-development.md
@@ -180,8 +180,11 @@ Grafana with `{container=~"hill90dev-.*"}`.
 
 **Routers from another project appear in the dashboard.** Traefik's Docker
 provider sees every container on the socket. The local static config constrains
-it to the `hill90-local-edge` / `hill90-local-observability` compose projects; production has no such neighbours
-and does not need the constraint.
+it to three compose projects — `hill90-local-edge`, `hill90-local-observability`
+and `hill90-local`, the last being the
+[hill90-app](https://github.com/jonhill90/hill90-app) stack, which attaches to
+these networks through its own opt-in overlay. Production has no such
+neighbours and does not need the constraint.
 
 ## See Also
 


### PR DESCRIPTION
Documentation only — one paragraph in the local-development runbook.

#508 added a third clause to the local Traefik Docker-provider constraint so the [hill90-app](https://github.com/jonhill90/hill90-app) stack can be routed locally, but the troubleshooting note still described two projects. Found while doing a clean cold run of the combined setup from fresh clones of both repos.

## Redeploy impact: none

`docs/**` matches no push-triggered workflow. The only two are `deploy.yml` (`platform/observability/**`, `docker-compose.vault.yml`, `docker-compose.observability.yml`) and `tailscale.yml` (`policy.hujson`). Nothing under `deploy/`, `platform/` or any vault path is touched.

## Context

The rest of the runbook held up exactly as written on a cold machine. `bash scripts/local.sh up` created `.env.local` on its own and brought up all ten containers; `health` reported every check green; the `hill90dev_*` networks were created as documented. The app then attached to those networks via its overlay and served through Traefik on `:8080`, with the infra surfaces unaffected:

```
UI               http://app.localtest.me:8080/                  200
API health       http://api.localtest.me:8080/health            200
Keycloak realm   http://auth.localtest.me:8080/realms/hill90    200
MCP gateway      http://ai.localtest.me:8080/mcp/health         200
MinIO console    http://storage.localtest.me:8080/              200

traefik      302
grafana      302
portainer    200
```

The `NETWORK_PREFIX` rename to `hill90dev` was the other cross-repo drift; that side is fixed in hill90-app#5, since the stale value lived there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)