### PR TITLE
fix(edge): stop Tailscale masquerading tailnet traffic, and close the inbound IPv6 path

### DIFF
--- a/platform/edge/dynamic/middlewares.yml
+++ b/platform/edge/dynamic/middlewares.yml
@@ -31,6 +31,22 @@ http:
         usersFile: /etc/traefik/dynamic/.htpasswd
 
     # Tailscale-only access (CGNAT range)
+    #
+    # This is CGNAT-only again as of 2026-07-27, and it is now a real control.
+    # Traefik previously saw 172.18.0.1 for tailnet traffic because Tailscale
+    # masqueraded anything carrying its firewall mark; `tailscale set
+    # --snat-subnet-routes=false` removed that rule, and Traefik now logs true
+    # client addresses (verified: a request from 100.127.120.73 logs as
+    # 100.127.120.73, not the gateway).
+    #
+    # Removing the gateway CIDR also closed an inbound IPv6 path. hill90_edge is
+    # IPv4-only so Docker writes no v6 DNAT rule, but docker-proxy still binds
+    # [::]:443, so a v6 connection is re-originated from the bridge gateway.
+    # It used to match this list. It no longer does: grafana and portainer now
+    # answer 403 to that path and 302/200 over the tailnet.
+    #
+    # Do not re-add 172.18.0.1/32 without first re-checking the SNAT rule --
+    # if it returns, tailnet traffic breaks and adding the CIDR back reopens v6.
     # NOTE: ipWhiteList is Traefik v2. If upgrading to v3, use ipAllowList.
     #
     # This list must contain ONLY the Tailscale CGNAT range. It previously also
@@ -61,21 +77,6 @@ http:
       ipWhiteList:
         sourceRange:
           - "100.64.0.0/10"
