### PR TITLE
fix: route Prometheus locally and harden the local network guards

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -32,6 +32,10 @@ PORTAINER_HOST=portainer
 GRAFANA_HOST=grafana
 VAULT_HOST=vault
 
+# Prometheus is routed LOCALLY ONLY, by deploy/compose/overrides/local.observability.yml.
+# Production leaves it unrouted on the internal network, reached through Grafana.
+PROMETHEUS_HOST=prometheus
+
 # Plain HTTP locally. There is no certificate authority that can validate a
 # name resolving to 127.0.0.1, so there is nothing to serve over TLS.
 # Production default: websecure

--- a/deploy/compose/overrides/local.observability.yml
+++ b/deploy/compose/overrides/local.observability.yml
@@ -7,3 +7,21 @@ services:
   grafana:
     labels:
       - "traefik.http.routers.grafana.tls=false"
+
+  prometheus:
+    # Production deliberately does not route Prometheus: it sits on the internal
+    # network and is reached through Grafana, so it has no router and publishes
+    # no port. That is correct for a server nobody logs into directly.
+    #
+    # It is wrong for development. Prometheus' own UI is where you check the
+    # targets page and use the expression browser, and without this a developer
+    # cannot open it at all — port 9090 is not published to the host either.
+    # Prometheus is already on the edge network, so routing it locally needs
+    # nothing but labels, and none of this reaches production.
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.prometheus.rule=Host(`${PROMETHEUS_HOST:-prometheus}.${BASE_DOMAIN:-hill90.com}`)"
+      - "traefik.http.routers.prometheus.entrypoints=${ADMIN_ENTRYPOINT:-websecure}"
+      - "traefik.http.routers.prometheus.tls=false"
+      - "traefik.http.routers.prometheus.middlewares=${ADMIN_MIDDLEWARES:-tailscale-only@file}"
+      - "traefik.http.services.prometheus.loadbalancer.server.port=9090"

