### PR TITLE
chore(vault): pin the OpenBao image to 2.6.1

### DIFF
--- a/deploy/compose/prod/docker-compose.vault.yml
+++ b/deploy/compose/prod/docker-compose.vault.yml
@@ -17,7 +17,21 @@ volumes:
 
 services:
   openbao:
-    image: ghcr.io/openbao/openbao:2
+    # PINNED DELIBERATELY. This was ghcr.io/openbao/openbao:2 — a floating major
+    # tag — which means a routine pull would have taken this container to v2.7.0
+    # the day it ships. v2.7.0 REMOVES the `file` storage backend that
+    # platform/vault/config.hcl uses, so the vault would have failed to start
+    # with no warning and no change on our side.
+    #
+    # Pinning does not fix that; it converts a surprise outage into a deliberate
+    # upgrade. Before moving off 2.6.x, migrate the storage backend — the path is
+    # written up in docs/decisions/vault-vs-sops.md, section "Decision needed:
+    # replacing the `file` storage backend".
+    #
+    # 2.6.1 is exactly what was running when this was pinned: tags 2, 2.6, 2.6.1
+    # and latest all resolved to sha256:5b2486ab0fb90bbc788cc345b0a08616dfb375873ee8be5df3a2fd4d378a67e0
+    # on 2026-07-26, so this pin was a no-op at the time it landed.
+    image: ghcr.io/openbao/openbao:2.6.1
     container_name: ${CONTAINER_PREFIX:-}openbao
     restart: unless-stopped
     command: server

--- a/docs/decisions/2026-07-26-overnight-summary.md
+++ b/docs/decisions/2026-07-26-overnight-summary.md
@@ -47,17 +47,18 @@ This applies whichever way you decide above.
 use bao operator migrate to move to a supported storage backend by v2.7.0
 ```
 
-`platform/vault/config.hcl` uses `storage "file"`, and the compose file pins
-`ghcr.io/openbao/openbao:2` — a floating major tag. **This breaks on a routine
-image pull, not on a deliberate upgrade.**
+`platform/vault/config.hcl` uses `storage "file"`. The compose file used to pin
+`ghcr.io/openbao/openbao:2`, a floating major tag, which would have broken on a
+routine image pull rather than a deliberate upgrade — **it is now pinned to
+`2.6.1`** (#518), so the surprise is gone. The vault still cannot be upgraded
+past 2.6.x until the storage backend moves.
 
 The migration path is now researched and written up in
 [vault-vs-sops.md](vault-vs-sops.md#decision-needed-replacing-the-file-storage-backend-jon-48):
 raft is the answer, the config change is three additive lines, and the unseal
 and auto-unseal flow is unaffected. The useful part: **if you reinitialize the
 vault anyway, switching storage in the same pass costs essentially nothing** —
-the volume is already being wiped. If you decide nothing today, pin the image
-tag; that one line turns an ambush into a scheduled decision.
+the volume is already being wiped.
 
 ---
 

--- a/docs/decisions/vault-vs-sops.md
+++ b/docs/decisions/vault-vs-sops.md
@@ -203,10 +203,13 @@ use bao operator migrate to move to a supported storage backend by v2.7.0
 
 `platform/vault/config.hcl` uses `storage "file"`. Upstream calls it
 "a development-only, non-production backend", deprecated in v2.6.0 and
-**removed in v2.7.0**. `docker-compose.vault.yml` pins
-`ghcr.io/openbao/openbao:2` — a floating major tag — so **this breaks on a
-routine image pull, not on a deliberate upgrade**. There is no published date
-for v2.7.0.
+**removed in v2.7.0**. There is no published date for v2.7.0.
+
+`docker-compose.vault.yml` used to pin `ghcr.io/openbao/openbao:2` — a floating
+major tag — so this would have broken on a routine image pull rather than a
+deliberate upgrade. **It is now pinned to `2.6.1`** (#518), which removes the
+ambush but not the underlying problem: the storage backend still has to move
+before OpenBao can be upgraded past 2.6.x.
 
 ### What to replace it with
 
@@ -328,6 +331,11 @@ inaction eventually breaks the container on an image pull.
 
 ### If you decide nothing right now
 
-**Pin the image tag.** Change `ghcr.io/openbao/openbao:2` to `openbao:2.6.1` in
-`docker-compose.vault.yml`. One line, no migration, and it converts an ambush
-into a scheduled decision. Worth doing even if everything else waits.
+**The image tag is already pinned** to `2.6.1` (#518), so nothing is on fire and
+no upgrade can arrive by surprise. That was the one piece worth doing ahead of
+the decision.
+
+What remains is that the vault cannot move past 2.6.x until the storage backend
+changes. That is a decision with no deadline attached now — but it is still a
+decision, and it will resurface the first time a security fix lands in a version
+this pin cannot reach.


### PR DESCRIPTION
> ## ⚠️ This merge deploys to the live host
>
> `deploy/compose/prod/docker-compose.vault.yml` is a trigger path in
> `deploy.yml`, so merging runs **deploy-vault** and **recreates the openbao
> container** on the VPS.
>
> **Expected sequence:** container recreated onto the *identical* image →
> `deploy.sh vault` calls `vault.sh auto-unseal` → vault returns to
> `healthy`, unsealed.
>
> The vault is initialized and auto-unseal is proven, including through the
> `hill90-vault-unseal.service` systemd unit, so a recreate is the routine path
> rather than a risk. The one thing worth watching is that it comes back
> **unsealed**, not merely running — a sealed vault still reports the container
> as up.

## Why

`docker-compose.vault.yml` pinned `ghcr.io/openbao/openbao:2` — a floating major
tag. **v2.7.0 removes the `file` storage backend** that
`platform/vault/config.hcl` uses, so the vault would have failed to start on a
routine pull, with no change on our side and no warning.

Pinning does not fix that. It converts a surprise outage into a deliberate
upgrade, which is the whole point.

## Pinned to what is actually deployed, not to an assumption

You asked me not to assume 2.6.1 — so I checked the live container and then the
registry.

```
$ docker inspect openbao --format '{{.Config.Image}}'
ghcr.io/openbao/openbao:2
$ docker inspect openbao --format '{{.Image}}'
sha256:5b2486ab0fb90bbc788cc345b0a08616dfb375873ee8be5df3a2fd4d378a67e0
$ docker exec openbao bao version
OpenBao v2.6.1 (ba7ad88…), committed 2026-07-22T14:22:20Z
```

And what each candidate tag resolves to on ghcr.io right now:

```
tag 2        -> sha256:5b2486ab0fb90bbc788cc345b0a08616dfb375873ee8be5df3a2fd4d378a67e0
tag 2.6.1    -> sha256:5b2486ab0fb90bbc788cc345b0a08616dfb375873ee8be5df3a2fd4d378a67e0
tag 2.6      -> sha256:5b2486ab0fb90bbc788cc345b0a08616dfb375873ee8be5df3a2fd4d378a67e0
tag latest   -> sha256:5b2486ab0fb90bbc788cc345b0a08616dfb375873ee8be5df3a2fd4d378a67e0

