### PR TITLE
docs: refresh the overnight summary as of main 9191015

### DIFF
--- a/docs/decisions/2026-07-26-overnight-summary.md
+++ b/docs/decisions/2026-07-26-overnight-summary.md
@@ -1,7 +1,7 @@
 # Overnight summary — 2026-07-26
 
-What changed in Hill90 while you were asleep. Twenty PRs merged; `main` is
-`ce2363b`. Nothing is broken and nothing is waiting on you to unblock work.
+What changed while you slept. Hill90 `main` is `9191015`, 25 PRs merged since the
+strip began. Nothing is broken and nothing is waiting on you to unblock work.
 
 ---
 
@@ -10,128 +10,132 @@ What changed in Hill90 while you were asleep. Twenty PRs merged; `main` is
 ### 1. Whether to reinitialize the vault
 
 OpenBao is running, unsealed, healthy, auto-unsealing across reboots — and
-**permanently unconfigurable**. The root token was revoked immediately after
-init, before any policies, AppRoles or KV data existed. On OpenBao ≥ 2.5.3 the
-unauthenticated root-generation endpoints are disabled by default, so
-`bao operator generate-root` returns 403; that was verified against 2.6.1 on a
-throwaway instance and again on the live vault. There is no supported way back
-to root.
+**permanently unconfigurable**. Root was revoked immediately after init, before
+any policies, AppRoles or KV data existed. On OpenBao ≥ 2.5.3 the
+root-regeneration endpoints are disabled by default, so `bao operator
+generate-root` returns 403 — verified on a throwaway 2.6.1 instance and again on
+the live vault. There is no supported way back to root.
 
-So the vault holds nothing, and every deploy falls back to SOPS — visibly:
-
-```
-WARNING: OpenBao available but login failed for vault, falling back to SOPS
-```
-
-Nothing is broken by this. SOPS has been the operative secrets store since June
-and still is.
+Nothing is broken by this. The vault holds nothing, every deploy falls back to
+SOPS, and SOPS has been the operative store since June.
 
 The choice is in [vault-vs-sops.md](vault-vs-sops.md), which recommends
-documenting SOPS as the active path and leaving the vault code dormant until
-there is a concrete consumer. If you'd rather reinitialize, the ordered runbook
-is in the same doc — it costs a volume deletion on the live host and a second PR
-for the new unseal key, because a fresh init invalidates the one merged in #505.
-The ordering matters: revoking root early is exactly what produced the current
-inert vault.
+documenting SOPS as the active path and leaving the vault dormant until there is
+a concrete consumer. The reinit runbook is in the same doc; it costs a volume
+deletion on the live host and a second PR for the new unseal key.
 