--- a/docs/runbooks/local-development.md
+++ b/docs/runbooks/local-development.md
@@ -31,8 +31,10 @@ bash scripts/local.sh reset      # also delete the local volumes (prompts)
 ```
 
 Cold start takes roughly a minute, most of it Grafana installing plugins. From a
-completely clean machine — no containers, no volumes, no `.env.local` — the
-measured time is 65 seconds.
+genuinely clean machine — no containers, no volumes, no networks, no
+`.env.local`, **no images and no build cache** — the measured time is 83
+seconds, including pulling all nine images. With images already present it is
+about 65 seconds.
 
 Verify it worked:
 
@@ -61,6 +63,15 @@ Observability internals
 | Traefik dashboard | http://traefik.localtest.me:8080/dashboard/ |
 | Portainer | http://portainer.localtest.me:8080/ |
 | Grafana | http://grafana.localtest.me:8080/ (admin / admin) |
+| Prometheus | http://prometheus.localtest.me:8080/ (local only) |
+
+**Prometheus is routed locally but not in production.** In production it sits on
+the internal network with no router and no published port, reached through
+Grafana — correct for a server nobody logs into directly. Locally you want its
+targets page and expression browser, so
+`deploy/compose/overrides/local.observability.yml` adds a router. Nothing about
+that reaches production; `docker compose -f …observability.yml config` still
+resolves to zero Prometheus router labels.
 
 `localtest.me` is a public DNS zone where every name resolves to `127.0.0.1`.
 That gives real `Host`-header routing through Traefik with no `/etc/hosts`
@@ -99,6 +110,7 @@ and no path to Let's Encrypt. Each difference is one variable:
 
 | Difference | Mechanism | Production default |
 |---|---|---|
+| Prometheus UI reachable | router added in the local override | not routed |
 | Hostnames | `BASE_DOMAIN=localtest.me` | `hill90.com` |
 | Plain HTTP, no TLS | `ADMIN_ENTRYPOINT=web` | `websecure` |
 | No certificates | `ADMIN_CERT_RESOLVER=` | `letsencrypt-dns` |
@@ -107,10 +119,13 @@ and no path to Let's Encrypt. Each difference is one variable:
 | Port 80 already in use | `HTTP_PORT=8080` | `80` |
 | Coexist with other stacks | `CONTAINER_PREFIX`, `NETWORK_PREFIX`, `VOLUME_PREFIX` | unset / `hill90` / `prod` |
 
-If `up` reports that a network belongs to another compose project, change
-`NETWORK_PREFIX` in `.env.local`. The default is `hill90dev`; an earlier default
-of `hill90local` collided with a separate Hill90 app stack on the reference
-machine, which is why that check exists.
+If `up` reports a network is shared, change `NETWORK_PREFIX` in `.env.local`.
+The check looks at what is actually attached to the network, not just its
+compose-project label, because `internal` and `agent_internal` are created by
+hand and carry no label — and because another stack can join a network this one
+created. Both shapes were observed on the reference machine. `down` applies the
+same rule in reverse: it leaves a shared network in place and says so, rather
+than removing something another stack still needs.
 
 ### The one file that is genuinely duplicated
 

--- a/scripts/local.sh
+++ b/scripts/local.sh
@@ -118,18 +118,36 @@ cmd_up() {
     info "Building and starting the edge stack (traefik, dns-manager, portainer)..."
     compose_edge up -d --build --force-recreate || die "Edge stack failed to start"
 
-    # Refuse to share networks with an unrelated project. Docker will happily
-    # let two stacks attach to the same network name, and then a teardown here
-    # removes something the other stack still needs — observed on this machine
-    # with an older Hill90 app stack.
+    # Refuse to share networks with an unrelated project.
+    #
+    # Two shapes matter and the compose-project label only catches one. A
+    # network created by hand — which is how internal and agent_internal are
+    # made, here and in production — carries no project label at all, and
+    # another stack can quietly join a network we created. Both were observed
+    # on the reference machine: a separate Hill90 app stack attached to
+    # hill90dev_edge, hill90dev_internal and hill90dev_agent_internal.
+    #
+    # So check what is actually attached, not just who nominally owns it. Any
+    # container that is not ours means the network is shared, and a teardown
+    # here would disrupt something else.
     local netpfx_pre; netpfx_pre=$(env_get NETWORK_PREFIX hill90dev)
+    local cprefix; cprefix=$(env_get CONTAINER_PREFIX "")
     for net in edge internal agent_internal; do
-        local owner
+        local owner foreign
         owner=$(docker network inspect "${netpfx_pre}_${net}" \
                 --format '{{index .Labels "com.docker.compose.project"}}' 2>/dev/null || true)
         if [ -n "$owner" ] && [ "$owner" != "$EDGE_PROJECT" ] && [ "$owner" != "$OBS_PROJECT" ]; then
             die "Network ${netpfx_pre}_${net} already exists and belongs to compose project '${owner}'.
     Change NETWORK_PREFIX in .env.local to something unused, then retry."
+        fi
+        foreign=$(docker network inspect "${netpfx_pre}_${net}" \
+                  --format '{{range .Containers}}{{.Name}} {{end}}' 2>/dev/null \
+                  | tr ' ' '\n' | grep -v '^$' | grep -v "^${cprefix}" || true)
+        if [ -n "$foreign" ]; then
+            die "Network ${netpfx_pre}_${net} is shared with containers that are not ours:
+    $(echo "$foreign" | tr '\n' ' ')
+    Sharing it means a teardown here would disrupt them. Change NETWORK_PREFIX
+    in .env.local to something unused, then retry."
         fi
     done
 
@@ -165,17 +183,28 @@ cmd_up() {
         waited=$((waited + 3))
     done
 
-    # Container health says the process is up; it does not say Traefik has
-    # discovered the router or that Grafana has finished installing plugins.
-    # Poll the thing we actually promise works.
+    # Container health says the process is up. It does not say Traefik has
+    # discovered the router, and Traefik discovers routers asynchronously from
+    # container start. Poll every routed surface, not just one — waiting on
+    # Grafana alone once let `up` return while Prometheus was still 404ing,
+    # which looks exactly like a broken config to whoever runs it next.
     info "Waiting for routed surfaces to answer..."
-    local grafana_url; grafana_url="$(base_url "$(env_get GRAFANA_HOST grafana)")/login"
-    waited=0
+    local waited=0 pending
     while [ "$waited" -lt 120 ]; do
-        [ "$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 "$grafana_url" 2>/dev/null)" = "200" ] && break
+        pending=0
+        for probe in \
+            "$(base_url "$(env_get TRAEFIK_HOST traefik)")/dashboard/" \
+            "$(base_url "$(env_get PORTAINER_HOST portainer)")/" \
+            "$(base_url "$(env_get GRAFANA_HOST grafana)")/login" \
+            "$(base_url "$(env_get PROMETHEUS_HOST prometheus)")/graph"
+        do
+            [ "$(curl -sL -o /dev/null -w '%{http_code}' --max-time 5 "$probe" 2>/dev/null)" = "200" ] || pending=1
+        done
+        [ "$pending" -eq 0 ] && break
         sleep 3
         waited=$((waited + 3))
     done
+    [ "$waited" -ge 120 ] && warn "Some routed surfaces did not answer within 120s — run 'local.sh health'"
 
     echo ""
     cmd_status
@@ -254,6 +283,7 @@ cmd_urls() {
     echo "  Traefik dashboard   $(base_url "$(env_get TRAEFIK_HOST traefik)")/dashboard/"
     echo "  Portainer           $(base_url "$(env_get PORTAINER_HOST portainer)")/"
     echo "  Grafana             $(base_url "$(env_get GRAFANA_HOST grafana)")/"
+    echo "  Prometheus          $(base_url "$(env_get PROMETHEUS_HOST prometheus)")/  (local only; prod reaches it via Grafana)"
 }
 
 cmd_health() {
@@ -265,6 +295,7 @@ cmd_health() {
     check_http "Traefik dashboard" "$(base_url "$(env_get TRAEFIK_HOST traefik)")/dashboard/" 200 || failed=1
     check_http "Portainer"         "$(base_url "$(env_get PORTAINER_HOST portainer)")/"        200 || failed=1
     check_http "Grafana"           "$(base_url "$(env_get GRAFANA_HOST grafana)")/login"       200 || failed=1
+    check_http "Prometheus"        "$(base_url "$(env_get PROMETHEUS_HOST prometheus)")/graph"  200 || failed=1
 
     echo ""
     echo "${BOLD}Observability internals${NC}"
@@ -283,8 +314,11 @@ cmd_health() {
 }
 
 check_http() {
+    # -L because a browser follows redirects and so should this: Prometheus
+    # sends /graph to /query, and Grafana sends / to /login. Asserting on the
+    # first response would fail on a page that works fine.
     local name="$1" url="$2" expect="$3" code
-    code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "$url" 2>/dev/null || echo 000)
+    code=$(curl -sL -o /dev/null -w '%{http_code}' --max-time 10 "$url" 2>/dev/null || echo 000)
     if [ "$code" = "$expect" ]; then
         echo "  ${GREEN}✓${NC} ${name} — HTTP ${code}"
     else

--- a/tests/scripts/local.bats
+++ b/tests/scripts/local.bats
@@ -114,3 +114,25 @@
   run bash -c 'sed -n "/^cmd_reset/,/^}/p" scripts/local.sh | grep -c "read -r -p"'
   [ "$output" = "1" ]
 }
+
+@test "prometheus is routed locally but NOT in production" {
+  # Production reaches Prometheus through Grafana; it has no router there.
+  run docker compose -f deploy/compose/prod/docker-compose.observability.yml config
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"routers.prometheus"* ]]
+
+  # Locally it is routed, so the targets page and expression browser work.
+  run docker compose --env-file .env.local.example \
+        -f deploy/compose/prod/docker-compose.observability.yml \
+        -f deploy/compose/overrides/local.observability.yml config
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"routers.prometheus"* ]]
+  [[ "$output" == *"prometheus.localtest.me"* ]]
+}
+
+@test "local health checks follow redirects" {
+  # Prometheus sends /graph to /query and Grafana sends / to /login; asserting
+  # on the first response would fail on pages that work.
+  run bash -c 'sed -n "/^check_http/,/^}/p" scripts/local.sh | grep -c -- "curl -sL"'
+  [ "$output" = "1" ]
+}


### PR DESCRIPTION
Ran `docs/runbooks/local-development.md` cold on this Mac with **nothing**
pre-existing — no containers, volumes, networks, `.env.local`, **images or build
cache**. Three real problems surfaced that only a from-scratch run would show.

## 1. Prometheus was not reachable in a browser at all

Not routed through Traefik, and port 9090 is not published to the host either:

```
$ curl http://localhost:9090/                    HTTP 000  (unreachable)
$ curl http://prometheus.localtest.me:8080/      HTTP 404
```

Production leaves Prometheus unrouted on the internal network, reached through
Grafana — correct for a server nobody logs into directly. It is wrong for
development, where the targets page and expression browser are exactly what you
want. A router is added **in the local override only**:

```
$ docker compose -f deploy/compose/prod/docker-compose.observability.yml config | grep -c routers.prometheus
0        # production: still unrouted
```

Asserted by a test that checks both directions.

## 2. The health check did not follow redirects

Prometheus sends `/graph` → `/query`; asserting on the first response failed at
302 on a page that works fine. It now uses `-L`, like the browser it stands in
for. Grafana's `/` → `/login` had the same shape.

## 3. `up` returned before every surface answered

It waited only on Grafana. Once it returned while Prometheus was still 404ing,
which reads as broken config to whoever runs it next. It now polls all four
routed surfaces before returning.

I could not reproduce that particular 404 afterwards and am not going to invent a
root cause for it — the fix removes the whole class regardless of which race it
was.

## 4. The network collision guard was too narrow

The guard added last time compared compose-project labels. But `internal` and
`agent_internal` are created by hand and carry **no label**, and another stack
can join a network this one created. Both shapes were live on this machine —
a separate Hill90 app stack attached to all three `hill90dev_*` networks:

```
hill90dev_internal   project=        containers=hill90-keycloak hill90-postgres hill90-api …
hill90dev_edge       project=hill90-local-edge   containers=hill90-ui hill90-mcp hill90-minio …
```

The **teardown** guard caught it correctly in the real run and refused to remove
anything:

```
! Left hill90dev_internal in place — 9 container(s) from another project are attached
```

The preflight did not. It now checks what is actually attached, not who owns the
label. Proven by attaching a foreign container:

```
$ docker run -d --name intruder-test --network hill90dev_internal alpine sleep 300
$ bash scripts/local.sh up
✗ Network hill90dev_internal is shared with containers that are not ours:
    intruder-test
    Sharing it means a teardown here would disrupt them. Change NETWORK_PREFIX…