live         -> sha256:5b2486ab0fb90bbc788cc345b0a08616dfb375873ee8be5df3a2fd4d378a67e0
```

All identical, so **this pin is provably a no-op today** — the recreate lands on
the same image bytes that are already running.

`2.6.1` rather than `2.6`, because `2.6` floats too and would carry patch
releases in silently. The point is that version changes become deliberate.

## The change

One line, plus a comment explaining why it is pinned, that pinning is a deferral
rather than a fix, and where the migration path is written up.

Resolved-config diff is exactly the image line and nothing else:

```
$ diff <(git show origin/main:…vault.yml | docker compose -f - config) <(docker compose -f …vault.yml config)
24c24
<     image: ghcr.io/openbao/openbao:2
---
>     image: ghcr.io/openbao/openbao:2.6.1
```

Both decision docs are updated in the same commit — they described the floating
tag as the current state, which stops being true when this merges.

## What this does not do

It does not solve the storage problem. The vault still cannot be upgraded past
2.6.x until `file` moves to `raft`; that path is in
[vault-vs-sops.md](docs/decisions/vault-vs-sops.md#decision-needed-replacing-the-file-storage-backend-jon-48).
The pin buys time and removes the deadline pressure — it will resurface the first
time a security fix lands in a version this pin cannot reach.

## Checks

```
$ bats tests/scripts/                203 tests, 0 failures
$ python3 -m pytest tests/checks/ -q 29 passed
$ check_volume_names.py / check_secrets_schema.py / check_env_surface.py / check_md_links.py / check_destructive_commands.sh   (all clean)
$ docker compose config — all three prod stacks validate
```

Nothing in the test suite asserted the floating tag, so nothing needed loosening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)