### PR TITLE
docs(security): record why the tailscale-only allowlist was not a real control

### DIFF
--- a/docs/architecture/security.md
+++ b/docs/architecture/security.md
@@ -58,10 +58,118 @@ No service in the current stack sends email. Keycloak was the only sender;
 - `hill90_edge`: ingress-facing network for Traefik and the routed services.
 - `hill90_internal`: `internal: true`, unreachable from outside the host; used for private service-to-service traffic.
 - `hill90_agent_internal`: `internal: true`, created by the edge stack. Retained from the shelved application and currently unused by any running container.
-- Tailscale-only routes are protected with Traefik middleware and IP allowlists in addition to the firewall.
+- Tailscale-only routes are protected with Traefik middleware and IP allowlists in addition to the firewall. That control depends on Traefik seeing the true client address — see [Network-Layer Client Identity](#network-layer-client-identity).
 
 `docker-compose.infra.yml` is the sole owner of all three networks; the
 observability and vault stacks attach to them as external.
+
+## Network-Layer Client Identity
+
+The `tailscale-only` middleware is an `ipWhiteList` on `100.64.0.0/10`. It is only
+a real control if Traefik sees the address the request actually came from. Until
+2026-07-27 it did not, and the allowlist had to carry the Docker bridge gateway
+`172.18.0.1/32` for tailnet access to work at all — an entry that cannot
+distinguish on-network from off-network traffic, which is the middleware's whole
+job.
+
+Two independent mechanisms rewrote the source address to that same gateway. Both
+are fixed; the reasoning is recorded here because the failure mode is invisible
+in normal operation and easy to reintroduce.
+
+### Tailscale masqueraded forwarded tailnet traffic
+
+Tailscale installs two netfilter rules. Anything **forwarded** from `tailscale0`
+is marked, and anything carrying that mark is masqueraded on the way out:
+
+```
+chain ts-forward     { iifname "tailscale0" ... meta mark set mark and 0xff00ffff xor 0x40000 }
+chain ts-postrouting { meta mark & 0x00ff0000 == 0x00040000 ... masquerade }
+```
+
+Docker's DNAT was working correctly, and that is what triggered it. A tailnet
+request to the host's Tailscale address is destined to a *local* address, so
+`PREROUTING` sends it to the `DOCKER` chain and DNAT rewrites the destination to
+the container. That converts local delivery into **forwarding** — which is
+exactly what Tailscale masquerades. The source became the outbound interface's
+address, the bridge gateway.
+
+The host is not a subnet router (`AdvertiseRoutes: None`) and is not an exit
+node, but DNAT-into-a-container is indistinguishable from routing into a subnet,
+so the subnet-router masquerade applied anyway.
+
+Measured with rule counters, same client and URL, varying only the path:
+
+| Path | `ts-postrouting` | Docker DNAT `:443` | Traefik `ClientHost` |
+|---|---|---|---|
+| Tailnet | 172 → 173 | 70 → 71 | `172.18.0.1` |
+| Public | 173 → 173 | 71 → 72 | the client's real public address |
+
+Address family was not the variable — tailnet IPv4 and IPv6 both logged the
+gateway. Public traffic arrives on `eth0`, never gets the mark, is DNAT'd only,
+and its source survives.
+
+**Fix:** `tailscale set --snat-subnet-routes=false`, which removes the
+`ts-postrouting` masquerade. Traefik now logs true tailnet addresses.
+
+Use `tailscale set`, **not** `tailscale up`. `up` re-applies the entire
+preference set and silently resets flags not passed on the command line, on a
+host whose only route in is the tailnet.
+
+Verify against the live ruleset rather than the setting — `sudo nft list chain ip
+nat ts-postrouting` should contain no `masquerade`. Reading `tailscale debug
+prefs` reports intent, and intent diverging from effective state is the whole
+reason this went unnoticed.
+
+### Inbound IPv6 reached the same gateway address by a different route
+
+This one is not obvious and is worth stating separately.
+
+`hill90_edge` is IPv4-only, so Docker writes **no IPv6 DNAT rule** — the `ip6`
+`nat DOCKER` chain is empty. But `docker-proxy` still binds the IPv6 wildcard,
+`[::]:80` and `[::]:443`. An inbound IPv6 connection therefore has nothing to
+redirect it, reaches the userspace proxy, and is re-originated to the container
+from the bridge gateway. It then matched the same allowlist entry.
+
+Removing `172.18.0.1/32` closed that path. The allowlist-only routes now answer
+`403` to the public IPv6 literal and are unchanged over the tailnet:
+
+```
+                 tailnet     public IPv6 literal
+grafana            302              403
+portainer          200              403
+vault              307              403
+```
+
+The zone still publishes no AAAA records, so nothing resolves there by name.
+That is a second layer, not the control — the allowlist is what closes it. Decide
+[#542](https://github.com/jonhill90/Hill90/issues/542) before adding AAAA records,
+not after.
+
+### Two traps when verifying this
+
+**Absence proves nothing.** `accessLog` is filtered to `statusCodes: 400-599`, so
+a *successful* request is never written. Grepping the log for `172.18.0.1` and
+finding nothing is indistinguishable from the log being empty because everything
+worked. Use a positive test: provoke a 4xx from a known client and assert the
+expected address is present.
+
+```bash
+MARK=$(date +%s)
+curl -sk --resolve "portainer.hill90.com:443:<tailscale-ip>" \
+  "https://portainer.hill90.com/nope-$MARK"
+# on the host:
+docker logs traefik --since 3m | grep "nope-$MARK"
+# pass: "ClientHost":"<the client's own tailnet address>"
+```
+
+**`traefik.hill90.com` is not a valid probe for the allowlist.** Its router is
+`auth@file,tailscale-only@file`, and middlewares run in order, so basic auth
+answers `401` before the allowlist is ever evaluated. A `401` there says nothing
+about whether the request would have been admitted.
+
+Probe `grafana`, `portainer` or `vault` instead — their routers carry
+`tailscale-only@file` alone, so `403` means the allowlist rejected the request
+and any other status means it admitted it.
 
 ## TLS And Certificate Controls
 
@@ -95,6 +203,11 @@ observability and vault stacks attach to them as external.
 - `make dns-verify` confirms expected A/TXT propagation.
 - Traefik logs show successful ACME issuance/renewal.
 - `docker ps` shows the expected ten containers.
+- `sudo nft list chain ip nat ts-postrouting` contains no `masquerade` rule.
+- A tailnet request to `portainer.hill90.com` logs the client's own tailnet
+  address as `ClientHost`, not `172.18.0.1` — see the positive test above.
+- `grafana`, `portainer` and `vault` answer `403` to the public IPv6 literal and
+  their normal status over the tailnet.
 
 ## See Also
 


### PR DESCRIPTION
## Plan

Nothing in `docs/` recorded that the `tailscale-only` allowlist was not a real network control until #550. `certificates.md` mentions `tailscale-only@file` in a label example, but no page explained what the middleware depends on or why it needed the bridge-gateway entry.

That gap matters more than a typical stale doc: the **reasoning** is what stops someone reintroducing `172.18.0.1/32`. The entry looked like a working control, and its removal is what caused the outage — so "don't add it back" without the mechanism behind it is an instruction that will lose an argument at 4am.

Adds a `Network-Layer Client Identity` section to `docs/architecture/security.md`, plus four entries in the Verification Checklist and a cross-reference from Network Segmentation.

## What it records

**The dependency.** The middleware is an `ipWhiteList` on `100.64.0.0/10`. It is only a control if Traefik sees the address the request actually came from.

**Mechanism 1 — Tailscale masqueraded forwarded tailnet traffic.** `ts-forward` marks anything forwarded from `tailscale0`; `ts-postrouting` masquerades anything marked. Docker's DNAT was working correctly and is what triggered it: a tailnet request to a local address gets DNAT'd to the container, which converts local delivery into *forwarding* — exactly what Tailscale masquerades. The host is not a subnet router, but DNAT-into-a-container is indistinguishable from routing into a subnet.

Fixed with `tailscale set --snat-subnet-routes=false`, documented with the `set` vs `up` warning: `up` re-applies the entire preference set and silently resets flags not passed, on a host whose only route in is the tailnet. Also documented: verify against `nft list chain ip nat ts-postrouting`, not `tailscale debug prefs` — reading intent instead of effective state is the reason this went unnoticed.

**Mechanism 2 — inbound IPv6, own section because it is not obvious.** `hill90_edge` is IPv4-only so Docker writes no v6 DNAT rule, but `docker-proxy` still binds `[::]:80` and `[::]:443`. An inbound IPv6 connection has nothing to redirect it, reaches the userspace proxy, and is re-originated from the bridge gateway — matching the same entry. Removing the entry closed it.

**Two verification traps**, both of which I hit myself:

- **Absence proves nothing.** `accessLog` is filtered to `statusCodes: 400-599`, so a successful request is never written. Grepping for `172.18.0.1` and finding nothing is indistinguishable from the log being empty because everything worked. The section gives a positive test instead.
- **`traefik.hill90.com` is not a valid allowlist probe.** Its router is `auth@file,tailscale-only@file` and middlewares run in order, so basic auth answers `401` before the allowlist is evaluated. `grafana`, `portainer` and `vault` carry `tailscale-only@file` alone, so `403` there means rejected and anything else means admitted.

## Validation Evidence

Every figure in the doc is first-hand, not carried over from the issue thread.

Rule counters, same client and URL, varying only the path:

```
Path      ts-postrouting   docker DNAT :443   ClientHost
tailnet     172 → 173         70 → 71         172.18.0.1
public      173 → 173         71 → 72         (real public address)
```

Post-fix state on the host:

```
$ sudo nft list chain ip nat ts-postrouting
table ip nat { chain ts-postrouting { } }        # masquerade rule gone
NoSNAT: True
```

Post-fix status codes, measured for this PR:

```
             tailnet    public IPv6 literal
grafana        302             403
portainer      200             403
vault          307             403
```

Positive test, from the tailnet:

```
LOGGED ClientHost=100.127.120.73 status=404 router=portainer@docker
```

`portainer@docker` carries the allowlist alone, so that entry demonstrates both that the true client address is now logged and that the allowlist admitted it.

Repo checks:

```
$ python3 scripts/checks/check_md_links.py       no missing local links
$ python3 scripts/checks/check_env_surface.py    35 variable(s), all documented
$ python3 scripts/checks/check_secrets_schema.py all checks passed
$ python3 scripts/checks/check_volume_names.py   all explicit
$ bats tests/scripts/                            317 ok, 0 failures
```

## Risks

Documentation only — no code, config or infrastructure change. The risk is the doc going stale: if the SNAT setting is ever re-enabled or the allowlist re-widened, this section becomes wrong. The Verification Checklist entries are there so that shows up rather than sitting unnoticed.

Public repository: the section describes a closed configuration and a fix already applied. No addresses beyond ones already published in this repo, no credentials.

## Rollback

`git revert`. Nothing depends on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