$ bash scripts/local.sh down
! Left hill90dev_internal in place — 1 container(s) from another project are attached
```

## Cold-run evidence

```
COLD: .env.local=absent  containers=0  volumes=0  networks=0  images=0  build cache=0B

$ bash scripts/local.sh up      → 1:23.10  (includes pulling all nine images)
$ bash scripts/local.sh health
Routed surfaces
  ✓ Traefik dashboard — HTTP 200
  ✓ Portainer — HTTP 200
  ✓ Grafana — HTTP 200
  ✓ Prometheus — HTTP 200
Observability internals
  ✓ Prometheus ready
  ✓ Loki ready
  ✓ Grafana health
✓ All local checks passed.
```

All four serving their real UIs:

```
http://traefik.localtest.me:8080/dashboard/   HTTP 200  <title>Traefik</title>
http://portainer.localtest.me:8080/           HTTP 200  <title>Portainer</title>
http://grafana.localtest.me:8080/             HTTP 200  <title>Grafana</title>
http://prometheus.localtest.me:8080/          HTTP 200  <title>Prometheus Time Series Collection and Processing Server</title>
                                                        7 targets, 7 up
```

Teardown, exactly as the runbook claims:

```
before: containers=10 networks=4 volumes=7
after:  containers=0  networks=0 volumes=7      ← volumes intact
```

Runbook cold-start figure corrected to 83 seconds from truly cold, 65 with images
present.

## Checks

```
$ bats tests/scripts/                       203 tests, 0 failures
$ python3 -m pytest tests/checks/ -q        29 passed
$ shellcheck --severity=error scripts/*.sh  (clean)
$ check_env_surface.py   Configuration surface consistent: 22 variable(s)
$ check_md_links.py      no missing local links
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)