-          # RESTORED 2026-07-27. Removing this in #545 took grafana, portainer,
-          # traefik and vault to HTTP 403 for legitimate Tailscale traffic.
-          #
-          # #545 argued the entry was stale, citing an access-log window in which
-          # every Tailscale request carried its real CGNAT source. That window did
-          # not contain the triggering condition. The original comment said the
-          # symptom appears after a daemon restart; Traefik was restarted several
-          # times that night, and afterwards a request from Tailscale 100.127.120.73
-          # arrived at Traefik as ClientHost 172.18.0.1.
-          #
-          # So the entry is load-bearing, not vestigial. It is also genuinely a weak
-          # control -- it cannot distinguish on- from off-network traffic once the
-          # source has been rewritten. The real fix is to stop the rewrite so Traefik
-          # sees true client addresses; until then this stays.
-          - "172.18.0.1/32"
 
     # Compression
     compress:

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -199,10 +199,10 @@ cmd_traefik() {
         # until that rewrite is fixed. Everything else is still rejected.
         _ts_body=$(sed -n "/tailscale-only:/,/^    [a-z]/p" "$dynamic_dir/middlewares.yml" 2>/dev/null \
              | grep -v "^[[:space:]]*#")
-        if echo "$_ts_body" | grep -qE "\"(10\.|192\.168\.|127\.|0\.0\.0\.0)" \
-           || echo "$_ts_body" | grep -E "\"172\." | grep -qv "172\.18\.0\.1/32"; then
-            echo "✗ Allowlist contains an undocumented private or bridge CIDR"
-            echo "   Only the Tailscale CGNAT range and 172.18.0.1/32 belong here."
+        if echo "$_ts_body" | grep -qE "\"(172\.|10\.|192\.168\.|127\.|0\.0\.0\.0)"; then
+            echo "✗ Allowlist contains a private or bridge CIDR"
+            echo "   Only the Tailscale CGNAT range belongs here. Re-adding the bridge"
+            echo "   gateway breaks tailnet traffic and reopens the inbound IPv6 path."
             all_valid=false
         else
             echo "✓"

--- a/tests/scripts/traefik-config.bats
+++ b/tests/scripts/traefik-config.bats
@@ -285,7 +285,7 @@ for name,v in r.items():
 # reads as a working control while narrowing nothing.
 # ---------------------------------------------------------------------------
 
-@test "tailscale-only allows the CGNAT range plus at most the documented bridge exception" {
+@test "tailscale-only allows only the Tailscale CGNAT range" {
   # This asserted an exact match on the CGNAT range alone until 2026-07-27,
   # when enforcing that took every admin surface to 403: Docker rewrites some
   # Tailscale traffic to the bridge gateway, so the exception is load-bearing.
@@ -295,7 +295,7 @@ for name,v in r.items():
 import sys, yaml
 d = yaml.safe_load(open("platform/edge/dynamic/middlewares.yml"))
 rng = set(d["http"]["middlewares"]["tailscale-only"]["ipWhiteList"]["sourceRange"])
-allowed = {"100.64.0.0/10", "172.18.0.1/32"}
+allowed = {"100.64.0.0/10"}
 if "100.64.0.0/10" not in rng:
     print("tailscale-only is missing the CGNAT range:", sorted(rng)); sys.exit(1)
 extra = rng - allowed
@@ -306,7 +306,7 @@ PY
   [ "$status" -eq 0 ]
 }
 
-@test "tailscale-only carries no private or loopback CIDR beyond the bridge gateway" {
+@test "tailscale-only carries no bridge, private or loopback CIDR" {
   # Removing the bridge gateway entirely 403'd every admin surface on
   # 2026-07-27 — Docker rewrites some Tailscale traffic to it, so it is
   # load-bearing until the source rewrite itself is fixed. It remains a weak
@@ -314,8 +314,7 @@ PY
   # So the single documented exception is tolerated and everything else is not.
   run bash -c '
     body=$(sed -n "/tailscale-only:/,/^    [a-z]/p" platform/edge/dynamic/middlewares.yml | grep -v "^[[:space:]]*#")
-    echo "$body" | grep -E "\"(10\.|192\.168\.|127\.|0\.0\.0\.0)" && exit 1
-    echo "$body" | grep -E "\"172\." | grep -v "172\.18\.0\.1/32" && exit 1
+    echo "$body" | grep -E "\"(172\.|10\.|192\.168\.|127\.|0\.0\.0\.0)" && exit 1
     exit 0
   '
   [ "$status" -eq 0 ]


### PR DESCRIPTION
## Plan
Remove the Tailscale SNAT rule so Traefik sees true client addresses, then take `172.18.0.1/32` out of the `tailscale-only` allowlist and tighten the guards back to CGNAT-only.

## Risks
Touches the ingress path. Mitigated by applying the runtime change first and verifying before committing. Rollback is `tailscale set --snat-subnet-routes=true` plus reverting this commit.

## Rollback
```
sudo tailscale set --snat-subnet-routes=true
git revert <sha>
```

## Validation Evidence
Positive assertions throughout — absence proves nothing here, because `accessLog.filters.statusCodes: 400-599` means a successful request is never logged.

| | before | after |
|---|---|---|
| tailnet request from 100.127.120.73 | `ClientHost 172.18.0.1` | `ClientHost 100.127.120.73` |
| grafana over IPv6 | 401 (admitted) | **403 (blocked)** |
| portainer over IPv6 | 401 (admitted) | **403 (blocked)** |
| grafana / portainer / traefik / vault over tailnet | 302 / 200 / 401 / 307 | unchanged |

Runtime state: `NoSNAT = True`, zero MASQUERADE rules in `ts-postrouting`, SSH unaffected.

## Note for future readers
`traefik.hill90.com` is **not** a valid test of the allowlist — `auth@file` precedes `tailscale-only@file`, so an unauthenticated request returns 401 from basic auth before the allowlist is evaluated. I made that mistake mid-verification. `grafana` and `portainer` carry the allowlist alone and are the correct probes.

Closes #549. Resolves the exposure in #542.