### PR TITLE
feat(vault): reinitialize as one action, with the raft switch included (JON-49)

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -92,6 +92,21 @@ HTTP_PORT=8080
 HTTPS_PORT=8443
 
 
+# --- Vault storage backend ---------------------------------------------------
+#
+# Which OpenBao config file to mount and where its data lives. Production
+# defaults to the file backend, which is what it has always run. The raft
+# variant is selected by .github/workflows/vault-reinitialize.yml at the moment
+# the volume is wiped — the only time storage can change for free.
+#
+# Local development does not run the vault stack, so these are here for the
+# parity check rather than for you to set.
+#
+# Production defaults: config.hcl / /openbao/file
+VAULT_CONFIG_FILE=config.hcl
+VAULT_DATA_PATH=/openbao/file
+
+
 # --- Namespacing -------------------------------------------------------------
 #
 # A developer Mac may already be running other Docker projects — including, as

--- a/.github/workflows/vault-reinitialize.yml
+++ b/.github/workflows/vault-reinitialize.yml
@@ -1,0 +1,378 @@
+name: Vault Reinitialize (Prod)
+
+# The whole reinitialize decision as ONE action.
+#
+# docs/decisions/vault-vs-sops.md describes reinitializing as seven ordered
+# steps, and JON-48 adds a storage migration that is only free at the moment the
+# volume is wiped. Doing those by hand means getting the order right under
+# pressure — and getting it wrong is what produced the current inert vault, by
+# revoking root before anything had been configured.
+#
+# So this runs the whole sequence, in the order that works:
+#
+#   backup -> wipe -> redeploy (on raft) -> init -> unseal -> store key
+#          -> setup -> seed -> setup-sync-token -> PR the new secrets
+#
+# Root is NOT revoked. That is the one-way door, it is the mistake this
+# workflow exists to avoid repeating, and it is left as a separate deliberate
+# command printed at the end.
+#
+# DESTRUCTIVE: it deletes the openbao-data volume. Three things stand in the
+# way of that happening by accident:
+#
+#   1. A typed confirmation. The input must be exactly REINITIALIZE.
+#   2. A data check. If the vault holds KV secrets, the run stops. A vault that
+#      someone has since put real secrets into is never silently destroyed.
+#   3. A backup. The volume is archived before anything is removed, and the run
+#      aborts if that backup fails.
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: 'Type REINITIALIZE (exactly) to confirm. This DELETES the vault data volume.'
+        required: true
+        type: string
+      switch_to_raft:
+        description: 'Also move storage from the deprecated file backend to raft. Free to do now — the volume is being wiped anyway.'
+        required: false
+        default: true
+        type: boolean
+      i_have_read_the_decision_doc:
+        description: 'Confirm you have read docs/decisions/vault-vs-sops.md and intend to reinitialize.'
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: deploy-prod
+  cancel-in-progress: false
+
+jobs:
+  reinitialize:
+    name: Reinitialize OpenBao
+    runs-on: ubuntu-latest
+    environment: production
+
+    steps:
+      # ---- Guards, before anything is touched --------------------------------
+
+      - name: Check confirmation
+        run: |
+          if [ "${{ inputs.confirm }}" != "REINITIALIZE" ]; then
+            echo "::error::Confirmation not matched. Type exactly: REINITIALIZE"
+            exit 1
+          fi
+          if [ "${{ inputs.i_have_read_the_decision_doc }}" != "true" ]; then
+            echo "::error::Read docs/decisions/vault-vs-sops.md first, then set the acknowledgement to true."
+            exit 1
+          fi
+          echo "Confirmed. Storage target: ${{ inputs.switch_to_raft && 'raft (integrated storage)' || 'file (deprecated, removed in v2.7.0)' }}"
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Tailscale
+        uses: tailscale/github-action@v2
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:github-actions
+
+      - name: Setup SSH key
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.VPS_SSH_PRIVATE_KEY }}" > ~/.ssh/vps_key
+          chmod 600 ~/.ssh/vps_key
+
+      - name: Setup SOPS/age for secrets
+        env:
+          SOPS_VERSION: "3.9.4"
+        run: |
+          SOPS_URL="https://github.com/getsops/sops/releases/download/v${SOPS_VERSION}/sops-v${SOPS_VERSION}.linux.amd64"
+          curl -fsSL -o /tmp/sops "$SOPS_URL"
+          if file /tmp/sops | grep -q "HTML"; then
+            echo "::error::SOPS download returned HTML instead of binary — check URL: $SOPS_URL"
+            exit 1
+          fi
+          chmod +x /tmp/sops
+          sudo mv /tmp/sops /usr/local/bin/sops
+          mkdir -p ~/.config/sops/age
+          echo "${{ secrets.SOPS_AGE_KEY }}" > ~/.config/sops/age/keys.txt
+          chmod 600 ~/.config/sops/age/keys.txt
+
+      - name: Get Tailscale IP from secrets
+        id: get-ip
+        run: |
+          TAILSCALE_IP=$(sops -d --extract '["TAILSCALE_IP"]' infra/secrets/prod.enc.env)
+          echo "::add-mask::$TAILSCALE_IP"
+          echo "tailscale_ip=$TAILSCALE_IP" >> $GITHUB_OUTPUT
+
+      - name: Verify SSH connectivity
+        run: |
+          ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no -o ConnectTimeout=10 \
+            deploy@${{ steps.get-ip.outputs.tailscale_ip }} 'echo "SSH connection successful"'
+
+      # The guard that matters. If the vault holds KV data, someone has put real
+      # secrets in it since this decision was written, and wiping it would
+      # destroy them. Refuse rather than assume.
+      #
+      # A root token on disk means the vault is configurable, so the data can be
+      # enumerated directly. Without one the vault cannot be read at all — which
+      # is the current state and is itself evidence it holds nothing usable —
+      # but the backup below covers that case regardless.
+      - name: Refuse if the vault holds data
+        run: |
+          IP=${{ steps.get-ip.outputs.tailscale_ip }}
+          HAS_TOKEN=$(ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no deploy@$IP \
+            'test -s /opt/hill90/secrets/openbao-root.token && echo yes || echo no')
+          echo "root token on host: $HAS_TOKEN"
+
+          if [ "$HAS_TOKEN" = "yes" ]; then
+            KEYS=$(ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no deploy@$IP \
+              'docker exec -e BAO_ADDR=http://127.0.0.1:8200 \
+                 -e BAO_TOKEN="$(cat /opt/hill90/secrets/openbao-root.token)" \
+                 openbao bao kv list -format=json secret/ 2>/dev/null | jq -r "length" || echo 0')
+            echo "KV entries under secret/: ${KEYS:-0}"
+            if [ "${KEYS:-0}" != "0" ]; then
+              echo "::error::The vault holds ${KEYS} KV entrie(s) under secret/. Refusing to destroy it."
+              echo "::error::Back them up and remove them deliberately, or reinitialize by hand."
+              exit 1
+            fi
+            echo "Vault is configurable and empty. Safe to proceed."
+          else
+            echo "No root token on the host: the vault cannot be read or configured."
+            echo "That is the documented inert state. Proceeding — the backup below is the safety net."
+          fi
+
+      # Unconditional, and a hard failure. Whatever the guard above could or
+      # could not prove, the bytes are archived before anything is deleted.
+      - name: Back up the existing vault volume
+        run: |
+          ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
+            deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
+            'cd /opt/hill90/app && bash scripts/backup.sh backup vault'
+
+      - name: Verify the backup exists and is non-empty
+        run: |
+          OUT=$(ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
+            deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
+            'find /opt/hill90/backups/vault -name "openbao-data.tar.gz" -newermt "-15 minutes" -size +1k | sort | tail -1')
+          echo "backup archive: ${OUT:-<none>}"
+          if [ -z "$OUT" ]; then
+            echo "::error::No fresh non-empty vault backup found. Refusing to wipe the volume."
+            exit 1
+          fi
+
+      - name: Sync host checkout to main
+        run: |
+          ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
+            deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
+            'cd /opt/hill90/app && git fetch origin && git reset --hard origin/main'
+
+      # ---- The destructive part ---------------------------------------------
+
+      - name: Stop the vault stack and remove its volume
+        run: |
+          IP=${{ steps.get-ip.outputs.tailscale_ip }}
+          ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no deploy@$IP \
+            'cd /opt/hill90/app && docker compose -p hill90-prod-platform -f deploy/compose/prod/docker-compose.vault.yml down'
+          ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no deploy@$IP \
+            'docker volume rm openbao-data'
+          echo "Volume removed."
+
+      # Storage is chosen here, at the only moment it is free to change. The
+      # variables default to the file backend, so leaving switch_to_raft off
+      # reproduces the previous behaviour exactly.
+      - name: Redeploy the vault
+        run: |
+          IP=${{ steps.get-ip.outputs.tailscale_ip }}
+          if [ "${{ inputs.switch_to_raft }}" = "true" ]; then
+            ENVS='export VAULT_CONFIG_FILE=config.raft.hcl VAULT_DATA_PATH=/openbao/raft;'
+            echo "Deploying onto raft (integrated storage)."
+          else
+            ENVS=''
+            echo "Deploying onto the file backend — deprecated, removed in OpenBao v2.7.0."
+          fi
+          # deploy.sh calls auto-unseal, which is a no-op on an uninitialized
+          # vault. Verify readiness legitimately fails here: an uninitialized
+          # OpenBao answers 501 on /v1/sys/health. That is expected, so the
+          # deploy is allowed to fail and the guard is the explicit check below.
+          ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no deploy@$IP \
+            "cd /opt/hill90/app && export SOPS_AGE_KEY_FILE=/opt/hill90/secrets/keys/keys.txt && ${ENVS} bash scripts/deploy.sh vault prod" || true
+
+      - name: Confirm the vault is up and uninitialized
+        run: |
+          IP=${{ steps.get-ip.outputs.tailscale_ip }}
+          for i in $(seq 1 30); do
+            STATE=$(ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no deploy@$IP \
+              'docker exec -e BAO_ADDR=http://127.0.0.1:8200 openbao bao status -format=json 2>/dev/null | jq -r ".initialized"' || echo "")
+            [ -n "$STATE" ] && break
+            sleep 4
+          done
+          echo "initialized=$STATE"
+          if [ "$STATE" != "false" ]; then
+            echo "::error::Expected a fresh uninitialized vault, got initialized=$STATE"
+            exit 1
+          fi
+          if [ "${{ inputs.switch_to_raft }}" = "true" ]; then
+            STORAGE=$(ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no deploy@$IP \
+              'docker exec -e BAO_ADDR=http://127.0.0.1:8200 openbao bao status -format=json 2>/dev/null | jq -r ".storage_type"')
+            echo "storage_type=$STORAGE"
+            if [ "$STORAGE" != "raft" ]; then
+              echo "::error::Asked for raft, vault reports storage_type=$STORAGE"
+              exit 1
+            fi
+          fi
+
+      # ---- Rebuild, in the order that works ---------------------------------
+
+      - name: Initialize
+        run: |
+          ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
+            deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
+            'cd /opt/hill90/app && bash scripts/vault.sh init'
+
+      - name: Verify key file ownership and mode
+        run: |
+          OUT=$(ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
+            deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
+            'stat -c "%a %U:%G" /opt/hill90/secrets/openbao-unseal.key')
+          echo "unseal key: $OUT"
+          if [ "$OUT" != "600 deploy:deploy" ]; then
+            echo "::error::Unseal key must be 600 deploy:deploy — the auto-unseal systemd unit runs as deploy. Got: $OUT"
+            exit 1
+          fi
+
+      - name: Unseal
+        run: |
+          ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
+            deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
+            'cd /opt/hill90/app && bash scripts/vault.sh unseal'
+
+      - name: Store the unseal key in SOPS on the host
+        run: |
+          ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
+            deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
+            'cd /opt/hill90/app && export SOPS_AGE_KEY_FILE=/opt/hill90/secrets/keys/keys.txt && bash scripts/vault.sh store-unseal-key'
+
+      # Order is the entire point. setup and seed need root, so they run while
+      # root still exists — which is what did not happen last time.
+      - name: Configure — policies, AppRoles, KV engine
+        run: |
+          ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
+            deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
+            'cd /opt/hill90/app && export SOPS_AGE_KEY_FILE=/opt/hill90/secrets/keys/keys.txt && export BAO_TOKEN="$(cat /opt/hill90/secrets/openbao-root.token)" && bash scripts/vault.sh setup'
+
+      - name: Seed — populate the KV paths from SOPS
+        run: |
+          ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
+            deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
+            'cd /opt/hill90/app && export SOPS_AGE_KEY_FILE=/opt/hill90/secrets/keys/keys.txt && export BAO_TOKEN="$(cat /opt/hill90/secrets/openbao-root.token)" && bash scripts/vault.sh seed'
+
+      - name: Mint the read-only sync token
+        run: |
+          ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
+            deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
+            'cd /opt/hill90/app && export SOPS_AGE_KEY_FILE=/opt/hill90/secrets/keys/keys.txt && export BAO_TOKEN="$(cat /opt/hill90/secrets/openbao-root.token)" && bash scripts/vault.sh setup-sync-token'
+
+      # ---- Prove it, then hand back the secrets ------------------------------
+
+      - name: Prove auto-unseal survives a container restart
+        run: |
+          IP=${{ steps.get-ip.outputs.tailscale_ip }}
+          ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no deploy@$IP 'docker restart openbao >/dev/null && sleep 8'
+          ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no deploy@$IP \
+            'sudo systemctl restart hill90-vault-unseal.service && sleep 5' || \
+            ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no deploy@$IP \
+            'cd /opt/hill90/app && bash scripts/vault.sh auto-unseal'
+          SEALED=$(ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no deploy@$IP \
+            'docker exec -e BAO_ADDR=http://127.0.0.1:8200 openbao bao status -format=json 2>/dev/null | jq -r ".sealed"')
+          echo "sealed after restart: $SEALED"
+          if [ "$SEALED" != "false" ]; then
+            echo "::error::Vault did not auto-unseal after restart (sealed=$SEALED)"
+            exit 1
+          fi
+
+      - name: Copy updated SOPS back
+        run: |
+          scp -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
+            deploy@${{ steps.get-ip.outputs.tailscale_ip }}:/opt/hill90/app/infra/secrets/prod.enc.env \
+            infra/secrets/prod.enc.env
+          for k in OPENBAO_UNSEAL_KEY VAULT_SYNC_TOKEN; do
+            LEN=$(sops -d --extract "[\"$k\"]" infra/secrets/prod.enc.env | wc -c)
+            echo "$k decrypts to $LEN bytes"
+            [ "$LEN" -gt 0 ] || { echo "::error::$k missing after copy-back"; exit 1; }
+          done
+
+      - name: Restore host checkout
+        if: always()
+        run: |
+          ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
+            deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
+            'cd /opt/hill90/app && git checkout -- infra/secrets/prod.enc.env && rm -f infra/secrets/prod.enc.env.backup.*' || true
+
+      - name: Open a PR with the new secrets
+        uses: peter-evans/create-pull-request@v6
+        with:
+          branch: chore/vault-reinit-secrets
+          delete-branch: true
+          commit-message: |
+            chore(vault): new unseal key and sync token after reinitialize
+
+            Generated by .github/workflows/vault-reinitialize.yml. A fresh init
+            mints a new unseal key, so the previous OPENBAO_UNSEAL_KEY is dead
+            and nothing in CI works against this vault until this lands.
+          title: "chore(vault): new unseal key and sync token after reinitialize"
+          body: |
+            Opened automatically by **Vault Reinitialize**.
+
+            The vault was reinitialized, so `OPENBAO_UNSEAL_KEY` and
+            `VAULT_SYNC_TOKEN` are new. The old values are dead.
+
+            **Merge this promptly** — until it lands, `main` carries an unseal
+            key for a vault that no longer exists.
+
+            Verified in the run that produced this:
+
+            - the vault came back uninitialized on the requested storage backend
+            - the unseal key file is `600 deploy:deploy`
+            - setup, seed and setup-sync-token all ran while root still existed
+            - auto-unseal survived a container restart, through the systemd unit
+
+            Root is **not** revoked. See the run summary for the one command
+            that does it, once you are satisfied.
+          add-paths: |
+            infra/secrets/prod.enc.env
+
+      - name: What is left to do
+        run: |
+          {
+            echo "## Vault reinitialized"
+            echo ""
+            echo "Storage backend: **${{ inputs.switch_to_raft && 'raft (integrated storage)' || 'file (deprecated)' }}**"
+            echo ""
+            echo "Done in this run: backup, wipe, redeploy, init, unseal, store key, setup, seed, sync token, auto-unseal proof."
+            echo ""
+            echo "### Two things remain, in this order"
+            echo ""
+            echo "1. **Merge the secrets PR.** Until then \`main\` has an unseal key for a vault that no longer exists."
+            echo "2. **Revoke root**, once you are satisfied the vault behaves:"
+            echo ""
+            echo '   ```'
+            echo '   ssh deploy@remote.hill90.com "cd /opt/hill90/app && bash scripts/vault.sh revoke-root"'
+            echo '   ```'
+            echo ""
+            echo "   This is a one-way door. On OpenBao >= 2.5.3 the root-regeneration endpoints are disabled,"
+            echo "   so after this the vault cannot be reconfigured without repeating this whole workflow."
+            echo "   It is deliberately not automated here."
+            echo ""
+            echo "### Optional"
+            echo ""
+            echo "Re-enable the weekly sync schedule in \`.github/workflows/vault-sync-to-sops.yml\`,"
+            echo "but only after a manual \`workflow_dispatch\` run of it has gone green."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/deploy/compose/prod/docker-compose.vault.yml
+++ b/deploy/compose/prod/docker-compose.vault.yml
@@ -41,8 +41,13 @@ services:
       - edge
       - internal
     volumes:
-      - openbao-data:/openbao/file
-      - ../../../platform/vault/config.hcl:/openbao/config/config.hcl:ro
+      # Data path and config file are selectable so the raft storage variant can
+      # be chosen at deploy time. Both default to the file-backend values, so an
+      # unset environment resolves to exactly what production has always run.
+      # See platform/vault/config.raft.hcl and
+      # .github/workflows/vault-reinitialize.yml.
+      - openbao-data:${VAULT_DATA_PATH:-/openbao/file}
+      - ../../../platform/vault/${VAULT_CONFIG_FILE:-config.hcl}:/openbao/config/config.hcl:ro
       - ../../../platform/vault/policies:/openbao/policies:ro
     environment:
       - BAO_ADDR=http://127.0.0.1:8200

--- a/docs/decisions/vault-vs-sops.md
+++ b/docs/decisions/vault-vs-sops.md
@@ -150,7 +150,39 @@ it over.
   only on the host at `/opt/hill90/secrets/openbao-unseal.key`.
 - Roughly 20 minutes, most of it waiting on workflow runs and one merge.
 
-### The steps, in order
+### One action, not seven steps
+
+`.github/workflows/vault-reinitialize.yml` runs the whole sequence:
+
+```
+gh workflow run vault-reinitialize.yml \
+  -f confirm=REINITIALIZE \
+  -f i_have_read_the_decision_doc=true \
+  -f switch_to_raft=true
+```
+
+It does, in this order: back up the volume and verify the archive → wipe →
+redeploy (onto raft if asked) → init → unseal → store the key in SOPS → setup →
+seed → mint the sync token → prove auto-unseal survives a restart → open a PR
+with the new secrets.
+
+**Storage is switched in the same run**, because the volume is being wiped
+anyway. Doing it separately means a second outage and an `operator migrate` for
+no benefit.
+
+**Root is not revoked.** That is the one-way door, and revoking it before
+anything was configured is precisely what produced the current inert vault. The
+run summary prints the single command to do it once you are satisfied.
+
+It cannot fire by accident. The confirmation input must be exactly
+`REINITIALIZE`, a second acknowledgement input must be set, the run refuses if
+the vault holds KV data, and it refuses if the pre-wipe backup is missing or
+empty.
+
+Two things remain manual afterwards: merge the secrets PR — until then `main`
+carries an unseal key for a vault that no longer exists — and revoke root.
+
+### The steps, in order, if you would rather do it by hand
 
 Order matters. Revoking root before `setup-sync-token` is what produced the
 current inert vault.

--- a/platform/vault/config.raft.hcl
+++ b/platform/vault/config.raft.hcl
@@ -1,0 +1,47 @@
+# OpenBao server configuration for Hill90 — RAFT (integrated storage) variant.
+#
+# INERT until selected. docker-compose.vault.yml mounts
+# platform/vault/${VAULT_CONFIG_FILE:-config.hcl}, so with no environment set
+# production continues to use config.hcl and this file does nothing.
+#
+# It exists because the `file` backend config.hcl uses is deprecated in
+# OpenBao v2.6.0 and REMOVED in v2.7.0 — upstream calls it "a development-only,
+# non-production backend". Raft is the supported replacement: production-ready,
+# recommended upstream for most cases, and needs no additional software.
+#
+# Selected by .github/workflows/vault-reinitialize.yml, which sets
+# VAULT_CONFIG_FILE=config.raft.hcl and VAULT_DATA_PATH=/openbao/raft. Storage
+# cannot be changed on a live vault without either `bao operator migrate` or a
+# fresh init, so switching is only free at the moment the volume is wiped —
+# which is exactly what that workflow does.
+#
+# Differences from config.hcl, and only these:
+#   - storage "raft" instead of storage "file"
+#   - listener gains cluster_address (raft peer traffic)
+#   - top-level cluster_addr, required by raft even for a single node
+#
+# Everything else is identical on purpose. See
+# docs/decisions/vault-vs-sops.md, "Decision needed: replacing the `file`
+# storage backend". If you change one file, change both.
+
+ui = true
+disable_mlock = true
+
+storage "raft" {
+  path    = "/openbao/raft"
+  node_id = "hill90-vault-1"
+}
+
+listener "tcp" {
+  address         = "0.0.0.0:8200"
+  cluster_address = "0.0.0.0:8201"
+  tls_disable     = 1
+}
+
+# Required by raft even for a cluster of one. Not published or routed: nothing
+# outside the container speaks to 8201 on a single node.
+cluster_addr = "http://127.0.0.1:8201"
+
+api_addr         = "https://vault.hill90.com"
+default_lease_ttl = "1h"
+max_lease_ttl     = "24h"

--- a/platform/vault/secrets-schema.yaml
+++ b/platform/vault/secrets-schema.yaml
@@ -35,6 +35,11 @@ excluded_vars:
   - VOLUME_PREFIX_BARE
   - HTTP_PORT
   - HTTPS_PORT
+  # Storage backend selection for the vault, used by
+  # .github/workflows/vault-reinitialize.yml. Both default to the file-backend
+  # values so an unset environment resolves to what production has always run.
+  - VAULT_CONFIG_FILE
+  - VAULT_DATA_PATH
 
 runtime_secrets:
   - key: TRAEFIK_ADMIN_PASSWORD_HASH

--- a/scripts/checks/check_destructive_commands.sh
+++ b/scripts/checks/check_destructive_commands.sh
@@ -23,7 +23,15 @@ PAT_PRUNE="docker system prune"
 # hill90-local-, prompts for typed confirmation, and exists precisely so a
 # developer can wipe and rebuild their own machine. It can no more reach the
 # VPS than `ls` can.
-ALLOW_VOLUME_DESTRUCTION="scripts/local.sh"
+#
+# .github/workflows/vault-reinitialize.yml is exempt for the same reason and no
+# other: destroying the vault volume IS the operation. It is gated behind a
+# typed REINITIALIZE confirmation, a separate acknowledgement input, a check
+# that refuses if the vault holds KV data, and a backup that must succeed and be
+# verified non-empty before anything is removed. Adding a second file here needs
+# that standard of justification.
+ALLOW_VOLUME_DESTRUCTION="scripts/local.sh
+.github/workflows/vault-reinitialize.yml"
 
 for f in scripts/*.sh .github/workflows/*.yml; do
   [ -f "$f" ] || continue
@@ -31,7 +39,7 @@ for f in scripts/*.sh .github/workflows/*.yml; do
   # Strip comment and blank lines before checking
   STRIPPED=$(grep -v '^[[:space:]]*#' "$f" 2>/dev/null | grep -v '^[[:space:]]*$') || true
 
-  if [ "$f" != "$ALLOW_VOLUME_DESTRUCTION" ]; then
+  if ! echo "$ALLOW_VOLUME_DESTRUCTION" | grep -qxF "$f"; then
     if echo "$STRIPPED" | grep -qE "$PAT_DOWN"; then
       echo "FAIL: $f contains a compose 'down' with volume removal"
       FAIL=1

--- a/tests/scripts/vault.bats
+++ b/tests/scripts/vault.bats
@@ -448,3 +448,75 @@ assert records[0]["content"] == "${TAILSCALE_IP}"
     [ "$status" -eq 1 ]
   done
 }
+
+# --- Vault reinitialize workflow (JON-49) -----------------------------------
+
+@test "vault-reinitialize workflow exists and is dispatch-only" {
+  [ -f .github/workflows/vault-reinitialize.yml ]
+  run grep -c "workflow_dispatch" .github/workflows/vault-reinitialize.yml
+  [ "$output" != "0" ]
+  run grep -E "^\s+(push|pull_request|schedule):" .github/workflows/vault-reinitialize.yml
+  [ "$status" -eq 1 ]
+}
+
+@test "vault-reinitialize requires the typed REINITIALIZE confirmation" {
+  run grep -c 'inputs.confirm }}" != "REINITIALIZE"' .github/workflows/vault-reinitialize.yml
+  [ "$output" = "1" ]
+}
+
+@test "vault-reinitialize refuses when the vault holds KV data" {
+  run bash -c 'grep -c "Refuse if the vault holds data" .github/workflows/vault-reinitialize.yml'
+  [ "$output" = "1" ]
+}
+
+@test "vault-reinitialize backs up and verifies before it wipes" {
+  # The backup and its verification must both appear before the volume removal.
+  b=$(grep -n "backup.sh backup vault" .github/workflows/vault-reinitialize.yml | head -1 | cut -d: -f1)
+  v=$(grep -n "Verify the backup exists" .github/workflows/vault-reinitialize.yml | head -1 | cut -d: -f1)
+  d=$(grep -n "docker volume rm openbao-data" .github/workflows/vault-reinitialize.yml | head -1 | cut -d: -f1)
+  [ -n "$b" ] && [ -n "$v" ] && [ -n "$d" ]
+  [ "$b" -lt "$d" ]
+  [ "$v" -lt "$d" ]
+}
+
+@test "vault-reinitialize does NOT revoke root" {
+  # Revoking root before configuration is what produced the inert vault, and
+  # revoking at all is a one-way door. It stays a separate deliberate command.
+  run grep -E "vault\.sh revoke-root" .github/workflows/vault-reinitialize.yml
+  [ "$status" -eq 0 ]
+  # ...only inside the summary text telling the operator how, never as a step.
+  run bash -c 'grep -E "^\s+run:.*vault\.sh revoke-root" .github/workflows/vault-reinitialize.yml'
+  [ "$status" -eq 1 ]
+}
+
+@test "vault-reinitialize configures before it could ever revoke" {
+  s=$(grep -n "vault.sh setup'" .github/workflows/vault-reinitialize.yml | head -1 | cut -d: -f1)
+  d=$(grep -n "vault.sh seed'" .github/workflows/vault-reinitialize.yml | head -1 | cut -d: -f1)
+  t=$(grep -n "vault.sh setup-sync-token'" .github/workflows/vault-reinitialize.yml | head -1 | cut -d: -f1)
+  [ -n "$s" ] && [ -n "$d" ] && [ -n "$t" ]
+  [ "$s" -lt "$d" ]
+  [ "$d" -lt "$t" ]
+}
+
+@test "raft config exists and differs from the file config only in storage" {
+  [ -f platform/vault/config.raft.hcl ]
+  # Count directives, not the header comment that names both backends.
+  run bash -c 'grep -v "^\s*#" platform/vault/config.raft.hcl | grep -c "storage \"raft\""'
+  [ "$output" = "1" ]
+  run bash -c 'grep -v "^\s*#" platform/vault/config.raft.hcl | grep -c "^cluster_addr"'
+  [ "$output" = "1" ]
+  run bash -c 'grep -v "^\s*#" platform/vault/config.raft.hcl | grep -c "cluster_address"'
+  [ "$output" = "1" ]
+  # The file backend config must stay untouched, and must NOT gain raft.
+  run bash -c 'grep -v "^\s*#" platform/vault/config.hcl | grep -c "storage \"file\""'
+  [ "$output" = "1" ]
+  run bash -c 'grep -v "^\s*#" platform/vault/config.hcl | grep -c "storage \"raft\""'
+  [ "$output" = "0" ]
+}
+
+@test "vault compose defaults to the file backend with no environment set" {
+  run docker compose -f deploy/compose/prod/docker-compose.vault.yml config
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"/openbao/file"* ]]
+  [[ "$output" != *"config.raft.hcl"* ]]
+}


### PR DESCRIPTION
Jon has to decide **whether** to reinitialize the vault. He should not also have
to orchestrate it.

Saying yes previously meant seven ordered steps by hand, plus the storage
migration from JON-48 that only makes sense at the same moment. Getting that
order wrong is precisely what produced the current inert vault — root revoked
before anything had been configured.

**Not run.** The point is that it sits ready and he chooses. Closes JON-49.

## One action

```bash
gh workflow run vault-reinitialize.yml \
  -f confirm=REINITIALIZE \
  -f i_have_read_the_decision_doc=true \
  -f switch_to_raft=true
```

Sequence, in the order that works:

```
back up + verify → wipe → redeploy (on raft) → init → unseal → store key
                 → setup → seed → sync token → auto-unseal proof → PR the secrets
```

## It cannot fire by accident

Four independent gates:

1. **Typed confirmation** — `confirm` must be exactly `REINITIALIZE`.
2. **Second acknowledgement** — `i_have_read_the_decision_doc` must be true.
3. **Data check** — refuses if the vault holds KV entries under `secret/`. It reads the vault directly when a root token exists, and says plainly when it cannot rather than implying a guarantee it hasn't made.
4. **Backup gate** — the volume is archived first, and the run aborts unless a fresh archive over 1 KB is found. That covers the case where the data check *couldn't* prove emptiness.

## Root is not revoked

Deliberately. It is the one-way door and the exact mistake this exists to avoid
repeating. The run summary prints the single command for when he's satisfied. A
test asserts there is no `revoke-root` step, only the instruction.

## Raft, in the same run

Free, because the volume is being wiped anyway — separately it costs a second
outage and an `operator migrate` for nothing.

`platform/vault/config.raft.hcl` is new and **inert until selected**. The compose
mount became `${VAULT_CONFIG_FILE:-config.hcl}` at `${VAULT_DATA_PATH:-/openbao/file}`,
so production is untouched:

```
$ diff <(before) <(after)   # docker compose config, no env set
  IDENTICAL
```

The workflow also asserts `storage_type=raft` after redeploy, so asking for raft
and silently getting file is a hard failure.

## My own guard had to be amended, narrowly

`check_destructive_commands.sh` bans `docker volume rm` in workflows — and this
workflow needs it, because destroying that volume *is* the operation. Added as a
second scoped allowlist entry with the reasoning recorded inline, then proven
the guard still catches a new offender:

```
$ # plant `docker volume rm` in ops.sh
FAIL: scripts/ops.sh contains 'docker volume rm'    exit=1
$ # restore
No destructive volume commands found.
```

## Verified, not dispatched

```
$ python3 -c "yaml.safe_load(...)"
  parses OK · 26 steps · workflow_dispatch only
  input confirm: required=True type=string
  input switch_to_raft: required=False type=boolean default=True
  input i_have_read_the_decision_doc: required=True type=boolean default=False

$ bats tests/scripts/                211 tests, 0 failures   (8 new)
$ python3 -m pytest tests/checks/ -q  29 passed
$ check_env_surface / check_secrets_schema / check_volume_names /
  check_md_links / check_destructive_commands / shellcheck   all clean
```

The eight new tests lock the safety properties: dispatch-only, the typed
confirmation, the data refusal, backup-and-verify **ordered before** the wipe,
no revoke-root step, setup→seed→sync-token ordering, and the compose defaulting
to the file backend with no environment.

One caught a real slip while writing them — my first assertion counted
`storage "raft"` twice because the file's header comment names both backends.
Tightened to ignore comments.

`gh workflow list` registration confirmed after merge; it cannot register from a
branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)