### PR TITLE
chore: move issue tracking from Linear to GitHub Issues

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,8 @@
 ## Summary
 - 
 
-## Linear
-- Issue: 
+## Issue
+- Closes: 
 
 ## Validation Evidence
 - UI (if applicable): 

--- a/.linear.toml
+++ b/.linear.toml
@@ -1,2 +1,0 @@
-workspace = "jonhill90"
-team_id = "JON"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,43 @@ secrets, and Tailscale-secured SSH.
 > [Infra/app separation](docs/decisions/infra-app-separation.md); the code is
 > preserved at the `archive/app-stack-final` tag.
 
+## Issue Tracking
+
+Issues live in **GitHub Issues, in the repository whose code they touch**.
+
+| Work | Repository |
+|---|---|
+| VPS, Traefik, observability, secrets, Ansible, deploy | [Hill90](https://github.com/jonhill90/Hill90) — public |
+| The AI agent platform | [hill90-app](https://github.com/jonhill90/hill90-app) — **private** |
+| The published docs site, docs.hill90.com | [hill90-docs](https://github.com/jonhill90/hill90-docs) — **private** |
+| The extracted, reusable compose template | [docker-infra-template](https://github.com/jonhill90/docker-infra-template) — public |
+
+Two of those repositories are private and will 404 for anyone but their owner.
+If you cannot reach the repository a thing belongs to, file it here instead.
+
+Work spanning more than one repository is filed here in Hill90 and links out to
+the repositories it touches. Do not mirror one issue into several repositories.
+Hill90 is public, so keep anything that should not be public — private-repo
+internals, hostnames, anything resembling a credential — in the private
+repository's own issue and link to it rather than restating it here.
+
+### `AI-###` and `JON-###` in the history
+
+Until 2026-07-26 this project tracked work in a Linear workspace with two teams:
+`AI` for the application and `JON` for the infrastructure. Identifiers like
+`AI-124` or `JON-47` appear throughout commit messages, code comments, decision
+records and runbooks in all four repositories. **They are Linear identifiers,
+not GitHub issue numbers** — `JON-47` is unrelated to `#47` in this repository,
+which is a pull request about logo animation.
+
+That workspace was retired as a tracker but deliberately not deleted; it is the
+record of how the project got here. It held about 250 issues across the two
+teams, and all but two were already closed at the cutover, so only those two
+were carried across: `JON-55` became [#532](https://github.com/jonhill90/Hill90/issues/532)
+here, and `AI-258` became [hill90-app#8](https://github.com/jonhill90/hill90-app/issues/8).
+The rest were deliberately left in Linear rather than imported, so following one
+of those identifiers means looking it up there.
+
 ## Pull Request Workflow
 
 1. **Plan** — for anything touching three or more files, agree on the approach


### PR DESCRIPTION
## Summary
- Retires Linear as the issue tracker. Issues now live in GitHub Issues, in the repository whose code they touch; cross-repository work is filed here in Hill90 and links out.
- Removes `.linear.toml` and replaces the `## Linear` field in the PR template with `## Issue` / `Closes:`.
- Adds an **Issue Tracking** section to `CONTRIBUTING.md` with the routing table and an explanation of the `AI-###` / `JON-###` identifiers.

## What was migrated, and what was deliberately left in Linear

The Linear workspace held **about 250 issues** across two teams (`AI` for the application, `JON` for the infrastructure). At the cutover **all but two were already closed**.

**Migrated — the two that were open:**

| Linear | Now |
|---|---|
| `JON-55` Restore Keycloak and Postgres as platform services (In Progress) | [#532](https://github.com/jonhill90/Hill90/issues/532) — since closed by #531 |
| `AI-258` Remove agent level/XP/artifacts UI (ToDo) | [hill90-app#8](https://github.com/jonhill90/hill90-app/issues/8) |

`AI-258` is not mentioned in #528, which said only `JON-55` was open. That was true of the `JON` team but not of the workspace — the `AI` team had one open item too. It was migrated rather than dropped: hill90-app is its correct home now that the app has its own repo.

**Left in Linear — the other ~248, all closed.** Importing several hundred closed records would add noise without adding information. The workspace is **not deleted**; it stays as the record of how the project got here.

Each of the two migrated issues has a comment in Linear pointing at its GitHub replacement. Their Linear states were left untouched rather than force-closed, so the historical record reads exactly as it did.

## The `AI-###` / `JON-###` trail

Those identifiers appear throughout commit messages, code comments, decision records, runbooks and specs in all four repositories, and **none of them were scrubbed** — the history stays readable. What changed is that every repository now says, somewhere a person will actually find it, what they mean and that they are not GitHub issue numbers:

- **Hill90** — `CONTRIBUTING.md` § Issue Tracking (this PR)
- **hill90-app** — `CONTRIBUTING.md` § Issue tracking
- **hill90-docs** — `README.md` § Issue tracking
- **docker-infra-template** — `README.md` § Provenance, with a pointer from `CONTRIBUTING.md`

## Note on the routing table

Two of the four repositories are private. The table marks them, and says to file here if you cannot reach the repository something belongs to. Because Hill90 is public and takes cross-repository work, the section also says to keep anything that should not be public in the private repository's own issue and link to it.

## Companion PRs

- jonhill90/hill90-app — same change
- jonhill90/hill90-docs — same change
- jonhill90/docker-infra-template — same change

## Test plan
- [x] `python3 scripts/checks/check_md_links.py` — `Markdown link check passed: no missing local links found.`
- [x] `git ls-files | grep -i linear` returns nothing
- [x] Subagent audit across all four repos before opening; four prose defects it found are fixed in this branch
- [ ] CI checks pass

Closes #528
