### PR TITLE
feat(local): run the vault locally and rehearse its full lifecycle (JON-50)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -189,3 +189,4 @@ tests/e2e/playwright-report/
 .next/
 next-env.d.ts
 *.tsbuildinfo
+.local-vault/

--- a/deploy/compose/overrides/local.vault.yml
+++ b/deploy/compose/overrides/local.vault.yml
@@ -1,0 +1,15 @@
+# Local development override for the vault stack.
+#
+# Layered on top of deploy/compose/prod/docker-compose.vault.yml — the SAME file
+# production uses. Only the routing differences a Mac forces, exactly as
+# local.infra.yml and local.observability.yml do.
+#
+# The vault was prod-only until JON-50, which meant the one part of the stack
+# with an irreversible lifecycle — init, seal, root revocation — could never be
+# rehearsed before it reached the VPS. Locally the whole sequence is free and
+# the volume is disposable.
+
+services:
+  openbao:
+    labels:
+      - "traefik.http.routers.vault.tls=false"

--- a/docs/runbooks/local-development.md
+++ b/docs/runbooks/local-development.md
@@ -38,9 +38,10 @@ not need to copy it yourself. It is gitignored.
 bash scripts/local.sh up
 ```
 
-That builds and starts ten containers — the edge stack (Traefik, dns-manager,
-Portainer) and the observability stack (Prometheus, Grafana, Loki, Tempo,
-Promtail, node-exporter, cAdvisor) — and waits until they actually answer.
+That builds and starts eleven containers — the edge stack (Traefik, dns-manager,
+Portainer), the observability stack (Prometheus, Grafana, Loki, Tempo, Promtail,
+node-exporter, cAdvisor) and the vault (OpenBao) — and waits until they actually
+answer.
 
 ```bash
 bash scripts/local.sh health     # probe every routed surface
@@ -85,6 +86,7 @@ Observability internals
 | Portainer | http://portainer.localtest.me:8080/ |
 | Grafana | http://grafana.localtest.me:8080/ (admin / admin) |
 | Prometheus | http://prometheus.localtest.me:8080/ (local only) |
+| OpenBao | http://vault.localtest.me:8080/ (uninitialized until you run `vault init`) |
 
 **Prometheus is routed locally but not in production.** In production it sits on
 the internal network with no router and no published port, reached through
@@ -166,6 +168,37 @@ The flag is silently ignored. So the local variant cannot be an override; it
 has to be a second file. The two differ only in ACME, the HTTPS redirect, the
 log level, and a local-only Docker provider constraint. **If you change one,
 change both.**
+
+## Rehearsing the vault lifecycle
+
+The vault is the one part of the stack with irreversible steps — initialization
+mints a key that cannot be recovered, and revoking root is a one-way door on
+OpenBao ≥ 2.5.3. Locally all of it is free and the volume is disposable, so the
+sequence can be practised before it is run against the VPS:
+
+```bash
+bash scripts/local.sh vault init              # writes 0600 key + root token, prints neither
+bash scripts/local.sh vault unseal
+bash scripts/local.sh vault setup             # policies, AppRoles, KV engine
+bash scripts/local.sh vault seed              # KV paths from the local SOPS store
+bash scripts/local.sh vault setup-sync-token
+bash scripts/local.sh vault revoke-root       # LAST — after everything above
+```
+
+**The order is the whole point.** Revoking root before `setup` and `seed` leaves
+a vault that is up, healthy, unsealed and permanently unconfigurable — which is
+exactly the state the production vault is in. Doing it in this order leaves a
+vault that still works with no root in existence.
+
+`local.sh vault` runs `scripts/vault.sh` unmodified. It only sets the container
+name, key paths and secrets file, all of which `vault.sh` already reads from the
+environment — so what you rehearse is the same script the VPS runs.
+
+Local vault state lives in `.local-vault/` (gitignored) with its own throwaway
+age key and SOPS store. **It never touches `infra/secrets/prod.enc.env`.**
+
+To start over: `bash scripts/local.sh reset` deletes the volume and
+`.local-vault/` together.
 
 ## Teardown and rebuild
 

--- a/scripts/local.sh
+++ b/scripts/local.sh
@@ -25,6 +25,12 @@ ENV_EXAMPLE="$PROJECT_ROOT/.env.local.example"
 # never be confused in `docker compose ls`.
 EDGE_PROJECT="hill90-local-edge"
 OBS_PROJECT="hill90-local-observability"
