### PR TITLE
docs: document the raft migration path for the file storage deprecation (JON-48)

### DIFF
--- a/docs/decisions/2026-07-26-overnight-summary.md
+++ b/docs/decisions/2026-07-26-overnight-summary.md
@@ -49,8 +49,15 @@ use bao operator migrate to move to a supported storage backend by v2.7.0
 
 `platform/vault/config.hcl` uses `storage "file"`, and the compose file pins
 `ghcr.io/openbao/openbao:2` — a floating major tag. **This breaks on a routine
-image pull, not on a deliberate upgrade.** Worth pinning the tag now even if the
-vault decision waits.
+image pull, not on a deliberate upgrade.**
+
+The migration path is now researched and written up in
+[vault-vs-sops.md](vault-vs-sops.md#decision-needed-replacing-the-file-storage-backend-jon-48):
+raft is the answer, the config change is three additive lines, and the unseal
+and auto-unseal flow is unaffected. The useful part: **if you reinitialize the
+vault anyway, switching storage in the same pass costs essentially nothing** —
+the volume is already being wiped. If you decide nothing today, pin the image
+tag; that one line turns an ambush into a scheduled decision.
 
 ---
 

--- a/docs/decisions/vault-vs-sops.md
+++ b/docs/decisions/vault-vs-sops.md
@@ -188,29 +188,146 @@ Then nothing needs doing. SOPS is already the operative store, the schedule is
 off, and the inert vault costs a few hundred MB and one container. Removing it
 entirely is a separate, easy change whenever you want.
 
-## Known future break: the `file` storage backend
+## Decision needed: replacing the `file` storage backend (JON-48)
 
-Independent of which option you pick.
+Independent of the vault-versus-SOPS choice above. This one has a deadline set
+by someone else.
 
-OpenBao logs this on every start of the live vault:
+OpenBao logs this on every start of the live vault (verified on the running
+container, v2.6.1):
 
 ```
 [WARN] storage.file: the file physical backend is deprecated;
 use bao operator migrate to move to a supported storage backend by v2.7.0
 ```
 
-`platform/vault/config.hcl` uses `storage "file"`. It is **removed in v2.7.0**,
-and the compose file pins `ghcr.io/openbao/openbao:2` — a floating major tag —
-so this breaks on a routine image pull, not on a deliberate upgrade.
+`platform/vault/config.hcl` uses `storage "file"`. Upstream calls it
+"a development-only, non-production backend", deprecated in v2.6.0 and
+**removed in v2.7.0**. `docker-compose.vault.yml` pins
+`ghcr.io/openbao/openbao:2` — a floating major tag — so **this breaks on a
+routine image pull, not on a deliberate upgrade**. There is no published date
+for v2.7.0.
 
-Three ways out, in increasing order of effort:
+### What to replace it with
 
-1. **Pin the image** to a 2.6.x tag. Buys time; does not fix it.
-2. **Migrate** to a supported backend with `bao operator migrate`. The obvious
-   target is `raft` (integrated storage), which is single-node friendly.
-3. **Retire the vault**, if the decision above goes that way, and the question
-   disappears.
+Two backends are marked production-ready upstream:
 
-Worth deciding before v2.7.0 lands rather than discovering it when a pull
-breaks the stack. If the vault is reinitialized anyway, switching to `raft` at
-the same time costs almost nothing extra — the volume is being wiped regardless.
+| Backend | Fit for Hill90 |
+|---|---|
+| **`raft`** (integrated storage) | Recommended upstream "for most use cases", needs no additional software, bootstraps as a cluster of size 1. |
+| `postgresql` | Also production-ready, but requires an external Postgres — the one this repo *deleted* in #495. Reintroducing a database to store three secrets would undo the strip. |
+
+**Raft is the answer**, unless the vault is retired entirely.
+
+### What changes in config.hcl
+
+Three edits, all additive:
+
+```hcl
+storage "raft" {
+  path    = "/openbao/raft"
+  node_id = "hill90-vault-1"
+}
+
+listener "tcp" {
+  address         = "0.0.0.0:8200"
+  cluster_address = "0.0.0.0:8201"     # new: raft peer traffic
+  tls_disable     = 1
+}
+
+cluster_addr = "http://127.0.0.1:8201"  # new: required even for one node
+```
+
+`ui`, `disable_mlock`, `api_addr` and the lease TTLs are unchanged.
+`disable_mlock = true` stays as it is.
+
+And in `docker-compose.vault.yml`, the volume mount moves with the path:
+
+```yaml
+- openbao-data:/openbao/raft     # was /openbao/file
+```
+
+Port 8201 does not need publishing or routing — nothing outside the container
+talks to it on a single node.
+
+### Can existing data migrate in place?
+
+**Yes.** `bao operator migrate` works at the storage layer with no decryption,
+so the encrypted blobs — including the unseal key material and any tokens — are
+copied verbatim. **The existing unseal key stays valid.** Documented caveats:
+
+- OpenBao **must be stopped** during the migration.
+- The destination **must not already be initialized**.
+- The source is left intact apart from a lock key, so it is a safe fallback if
+  the migration is abandoned.
+
+The migration config is a small file of its own:
+
+```hcl
+storage_source "file" {
+  path = "/openbao/file"
+}
+storage_destination "raft" {
+  path    = "/openbao/raft"
+  node_id = "hill90-vault-1"
+}
+```
+
+**But for *this* vault, migrating is the wrong move.** The live vault holds no
+policies, no AppRoles and no KV data, and its root token is revoked and
+unrecoverable. A faithful migration would preserve exactly that: an empty,
+permanently unconfigurable vault, now on raft. There is nothing worth carrying
+across.
+
+So the in-place path matters as a general capability and as a fallback — not as
+the recommendation here.
+
+### The useful overlap
+
+**If the vault is being reinitialized anyway, switch storage in the same pass
+and the migration cost is essentially zero.** The reinit runbook above already
+wipes the volume at step 1; changing `config.hcl` and the compose mount before
+step 2 means the fresh `bao operator init` bootstraps directly onto raft. No
+`operator migrate`, no second outage, no extra PR — two lines of config folded
+into work that is already happening.
+
+That is the strongest argument for deciding both questions together rather than
+sequentially.
+
+### What it means for unseal and auto-unseal
+
+**Nothing changes.** The seal is unchanged — still a single Shamir key with
+`-key-shares=1 -key-threshold=1` — and raft alters where data lives, not how it
+is encrypted. `vault.sh unseal`, `vault.sh auto-unseal`, the
+`hill90-vault-unseal.service` systemd unit and its `600 deploy:deploy` key-file
+check all work unmodified.
+
+One genuine improvement: raft brings `bao operator raft snapshot save` and
+`restore`, a consistent point-in-time backup taken from the running server.
+`scripts/backup.sh backup vault` currently tars the volume, which is a
+crash-consistent copy of files under an active writer. Switching it to a raft
+snapshot would be strictly better, and is worth doing at the same time. Note
+the tar path would need updating regardless, since the directory moves.
+
+### Does it shift the vault-versus-SOPS calculus?
+
+**Marginally, and not enough to change the recommendation.**
+
+- *Toward keeping the vault:* raft is the supported, production-grade path, and
+  it improves backups. It removes the "we are running a dev-only backend"
+  objection outright.
+- *Toward SOPS:* it is more moving parts — a peer port, a node identity, an
+  autopilot subsystem and quorum semantics — in service of a single-node vault
+  that currently protects three infrastructure secrets. Single-node raft has a
+  failure tolerance of zero, so it buys no availability here.
+
+The recommendation stands: SOPS is the operative store, and the vault should
+earn its place by having a concrete consumer. What this deprecation changes is
+the *deadline* — the question can no longer be deferred indefinitely, because
+inaction eventually breaks the container on an image pull.
+
+### If you decide nothing right now
+
+**Pin the image tag.** Change `ghcr.io/openbao/openbao:2` to `openbao:2.6.1` in
+`docker-compose.vault.yml`. One line, no migration, and it converts an ambush
+into a scheduled decision. Worth doing even if everything else waits.


### PR DESCRIPTION
Documentation only. The running vault and its config are untouched — the diff is
two markdown files.

Closes JON-48.

## The problem, verified rather than assumed

Read off the live container, not from memory:

```
$ docker exec openbao bao version
OpenBao v2.6.1 (ba7ad88…), committed 2026-07-22

$ docker logs openbao | grep deprecat
[WARN] storage.file: the file physical backend is deprecated;
use bao operator migrate to move to a supported storage backend by v2.7.0
```

Upstream calls `file` "a development-only, non-production backend", deprecated in
v2.6.0 and removed in v2.7.0. `docker-compose.vault.yml` pins
`ghcr.io/openbao/openbao:2` — a floating major tag — so **this breaks on a
routine image pull, not a deliberate upgrade**. No published date for v2.7.0.

## Raft, because Postgres would undo the strip

Only two backends are marked production-ready upstream. Raft is recommended "for
most use cases" and needs no additional software. PostgreSQL is the other — and
would mean reintroducing the database this repo deleted in #495, to store three
infrastructure secrets.

## What actually changes

Three additive lines in `config.hcl` — a `storage "raft"` block, a listener
`cluster_address`, and a top-level `cluster_addr` that is required even for a
single node — plus the compose mount moving `/openbao/file` → `/openbao/raft`.
`ui`, `disable_mlock`, `api_addr` and the lease TTLs are untouched. Port 8201
needs no publishing or routing on one node.

## Can it migrate in place? Yes — but it shouldn't here

`bao operator migrate` works at the storage layer with **no decryption**, so the
encrypted blobs and the existing unseal key survive verbatim. It needs the server
stopped and an uninitialized destination, and leaves the source intact as a
fallback.

**But this vault holds nothing worth carrying.** No policies, no AppRoles, no KV
data, and a revoked, unrecoverable root. A faithful migration would preserve
exactly that: an empty, permanently unconfigurable vault, now on raft. So the
in-place path is documented as a general capability and a fallback, not as the
recommendation.

## The overlap, stated plainly

**If the vault is reinitialized anyway, switching storage in the same pass costs
essentially nothing.** The reinit runbook already wipes the volume at step 1;
changing the config before step 2 makes the fresh `bao operator init` bootstrap
straight onto raft. No `operator migrate`, no second outage, no extra PR — two
lines folded into work already happening.

That is the strongest argument for deciding both questions together.

## Unseal, auto-unseal, systemd: unaffected

The seal is unchanged — still a single Shamir key at
`-key-shares=1 -key-threshold=1`. Raft changes where data lives, not how it is
encrypted. `vault.sh unseal`, `auto-unseal`, `hill90-vault-unseal.service` and
its `600 deploy:deploy` check all work unmodified.

One genuine gain: raft adds `operator raft snapshot save/restore`, a consistent
point-in-time backup from the running server. `backup.sh backup vault` currently
tars the volume under an active writer — worth switching at the same time, and
the tar path has to change anyway since the directory moves.

## Does it move the vault-vs-SOPS needle?

Marginally, both directions, and not enough to change the recommendation. It
removes the "we're running a dev-only backend" objection; it also adds a peer
port, a node identity and quorum semantics to a single-node vault with a failure
tolerance of zero. **What it really changes is the deadline** — the question can
no longer be deferred indefinitely, because inaction eventually breaks the
container.

## If nothing is decided now

Pin the tag to `openbao:2.6.1`. One line, turns an ambush into a scheduled
decision. Worth doing even if everything else waits.

## Verification

Every claim cross-checked against the repo rather than recalled:

```
key-shares=1 -key-threshold=1 in vault.sh      1
compose mounts openbao-data:/openbao/file      1
backup.sh tars openbao-data                    1
config.hcl has ui/disable_mlock/api_addr       3
auto-unseal checks 600 perms                   2
floating openbao:2 tag                         1
```

```
$ bats tests/scripts/                203 tests, 0 failures
$ python3 -m pytest tests/checks/ -q 29 passed
$ shellcheck --severity=error scripts/*.sh  (clean)
$ check_md_links.py                  no missing local links
$ git status --porcelain
 M docs/decisions/2026-07-26-overnight-summary.md
 M docs/decisions/vault-vs-sops.md
```

Sources: [raft storage config](https://openbao.org/docs/configuration/storage/raft/) ·
[operator migrate](https://openbao.org/docs/commands/operator/migrate/) ·
[deprecation notices](https://openbao.org/community/deprecation/) ·
[storage backends](https://openbao.org/docs/configuration/storage/) ·
[operator raft](https://openbao.org/docs/commands/operator/raft/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)