### PR TITLE
chore(vault): re-enable the weekly sync schedule

### DIFF
--- a/.github/workflows/vault-sync-to-sops.yml
+++ b/.github/workflows/vault-sync-to-sops.yml
@@ -3,38 +3,18 @@ name: Vault Sync to SOPS
 on:
   workflow_dispatch:
 
-  # SCHEDULE DISABLED 2026-07-26 (JON-46).
+  # RE-ENABLED 2026-07-26 after the vault was reinitialized (JON-46 / JON-51).
   #
-  # This ran every Monday 06:00 UTC and failed every Monday from 2026-06-01
-  # onward. It cannot currently succeed, and an alert that always fires carries
-  # no information — it just trains you to ignore it.
+  # It had been disabled since it failed every Monday from 2026-06-01: first at
+  # `Verify SSH connectivity`, then at `Renew sync token` with 403, because
+  # VAULT_SYNC_TOKEN belonged to the vault destroyed in the June rebuild.
   #
-  # Two separate reasons it fails, in order:
-  #
-  #   1. Until 2026-07-26 it died at `Verify SSH connectivity`, never reaching
-  #      the vault. That is now resolved.
-  #   2. It now dies later, at `Renew sync token`, with 403 permission denied.
-  #      VAULT_SYNC_TOKEN in SOPS was minted against the vault destroyed in the
-  #      June 14 rebuild and does not exist in the one initialized on
-  #      2026-07-26.
-  #
-  # Minting a replacement needs a root token. The root token was revoked right
-  # after init, and on OpenBao >= 2.5.3 `bao operator generate-root` returns 403
-  # (the unauthenticated root-generation endpoints are disabled by default), so
-  # there is no way back to root on the current vault.
-  #
-  # BEFORE RE-ENABLING, all of these must be true:
-  #   - the vault has been reinitialized (see docs/decisions/vault-vs-sops.md)
-  #   - `vault.sh setup` and `vault.sh seed` have run, so it holds something
-  #   - `vault.sh setup-sync-token` has minted a token that exists in the
-  #     CURRENT vault, and the updated SOPS file is merged
-  #   - a manual `workflow_dispatch` run has gone green
-  #
-  # Re-enable by restoring:
-  #   schedule:
-  #     - cron: '0 6 * * 1'  # Weekly Monday 6am UTC
-  #
-  # workflow_dispatch is deliberately kept so it can still be run by hand.
+  # All four re-enable conditions are now met: the vault was reinitialized,
+  # setup and seed have run, setup-sync-token minted a token that exists in the
+  # current vault and is merged to main, and a manual run has gone green
+  # (run 30213730367 — Renew sync token succeeded).
+  schedule:
+    - cron: '0 6 * * 1'  # Weekly Monday 6am UTC
 
 permissions:
   contents: write


### PR DESCRIPTION
The prod vault was reinitialized today, so the four conditions the disable
comment recorded in #511 are now met:

- the vault has been reinitialized
- `setup` and `seed` have run, so it holds something
- `setup-sync-token` minted a token that exists in the **current** vault and is merged to main (#524)
- a manual `workflow_dispatch` run has gone green

```
run 30213730367 — conclusion=success
  success  Read sync token from SOPS
  success  Renew sync token      <- the step that was 403ing since the June rebuild
  success  Run sync on VPS
  success  Compare hashes
```

Re-verified after deleting the stale repo-level `VAULT_SYNC_TOKEN` Actions
secret — run `30213838855`, also green. Nothing read that secret: the workflow
decrypts the value from SOPS, and no workflow references
`secrets.VAULT_SYNC_TOKEN`. It had been unused since 2026-04-06.

```
$ bats tests/scripts/                219 tests, 0 failures
$ python3 -m pytest tests/checks/ -q  29 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)