### PR TITLE
fix(local): make Traefik's backend network follow NETWORK_PREFIX

### DIFF
--- a/deploy/compose/overrides/local.observability.yml
+++ b/deploy/compose/overrides/local.observability.yml
@@ -7,6 +7,12 @@ services:
   grafana:
     labels:
       - "traefik.http.routers.grafana.tls=false"
+      # Traefik reaches this container over the edge network. The provider-wide
+      # default lives in the static config, which Traefik v2 cannot interpolate,
+      # so it cannot follow NETWORK_PREFIX. This label can, and takes precedence.
+      # Defaults to hill90_edge — exactly what production's traefik.yml already
+      # pins — so production resolves identically.
+      - "traefik.docker.network=${NETWORK_PREFIX:-hill90}_edge"
 
   prometheus:
     # Production deliberately does not route Prometheus: it sits on the internal
@@ -25,3 +31,9 @@ services:
       - "traefik.http.routers.prometheus.tls=false"
       - "traefik.http.routers.prometheus.middlewares=${ADMIN_MIDDLEWARES:-tailscale-only@file}"
       - "traefik.http.services.prometheus.loadbalancer.server.port=9090"
+      # Traefik reaches this container over the edge network. The provider-wide
+      # default lives in the static config, which Traefik v2 cannot interpolate,
+      # so it cannot follow NETWORK_PREFIX. This label can, and takes precedence.
+      # Defaults to hill90_edge — exactly what production's traefik.yml already
+      # pins — so production resolves identically.
+      - "traefik.docker.network=${NETWORK_PREFIX:-hill90}_edge"


### PR DESCRIPTION
## Expected effect on the live VPS: none. No redeploy fires.

Stating this first since it gates merging.

- **No workflow triggers on this path.** The only two push-triggered workflows are `deploy.yml` (`platform/observability/**`, `deploy/compose/prod/docker-compose.vault.yml`, `deploy/compose/prod/docker-compose.observability.yml`) and `tailscale.yml` (`policy.hujson`). This PR touches **only** `deploy/compose/overrides/local.observability.yml`, which matches neither.
- **The file is never used in production.** The overrides are layered in by `scripts/local.sh` only; `deploy.sh` runs the prod compose files alone.
- **The production render is byte-identical.** With no environment set:

```
before: 00c38c17fe7f9503
after:  00c38c17fe7f9503
```

Nothing under `platform/`, no vault paths, no prod compose file. The ten-container census should be unchanged, because nothing is deployed.

## The bug

Changing `NETWORK_PREFIX` silently breaks local routing for any container on more than one network.

`platform/edge/traefik.local.yml:72` pins the Docker provider's network to a literal `hill90dev_edge`. Traefik v2 does no environment interpolation in the static config file, so that value cannot follow the variable. Traefik is then pointed at a network it is not attached to, and requests **hang** rather than fail:

| service | networks | result with a changed prefix |
|---|---|---|
| Prometheus | edge + internal | `000` — no response |
| Grafana | edge + internal | intermittent |
| Portainer | edge only | fine |
| Traefik dashboard | `api@internal` | fine |

This is the opposite of what the runbook advises — *"If `up` reports that a network belongs to another compose project, change `NETWORK_PREFIX` in `.env.local`"* — which is precisely the change that breaks it. Found while running two local stacks side by side to avoid colliding with another lane.

## The fix

`traefik.docker.network` is a **per-container label**, so it lives in compose, which *does* interpolate, and it takes precedence over the provider-wide default. Added to the two routed multi-network services:

```yaml
- "traefik.docker.network=${NETWORK_PREFIX:-hill90}_edge"
```

Fits the #500 pattern: it defaults to `hill90_edge`, the literal already pinned in production's `traefik.yml:53`, so production resolves to exactly what it uses today and only local overrides differ.

## Verification

With `NETWORK_PREFIX=hill90vfy` and the static config left **deliberately** pointing at `hill90dev_edge`, to prove the label carries it:

```
Routed surfaces
  ✓ Traefik dashboard — HTTP 200
  ✓ Portainer — HTTP 200
  ✓ Grafana — HTTP 200
  ✓ Prometheus — HTTP 200

Observability internals
  ✓ Prometheus ready
  ✓ Loki ready
  ✓ Grafana health

✓ All local checks passed.
```

Before the change, the same configuration failed on Prometheus. Local run of the checks CI runs — `check_md_links`, `check_volume_names`, `check_env_surface` (22 variables, all documented and prod-defaulted), `check_secrets_schema`, `check_destructive_commands`, `shellcheck`, and `pytest tests/checks/` (29 passed) — all green.

## Two things deliberately left alone

1. **The static `network:` line stays.** It still cannot be parameterized, and it remains the fallback for containers that carry no label — including the hill90-app stack's services, which are multi-network and would need the same label to be prefix-agnostic. That is a change in the app repo, not here; at the default prefix everything works today. Narrowing this PR to the two services Hill90 owns keeps it reviewable.
2. **`scripts/checks/check_local_parity.py` still does not exist**, though `traefik.local.yml` cites it twice — once specifically as guarding that the network name matches `NETWORK_PREFIX`, which is this exact bug. Flagged in #508 and worth its own change; not invented here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)