+VAULT_PROJECT="hill90-local-platform"
+
+# Vault state lives beside the repo, not in /opt/hill90 as it does on the VPS.
+# vault.sh takes both paths from the environment, so nothing in it needs to know
+# it is running locally.
+LOCAL_VAULT_DIR="$PROJECT_ROOT/.local-vault"
 
 RED=$'\033[0;31m'; GREEN=$'\033[0;32m'; YELLOW=$'\033[1;33m'
 BLUE=$'\033[0;34m'; BOLD=$'\033[1m'; NC=$'\033[0m'
@@ -46,6 +52,7 @@ Commands:
   reset     down, then DELETE the local volumes (destructive, prompts first)
   status    Show container status
   health    Probe every routed surface over HTTP
+  vault     Run a vault.sh subcommand against the LOCAL vault
   logs      Follow logs (optionally: logs <container>)
   urls      Print the local URLs
   help      Show this help
@@ -78,6 +85,34 @@ compose_obs() {
     docker compose --env-file "$ENV_FILE" -p "$OBS_PROJECT" \
         -f "$COMPOSE_DIR/docker-compose.observability.yml" \
         -f "$OVERRIDE_DIR/local.observability.yml" "$@"
+}
+
+compose_vault() {
+    docker compose --env-file "$ENV_FILE" -p "$VAULT_PROJECT" \
+        -f "$COMPOSE_DIR/docker-compose.vault.yml" \
+        -f "$OVERRIDE_DIR/local.vault.yml" "$@"
+}
+
+# Point vault.sh at the local container and local state. Every one of these is
+# an override vault.sh already supports, so the script itself is identical to
+# what runs on the VPS.
+# Run a vault.sh subcommand against the LOCAL vault. Every variable here is an
+# override vault.sh already supports, so the script executed is byte-identical
+# to the one that runs on the VPS — which is what makes this a rehearsal rather
+# than a simulation.
+cmd_vault() {
+    [ $# -gt 0 ] || die "Usage: local.sh vault <init|unseal|status|setup|seed|setup-sync-token|revoke-root|auto-unseal|...>"
+    require_docker
+    require_env
+    mkdir -p "$LOCAL_VAULT_DIR"
+    local cp; cp=$(env_get CONTAINER_PREFIX "")
+    VAULT_CONTAINER="${cp}openbao" \
+    VAULT_UNSEAL_KEY_PATH="$LOCAL_VAULT_DIR/openbao-unseal.key" \
+    VAULT_ROOT_TOKEN_PATH="$LOCAL_VAULT_DIR/openbao-root.token" \
+    VAULT_SECRETS_FILE="$LOCAL_VAULT_DIR/local.enc.env" \
+    SOPS_AGE_KEY_FILE="$LOCAL_VAULT_DIR/age.key" \
+    BAO_TOKEN="${BAO_TOKEN:-$(cat "$LOCAL_VAULT_DIR/openbao-root.token" 2>/dev/null || true)}" \
+        bash "$SCRIPT_DIR/vault.sh" "$@"
 }
 
 # Read a value out of .env.local without sourcing it.
@@ -166,6 +201,9 @@ cmd_up() {
     info "Starting the observability stack (prometheus, grafana, loki, tempo, collectors)..."
     compose_obs up -d || die "Observability stack failed to start"
 
+    info "Starting the vault stack (openbao)..."
+    compose_vault up -d || die "Vault stack failed to start"
+
     echo ""
     info "Waiting for containers to become healthy..."
     # Two separate queries: passing two --filter label=... to docker ps ANDs
@@ -217,6 +255,8 @@ cmd_up() {
 cmd_down() {
     require_docker
     require_env
+    info "Stopping the vault stack..."
+    compose_vault down --remove-orphans 2>/dev/null || true
     info "Stopping the observability stack..."
     compose_obs down --remove-orphans 2>/dev/null || true
     info "Stopping the edge stack..."
@@ -261,6 +301,8 @@ cmd_reset() {
     fi
 
     info "Tearing down with volumes..."
+    compose_vault down -v --remove-orphans 2>/dev/null || true
+    rm -rf "$LOCAL_VAULT_DIR"
     compose_obs down -v --remove-orphans 2>/dev/null || true
     compose_edge down -v --remove-orphans 2>/dev/null || true
     success "Local stack reset. Run 'bash scripts/local.sh up' to rebuild from the repo."
@@ -275,6 +317,9 @@ cmd_status() {
     docker ps -a \
         --filter "label=com.docker.compose.project=${OBS_PROJECT}" \
         --format 'table {{.Names}}\t{{.Status}}' 2>/dev/null | tail -n +2
+    docker ps -a \
+        --filter "label=com.docker.compose.project=${VAULT_PROJECT}" \
+        --format 'table {{.Names}}\t{{.Status}}' 2>/dev/null | tail -n +2
 }
 
 cmd_urls() {
@@ -284,6 +329,7 @@ cmd_urls() {
     echo "  Portainer           $(base_url "$(env_get PORTAINER_HOST portainer)")/"
     echo "  Grafana             $(base_url "$(env_get GRAFANA_HOST grafana)")/"
     echo "  Prometheus          $(base_url "$(env_get PROMETHEUS_HOST prometheus)")/  (local only; prod reaches it via Grafana)"
+    echo "  OpenBao             $(base_url "$(env_get VAULT_HOST vault)")/  (uninitialized until: local.sh vault init)"
 }
 
 cmd_health() {
@@ -303,6 +349,17 @@ cmd_health() {
     check_exec "Prometheus ready"  "${cp}prometheus" wget -qO- http://localhost:9090/-/ready || failed=1
     check_exec "Loki ready"        "${cp}loki"       wget -qO- http://localhost:3100/ready   || failed=1
     check_exec "Grafana health"    "${cp}grafana"    wget -qO- http://localhost:3000/api/health || failed=1
+
+    # The vault answers /v1/sys/health with 501 when uninitialized and 503 when
+    # sealed, so "is the process up" is the honest check here; seal state is
+    # reported separately because both are legitimate local states.
+    if docker inspect "${cp}openbao" >/dev/null 2>&1; then
+        check_exec "OpenBao responding" "${cp}openbao" sh -c 'wget -qO- --spider http://127.0.0.1:8200/v1/sys/seal-status' || failed=1
+        local seal
+        seal=$(docker exec -e BAO_ADDR=http://127.0.0.1:8200 "${cp}openbao" bao status -format=json 2>/dev/null \
+               | python3 -c 'import sys,json;d=json.load(sys.stdin);print(("uninitialized" if not d["initialized"] else ("sealed" if d["sealed"] else "unsealed")))' 2>/dev/null || echo unknown)
+        echo "  ${BLUE}i${NC} OpenBao state — ${seal}"
+    fi
 
     echo ""
     if [ "$failed" -eq 0 ]; then
@@ -359,6 +416,7 @@ main() {
         reset)          cmd_reset "$@" ;;
         status)         cmd_status "$@" ;;
         health)         cmd_health "$@" ;;
+        vault)          cmd_vault "$@" ;;
         logs)           cmd_logs "$@" ;;
         urls)           cmd_urls "$@" ;;
         help|--help|-h) usage ;;

--- a/tests/scripts/local.bats
+++ b/tests/scripts/local.bats
@@ -136,3 +136,70 @@
   run bash -c 'sed -n "/^check_http/,/^}/p" scripts/local.sh | grep -c -- "curl -sL"'
   [ "$output" = "1" ]
 }
+
+# --- Local vault parity (JON-50) --------------------------------------------
+
+@test "a local override exists for every prod stack" {
+  for stack in infra observability vault; do
+    [ -f "deploy/compose/overrides/local.${stack}.yml" ]
+  done
+}
+
+@test "local.sh brings up the vault stack" {
+  run grep -c "compose_vault up -d" scripts/local.sh
+  [ "$output" = "1" ]
+}
+
+@test "local.sh exposes a vault subcommand" {
+  run bash scripts/local.sh
+  [[ "$output" == *"vault"* ]]
+}
+
+@test "local vault state is gitignored and outside /opt" {
+  run grep -qxF ".local-vault/" .gitignore
+  [ "$status" -eq 0 ]
+  run bash -c 'grep -c "LOCAL_VAULT_DIR=\"\$PROJECT_ROOT/.local-vault\"" scripts/local.sh'
+  [ "$output" = "1" ]
+}
+
+@test "local vault never points at the production secrets file" {
+  # VAULT_SECRETS_FILE must resolve under LOCAL_VAULT_DIR (which test above
+  # pins to .local-vault), and must never name the production secrets file.
+  run bash -c 'sed -n "/^cmd_vault/,/^}/p" scripts/local.sh | grep "VAULT_SECRETS_FILE"'
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'LOCAL_VAULT_DIR'* ]]
+  [[ "$output" != *"infra/secrets"* ]]
+  # And nothing in the local path may reference the prod secrets file at all.
+  run bash -c 'sed -n "/^cmd_vault/,/^}/p" scripts/local.sh | grep -c "prod.enc.env"'
+  [ "$output" = "0" ]
+}
+
+@test "local vault uses vault.sh unmodified, via its documented env overrides" {
+  # vault.sh reads each of these as a ${VAR:-<prod default>}, so local can point
+  # them elsewhere without the script differing by a byte from the VPS copy.
+  run grep -c 'VAULT_CONTAINER:-' scripts/vault.sh
+  [ "$output" = "1" ]
+  run grep -c 'VAULT_UNSEAL_KEY_PATH:-' scripts/vault.sh
+  [ "$output" = "1" ]
+  run grep -c 'VAULT_ROOT_TOKEN_PATH:-' scripts/vault.sh
+  [ "$output" = "1" ]
+  run grep -c 'VAULT_SECRETS_FILE:-' scripts/vault.sh
+  [ "$output" = "1" ]
+}
+
+@test "vault compose resolves to production names with no environment set" {
+  run docker compose -f deploy/compose/prod/docker-compose.vault.yml config
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"container_name: openbao"* ]]
+  [[ "$output" == *"vault.hill90.com"* ]]
+  [[ "$output" == *"tailscale-only@file"* ]]
+}
+
+@test "local vault override produces local routing from the same file" {
+  run docker compose --env-file .env.local.example \
+        -f deploy/compose/prod/docker-compose.vault.yml \
+        -f deploy/compose/overrides/local.vault.yml config
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"vault.localtest.me"* ]]
+  [[ "$output" != *"tailscale-only@file"* ]]
+}


