### PR TITLE
feat(local): warn when .env.local drifts behind .env.local.example

### DIFF
--- a/scripts/local.sh
+++ b/scripts/local.sh
@@ -450,6 +450,44 @@ cmd_reset() {
     success "Local stack reset. Run 'bash scripts/local.sh up' to rebuild from the repo."
 }
 
+# ---------------------------------------------------------------------------
+# Env drift
+# ---------------------------------------------------------------------------
+#
+# .env.local is gitignored, so it does not move when .env.local.example gains a
+# variable. Compose substitutes an unset variable with an empty string rather
+# than failing, so the stack comes up looking fine with auth, the database or
+# SSO silently unconfigured. This check exists because that happened: a
+# .env.local drifted twenty variables behind the example with no signal at all.
+#
+# Reports only. It never edits .env.local.
+check_env_drift() {
+    local example="${PROJECT_ROOT}/.env.local.example"
+    local envfile="${PROJECT_ROOT}/.env.local"
+
+    [ -f "$example" ] || return 0
+    if [ ! -f "$envfile" ]; then
+        echo "${YELLOW}!${NC} .env.local does not exist — copy it from .env.local.example"
+        return 0
+    fi
+
+    local missing
+    missing=$(comm -23 \
+        <(grep -oE '^[A-Z_]+' "$example" | sort -u) \
+        <(grep -oE '^[A-Z_]+' "$envfile" | sort -u))
+
+    if [ -n "$missing" ]; then
+        local count
+        count=$(echo "$missing" | wc -l | tr -d ' ')
+        echo "${YELLOW}!${NC} .env.local is missing ${count} variable(s) present in .env.local.example:"
+        echo "$missing" | sed 's/^/    /'
+        echo "  Compose substitutes these as empty strings rather than failing, so the"
+        echo "  stack may start with those features silently unconfigured."
+    else
+        echo "${GREEN}✓${NC} .env.local carries every variable in .env.local.example"
+    fi
+}
+
 cmd_status() {
     require_docker
     echo "${BOLD}Containers${NC}"
@@ -468,6 +506,9 @@ cmd_status() {
     docker ps -a \
         --filter "label=com.docker.compose.project=${DB_PROJECT}" \
         --format 'table {{.Names}}\t{{.Status}}' 2>/dev/null | tail -n +2
+    echo
+    echo "${BOLD}Environment${NC}"
+    check_env_drift
 }
 
 cmd_urls() {


### PR DESCRIPTION
## Plan
Add a drift check to `local.sh status` that compares variable names in `.env.local` against `.env.local.example` and reports what is missing.

## Risks
None to running systems — read-only, reports only, never edits `.env.local`. Only touches `scripts/local.sh`.

## Rollback
Revert.

## Validation Evidence
Tested in both directions, because a check that only ever passes proves nothing.

Complete file:
```
Environment
✓ .env.local carries every variable in .env.local.example
```

With `KC_REALM` and `DB_USER` deliberately removed:
```
Environment
! .env.local is missing 2 variable(s) present in .env.local.example:
    DB_USER
    KC_REALM
  Compose substitutes these as empty strings rather than failing, so the
  stack may start with those features silently unconfigured.
```

## Why
A local `.env.local` was found **twenty variables behind** the example — missing every `KC_*`, both DB credentials, all three OIDC client secrets and the vault config paths. `make local-up` would have come up without auth, without the database wired and without SSO, silently. This is the same silent-config failure shape as #537, #541 and #543: configuration that is ignored rather than rejected.