### PR TITLE
docs: record that the local runbook is verified cold against main

### DIFF
--- a/docs/runbooks/local-development.md
+++ b/docs/runbooks/local-development.md
@@ -3,6 +3,27 @@
 Run the Hill90 infrastructure stack on a Mac, using the same compose files
 production uses.
 
+> **Verified cold on 2026-07-26 against `main` at `0b40403`.**
+>
+> Not "it worked on the machine that built it" — a fresh `git clone` of `main`
+> into an empty directory, on a Mac with every stack image deleted, no Docker
+> volumes, no networks, no `.env.local` and an empty build cache. Every command
+> below was run exactly as written, in order, with nothing else. Nothing outside
+> this document was needed.
+>
+> | Step | Result |
+> |---|---|
+> | `local.sh up` from a fresh clone, zero images | 10/10 containers, **1:22** |
+> | `local.sh health` | 7/7 checks pass |
+> | Traefik routers | 4 registered, all enabled |
+> | Traefik, Portainer, Grafana, Prometheus in a browser | HTTP 200, each serving its own UI |
+> | Prometheus targets | **7 targets, 7 up, 0 down** |
+> | Grafana `admin/admin` | logs in; 3 datasources, 4 dashboards |
+> | `local.sh down` | containers 10→0, networks 3→0, **volumes 7→7** |
+> | `local.sh up` again | 10/10 containers, **1:06**, 7/7 checks, data intact |
+>
+> Re-verify any time with the commands below; that is the whole point of them.
+
 ## Before you start
 
 Docker Desktop must be running. Nothing else is required — no SOPS, no age key,


### PR DESCRIPTION
The runbook is now the thing Jon actually asked for: instructions someone else
can trust without re-running them.

**Nothing in the runbook needed changing.** The only change is the verification
statement at the top, because the cold proof passed end to end with no knowledge
required beyond the document itself.

## How it was proven

A fresh `git clone` of `main` into an empty directory — not the worktree this was
built in — on a Mac with every stack image deleted, no volumes, no networks, no
`.env.local`, and an empty build cache.

```
$ git clone https://github.com/jonhill90/Hill90.git hill90
$ git rev-parse HEAD
0b40403e63fc455e3e71642d7eb355c47a35c288
$ ls -a | grep -c '^\.env\.local$'
0        # gitignored, as the runbook says

TOTAL-SCRATCH VERIFICATION
  hill90dev containers: 0
  hill90dev volumes:    0
  hill90dev networks:   0
  stack images present: 0
  build cache:          0
```

Then the runbook, verbatim, in order.

**Step 1 — the one command it gives:**

```
$ bash scripts/local.sh up            → 1:22.46 total
10/10 containers up
```

**Step 2 — `bash scripts/local.sh health`:**

```
Routed surfaces
  ✓ Traefik dashboard — HTTP 200
  ✓ Portainer — HTTP 200
  ✓ Grafana — HTTP 200
  ✓ Prometheus — HTTP 200
Observability internals
  ✓ Prometheus ready
  ✓ Loki ready
  ✓ Grafana health
✓ All local checks passed.
```

**Step 3 — Traefik is genuinely routing:**

```
grafana@docker      enabled  ['web']
portainer@docker    enabled  ['web']
prometheus@docker   enabled  ['web']
traefik@docker      enabled  ['web']
```

**Step 4 — each surface serves its own UI in a browser:**

```
http://traefik.localtest.me:8080/dashboard/  HTTP 200  <title>Traefik</title>
http://portainer.localtest.me:8080/          HTTP 200  <title>Portainer</title>
http://grafana.localtest.me:8080/            HTTP 200  <title>Grafana</title>
http://prometheus.localtest.me:8080/         HTTP 200  <title>Prometheus Time Series Collection and Processing Server</title>
```

**Step 5 — Prometheus targets actually up, through the browser-facing route:**

```
cadvisor         up     http://cadvisor:8080/metrics
grafana          up     http://grafana:3000/metrics
loki             up     http://loki:3100/metrics
node-exporter    up     http://node-exporter:9100/metrics
prometheus       up     http://localhost:9090/metrics
tempo            up     http://tempo:3200/metrics
traefik          up     http://traefik:8082/metrics
→ 7 targets, 7 up, 0 down
```

**Step 6 — Grafana with the runbook's own credentials:**

```
login admin/admin: {"message":"Logged in","redirectUrl":"/"}
3 datasources (Loki, Prometheus, Tempo), 4 dashboards
```

**Step 7 — `bash scripts/local.sh down`:**

```
BEFORE: containers 10   networks hill90dev_{edge,internal,agent_internal}   volumes 7
AFTER:  containers 0    networks []                                        volumes 7
```

Containers and networks gone, all seven volumes intact — exactly as documented.

**Step 8 — up a second time:**

```
$ bash scripts/local.sh up            → 1:05.83
✓ All local checks passed.
containers 10 · volumes 7 · 4 dashboards · 7 targets, 7 up
```

Data survived the cycle.

## What the statement records

The SHA, the date, and the measured result of each step — including that the
documented timings are real (1:22 cold with no images, 1:06 with them).

## Checks

```
$ bats tests/scripts/                       203 tests, 0 failures
$ python3 -m pytest tests/checks/ -q        29 passed
$ shellcheck --severity=error scripts/*.sh  (clean)
$ check_env_surface.py   Configuration surface consistent: 22 variable(s)
$ check_md_links.py      no missing local links
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)