### PR DESCRIPTION
Jon couldn't see openbao running locally because **it wasn't there**. Ten
containers, no vault: only `local.infra.yml` and `local.observability.yml`
existed, and `local.sh` had zero vault references.

That broke the parity principle JON-41 established — and it mattered most for
the vault, because it is the one component with an irreversible lifecycle. Init
mints an unrecoverable key; revoking root is a one-way door on OpenBao ≥ 2.5.3.
So the sequence that most needed rehearsing was the only one that could never be
rehearsed.

## The rehearsal, from an empty vault

```
0. start            init=False sealed=True
1. init             init=True  sealed=True   key=600 root=present
2. unseal           init=True  sealed=False
3. setup            policies=4 approles=2
4. seed             kv=2 top-level paths
5. sync token       stored=1
6. restart          init=True  sealed=True   <- sealed by the restart
7. auto-unseal      init=True  sealed=False  <- recovered
8. revoke-root      root file=removed

AFTER revocation — is the vault still usable?
  consumer read secret/infra/traefik -> ACME_CA_SERVER, ACME_EMAIL, TRAEFIK_ADMIN_PASSWORD_HASH
  generate-root: Code: 403
  prod secrets changes: 0
```

**That last block is the finding.** The vault ends with 4 policies, 2 AppRoles
and 2 KV paths that a **non-root consumer still reads after root is gone**,
while `generate-root` returns 403.

