### PR TITLE
fix(local): reconcile the prefix warning with the runbook's own advice

### DIFF
--- a/docs/runbooks/local-development.md
+++ b/docs/runbooks/local-development.md
@@ -144,7 +144,14 @@ and no path to Let's Encrypt. Each difference is one variable:
 | Port 80 already in use | `HTTP_PORT=8080` | `80` |
 | Coexist with other stacks | `CONTAINER_PREFIX`, `NETWORK_PREFIX`, `VOLUME_PREFIX` | unset / `hill90` / `prod` |
 
-If `up` reports a network is shared, change `NETWORK_PREFIX` in `.env.local`.
+If `up` reports a network is shared, change `NETWORK_PREFIX` in `.env.local` —
+but **bring the current stack down first**. Compose keys containers on
+`container_name`, so starting up under a new prefix does not rename the running
+containers; it leaves them orphaned and builds a second set beside them, which
+then collides on `HTTP_PORT`/`HTTPS_PORT`. `local.sh status` warns when these
+four differ from `.env.local.example` for exactly this reason. A deliberate
+change is fine — an accidental one is how you end up with fifteen orphaned
+containers and a port conflict.
 The check looks at what is actually attached to the network, not just its
 compose-project label, because `internal` and `agent_internal` are created by
 hand and carry no label — and because another stack can join a network this one

--- a/scripts/local.sh
+++ b/scripts/local.sh
@@ -487,11 +487,13 @@ check_env_drift() {
         echo "${GREEN}✓${NC} .env.local carries every variable in .env.local.example"
     fi
 
-    # Structural variables: the example is authoritative, not a suggestion.
+    # Structural variables: differing from the example is meaningful, not neutral.
     #
-    # These name the containers, networks and volumes the stack creates. They are
-    # not personal preferences like ports or passwords -- a local value that
-    # disagrees with the example does not customise anything, it forks the stack.
+    # These name the containers, networks and volumes the stack creates. Changing
+    # them is a supported, deliberate act -- it is how you run two stacks side by
+    # side, and docs/runbooks/local-development.md tells you to do exactly that
+    # when a network turns out to be shared. What is NOT safe is changing them
+    # while a stack is already running under the old prefix.
     # Compose keys containers on container_name, so `up` with a different prefix
     # orphans whatever is already running and builds a duplicate set beside it,
     # which then collides on the published ports.
@@ -512,11 +514,14 @@ check_env_drift() {
     done
 
     if [ -n "$mismatched" ]; then
-        echo "${YELLOW}!${NC} .env.local disagrees with the example on structural variables:"
+        echo "${YELLOW}!${NC} .env.local uses non-default values for structural variables:"
         printf "%b" "$mismatched"
-        echo "  These name containers, networks and volumes -- the example is authoritative."
-        echo "  Running 'up' with a different prefix orphans the current stack and builds a"
-        echo "  duplicate beside it, which then collides on the published ports."
+        echo "  These name the containers, networks and volumes this stack creates."
+        echo "  Deliberate? Fine -- that is how you run two stacks side by side. But bring"
+        echo "  the other one down first: compose keys containers on container_name, so 'up'"
+        echo "  under a new prefix orphans whatever is running and builds a duplicate beside"
+        echo "  it, which then collides on the published ports."
+        echo "  Unintentional? Align them with .env.local.example before running 'up'."
     else
         echo "${GREEN}✓${NC} structural prefixes match the example"
     fi


### PR DESCRIPTION
## Plan
#554 shipped a check saying a non-default structural prefix is always wrong. `docs/runbooks/local-development.md` already said the opposite — change `NETWORK_PREFIX` when a network turns out to be shared. Both are now consistent.

## Why it matters
A check that contradicts the runbook teaches people to ignore the check. Changing a prefix is legitimate: it is how you run two stacks side by side. The unsafe part is changing it **while a stack is already running under the old prefix** — compose keys containers on `container_name`, so `up` orphans the running set and builds a duplicate that collides on the published ports.

## Risks
None to running systems. Wording only, plus one added precondition in the runbook.

## Rollback
Revert.

## Validation Evidence
Drifted:
```
! .env.local uses non-default values for structural variables:
    CONTAINER_PREFIX: yours=hill90local-  example=hill90dev-
  These name the containers, networks and volumes this stack creates.
  Deliberate? Fine -- that is how you run two stacks side by side. But bring
  the other one down first: compose keys containers on container_name, so 'up'
  under a new prefix orphans whatever is running and builds a duplicate beside
  it, which then collides on the published ports.
  Unintentional? Align them with .env.local.example before running 'up'.
```

Aligned: both lines report clean.