-The counter-argument the doc makes explicitly: this is a homelab, and running
-OpenBao to learn OpenBao is a perfectly good reason — worth stating deliberately
-rather than letting the docs assert it for you.
+**If you do reinitialize, switch storage to raft in the same pass** — the volume
+is being wiped anyway, so it is two lines of config rather than a separate
+migration. Full path in
+[the raft section](vault-vs-sops.md#decision-needed-replacing-the-file-storage-backend-jon-48)
+(#517). The `file` backend is removed in OpenBao v2.7.0; the image is now pinned
+to `2.6.1` (#518) so that arrives as a deliberate upgrade rather than an ambush,
+but the vault cannot move past 2.6.x until the backend changes.
 
-### 2. The `file` storage backend is removed in OpenBao v2.7.0
+### 2. Whether to delete 159 remote branches
 
-This applies whichever way you decide above.
+Hill90 has 168 branches besides `main`. The audit (#519) puts every one in a
+category, and **159 have nothing at risk** — either every file version already
+exists in a preserved history, or the only unique content is a superseded draft
+of a file that later merged.
 
+```bash
+bash scripts/cleanup-branches.sh delete-safe --yes    # 159 branches, one push
 ```
-[WARN] storage.file: the file physical backend is deprecated;
-use bao operator migrate to move to a supported storage backend by v2.7.0
-```
 
-`platform/vault/config.hcl` uses `storage "file"`. The compose file used to pin
-`ghcr.io/openbao/openbao:2`, a floating major tag, which would have broken on a
-routine image pull rather than a deliberate upgrade — **it is now pinned to
-`2.6.1`** (#518), so the surprise is gone. The vault still cannot be upgraded
-past 2.6.x until the storage backend moves.
+Dry-runs without `--yes`. It never touches the other nine.
 
-The migration path is now researched and written up in
-[vault-vs-sops.md](vault-vs-sops.md#decision-needed-replacing-the-file-storage-backend-jon-48):
-raft is the answer, the config change is three additive lines, and the unseal
-and auto-unseal flow is unaffected. The useful part: **if you reinitialize the
-vault anyway, switching storage in the same pass costs essentially nothing** —
-the volume is already being wiped.
+**The nine that did hold unique work are already tagged** under
+`archive/unmerged/`, verified present on the remote, so they are safe permanently
+whatever you decide. Between them they held ~1,059 lines existing nowhere else —
+the largest a 428-line tmux supervisor skill document, the rest shelved-app UI.
+Details in [the branch audit](2026-07-26-branch-audit.md).
 
 ---
 
-## The app strip is finished
+## The three repositories
 
-Steps 1–5 all merged. Hill90 is now what the June decision said it should be:
-infrastructure only, three stacks, ten containers.
+### Hill90 — infrastructure only, deployed and healthy
 
-| Step | PR |
-|---|---|
-| Remove the eight application services | #494 |
-| Remove Keycloak, Postgres, MinIO | #495 |
-| Rewrite the documentation | #496 |
-| Drop observability config for removed services | #497 |
-| Final verification and residual fixes | #498 |
+The strip is finished, steps 1–5 (#494–#498). Eleven containers on the VPS: edge
+(traefik, dns-manager, portainer), observability (prometheus, grafana, loki,
+tempo, promtail, node-exporter, cadvisor) and openbao. `services/dns-manager`
+stayed — it is the DNS-01 ACME webhook Traefik depends on, not app code.
 
-The application is preserved twice: the `archive/app-stack-final` tag, and the
-`hill90-app` repository with full history. `services/dns-manager` stayed — it is
-live infrastructure, the DNS-01 ACME webhook Traefik depends on, not app code.
-
-Confirmed on the live host after deploy: ten containers, observability
-redeployed healthy, edge serving. Detail in
-[infra-app-separation.md](infra-app-separation.md).
-
-## Hill90 now runs on your Mac
+It runs on your Mac now, from the same compose files production uses:
 
 ```bash
 bash scripts/local.sh up
 ```
-
-Ten containers in about 80 seconds. It is running right now — open these:
 
 - http://grafana.localtest.me:8080/ — admin / admin
 - http://prometheus.localtest.me:8080/
 - http://traefik.localtest.me:8080/dashboard/
 - http://portainer.localtest.me:8080/
 
-**The same compose files serve local and prod.** Every variable defaults to the
-production value, so with no environment set the files resolve byte-for-byte to
-what the VPS gets — local development is what happens when you *add* variables,
-and it cannot silently change production. `check_env_surface.py` fails CI if the
-two drift, and `deploy.sh teardown` makes rebuild routine without ever touching
-volumes.
+Every variable defaults to the production value, so with no environment set the
+compose files resolve byte-for-byte to what the VPS gets — local development is
+what happens when you *add* variables. `check_env_surface.py` fails CI if the two
+drift. Guide: [local-development.md](../runbooks/local-development.md).
 
-PRs #500, #508, #512, #513. Full guide:
-[local-development.md](../runbooks/local-development.md) — which carries a
-verified-cold statement: proven from a fresh clone on a machine with no images,
-no volumes and no config, not from the machine that built it (#514).
+### hill90-app — the extracted application, CI green
 
-## DNS and docs drift cleaned up
+The eight application services with full history. **CI passes on `main` across
+all six jobs — 1,953 tests, zero failures**, on its first ever run. For a
+codebase shelved for a year that is a better result than expected. Its local
+stack brings up nine healthy containers with a working login.
 
-**`dns sync` would have wiped the zone.** It posted `overwrite: true` with 7
-record groups against a 33-group zone, which replaces the whole zone. That would
-have destroyed the `remote` A record — the only SSH path to the VPS — plus every
-mail record, `www`, `docs` and a minecraft SRV. The flag is gone, verified
-empirically rather than from the API docs. `remote` was also missing from both
-repo record files despite being load-bearing; both now agree, with tests. #504
+There is still no deployment path; that is called out honestly in its
+`RESURRECTION.md`.
 
-Also: `vps.hill90.com` repointed from a dead address, `openclaw` and its orphaned
-ACME challenge deleted (zone 33 → 31, each verified after writing), and
-`secrets.md` corrected — it claimed the age private key is tracked in the repo,
-which `.gitignore` has always excluded.
+### docker-infra-template — the generic boilerplate
 
-## Housekeeping
+Scaffolded, with a tier-2 DNS-01 httpreq sidecar and Hostinger driver, the local
+functional verification matrix, the OpenBao and local-dev lessons back-ported
+from Hill90, and first-run docs written to assume no prior context. CI green.
 
-- `vault.sh init` and `setup-sync-token` no longer print the unseal key or root token — they were echoing secrets that would have landed in Actions logs. #499, #510
+---
+
+## What is verified, and how
+
+Claims here were checked rather than recalled.
+
+**The vault pin deployed and recovered unattended.** `deploy-vault` ran on merge
+and openbao came back on `2.6.1`, healthy and unsealed, without intervention — so
+auto-unseal surviving an unattended recreate is now proven in production rather
+than in a test. Pinned to what was genuinely running: tags `2`, `2.6`, `2.6.1`
+and `latest` all resolved to the same digest, so the pin was a no-op.
+
+**The local runbook is verified cold** (#514) — fresh clone into an empty
+directory, every stack image deleted, no volumes, no networks, no `.env.local`,
+empty build cache. Ten containers in 83 seconds, all four surfaces serving their
+own UI, 7/7 Prometheus targets up, teardown leaving volumes intact.
+
+**The branch audit used blob identity, not merge-base.** Ancestry would have
+called 162 branches unmerged, which is an artifact of squash merging; comparing
+content to `main` flags 160, because the strip deleted `services/`. Indexing all
+3,635 blob SHAs across the three histories survives rewritten SHAs, retitled
+squashes and filtered history. Two of my own checks had bugs producing false
+alarms before being caught — both recorded in the audit.
+
+**DNS drift is closed.** `dns sync` posted `overwrite: true` with 7 record groups
+against a 33-group zone, which would have destroyed the `remote` A record — the
+only SSH path to the VPS — plus every mail record (#504). Fixed and
+regression-tested. `vps` repointed, `openclaw` and its orphaned ACME challenge
+deleted; the zone is 31 groups, every hostname verified on two resolvers.
+
+---
+
+## Housekeeping already done
+
+- `vault.sh init` and `setup-sync-token` no longer print the unseal key or root token — they were echoing secrets into what would have been Actions logs. #499, #510
 - A sanctioned `vault-init.yml` workflow replaced hand-run SSH for initialization. #502
 - `OPENBAO_UNSEAL_KEY` is stored in SOPS without passing through the process table or shell history. #505
-- The weekly `vault-sync-to-sops` schedule is **disabled**. It had failed every Monday since June and cannot succeed without root; an alert that always fires just trains you to ignore it. `workflow_dispatch` still works, and the four conditions for re-enabling are recorded at the schedule block. Reversible in one line. #511
+- The weekly `vault-sync-to-sops` schedule is **disabled**. It had failed every Monday since June and cannot succeed without root; an alert that always fires only trains you to ignore it. `workflow_dispatch` still works and the four conditions for re-enabling are recorded at the schedule block. Reversible in one line. #511
+- `docs/reference/secrets.md` claimed the age private key is tracked in the repo. `.gitignore` has always excluded it. Corrected. #504
 
 ## Housekeeping you may want to do
 
-There are 31 containers on this Mac across three copies of the stack —
-`hill90dev` (yours, keep it), plus `hill90vfy` and `verify94072` from other
-lanes still mid-verification. Those two will be torn down by the lanes that own
-them; they are only noted here so the container count is not a surprise.
+Three copies of the infra stack are running on your Mac — `hill90dev` is yours,
+`hill90vfy` and `verify94072` belong to lanes that were mid-verification. They
+tear down on their own; noted only so the container count is not a surprise.


### PR DESCRIPTION
The summary said twenty PRs and `main ce2363b`. It is now **twenty-five** and
`9191015`, and what landed since is the part worth reading.

Same shape — decisions first, then repositories, then verification. Still ~1,050
words.

## What changed in it

**Decision 1 — the vault** is unchanged in substance but now carries the raft
migration path (#517) and the image pin (#518), so the `file` storage
deprecation reads as *part of that decision* rather than a separate alarm. The
key line: if you reinitialize anyway, switching storage in the same pass costs
two lines of config instead of a separate migration.

**Decision 2 — the branches** is new. The audit (#519) categorised all 168, and
**159 have nothing at risk**. The nine that held work existing nowhere else are
already tagged under `archive/unmerged/` and verified on the remote, so the
irreversible part is already neutralised — what remains is a one-command cleanup
that is Jon's call, not mine.

**The repositories section now covers all three** rather than only Hill90:

- **Hill90** — stripped, eleven containers on the VPS, running locally on the Mac
- **hill90-app** — CI green on its **first ever run**, 1,953 tests across six jobs, zero failures. Confirmed from the repo's own `RESURRECTION.md` and the run's job list, not assumed.
- **docker-infra-template** — scaffolded, DNS-01 httpreq sidecar with Hostinger driver, verification matrix, back-ported OpenBao and local-dev lessons, first-run docs. CI green.

**Verification section** records that the vault pin deployed and openbao came
back healthy and unsealed on its own — auto-unseal through an unattended
recreate, proven in production rather than in a test.

Also folded in the `secrets.md` age-key correction, which the previous version
mentioned only in passing.

## Verified rather than recalled

```
main SHA                          9191015
PRs since strip                   25
archive/unmerged tags on remote   9
openbao pinned in compose         1
raft-section anchor resolves      1
PR numbers #494 #498 #504 #505 #510 #511 #514 #517 #518 #519   all present in f03f12d..main
```

```
$ bats tests/scripts/                203 tests, 0 failures
$ python3 -m pytest tests/checks/ -q 29 passed
$ check_md_links.py                  no missing local links
```

I confirmed the 1,953 figure from `hill90-app`'s own record after a first
grep-with-`&&` gave a false positive — `head` always exits 0, so the confirmation
echo fired regardless of whether the match existed.

## Not done, deliberately

`delete-safe` was **not** run. 159 branches with nothing at risk is still Jon's
call, and the script makes it a one-minute job after a glance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)