Which demonstrates, rather than argues, the difference the ordering makes:

| | Result |
|---|---|
| revoke **before** setup/seed — what happened in prod | up, healthy, permanently inert |
| revoke **after** — this run | fully working, no root in existence |

The prod reinitialize workflow (#521) runs this exact order, so it now has a
rehearsal behind it. **The 403 one-way door is also reproduced locally**, having
previously only been seen on a throwaway instance and the live vault.

## Functional, not just healthy-container

Written through the vault and read back by a real consumer over the AppRole path
deploys actually use:

```
write   secret/infra/traefik REHEARSAL_CANARY=... -> version 2
login   auth/approle/login (role_id + secret_id)  -> non-root token
read    as that consumer -> ACME_EMAIL, REHEARSAL_CANARY
denied  reading secret/observability/grafana      -> policy scoping works
sync token reads both paths, denied write         -> read-only as intended
canary survived a container restart
```

## Prod is untouched

`local.sh vault` runs `scripts/vault.sh` **unmodified** — it only overrides the
container name, key paths and secrets file, all of which `vault.sh` already
reads from the environment. So the rehearsed script is byte-identical to the VPS
one.

Local state is `.local-vault/` (gitignored) with its own throwaway age key and
SOPS store. `infra/secrets/prod.enc.env` is never read or written — asserted by
a test and re-checked with `git status` after every step: **0 changes**, every
time.

Compose parity holds:

```
$ diff <(before) <(after)   # docker compose config on the vault stack, no env
  IDENTICAL
```

The VPS vault was not touched and the reinitialize workflow was not dispatched.

## Checks

```
$ bats tests/scripts/                219 tests, 0 failures   (8 new)
$ python3 -m pytest tests/checks/ -q  29 passed
$ shellcheck --severity=error         clean
$ check_env_surface / check_secrets_schema / check_volume_names /
  check_md_links / check_destructive_commands   all clean
$ bash scripts/local.sh health        11 containers, OpenBao state — unsealed
```

Three of the new tests caught my own mistakes while writing them — two assertion
bugs where I'd grepped for literal paths that actually resolve through
`$LOCAL_VAULT_DIR`, and for `VAULT_CONTAINER=` when `vault.sh` reads it as
`${VAULT_CONTAINER:-openbao}`. The code was right; my checks were wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)