### PR TITLE
feat(storage): restore MinIO as a platform service with Keycloak OIDC (#530)

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -149,6 +149,12 @@ MINIO_ROOT_PASSWORD=localdev-minio-password
 # the AGPL build (removed May 2025), so this does not give you a login button.
 MINIO_OIDC_CLIENT_SECRET=local-minio-secret-0123456789
 
+# Routing. Production resolves to storage.hill90.com with no environment set.
+MINIO_HOST=storage
+MINIO_PUBLIC_URL=http://storage.localtest.me:8080
+# The token claim MinIO reads the policy name from. keycloak.sh emits it.
+MINIO_OIDC_CLAIM_NAME=minio_policy
+
 # The local Portainer admin. portainer.sh uses it to call the Portainer API, and
 # it is your way in when Keycloak is unavailable. Portainer 2.39 requires the
 # admin to be created within a few minutes of first start, using a setup token

--- a/.env.local.example
+++ b/.env.local.example
@@ -140,6 +140,15 @@ GRAFANA_OIDC_ENABLED=true
 GRAFANA_OIDC_CLIENT_SECRET=local-grafana-secret-0123456789
 PORTAINER_OIDC_CLIENT_SECRET=local-portainer-secret-0123456789
 
+# --- Object store (MinIO) ----------------------------------------------------
+# Root credentials for the local object store. Disposable; production keeps its
+# own in SOPS.
+MINIO_ROOT_USER=minioadmin
+MINIO_ROOT_PASSWORD=localdev-minio-password
+# Gates the S3/STS path against Keycloak. MinIO's console has NO SSO login in
+# the AGPL build (removed May 2025), so this does not give you a login button.
+MINIO_OIDC_CLIENT_SECRET=local-minio-secret-0123456789
+
 # The local Portainer admin. portainer.sh uses it to call the Portainer API, and
 # it is your way in when Keycloak is unavailable. Portainer 2.39 requires the
 # admin to be created within a few minutes of first start, using a setup token

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,15 @@ jobs:
         run: bats tests/scripts/
 
       - name: Validate compose files
+        # Credentials that must never fall back to a default use ${VAR:?...},
+        # so `config` refuses to render without them. That guard is deliberate:
+        # an empty MinIO root password silently starts the server on
+        # minioadmin/minioadmin with only a WARN. Supply throwaway values here —
+        # this step validates STRUCTURE, not secrets.
+        env:
+          MINIO_ROOT_USER: placeholder
+          MINIO_ROOT_PASSWORD: placeholder
+          MINIO_OIDC_CLIENT_SECRET: placeholder
         run: |
           for f in deploy/compose/prod/docker-compose*.yml; do
             echo "Validating $f..."

--- a/.github/workflows/deploy-minio.yml
+++ b/.github/workflows/deploy-minio.yml
@@ -1,0 +1,18 @@
+name: Manual Deploy Object Store (Prod)
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: deploy-prod
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    uses: ./.github/workflows/reusable-deploy-service.yml
+    with:
+      service: minio
+    secrets: inherit

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,7 @@ on:
       - 'platform/data/postgres/**'
       - 'platform/observability/**'
       - 'deploy/compose/prod/docker-compose.db.yml'
+      - 'deploy/compose/prod/docker-compose.minio.yml'
       - 'deploy/compose/prod/docker-compose.auth.yml'
       - 'deploy/compose/prod/docker-compose.vault.yml'
       - 'deploy/compose/prod/docker-compose.observability.yml'
@@ -16,7 +17,7 @@ on:
       service:
         description: 'Service to deploy (or "all")'
         type: choice
-        options: [all, db, auth, vault, observability]
+        options: [all, db, auth, minio, vault, observability]
         default: 'all'
 
 permissions:
@@ -33,6 +34,7 @@ jobs:
     outputs:
       db: ${{ steps.filter.outputs.db }}
       auth: ${{ steps.filter.outputs.auth }}
+      minio: ${{ steps.filter.outputs.minio }}
       vault: ${{ steps.filter.outputs.vault }}
       observability: ${{ steps.filter.outputs.observability }}
     steps:
@@ -47,6 +49,8 @@ jobs:
             auth:
               - 'deploy/compose/prod/docker-compose.auth.yml'
               - 'platform/auth/keycloak/**'
+            minio:
+              - 'deploy/compose/prod/docker-compose.minio.yml'
             vault:
               - 'deploy/compose/prod/docker-compose.vault.yml'
             observability:
@@ -70,6 +74,17 @@ jobs:
     uses: ./.github/workflows/reusable-deploy-service.yml
     with:
       service: auth
+    secrets: inherit
+
+  # MinIO validates OIDC tokens against Keycloak, so it follows auth. It does
+  # not depend on it to START — a slow or absent IdP only affects federated
+  # logins, never root-credential access.
+  deploy-minio:
+    needs: [changes, deploy-auth]
+    if: always() && (needs.changes.outputs.minio == 'true' || github.event.inputs.service == 'all' || github.event.inputs.service == 'minio') && !failure() && !cancelled()
+    uses: ./.github/workflows/reusable-deploy-service.yml
+    with:
+      service: minio
     secrets: inherit
 
   deploy-vault:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,7 @@ on:
       - 'deploy/compose/prod/docker-compose.auth.yml'
       - 'deploy/compose/prod/docker-compose.vault.yml'
       - 'deploy/compose/prod/docker-compose.observability.yml'
+      - 'scripts/minio.sh'
   workflow_dispatch:
     inputs:
       service:
@@ -51,6 +52,7 @@ jobs:
               - 'platform/auth/keycloak/**'
             minio:
               - 'deploy/compose/prod/docker-compose.minio.yml'
+              - 'scripts/minio.sh'
             vault:
               - 'deploy/compose/prod/docker-compose.vault.yml'
             observability:
@@ -76,9 +78,10 @@ jobs:
       service: auth
     secrets: inherit
 
-  # MinIO validates OIDC tokens against Keycloak, so it follows auth. It does
-  # not depend on it to START — a slow or absent IdP only affects federated
-  # logins, never root-credential access.
+  # MinIO validates OIDC tokens against Keycloak, so it is ordered after auth
+  # (and therefore transitively after db). That is ordering, not a runtime
+  # dependency: MinIO STARTS fine with Keycloak absent, and root-credential
+  # access is unaffected — only federated S3 logins need the IdP.
   deploy-minio:
     needs: [changes, deploy-auth]
     if: always() && (needs.changes.outputs.minio == 'true' || github.event.inputs.service == 'all' || github.event.inputs.service == 'minio') && !failure() && !cancelled()

--- a/deploy/compose/overrides/local.minio.yml
+++ b/deploy/compose/overrides/local.minio.yml
@@ -1,0 +1,15 @@
+# Local development override for the object store.
+#
+# Layered on deploy/compose/prod/docker-compose.minio.yml — the SAME file prod
+# uses. Only the routing differences a Mac forces, exactly as the other local
+# overrides do.
+services:
+  minio:
+    labels:
+      - "traefik.http.routers.minio-console.tls=false"
+    # MinIO validates OIDC tokens server-side, so it has to REACH Keycloak.
+    # auth.localtest.me resolves to 127.0.0.1, which inside a container is the
+    # container itself — the same trap local.vault.yml and local.observability.yml
+    # document. Without this the OIDC config silently fails to load.
+    extra_hosts:
+      - "${AUTH_HOST:-auth}.${BASE_DOMAIN:-hill90.com}:host-gateway"

--- a/deploy/compose/prod/docker-compose.minio.yml
+++ b/deploy/compose/prod/docker-compose.minio.yml
@@ -1,0 +1,109 @@
+version: '3.9'
+
+# MinIO object store (platform service)
+# Deploy with: bash scripts/deploy.sh minio prod
+#
+# MinIO is a PLATFORM PRIMITIVE — the open-source counterpart to an Azure
+# Storage Account. See docs/decisions/platform-primitives.md. It is restored
+# here for the same reason Keycloak and Postgres were in #531: the primitive is
+# meant to exist so consumers can arrive.
+#
+# THERE IS NO CONSUMER TODAY. Loki is configured with filesystem storage, Tempo
+# with a local backend, and backup.sh has no S3 target. Nothing in this
+# repository reads or writes an object store. That is deliberate and recorded
+# rather than hidden.
+#
+# IDENTITY — read this before assuming SSO works:
+#   MinIO removed the management console from the AGPL community build in May
+#   2025. Verified by running each release against a real Keycloak: on
+#   RELEASE.2025-04-22 the console reports loginStrategy "redirect" with a
+#   working Keycloak button; from RELEASE.2025-05-24 onward it reports "form"
+#   with redirectRules null, no matter how OIDC is configured.
+#
+#   So the console login below is ROOT CREDENTIALS ONLY. What OIDC does still
+#   give us is the S3/STS path: AssumeRoleWithWebIdentity accepts Keycloak
+#   tokens, so Keycloak identities can obtain S3 credentials programmatically.
+#   That is genuinely useful and it is NOT "SSO into MinIO".
+#
+#   Pinning the April release to keep the login button was considered and
+#   rejected: a fifteen-month-old unpatched build on an internet-facing box is a
+#   bad trade for a button.
+
+networks:
+  edge:
+    external: true
+    name: ${NETWORK_PREFIX:-hill90}_edge
+  internal:
+    external: true
+    name: ${NETWORK_PREFIX:-hill90}_internal
+
+volumes:
+  minio-data:
+    name: ${VOLUME_PREFIX:-prod}_minio-data
+
+services:
+  minio:
+    # Current release. `latest` was RELEASE.2025-09-07 when this was written and
+    # the community edition has not shipped since — see the note in
+    # docs/decisions/object-store.md about that.
+    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
+    container_name: ${CONTAINER_PREFIX:-}minio
+    restart: unless-stopped
+    mem_limit: 512m
+    command: server /data --console-address ":9001"
+    networks:
+      - edge
+      - internal
+    volumes:
+      - minio-data:/data
+    environment:
+      - MINIO_ROOT_USER=${MINIO_ROOT_USER}
+      - MINIO_ROOT_PASSWORD=${MINIO_ROOT_PASSWORD}
+      # Prometheus scrapes /minio/v2/metrics/cluster on the internal network.
+      - MINIO_PROMETHEUS_AUTH_TYPE=public
+      # --- Keycloak OIDC (S3/STS only — see the header) --------------------
+      # Env var names taken from `mc admin config set identity_openid --env` on
+      # this exact image, not from documentation: the community docs URL now
+      # redirects to AIStor's and MinIO has renamed these settings before.
+      - MINIO_IDENTITY_OPENID_CONFIG_URL=${KC_PUBLIC_URL:-https://auth.hill90.com}/realms/${KC_REALM:-platform}/.well-known/openid-configuration
+      - MINIO_IDENTITY_OPENID_CLIENT_ID=minio
+      - MINIO_IDENTITY_OPENID_CLIENT_SECRET=${MINIO_OIDC_CLIENT_SECRET}
+      - MINIO_IDENTITY_OPENID_DISPLAY_NAME=Keycloak
+      - MINIO_IDENTITY_OPENID_SCOPES=openid,profile,email
+      # MinIO reads the policy to grant from this claim. keycloak.sh adds a
+      # mapper that emits it; a token without it gets no access rather than
+      # broad access.
+      - MINIO_IDENTITY_OPENID_CLAIM_NAME=${MINIO_OIDC_CLAIM_NAME:-minio_policy}
+      - MINIO_IDENTITY_OPENID_REDIRECT_URI=${MINIO_PUBLIC_URL:-https://storage.hill90.com}/oauth_callback
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 20s
+    labels:
+      - "traefik.enable=true"
+      # The console. Tailscale-only, like every other admin surface.
+      #
+      # CERTIFICATE: this host has never issued under the current ACME path —
+      # see issue #538. The resolver is NOT hardcoded; it inherits
+      # ADMIN_CERT_RESOLVER so that whichever DNS-01 provider is live applies.
+      # That matters because ACME DNS-01 is mid-migration from the Hostinger
+      # webhook to Cloudflare (#535): deploying this while the httpreq provider
+      # is still live would fail validation against a zone Hostinger no longer
+      # serves, and Traefik would present its default certificate. Order this
+      # deploy AFTER #535 and watch the first issuance — see
+      # docs/runbooks/object-store.md.
+      - "traefik.http.routers.minio-console.rule=Host(`${MINIO_HOST:-storage}.${BASE_DOMAIN:-hill90.com}`)"
+      - "traefik.http.routers.minio-console.entrypoints=${ADMIN_ENTRYPOINT:-websecure}"
+      - "traefik.http.routers.minio-console.tls.certresolver=${ADMIN_CERT_RESOLVER:-letsencrypt-dns}"
+      - "traefik.http.routers.minio-console.middlewares=${ADMIN_MIDDLEWARES:-tailscale-only@file}"
+      - "traefik.http.routers.minio-console.service=minio-console"
+      - "traefik.http.services.minio-console.loadbalancer.server.port=9001"
+      #
+      # The S3 API (:9000) is deliberately NOT routed. It stays on the internal
+      # network, reachable as http://minio:9000 by containers that need it.
+      # Publishing it would mean inventing a second hostname with no DNS record
+      # and a second certificate that has never issued — cost with no consumer
+      # to justify it. When something external needs S3, that is a deliberate
+      # addition: a DNS record, a router, and a watched first issuance.

--- a/deploy/compose/prod/docker-compose.minio.yml
+++ b/deploy/compose/prod/docker-compose.minio.yml
@@ -57,8 +57,12 @@ services:
     volumes:
       - minio-data:/data
     environment:
-      - MINIO_ROOT_USER=${MINIO_ROOT_USER}
-      - MINIO_ROOT_PASSWORD=${MINIO_ROOT_PASSWORD}
+      # The :? form, not a bare substitution: with an empty value MinIO starts
+      # happily on minioadmin/minioadmin and only WARNS. Every container on the
+      # internal network can reach the S3 API, so a silent fallback to default
+      # credentials is a real exposure. Fail the deploy instead.
+      - MINIO_ROOT_USER=${MINIO_ROOT_USER:?MINIO_ROOT_USER must be set}
+      - MINIO_ROOT_PASSWORD=${MINIO_ROOT_PASSWORD:?MINIO_ROOT_PASSWORD must be set}
       # Prometheus scrapes /minio/v2/metrics/cluster on the internal network.
       - MINIO_PROMETHEUS_AUTH_TYPE=public
       # --- Keycloak OIDC (S3/STS only — see the header) --------------------
@@ -67,7 +71,7 @@ services:
       # redirects to AIStor's and MinIO has renamed these settings before.
       - MINIO_IDENTITY_OPENID_CONFIG_URL=${KC_PUBLIC_URL:-https://auth.hill90.com}/realms/${KC_REALM:-platform}/.well-known/openid-configuration
       - MINIO_IDENTITY_OPENID_CLIENT_ID=minio
-      - MINIO_IDENTITY_OPENID_CLIENT_SECRET=${MINIO_OIDC_CLIENT_SECRET}
+      - MINIO_IDENTITY_OPENID_CLIENT_SECRET=${MINIO_OIDC_CLIENT_SECRET:?MINIO_OIDC_CLIENT_SECRET must be set}
       - MINIO_IDENTITY_OPENID_DISPLAY_NAME=Keycloak
       - MINIO_IDENTITY_OPENID_SCOPES=openid,profile,email
       # MinIO reads the policy to grant from this claim. keycloak.sh adds a

--- a/docs/decisions/object-store.md
+++ b/docs/decisions/object-store.md
@@ -73,6 +73,17 @@ with real migration cost and it deserves its own decision record — it is
 deliberately *not* smuggled into this change. This note exists so the question is
 on the record rather than discovered later.
 
+## The policy namespace is shared, and that is a sharp edge
+
+Realm role names map directly onto MinIO policy names, and MinIO's built-in
+policies — `consoleAdmin`, `readwrite`, `readonly`, `writeonly`, `diagnostics` —
+live in the same namespace. Today `REALM_ROLES` is fixed at `admin editor
+viewer`, so there is no collision.
+
+**A future realm role named `consoleAdmin` would silently grant MinIO admin** to
+anyone holding it, without anything in this repository changing. If the realm
+role set grows, check it against MinIO's built-ins first.
+
 ## Certificate path
 
 `storage.hill90.com` has **never issued a certificate** under the current ACME

--- a/docs/decisions/object-store.md
+++ b/docs/decisions/object-store.md
@@ -1,0 +1,102 @@
+# The object store: MinIO restored, with its limits recorded
+
+**Status:** decided. MinIO is restored as a platform service.
+**Related:** [platform-primitives.md](platform-primitives.md), issues #530, #538.
+
+## What was decided
+
+MinIO comes back as a **platform primitive** — the open-source counterpart to an
+Azure Storage Account, alongside Keycloak for Entra ID and OpenBao for Key Vault.
+It is pinned to the current release, its OIDC is wired to Keycloak for the
+S3/STS path, and its console login is root credentials only.
+
+## There is no consumer today
+
+Stated plainly because it is the most likely thing to be misread later:
+
+- Loki is configured with `filesystem` storage and `object_store: filesystem`.
+- Tempo is configured with `backend: local`.
+- `backup.sh` writes volume tars to disk and has no S3 target.
+
+Nothing in this repository reads or writes an object store. The primitive exists
+so that consumers can arrive, which is the same reasoning that restored Keycloak
+and Postgres in #531. The four `MINIO_*` and `VAULT_MINIO_*` keys that survived
+in `prod.enc.env` were orphans of the extracted application; they are live again
+rather than newly minted.
+
+The concrete problem this also solves: `storage.hill90.com` has resolved to the
+VPS throughout, so the platform has been advertising an object store that nothing
+served.
+
+## OIDC works. SSO does not. The difference matters
+
+**MinIO removed the management console from the AGPL community build in May
+2025.** Verified by running releases side by side against a real Keycloak with
+identical configuration:
+
+| Release | Console `loginStrategy` |
+|---|---|
+| `RELEASE.2025-04-22` | `redirect` — a working Keycloak button |
+| `RELEASE.2025-05-24` | `form` |
+| `RELEASE.2025-06-13` | `form` |
+| `RELEASE.2025-07-23` | `form` |
+| `RELEASE.2025-09-07` | `form` |
+
+So on any current release the console offers **only** root-credential form login,
+no matter how OIDC is configured. `redirectRules` is `null`.
+
+What OIDC still provides is the **S3/STS path**: `AssumeRoleWithWebIdentity`
+accepts a Keycloak token and returns temporary S3 credentials carrying the
+policy named in the token's claim. That was verified end to end — a Keycloak user
+with realm role `admin` obtained credentials and wrote an object.
+
+**This is not SSO and must not be described as SSO.** It closes the MinIO part of
+issue #530 only in the sense that the identity provider is genuinely wired in;
+nobody gets a login button.
+
+### Why not pin the April release
+
+Considered and rejected. Keeping the login button would mean freezing an
+internet-facing service on a build that stops receiving security updates, with no
+upgrade path that preserves the feature. A login button is not worth that.
+
+## The community edition looks like it is in maintenance
+
+**Flagged for Jon, not acted on.** `minio/minio:latest` resolves to
+`RELEASE.2025-09-07`, roughly ten months old at the time of writing. Combined
+with the console removal and the general push toward the commercial AIStor
+product, the community edition appears to be receiving little investment.
+
+If the Storage Account role should be filled by something actively developed,
+**Garage** and **SeaweedFS** are the obvious candidates. That is a real decision
+with real migration cost and it deserves its own decision record — it is
+deliberately *not* smuggled into this change. This note exists so the question is
+on the record rather than discovered later.
+
+## Certificate path
+
+`storage.hill90.com` has **never issued a certificate** under the current ACME
+configuration — see issue #538. The cause is not a broken ACME path: there was no
+Traefik router for the host, so nothing ever asked. Traefik serves its default
+self-signed certificate for hostnames it has no router for, which is correct
+behaviour.
+
+Restoring the service adds that router, so this deploy is the **first issuance**
+for the host. Two consequences:
+
+1. **This must deploy after the Cloudflare ACME migration (#535).** `main` still
+   configures DNS-01 through the `httpreq` provider pointed at the
+   `dns-manager` Hostinger shim, while the zone is now served by Cloudflare. A
+   DNS-01 challenge would write a TXT record to a zone Hostinger no longer
+   answers for, validation would fail, and `storage.hill90.com` would serve
+   Traefik's default certificate — exactly the untrusted-certificate state this
+   work is meant to end.
+2. The resolver is **not hardcoded**. The router inherits `ADMIN_CERT_RESOLVER`
+   like every other admin surface, so whichever provider is live applies.
+
+The first issuance should be watched rather than assumed. Procedure in
+[the runbook](../runbooks/object-store.md).
+
+The stale `_acme-challenge.storage` TXT record in the zone is a fossil from when
+MinIO last existed; it survives because `dns-manager`'s `/cleanup` has never
+successfully deleted a record. Retiring it is #538's business, not this change's.

--- a/docs/runbooks/object-store.md
+++ b/docs/runbooks/object-store.md
@@ -1,0 +1,127 @@
+# Object store (MinIO)
+
+MinIO is a platform primitive — the Storage Account equivalent. Background and
+the decisions behind it: [object-store.md](../decisions/object-store.md).
+
+- Console: `https://storage.hill90.com` — **root credentials only**
+- S3 API: `http://minio:9000` on the internal network, **not routed externally**
+- Locally: `http://storage.localtest.me:8080`
+
+## Logging in
+
+**The console has no SSO button, and adding one is not possible on a current
+release.** MinIO removed the management console from the AGPL build in May 2025.
+Sign in with `MINIO_ROOT_USER` / `MINIO_ROOT_PASSWORD` from SOPS.
+
+Keycloak identities work on the **S3/STS path** instead — see below. If you are
+looking for the SSO story for the other services, that is
+[sso-fallback.md](sso-fallback.md).
+
+## Getting S3 credentials from a Keycloak identity
+
+A user with realm role `admin`, `editor` or `viewer` can exchange a Keycloak
+token for temporary S3 credentials. The realm role name is carried in the
+`minio_policy` claim, and MinIO grants the policy of that name — which is why
+`scripts/minio.sh apply` creates policies called `admin`, `editor` and `viewer`.
+Without them every federated login is rejected with "no policy found".
+
+```bash
+# 1. Obtain an OIDC token for the `minio` client however you normally would.
+# 2. Exchange it. Note the parameters go in the BODY, form-encoded — passing
+#    them in the query string returns "unsupported API call for method: POST".
+curl -X POST "http://minio:9000/" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  --data-urlencode "Action=AssumeRoleWithWebIdentity" \
+  --data-urlencode "Version=2011-06-15" \
+  --data-urlencode "DurationSeconds=900" \
+  --data-urlencode "WebIdentityToken=$ID_TOKEN"
+```
+
+The response carries `AccessKeyId`, `SecretAccessKey` and `SessionToken`. With
+`mc`, the session token goes in the alias URL:
+
+```bash
+export MC_HOST_fed="http://${AK}:${SK}:${ST}@minio:9000"
+mc ls fed
+```
+
+**Verified end to end locally**: a Keycloak user with realm role `admin`
+exchanged a token for credentials and wrote a 29-byte object.
+
+## Policies
+
+| Realm role | MinIO policy | Grants |
+|---|---|---|
+| `admin` | `admin` | `s3:*` plus `admin:*` |
+| `editor` | `editor` | get/put/delete objects, list buckets |
+| `viewer` | `viewer` | get objects, list buckets |
+
+`scripts/minio.sh apply` provisions them and is idempotent. `deploy.sh minio`
+runs it automatically; a failure there is non-fatal and leaves root access
+unaffected.
+
+Note the `admin` policy needs `s3:*` and `admin:*` in **separate statements** —
+MinIO treats any statement containing an `admin:` action as admin-only and
+rejects `s3:*` inside it with `unsupported admin action 's3:*'`.
+
+## The first certificate issuance — read before deploying
+
+`storage.hill90.com` has **never issued a certificate** under the current ACME
+configuration (issue #538). Nothing was broken: there was no router for the host,
+so nothing ever asked. This deploy adds the router and therefore triggers the
+first issuance.
+
+**Deploy this after the Cloudflare ACME migration (#535).** While `main` still
+uses the `httpreq` provider pointed at the Hostinger `dns-manager` shim, a
+DNS-01 challenge writes to a zone Hostinger no longer serves. Validation fails
+and Traefik presents its default self-signed certificate — the exact untrusted
+state this work exists to end.
+
+### Watching it, rather than assuming it
+
+```bash
+# On the VPS, after `deploy.sh minio prod`:
+
+# 1. Is a router registered for the host at all?
+docker exec traefik wget -qO- http://localhost:8080/api/http/routers \
+  | grep -o 'minio-console[^,]*'
+
+# 2. Did ACME store a certificate for it?
+docker exec traefik sh -c 'cat /letsencrypt/acme-dns.json' \
+  | grep -o 'storage\.hill90\.com'
+
+# 3. What is actually served?
+echo | openssl s_client -connect storage.hill90.com:443 \
+  -servername storage.hill90.com 2>/dev/null \
+  | openssl x509 -noout -subject -dates
+```
+
+Expected: `subject=CN=storage.hill90.com` with a real expiry. If it says
+`CN=TRAEFIK DEFAULT CERT`, issuance failed — check Traefik's log for the ACME
+error and confirm which DNS provider is configured before retrying, because
+Let's Encrypt rate-limits repeated failures.
+
+**Rolling back the certificate attempt** is just removing the router: redeploy
+without the MinIO stack, or unset the resolver. Nothing else depends on it.
+
+## Local development
+
+```bash
+bash scripts/local.sh up     # brings up MinIO with the rest of the stack
+bash scripts/local.sh sso    # Keycloak client + MinIO policies
+```
+
+The local override maps `auth.localtest.me` to `host-gateway`, because MinIO
+validates OIDC tokens server-side and `localtest.me` resolves to `127.0.0.1` —
+which inside a container is the container itself. Without it the OIDC config
+loads but no token ever validates.
+
+## Backups
+
+`backup.sh backup minio` tars the `prod_minio-data` volume, and `deploy.sh minio`
+runs it before recreating the container. There is no `mc mirror` step: the volume
+is the whole store, and mirroring would need somewhere to mirror to.
+
+The volume was never deleted when MinIO was removed in #495, so a restore on the
+VPS may find existing objects. That is also why the root credentials are reused
+rather than rotated — rotating them is a separate, deliberate act.

--- a/docs/runbooks/sso-fallback.md
+++ b/docs/runbooks/sso-fallback.md
@@ -138,9 +138,26 @@ Keycloak's first boot; editing it later changes nothing while still logging
 "Import finished successfully". Use `scripts/keycloak.sh apply`. See
 [the Keycloak README](../../platform/auth/keycloak/README.md).
 
-## What is not covered
+## MinIO — OIDC yes, SSO no
 
-**MinIO is not deployed.** Issue #530 lists it, but there is no MinIO service in
-this repository — it was removed with the application in #495 and no compose file
-exists. Its SSO is therefore **deferred, not done**, and will be part of whatever
-work deploys MinIO in the first place.
+MinIO is now deployed as a platform service, and its OIDC is wired to Keycloak.
+**MinIO has no SSO login.** That is not a configuration gap:
+
+MinIO removed the management console from the AGPL community build in May 2025.
+On every release from `RELEASE.2025-05-24` onward the console reports
+`loginStrategy: form` with `redirectRules: null` regardless of OIDC settings —
+verified by running the releases side by side against a real Keycloak.
+
+So the MinIO console fallback is the *only* path: `MINIO_ROOT_USER` /
+`MINIO_ROOT_PASSWORD` from SOPS. There is nothing to fall back *from*.
+
+What does work is the S3/STS path: a Keycloak token exchanges for temporary S3
+credentials via `AssumeRoleWithWebIdentity`. See
+[object-store.md](object-store.md). Do not describe that as SSO.
+
+| Service | Fallback | Keycloak login? |
+|---|---|---|
+| Grafana | local `admin` | yes, org-admin mapping |
+| Portainer | local `admin` | yes, promote once |
+| OpenBao | AppRole / root token | yes |
+| MinIO | root credentials (**only** path) | no — S3/STS only |

--- a/infra/secrets/prod.enc.env
+++ b/infra/secrets/prod.enc.env
@@ -80,9 +80,10 @@ GRAFANA_OIDC_CLIENT_SECRET=ENC[AES256_GCM,data:+8J5W0ACzx2I7UmW++j3W2wCz7NytKuns
 PORTAINER_OIDC_CLIENT_SECRET=ENC[AES256_GCM,data:PojT9jxvE6JDxt6MLxuMFz2YgMlB2DgoZW0asBovWyEJGRr8OJhws9wBrxs=,iv:C8CJwS3sfZFY6T5kLsWOspgUqYcJjYWpMs/Awh9QJPQ=,tag:2iQyec8tnxxUhq6peZtsJw==,type:str]
 PORTAINER_ADMIN_PASSWORD=ENC[AES256_GCM,data:wNJ1CM7eZ9ujJVFJuTvQ/7wTfkU=,iv:y/QuT4jfvxH8BMAfrEgDw9Udr+paPRq0Rd7eAh1CjwA=,tag:ptai9mrCwQ0d8sZ8e3xORg==,type:str]
 VAULT_OIDC_CLIENT_SECRET=ENC[AES256_GCM,data:jeGsH9RdREYp+6X43zAOCGEtpmPfM6nWxwjnI2NwS65ccmvH5iYKvnFDEQ==,iv:nLWiu/KMoXzi376LbnGYYFU8TtiwoKlV3ot2USdP4ek=,tag:8vuXo1JPWvhf/CMI5Sa2Ug==,type:str]
+MINIO_OIDC_CLIENT_SECRET=ENC[AES256_GCM,data:MsbCBhBAl3CntYMenBS+bnq+hsRDFazAy/nxHWSxcWYTuOyGnzwRDEb3Zo8=,iv:fe+mcbi+nZMpNdPmHCAHBFISHuBC8uL8dYt4eN74KcU=,tag:06x/2/evwPQOyEEi9Vhq4w==,type:str]
 sops_age__list_0__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBrRy9IcWFNL2pOZWNxdzEr\nYk80dmdiYkVOa2RJYnM2Z29ucURmR05sQkdnCk9ZN2VmYUJpdVZ3WnljQU9XUXdv\nWFYyL2JERGlMd2hCSFAzNlRnUEdlSDQKLS0tIDdncUI5SkxORFE3dnI0aVloaE9z\nSGh3SnNsYnltNmJteFJUeVU3MWpvaDAKfJ6tZctOxb4xPFjesRxQw1Q8FvB8/Gnx\ncFwQpzTlIFc+uXS895d9ydS1VA5lot8PdbPUKk1/wCcuJR4EFR/elQ==\n-----END AGE ENCRYPTED FILE-----\n
 sops_age__list_0__map_recipient=age1p30vk2qpvlkj5pzh72f0wwvlqgmedvr204nldmpskmptgy9ryg8qg9qd5v
-sops_lastmodified=2026-07-27T02:58:20Z
-sops_mac=ENC[AES256_GCM,data:zj9I/u2sSJ9pfvaypa2f3GUsyaZ8ZBNy1DM4oRCn71h3TWEFztd8C2IdXgSoUvMWe994l+W21jUjCluGO4ETLS09A+4j6kSjRzAYpK+aVrrUBqxviYZJbZJgTyMtEgtwZ7Wqf/DBunOeNY8BQ1t6honCU4Ne1XCZ3HUkxeniKnE=,iv:nr76xyeQiwr7jsYcKVNECn/KG1H+SOnl+wKoJJgT9Bg=,tag:nSb6fL1Li6TcK2zr2CPvAA==,type:str]
+sops_lastmodified=2026-07-27T08:32:10Z
+sops_mac=ENC[AES256_GCM,data:JbfjHZNt/jrlVJnAxW/0oScqk+DdqUxMt3dCxXFnI5DdQbZUK4YyXI42kv/68OjYZozioApgHdgsEPLk/EQL7/oQ7MpWnof6JNpTRzx8scGgyy5xZVZ+9N/bzlLhWItrv36OGB/yuchIWD8zk1Y1xbj8xhkZ8uTskMHnPYhTwA0=,iv:UmaKaerF/F0Eu0uXNWpPYMicPw/9rxp8mCMgcIz/ie8=,tag:txzQGu2+OHLc20imdAWwPw==,type:str]
 sops_unencrypted_suffix=_unencrypted
 sops_version=3.11.0

--- a/infra/secrets/prod.enc.env.example
+++ b/infra/secrets/prod.enc.env.example
@@ -45,6 +45,10 @@ VAULT_INFRA_ROLE_ID=REPLACE_WITH_ROLE_ID
 VAULT_INFRA_SECRET_ID=REPLACE_WITH_SECRET_ID
 VAULT_OBSERVABILITY_ROLE_ID=REPLACE_WITH_ROLE_ID
 VAULT_OBSERVABILITY_SECRET_ID=REPLACE_WITH_SECRET_ID
+# Already present in the real prod.enc.env — orphaned by #495, live again now
+# the object store exists.
+VAULT_MINIO_ROLE_ID=REPLACE_WITH_ROLE_ID
+VAULT_MINIO_SECRET_ID=REPLACE_WITH_SECRET_ID
 # Note: mcp and vault have no compose secret refs — no AppRole creds needed
 
 # Vault sync token (read-only, for automated vault-to-SOPS sync)
@@ -79,6 +83,18 @@ VAULT_OIDC_CLIENT_SECRET=REPLACE_WITH_KEYCLOAK_CLIENT_SECRET
 # values, so both sides agree by construction. Set them to strong random
 # strings; they are not copied out of Keycloak.
 GRAFANA_OIDC_CLIENT_SECRET=REPLACE_WITH_RANDOM_SECRET
+
+# --- Object store (MinIO) ----------------------------------------------------
+# MINIO_ROOT_USER / MINIO_ROOT_PASSWORD already exist in the real prod.enc.env:
+# they outlived the service when MinIO was removed in #495. Keep the existing
+# values — the prod_minio-data volume was never deleted, and rotating the root
+# credential is a separate, deliberate act.
+MINIO_ROOT_USER=REPLACE_WITH_EXISTING_MINIO_ROOT_USER
+MINIO_ROOT_PASSWORD=REPLACE_WITH_EXISTING_MINIO_ROOT_PASSWORD
+# Written INTO Keycloak by scripts/keycloak.sh and read by MinIO, so both sides
+# agree by construction. This gates the S3/STS path only — MinIO's console has
+# no SSO login in the AGPL build.
+MINIO_OIDC_CLIENT_SECRET=REPLACE_WITH_RANDOM_SECRET
 PORTAINER_OIDC_CLIENT_SECRET=REPLACE_WITH_RANDOM_SECRET
 
 # The EXISTING local Portainer admin password. scripts/portainer.sh needs it to

--- a/platform/edge/traefik.local.yml
+++ b/platform/edge/traefik.local.yml
@@ -87,7 +87,7 @@ providers:
     # These are literals rather than ${VAR} on purpose: Traefik v2.11 does no
     # environment interpolation in the static config file, so a placeholder
     # here is matched as the literal string and silently matches nothing.
-    constraints: "Label(`com.docker.compose.project`,`hill90-local-edge`) || Label(`com.docker.compose.project`,`hill90-local-observability`) || Label(`com.docker.compose.project`,`hill90-local-identity`) || Label(`com.docker.compose.project`,`hill90-local-platform`) || Label(`com.docker.compose.project`,`hill90-local-db`)"
+    constraints: "Label(`com.docker.compose.project`,`hill90-local-edge`) || Label(`com.docker.compose.project`,`hill90-local-observability`) || Label(`com.docker.compose.project`,`hill90-local-identity`) || Label(`com.docker.compose.project`,`hill90-local-platform`) || Label(`com.docker.compose.project`,`hill90-local-db`) || Label(`com.docker.compose.project`,`hill90-local-storage`)"
 
   file:
     directory: /etc/traefik/dynamic

--- a/platform/observability/prometheus/prometheus.yml
+++ b/platform/observability/prometheus/prometheus.yml
@@ -42,3 +42,11 @@ scrape_configs:
   - job_name: tempo
     static_configs:
       - targets: ["tempo:3200"]
+
+  # MinIO exposes cluster metrics without auth because the compose file sets
+  # MINIO_PROMETHEUS_AUTH_TYPE=public. The endpoint is on the internal network
+  # only; nothing external can reach it.
+  - job_name: minio
+    metrics_path: /minio/v2/metrics/cluster
+    static_configs:
+      - targets: ['minio:9000']

--- a/platform/vault/secrets-schema.yaml
+++ b/platform/vault/secrets-schema.yaml
@@ -49,6 +49,11 @@ excluded_vars:
   - KC_PUBLIC_URL
   - KC_REALM
   - GRAFANA_OIDC_ENABLED
+  # Object store routing and the claim MinIO reads its policy from. Not
+  # secrets; all default to the production values.
+  - MINIO_HOST
+  - MINIO_PUBLIC_URL
+  - MINIO_OIDC_CLAIM_NAME
 
 runtime_secrets:
   - key: DB_USER
@@ -132,6 +137,25 @@ runtime_secrets:
     compose_refs:
       - docker-compose.observability.yml
 
+  # --- secret/storage/minio ---
+  # MINIO_ROOT_USER and MINIO_ROOT_PASSWORD already exist in prod.enc.env: they
+  # were orphaned when MinIO was removed in #495 and are REUSED rather than
+  # rotated, so the existing prod_minio-data volume stays readable.
+  - key: MINIO_ROOT_USER
+    vault_path: secret/storage/minio
+    compose_refs:
+      - docker-compose.minio.yml
+
+  - key: MINIO_ROOT_PASSWORD
+    vault_path: secret/storage/minio
+    compose_refs:
+      - docker-compose.minio.yml
+
+  - key: MINIO_OIDC_CLIENT_SECRET
+    vault_path: secret/storage/minio
+    compose_refs:
+      - docker-compose.minio.yml
+
   # Portainer stores auth settings in its own database, applied through its API
   # by scripts/portainer.sh, so there is no compose reference for these two.
   - key: PORTAINER_OIDC_CLIENT_SECRET
@@ -164,3 +188,6 @@ vault_approle_services:
   - auth
   - infra
   - observability
+  # VAULT_MINIO_ROLE_ID / VAULT_MINIO_SECRET_ID are already in prod.enc.env,
+  # orphaned by #495 and accounted for again now the service exists.
+  - minio

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -31,6 +31,7 @@ Commands:
 
 Services with backups:
   db             PostgreSQL SQL dump + data volume tar
+  minio          Object store data volume tar
   vault          OpenBao secrets data (volume tar)
   infra          Traefik certificates + Portainer data (volume tar)
   observability  Grafana dashboards + Prometheus data (volume tar)
@@ -146,6 +147,16 @@ backup_observability() {
     backup_volume "prometheus-data" "$backup_dir/prometheus-data.tar.gz" || true
 }
 
+backup_minio() {
+    local backup_dir="$1"
+    mkdir -p "$backup_dir"
+
+    echo "Backing up MinIO object store..."
+    # Volume tar only. `mc mirror` would need working credentials and somewhere
+    # to mirror TO; the volume is the whole store and is what a restore needs.
+    backup_volume "prod_minio-data" "$backup_dir/minio-data.tar.gz" || true
+}
+
 backup_vault() {
     local backup_dir="$1"
     mkdir -p "$backup_dir"
@@ -163,8 +174,8 @@ cmd_backup() {
 
     # Validate service before constructing any paths
     case "$service" in
-        db|vault|infra|observability) ;;
-        *) die "Unknown service for backup: $service. Use: db, vault, infra, observability" ;;
+        db|minio|vault|infra|observability) ;;
+        *) die "Unknown service for backup: $service. Use: db, minio, vault, infra, observability" ;;
     esac
 
     local timestamp
@@ -173,6 +184,7 @@ cmd_backup() {
 
     case "$service" in
         db)            backup_db "$backup_dir" ;;
+        minio)         backup_minio "$backup_dir" ;;
         vault)         backup_vault "$backup_dir" ;;
         infra)         backup_infra "$backup_dir" ;;
         observability) backup_observability "$backup_dir" ;;
@@ -188,7 +200,7 @@ cmd_backup_all() {
     echo "================================"
     echo ""
 
-    for svc in db vault infra observability; do
+    for svc in db minio vault infra observability; do
         cmd_backup "$svc"
         echo ""
     done

--- a/scripts/checks/check_env_surface.py
+++ b/scripts/checks/check_env_surface.py
@@ -69,6 +69,9 @@ SENSITIVE = {
     "KC_ADMIN_PASSWORD",
     "VAULT_OIDC_CLIENT_SECRET",
     "GRAFANA_OIDC_CLIENT_SECRET",
+    "MINIO_ROOT_USER",
+    "MINIO_ROOT_PASSWORD",
+    "MINIO_OIDC_CLIENT_SECRET",
 }
 
 # Consumed by scripts rather than by compose substitution.

--- a/scripts/checks/check_secrets_schema.py
+++ b/scripts/checks/check_secrets_schema.py
@@ -24,7 +24,10 @@ SCHEMA_PATH = ROOT / "platform" / "vault" / "secrets-schema.yaml"
 COMPOSE_DIR = ROOT / "deploy" / "compose" / "prod"
 SOPS_EXAMPLE = ROOT / "infra" / "secrets" / "prod.enc.env.example"
 
-VAR_RE = re.compile(r"\$\{([A-Z_][A-Z0-9_]*)(?::-[^}]*)?\}")
+# Matches ${VAR}, ${VAR:-default} and ${VAR:?message}. The :? form marks a
+# variable that MUST be supplied — compose refuses to render without it —
+# and is used for credentials where an empty value would be dangerous.
+VAR_RE = re.compile(r"\$\{([A-Z_][A-Z0-9_]*)(?::[-?][^}]*)?\}")
 
 
 def load_schema(path: Path) -> dict:

--- a/scripts/checks/check_volume_names.py
+++ b/scripts/checks/check_volume_names.py
@@ -13,6 +13,7 @@ Exit codes:
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -20,10 +21,22 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 
 # Stateful compose files that must have explicit volume names.
+# Variables declared with ${VAR:?...} in the compose files above. They have no
+# default by design; `compose config` refuses to render without them.
+REQUIRED_PLACEHOLDERS = [
+    "MINIO_ROOT_USER",
+    "MINIO_ROOT_PASSWORD",
+    "MINIO_OIDC_CLIENT_SECRET",
+]
+
 TARGET_FILES = [
     "deploy/compose/prod/docker-compose.infra.yml",
     "deploy/compose/prod/docker-compose.observability.yml",
     "deploy/compose/prod/docker-compose.vault.yml",
+    # Stateful stacks restored as platform services; an unnamed volume here
+    # would silently orphan data on rename.
+    "deploy/compose/prod/docker-compose.db.yml",
+    "deploy/compose/prod/docker-compose.minio.yml",
 ]
 
 
@@ -33,6 +46,13 @@ def check_file(rel_path: str) -> list[str]:
     if not full_path.exists():
         return [f"{rel_path}: file not found"]
 
+    # Credentials that MUST have no default use ${VAR:?...}, which makes
+    # `compose config` fail outright on an unset environment. That guard is
+    # deliberate (an empty MinIO root password silently yields
+    # minioadmin/minioadmin), so supply throwaway values here: this check is
+    # about volume NAMES, not about credentials.
+    env = {**os.environ, **{k: "placeholder" for k in REQUIRED_PLACEHOLDERS}}
+
     try:
         result = subprocess.run(
             ["docker", "compose", "-f", str(full_path), "config", "--format", "json"],
@@ -40,6 +60,7 @@ def check_file(rel_path: str) -> list[str]:
             text=True,
             check=True,
             cwd=ROOT,
+            env=env,
         )
     except FileNotFoundError:
         # docker compose not available — fall back to raw YAML key scan

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Deploy CLI — deploy infrastructure stacks
-# Usage: deploy.sh {infra|db|auth|vault|observability|verify|backup} [env]
+# Usage: deploy.sh {infra|db|auth|minio|vault|observability|verify|backup} [env]
 
 set -e
 
@@ -21,6 +21,7 @@ Commands:
   infra    Deploy infrastructure (Traefik, Portainer)
   db       Deploy PostgreSQL (platform database)
   auth     Deploy Keycloak (platform identity provider)
+  minio    Deploy MinIO object store (platform storage)
   vault    Deploy OpenBao secrets management
   observability  Deploy observability stack (Grafana, Prometheus, Loki, Tempo)
   teardown Stop and remove a stack's containers and networks (volumes KEPT)
@@ -55,6 +56,7 @@ cmd_verify() {
         auth)          check_cmd='[ "$(docker inspect --format="{{if .State.Health}}{{.State.Health.Status}}{{end}}" keycloak 2>/dev/null)" = "healthy" ]'; diag_container="keycloak" ;;
         vault)         check_cmd='[ "$(docker inspect --format="{{if .State.Health}}{{.State.Health.Status}}{{end}}" openbao 2>/dev/null)" = "healthy" ]'; diag_container="openbao" ;;
         observability) check_cmd='docker exec prometheus wget -qO- http://localhost:9090/-/healthy'; diag_container="prometheus" ;;
+        minio)         check_cmd='docker exec minio mc ready local'; diag_container="minio" ;;
         infra)         check_cmd='docker exec traefik wget -qO- http://localhost:8080/api/overview'; diag_container="traefik" ;;
         *)             echo "Unknown service: $service"; exit 1 ;;
     esac
@@ -233,6 +235,20 @@ cmd_service() {
   - postgres (platform database — Keycloak's store)
   - postgres-exporter (Prometheus metrics on :9187)"
             ;;
+        minio)
+            compose_file="deploy/compose/${env}/docker-compose.minio.yml"
+            containers="minio"
+            banner="Object Store Deployment"
+            stack="platform"
+            stateful=true
+            summary="Services deployed:
+  - minio (object store; console on storage.hill90.com, S3 API internal only)
+
+  Console login is ROOT CREDENTIALS ONLY. MinIO removed the management
+  console from the AGPL build in May 2025, so there is no SSO button.
+  Keycloak identities work on the S3/STS path — see
+  docs/runbooks/object-store.md."
+            ;;
         auth)
             compose_file="deploy/compose/${env}/docker-compose.auth.yml"
             containers="keycloak"
@@ -394,6 +410,18 @@ cmd_service() {
         bash "$SCRIPT_DIR/vault.sh" auto-unseal || warn "Auto-unseal failed — run 'vault.sh unseal' manually"
     fi
 
+    # Provision the MinIO policies that Keycloak realm roles map onto. MinIO
+    # grants the policy NAMED in the token claim, so admin/editor/viewer have to
+    # exist as policies or every federated login is rejected.
+    #
+    # Non-fatal: the object store must come up regardless, and root-credential
+    # access is unaffected.
+    if [ "$service" = "minio" ]; then
+        echo "Provisioning MinIO policies..."
+        bash "$SCRIPT_DIR/minio.sh" apply \
+            || warn "minio.sh apply failed — federated S3 access will be rejected with 'no policy found'. Root credentials are unaffected."
+    fi
+
     # Apply the SSO realm configuration after Keycloak comes up.
     #
     # This is not optional decoration: platform-realm.json is imported ONLY on
@@ -467,6 +495,20 @@ cmd_teardown() {
             compose_file="deploy/compose/${env}/docker-compose.db.yml"
             project_name="hill90-${env}-platform"
             ;;
+        minio)
+            compose_file="deploy/compose/${env}/docker-compose.minio.yml"
+            containers="minio"
+            banner="Object Store Deployment"
+            stack="platform"
+            stateful=true
+            summary="Services deployed:
+  - minio (object store; console on storage.hill90.com, S3 API internal only)
+
+  Console login is ROOT CREDENTIALS ONLY. MinIO removed the management
+  console from the AGPL build in May 2025, so there is no SSO button.
+  Keycloak identities work on the S3/STS path — see
+  docs/runbooks/object-store.md."
+            ;;
         auth)
             compose_file="deploy/compose/${env}/docker-compose.auth.yml"
             project_name="hill90-${env}-identity"
@@ -517,7 +559,7 @@ main() {
 
     case "$cmd" in
         infra)          cmd_infra "$@" ;;
-        db|auth|vault|observability) cmd_service "$cmd" "$@" ;;
+        db|auth|minio|vault|observability) cmd_service "$cmd" "$@" ;;
         teardown)       cmd_teardown "$@" ;;
         verify)         cmd_verify "$@" ;;
         backup)         bash "$SCRIPT_DIR/backup.sh" backup "$@" ;;

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -56,7 +56,10 @@ cmd_verify() {
         auth)          check_cmd='[ "$(docker inspect --format="{{if .State.Health}}{{.State.Health.Status}}{{end}}" keycloak 2>/dev/null)" = "healthy" ]'; diag_container="keycloak" ;;
         vault)         check_cmd='[ "$(docker inspect --format="{{if .State.Health}}{{.State.Health.Status}}{{end}}" openbao 2>/dev/null)" = "healthy" ]'; diag_container="openbao" ;;
         observability) check_cmd='docker exec prometheus wget -qO- http://localhost:9090/-/healthy'; diag_container="prometheus" ;;
-        minio)         check_cmd='docker exec minio mc ready local'; diag_container="minio" ;;
+        # `mc ready` is unauthenticated AND has no timeout: against an
+        # unreachable MinIO it retries forever, so the retry loop below would
+        # never run. `mc admin info` proves the credentials too.
+        minio)         check_cmd='timeout 15 docker exec -e MC_HOST_local="http://${MINIO_ROOT_USER}:${MINIO_ROOT_PASSWORD}@127.0.0.1:9000" minio mc admin info local'; diag_container="minio" ;;
         infra)         check_cmd='docker exec traefik wget -qO- http://localhost:8080/api/overview'; diag_container="traefik" ;;
         *)             echo "Unknown service: $service"; exit 1 ;;
     esac
@@ -497,17 +500,7 @@ cmd_teardown() {
             ;;
         minio)
             compose_file="deploy/compose/${env}/docker-compose.minio.yml"
-            containers="minio"
-            banner="Object Store Deployment"
-            stack="platform"
-            stateful=true
-            summary="Services deployed:
-  - minio (object store; console on storage.hill90.com, S3 API internal only)
-
-  Console login is ROOT CREDENTIALS ONLY. MinIO removed the management
-  console from the AGPL build in May 2025, so there is no SSO button.
-  Keycloak identities work on the S3/STS path — see
-  docs/runbooks/object-store.md."
+            project_name="hill90-${env}-platform"
             ;;
         auth)
             compose_file="deploy/compose/${env}/docker-compose.auth.yml"
@@ -519,7 +512,7 @@ cmd_teardown() {
                                    || project_name="hill90-${env}-observability"
             ;;
         *)
-            die "Unknown stack for teardown: $stack. Use: infra, db, auth, vault, observability"
+            die "Unknown stack for teardown: $stack. Use: infra, db, auth, minio, vault, observability"
             ;;
     esac
 

--- a/scripts/keycloak.sh
+++ b/scripts/keycloak.sh
@@ -32,6 +32,7 @@ KC_PUBLIC_URL="${KC_PUBLIC_URL:-https://auth.hill90.com}"
 GRAFANA_PUBLIC_URL="${GRAFANA_PUBLIC_URL:-https://grafana.hill90.com}"
 PORTAINER_PUBLIC_URL="${PORTAINER_PUBLIC_URL:-https://portainer.hill90.com}"
 VAULT_PUBLIC_URL="${VAULT_PUBLIC_URL:-https://vault.hill90.com}"
+MINIO_PUBLIC_URL="${MINIO_PUBLIC_URL:-https://storage.hill90.com}"
 
 # Realm roles mapped onto each service's own role model.
 REALM_ROLES="admin editor viewer"
@@ -56,6 +57,7 @@ Environment variables:
   GRAFANA_PUBLIC_URL     Grafana public base URL
   PORTAINER_PUBLIC_URL   Portainer public base URL
   VAULT_PUBLIC_URL       OpenBao public base URL
+  MINIO_PUBLIC_URL       MinIO public base URL
 
 Every default above is the production value. Local development overrides them;
 with nothing set, this configures production.
@@ -270,6 +272,9 @@ cmd_apply() {
         || die "Cannot resolve PORTAINER_OIDC_CLIENT_SECRET — refusing to reconfigure any client"
     vault_secret=$(secret_for VAULT_OIDC_CLIENT_SECRET) \
         || die "Cannot resolve VAULT_OIDC_CLIENT_SECRET — refusing to reconfigure any client"
+    local minio_secret
+    minio_secret=$(secret_for MINIO_OIDC_CLIENT_SECRET) \
+        || die "Cannot resolve MINIO_OIDC_CLIENT_SECRET — refusing to reconfigure any client"
 
     ensure_realm_roles
     echo ""
@@ -291,6 +296,18 @@ cmd_apply() {
         "${VAULT_PUBLIC_URL}/v1/auth/oidc/callback,${VAULT_PUBLIC_URL}/ui/vault/auth/oidc/oidc/callback" \
         "${VAULT_PUBLIC_URL}" \
         "realm_roles"
+
+    # MinIO reads the policy to grant from a dedicated claim, NOT from
+    # realm_access.roles: its claim is a policy NAME, and MinIO grants exactly
+    # the policy the claim contains. Pointing it at realm_access.roles would
+    # hand it a list of role names that are not MinIO policies.
+    #
+    # The console gets no SSO from this — MinIO removed the console from the
+    # AGPL build in May 2025. This gates the S3/STS path only.
+    ensure_client "minio" "$minio_secret" \
+        "${MINIO_PUBLIC_URL}/oauth_callback,${MINIO_PUBLIC_URL}/*" \
+        "${MINIO_PUBLIC_URL}" \
+        "${MINIO_OIDC_CLAIM_NAME:-minio_policy}"
 
     echo ""
     success "Realm '${KC_REALM}' configured."

--- a/scripts/local.sh
+++ b/scripts/local.sh
@@ -28,6 +28,7 @@ OBS_PROJECT="hill90-local-observability"
 VAULT_PROJECT="hill90-local-platform"
 DB_PROJECT="hill90-local-db"
 AUTH_PROJECT="hill90-local-identity"
+MINIO_PROJECT="hill90-local-storage"
 
 # Vault state lives beside the repo, not in /opt/hill90 as it does on the VPS.
 # vault.sh takes both paths from the environment, so nothing in it needs to know
@@ -116,6 +117,12 @@ compose_auth() {
         -f "$OVERRIDE_DIR/local.auth.yml" "$@"
 }
 
+compose_minio() {
+    docker compose --env-file "$ENV_FILE" -p "$MINIO_PROJECT" \
+        -f "$COMPOSE_DIR/docker-compose.minio.yml" \
+        -f "$OVERRIDE_DIR/local.minio.yml" "$@"
+}
+
 compose_vault() {
     docker compose --env-file "$ENV_FILE" -p "$VAULT_PROJECT" \
         -f "$COMPOSE_DIR/docker-compose.vault.yml" \
@@ -146,9 +153,12 @@ cmd_sso() {
     GRAFANA_PUBLIC_URL="$(base_url "$(env_get GRAFANA_HOST grafana)")" \
     PORTAINER_PUBLIC_URL="$(base_url "$(env_get PORTAINER_HOST portainer)")" \
     VAULT_PUBLIC_URL="$(base_url "$(env_get VAULT_HOST vault)")" \
+    MINIO_PUBLIC_URL="$(base_url "$(env_get MINIO_HOST storage)")" \
+    MINIO_OIDC_CLAIM_NAME="$(env_get MINIO_OIDC_CLAIM_NAME minio_policy)" \
     GRAFANA_OIDC_CLIENT_SECRET="$(env_get GRAFANA_OIDC_CLIENT_SECRET "")" \
     PORTAINER_OIDC_CLIENT_SECRET="$(env_get PORTAINER_OIDC_CLIENT_SECRET "")" \
     VAULT_OIDC_CLIENT_SECRET="$(env_get VAULT_OIDC_CLIENT_SECRET "")" \
+    MINIO_OIDC_CLIENT_SECRET="$(env_get MINIO_OIDC_CLIENT_SECRET "")" \
         bash "$SCRIPT_DIR/keycloak.sh" apply || die "keycloak.sh apply failed"
 
     echo ""
@@ -165,6 +175,16 @@ cmd_sso() {
     KC_REALM="$(env_get KC_REALM platform)" \
         bash "$SCRIPT_DIR/portainer.sh" apply \
         || warn "portainer.sh apply failed — is the Portainer admin initialised? See docs/runbooks/sso-fallback.md"
+
+    echo ""
+    info "Provisioning MinIO policies for Keycloak roles..."
+    MINIO_CONTAINER="${cp}minio" \
+    MINIO_SECRETS_FILE="$LOCAL_VAULT_DIR/local.enc.env" \
+    SOPS_AGE_KEY_FILE="$LOCAL_VAULT_DIR/age.key" \
+    MINIO_ROOT_USER="$(env_get MINIO_ROOT_USER "")" \
+    MINIO_ROOT_PASSWORD="$(env_get MINIO_ROOT_PASSWORD "")" \
+        bash "$SCRIPT_DIR/minio.sh" apply \
+        || warn "minio.sh apply failed — federated S3 access will be rejected with 'no policy found'"
 }
 
 # Run a vault.sh subcommand against the LOCAL vault. Every variable here is an
@@ -337,6 +357,9 @@ print(json.dumps([
         warn "Could not add local OIDC callbacks to hill90-vault — 'local.sh vault setup-oidc' logins will fail with 'Invalid parameter: redirect_uri'"
     fi
 
+    info "Starting the object store (minio)..."
+    compose_minio up -d || die "Object store failed to start"
+
     info "Starting the vault stack (openbao)..."
     compose_vault up -d || die "Vault stack failed to start"
 
@@ -391,6 +414,8 @@ print(json.dumps([
 cmd_down() {
     require_docker
     require_env
+    info "Stopping the object store..."
+    compose_minio down --remove-orphans 2>/dev/null || true
     info "Stopping the vault stack..."
     compose_vault down --remove-orphans 2>/dev/null || true
     info "Stopping the identity provider..."
@@ -441,6 +466,7 @@ cmd_reset() {
     fi
 
     info "Tearing down with volumes..."
+    compose_minio down -v --remove-orphans 2>/dev/null || true
     compose_vault down -v --remove-orphans 2>/dev/null || true
     compose_auth down -v --remove-orphans 2>/dev/null || true
     compose_db down -v --remove-orphans 2>/dev/null || true
@@ -545,6 +571,9 @@ cmd_status() {
     docker ps -a \
         --filter "label=com.docker.compose.project=${DB_PROJECT}" \
         --format 'table {{.Names}}\t{{.Status}}' 2>/dev/null | tail -n +2
+    docker ps -a \
+        --filter "label=com.docker.compose.project=${MINIO_PROJECT}" \
+        --format 'table {{.Names}}\t{{.Status}}' 2>/dev/null | tail -n +2
     echo
     echo "${BOLD}Environment${NC}"
     check_env_drift
@@ -559,6 +588,7 @@ cmd_urls() {
     echo "  Prometheus          $(base_url "$(env_get PROMETHEUS_HOST prometheus)")/  (local only; prod reaches it via Grafana)"
     echo "  OpenBao             $(base_url "$(env_get VAULT_HOST vault)")/  (uninitialized until: local.sh vault init)"
     echo "  Keycloak            $(base_url "$(env_get AUTH_HOST auth)")/  (platform realm; admin/admin)"
+    echo "  MinIO console       $(base_url "$(env_get MINIO_HOST storage)")/  (ROOT CREDENTIALS ONLY — no SSO in the AGPL build)"
 }
 
 cmd_health() {

--- a/scripts/minio.sh
+++ b/scripts/minio.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# MinIO CLI — provision the policies Keycloak identities map onto
+# Usage: minio.sh {apply|status|help}
+#
+# WHY THIS EXISTS
+#
+# MinIO's OIDC integration reads a POLICY NAME out of a token claim
+# (MINIO_IDENTITY_OPENID_CLAIM_NAME) and grants exactly that policy. Keycloak's
+# realm-role mapper puts ROLE NAMES in that claim — admin, editor, viewer — so
+# those names have to exist as MinIO policies or every federated login is
+# rejected with "no policy found". Creating them is this script's whole job.
+#
+# WHAT THIS DOES NOT DO
+#
+# It does not give anyone an SSO login button. MinIO removed the management
+# console from the AGPL community build in May 2025: from RELEASE.2025-05-24
+# onward the console reports loginStrategy "form" with redirectRules null no
+# matter how OIDC is configured. Verified by running the releases side by side
+# against a real Keycloak.
+#
+# What OIDC still buys is the S3/STS path: AssumeRoleWithWebIdentity accepts a
+# Keycloak token and returns temporary S3 credentials carrying the mapped
+# policy. That is real and useful, and it is not SSO.
+
+set -e
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/_common.sh"
+
+MINIO_CONTAINER="${MINIO_CONTAINER:-minio}"
+SECRETS_FILE="${MINIO_SECRETS_FILE:-${PROJECT_ROOT}/infra/secrets/prod.enc.env}"
+
+usage() {
+    cat <<EOF
+MinIO CLI — provision policies for Keycloak-federated identities
+
+Usage: minio.sh <command>
+
+Commands:
+  apply     Create the admin/editor/viewer policies (idempotent)
+  status    Show policies and the OIDC configuration MinIO has loaded
+  help      Show this help message
+
+Environment variables:
+  MINIO_CONTAINER        Container name (default: minio)
+  MINIO_SECRETS_FILE     SOPS file holding MINIO_ROOT_USER / MINIO_ROOT_PASSWORD
+EOF
+}
+
+secret_for() {
+    local var="$1" value="${!1:-}"
+    if [ -z "$value" ]; then
+        require_file "$SECRETS_FILE" "Secrets file"
+        ensure_age_key prod
+        value=$(sops -d "$SECRETS_FILE" 2>/dev/null | grep "^${var}=" | cut -d= -f2- || true)
+    fi
+    [ -n "$value" ] || die "${var} is not set and was not found in ${SECRETS_FILE}"
+    printf '%s' "$value"
+}
+
+require_running() {
+    docker inspect "$MINIO_CONTAINER" >/dev/null 2>&1 \
+        || die "Container $MINIO_CONTAINER is not running. Deploy it first: bash scripts/deploy.sh minio prod"
+}
+
+mc_setup() {
+    local user pass
+    user=$(secret_for MINIO_ROOT_USER) || die "Cannot resolve MINIO_ROOT_USER"
+    pass=$(secret_for MINIO_ROOT_PASSWORD) || die "Cannot resolve MINIO_ROOT_PASSWORD"
+    # Credentials go in on stdin, not argv, so they never reach the host process
+    # list. `mc alias set` reads them from the environment when not passed.
+    MC_HOST_local="http://${user}:${pass}@127.0.0.1:9000" \
+        docker exec -e MC_HOST_local -i "$MINIO_CONTAINER" mc ready local >/dev/null 2>&1 \
+        || die "MinIO is not ready, or the root credentials are wrong"
+    MC_ALIAS_ENV="http://${user}:${pass}@127.0.0.1:9000"
+    export MC_ALIAS_ENV
+}
+
+mc() { MC_HOST_local="$MC_ALIAS_ENV" docker exec -e MC_HOST_local -i "$MINIO_CONTAINER" mc "$@"; }
+
+# Realm role -> what it can do in the object store.
+#   admin  : full control, including the admin API
+#   editor : read and write objects
+#   viewer : read only
+policy_json() {
+    case "$1" in
+        # s3 and admin actions must be SEPARATE statements: MinIO validates a
+        # statement containing any admin: action as admin-only and rejects
+        # s3:* inside it with "unsupported admin action 's3:*'".
+        admin)  echo '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":["s3:*"],"Resource":["arn:aws:s3:::*"]},{"Effect":"Allow","Action":["admin:*"]}]}' ;;
+        editor) echo '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":["s3:GetObject","s3:PutObject","s3:DeleteObject","s3:ListBucket","s3:GetBucketLocation"],"Resource":["arn:aws:s3:::*"]}]}' ;;
+        viewer) echo '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":["s3:GetObject","s3:ListBucket","s3:GetBucketLocation"],"Resource":["arn:aws:s3:::*"]}]}' ;;
+        *)      die "Unknown policy: $1" ;;
+    esac
+}
+
+cmd_apply() {
+    require_running
+    mc_setup
+
+    echo "================================"
+    echo "MinIO policies for Keycloak roles"
+    echo "================================"
+    echo ""
+
+    local existing
+    existing=$(mc admin policy ls local 2>/dev/null | tr -d '\r' || true)
+
+    for policy in admin editor viewer; do
+        # `mc admin policy create` is an upsert, so this is idempotent either
+        # way; the check is only so the output says what changed.
+        local verb="+"
+        echo "$existing" | grep -qx "$policy" && verb="="
+        policy_json "$policy" | mc admin policy create local "$policy" /dev/stdin >/dev/null 2>&1 \
+            || die "Failed to create MinIO policy '${policy}'"
+        echo "  ${verb} ${policy}"
+    done
+
+    echo ""
+    success "Policies provisioned."
+    echo ""
+    echo "  A Keycloak user with realm role 'admin' now receives the MinIO"
+    echo "  'admin' policy when exchanging a token via"
+    echo "  AssumeRoleWithWebIdentity."
+    echo ""
+    echo "  This is the S3/STS path only. MinIO's console has no SSO login in"
+    echo "  the AGPL build — see docs/runbooks/object-store.md."
+}
+
+cmd_status() {
+    require_running
+    mc_setup
+    echo "Policies:"
+    mc admin policy ls local 2>/dev/null | sed 's/^/  /'
+    echo ""
+    echo "OIDC configuration loaded by the server:"
+    mc admin config get local identity_openid 2>/dev/null \
+        | tr ' ' '\n' | grep -vE 'client_secret' | sed 's/^/  /'
+}
+
+main() {
+    local cmd="${1:-help}"; shift || true
+    case "$cmd" in
+        apply)          cmd_apply "$@" ;;
+        status)         cmd_status "$@" ;;
+        help|-h|--help) usage ;;
+        *)              usage; die "Unknown command: $cmd" ;;
+    esac
+}
+
+main "$@"

--- a/scripts/minio.sh
+++ b/scripts/minio.sh
@@ -68,13 +68,29 @@ mc_setup() {
     local user pass
     user=$(secret_for MINIO_ROOT_USER) || die "Cannot resolve MINIO_ROOT_USER"
     pass=$(secret_for MINIO_ROOT_PASSWORD) || die "Cannot resolve MINIO_ROOT_PASSWORD"
-    # Credentials go in on stdin, not argv, so they never reach the host process
-    # list. `mc alias set` reads them from the environment when not passed.
-    MC_HOST_local="http://${user}:${pass}@127.0.0.1:9000" \
-        docker exec -e MC_HOST_local -i "$MINIO_CONTAINER" mc ready local >/dev/null 2>&1 \
-        || die "MinIO is not ready, or the root credentials are wrong"
+
+    # Credentials travel in the ENVIRONMENT, not argv: `docker exec -e VAR`
+    # with no value passes the variable through, so the password never reaches
+    # the host process list.
     MC_ALIAS_ENV="http://${user}:${pass}@127.0.0.1:9000"
     export MC_ALIAS_ENV
+
+    # `mc admin info`, NOT `mc ready`, for two reasons:
+    #   1. `mc ready` is UNAUTHENTICATED — it returns "cluster is ready" for
+    #      completely bogus credentials, so it cannot detect a wrong root
+    #      password and the operator gets pointed at policy creation instead.
+    #   2. `mc ready` has no timeout and retries forever against an unreachable
+    #      MinIO. Inside a deploy that means the job blocks until the CI
+    #      six-hour default while holding the deploy-prod concurrency group.
+    # `timeout` bounds it either way.
+    local out rc=0
+    out=$(MC_HOST_local="$MC_ALIAS_ENV" timeout 30 docker exec -e MC_HOST_local \
+            "$MINIO_CONTAINER" mc admin info local 2>&1) || rc=$?
+    if [ "$rc" -eq 124 ]; then
+        die "MinIO did not answer within 30s — it is running but not serving. Check: docker logs ${MINIO_CONTAINER}"
+    elif [ "$rc" -ne 0 ]; then
+        die "Cannot authenticate to MinIO as '${user}'. Are MINIO_ROOT_USER/MINIO_ROOT_PASSWORD correct for this data volume? (${out})"
+    fi
 }
 
 mc() { MC_HOST_local="$MC_ALIAS_ENV" docker exec -e MC_HOST_local -i "$MINIO_CONTAINER" mc "$@"; }
@@ -135,8 +151,11 @@ cmd_status() {
     mc admin policy ls local 2>/dev/null | sed 's/^/  /'
     echo ""
     echo "OIDC configuration loaded by the server:"
+    # Case-insensitive: the lowercase config key and the uppercase env override
+    # are both possible spellings. mc happens not to echo the env form, but this
+    # filter should not be the only reason nothing leaks.
     mc admin config get local identity_openid 2>/dev/null \
-        | tr ' ' '\n' | grep -vE 'client_secret' | sed 's/^/  /'
+        | tr ' ' '\n' | grep -viE 'client_secret' | sed 's/^/  /'
 }
 
 main() {

--- a/tests/checks/test_deploy_scope.py
+++ b/tests/checks/test_deploy_scope.py
@@ -163,6 +163,8 @@ class TestTriggerPaths:
             "deploy/compose/prod/docker-compose.observability.yml",
             "deploy/compose/prod/docker-compose.auth.yml",
             "deploy/compose/prod/docker-compose.db.yml",
+            # MinIO restored as a platform service; see docs/decisions/object-store.md.
+            "deploy/compose/prod/docker-compose.minio.yml",
         ])
         assert sorted(trigger_paths) == expected
 

--- a/tests/checks/test_deploy_scope.py
+++ b/tests/checks/test_deploy_scope.py
@@ -165,6 +165,9 @@ class TestTriggerPaths:
             "deploy/compose/prod/docker-compose.db.yml",
             # MinIO restored as a platform service; see docs/decisions/object-store.md.
             "deploy/compose/prod/docker-compose.minio.yml",
+            # scripts/minio.sh owns the policy documents deploy.sh applies, so a
+            # change to it must actually reach production.
+            "scripts/minio.sh",
         ])
         assert sorted(trigger_paths) == expected
 

--- a/tests/scripts/platform-services.bats
+++ b/tests/scripts/platform-services.bats
@@ -457,19 +457,36 @@ assert c == \"realm_roles\", c
   # Pinning RELEASE.2025-04-22 or earlier would restore the SSO button at the
   # cost of freezing an internet-facing service on an unpatched build. That was
   # considered and rejected; this stops it being done by accident.
-  run grep -E 'image: minio/minio:RELEASE\.2025-0[1-4]' deploy/compose/prod/docker-compose.minio.yml
-  [ "$status" -ne 0 ]
+  # Asserting a MINIMUM, not blacklisting four months of 2025: the first
+  # version of this test used RELEASE\.2025-0[1-4] and happily passed a 2024
+  # pin, which is even older and even more unpatched.
+  run python3 -c "
+import re
+src = open('deploy/compose/prod/docker-compose.minio.yml').read()
+m = re.search(r'image: minio/minio:RELEASE\.(\d{4})-(\d{2})', src)
+assert m, 'no pinned RELEASE tag found'
+year, month = int(m.group(1)), int(m.group(2))
+# The console was removed in May 2025; anything earlier keeps the SSO button
+# only by freezing on an unpatched build.
+assert (year, month) >= (2025, 5), (year, month)
+"
+  [ "$status" -eq 0 ]
 }
 
 @test "the S3 API is not routed externally" {
   # Only the console gets a router. Publishing the API would mean a hostname
   # with no DNS record and a second certificate that has never issued.
+  # Assert on the SHAPE, not on one router name: the first version banned the
+  # literal string 'minio-api', so a router called anything else pointing at
+  # port 9000 sailed through.
   run python3 -c "
 import re
 body = [l for l in open('deploy/compose/prod/docker-compose.minio.yml') if not re.match(r'\s*#', l)]
 src = ''.join(body)
-assert 'minio-console.rule' in src, 'console router missing'
-assert 'minio-api' not in src, 'S3 API router present — it should stay internal'
+routers = set(re.findall(r'traefik\.http\.routers\.([A-Za-z0-9_-]+)\.', src))
+assert routers == {'minio-console'}, routers
+ports = set(re.findall(r'loadbalancer\.server\.port=(\d+)', src))
+assert ports == {'9001'}, ports
 "
   [ "$status" -eq 0 ]
 }
@@ -492,11 +509,12 @@ for l in body:
 
 @test "the docs do not claim MinIO has SSO" {
   # The single most likely thing to be overstated.
-  for f in docs/decisions/object-store.md docs/runbooks/object-store.md; do
-    [ -f "$f" ]
-    run grep -iE "root credentials only|no SSO|not SSO" "$f"
-    [ "$status" -eq 0 ]
-  done
+  # One exact phrase per file, no alternation — three acceptable spellings meant
+  # deleting two of them still passed on the third.
+  run grep -F "This is not SSO and must not be described as SSO." docs/decisions/object-store.md
+  [ "$status" -eq 0 ]
+  run grep -F "The console has no SSO button" docs/runbooks/object-store.md
+  [ "$status" -eq 0 ]
 }
 
 @test "the MinIO admin policy separates s3 and admin actions" {
@@ -518,7 +536,12 @@ for s in stmts:
 
 @test "MinIO policies are provisioned on deploy, not just documented" {
   # Without them every federated login is rejected with "no policy found".
-  run grep -F 'minio.sh" apply' scripts/deploy.sh
+  # Comment lines excluded: prefixing the call with # left this passing.
+  run python3 -c "
+import re
+body = [l for l in open('scripts/deploy.sh') if not re.match(r'\s*#', l)]
+assert any('minio.sh\" apply' in l for l in body), 'minio.sh apply is not invoked'
+"
   [ "$status" -eq 0 ]
 }
 

--- a/tests/scripts/platform-services.bats
+++ b/tests/scripts/platform-services.bats
@@ -312,10 +312,15 @@ assert '\"SSO\": True' not in src
   done
 }
 
-@test "the runbook states plainly that MinIO SSO is deferred" {
-  # MinIO is in issue #530 but is not deployed in this repository. Saying so is
-  # the requirement; quietly skipping it is not acceptable.
-  run grep -iE "MinIO is not deployed|deferred, not done" docs/runbooks/sso-fallback.md
+@test "the runbook states plainly that MinIO has no SSO" {
+  # This started life asserting MinIO was DEFERRED. MinIO is now deployed, so
+  # the claim to guard changed: it must say plainly that there is no SSO login,
+  # because MinIO removed the console from the AGPL build in May 2025. The
+  # failure mode is someone reading "OIDC configured" as "SSO works".
+  # ONE exact phrase, no alternation. An earlier version offered several
+  # acceptable spellings, so deleting the disclaimer still passed via a
+  # different clause — the same tautology this suite has been bitten by before.
+  run grep -F "MinIO has no SSO login." docs/runbooks/sso-fallback.md
   [ "$status" -eq 0 ]
 }
 
@@ -429,5 +434,97 @@ c = m[0][\"config\"].get(\"claim.name\")
 assert c == \"realm_roles\", c
 "
   '
+  [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Object store (MinIO) — restored as a platform service
+#
+# The load-bearing claim is a NEGATIVE one: this is not SSO. MinIO removed the
+# console from the AGPL build in May 2025, so the console is root-credential
+# only. These guard against that being quietly overstated later.
+# ---------------------------------------------------------------------------
+
+@test "MinIO is pinned to a specific release, not a floating tag" {
+  # A floating tag would silently change the console behaviour the docs describe.
+  run grep -E 'image: minio/minio:RELEASE\.[0-9]' deploy/compose/prod/docker-compose.minio.yml
+  [ "$status" -eq 0 ]
+  run grep -E 'image: minio/minio:(latest|edge)' deploy/compose/prod/docker-compose.minio.yml
+  [ "$status" -ne 0 ]
+}
+
+@test "MinIO is not pinned to a pre-console-removal release" {
+  # Pinning RELEASE.2025-04-22 or earlier would restore the SSO button at the
+  # cost of freezing an internet-facing service on an unpatched build. That was
+  # considered and rejected; this stops it being done by accident.
+  run grep -E 'image: minio/minio:RELEASE\.2025-0[1-4]' deploy/compose/prod/docker-compose.minio.yml
+  [ "$status" -ne 0 ]
+}
+
+@test "the S3 API is not routed externally" {
+  # Only the console gets a router. Publishing the API would mean a hostname
+  # with no DNS record and a second certificate that has never issued.
+  run python3 -c "
+import re
+body = [l for l in open('deploy/compose/prod/docker-compose.minio.yml') if not re.match(r'\s*#', l)]
+src = ''.join(body)
+assert 'minio-console.rule' in src, 'console router missing'
+assert 'minio-api' not in src, 'S3 API router present — it should stay internal'
+"
+  [ "$status" -eq 0 ]
+}
+
+@test "MinIO's certificate resolver is inherited, not hardcoded" {
+  # storage.hill90.com has never issued under the current ACME path (#538), and
+  # DNS-01 is mid-migration to Cloudflare (#535). Hardcoding a resolver here
+  # would pin the wrong provider.
+  run grep -F 'ADMIN_CERT_RESOLVER' deploy/compose/prod/docker-compose.minio.yml
+  [ "$status" -eq 0 ]
+  run python3 -c "
+import re
+body = [l for l in open('deploy/compose/prod/docker-compose.minio.yml') if not re.match(r'\s*#', l)]
+for l in body:
+    if 'certresolver=' in l:
+        assert 'ADMIN_CERT_RESOLVER' in l, l
+"
+  [ "$status" -eq 0 ]
+}
+
+@test "the docs do not claim MinIO has SSO" {
+  # The single most likely thing to be overstated.
+  for f in docs/decisions/object-store.md docs/runbooks/object-store.md; do
+    [ -f "$f" ]
+    run grep -iE "root credentials only|no SSO|not SSO" "$f"
+    [ "$status" -eq 0 ]
+  done
+}
+
+@test "the MinIO admin policy separates s3 and admin actions" {
+  # MinIO rejects a statement mixing them with
+  # "unsupported admin action 's3:*'", which fails policy creation outright.
+  run python3 -c "
+import json, re, subprocess
+src = open('scripts/minio.sh').read()
+m = re.search(r\"admin\)\s+echo '([^']+)'\", src)
+assert m, 'admin policy not found'
+doc = json.loads(m.group(1))
+stmts = doc['Statement']
+for s in stmts:
+    acts = s['Action']
+    assert not (any(a.startswith('s3:') for a in acts) and any(a.startswith('admin:') for a in acts)), acts
+"
+  [ "$status" -eq 0 ]
+}
+
+@test "MinIO policies are provisioned on deploy, not just documented" {
+  # Without them every federated login is rejected with "no policy found".
+  run grep -F 'minio.sh" apply' scripts/deploy.sh
+  [ "$status" -eq 0 ]
+}
+
+@test "the object store decision record flags the maintenance question" {
+  # MinIO community's latest release is ~10 months old; the alternatives belong
+  # in their own decision, but the question must be on the record.
+  run grep -iE "Garage|SeaweedFS" docs/decisions/object-store.md
   [ "$status" -eq 0 ]
 }


### PR DESCRIPTION
Restores MinIO as a platform service and wires its OIDC to Keycloak. Closes the MinIO half of #530 — **but not as SSO**. Read the caveat before merging.

## ⚠️ Merge ordering — read this first

`scripts/keycloak.sh apply` resolves **every** client secret up front and aborts if any is missing. That is deliberate (an audit found it would otherwise write an empty secret over a live client and exit 0), but it makes the step **all-or-nothing**.

**Merging this without `MINIO_OIDC_CLIENT_SECRET` in SOPS would abort `keycloak.sh apply` and leave every client unconfigured — Grafana and Portainer included, undoing tonight's SSO work.** That is exactly what a missing `VAULT_OIDC_CLIENT_SECRET` cost us earlier this evening (#546).

**This is already handled**: the secret is added in this PR's first commit, verified by md5 with the trailing newline stripped, with the other five confirmed intact (70 keys, up from 69). Nothing further is required at merge time — this note exists so the ordering is understood rather than rediscovered.

## What this is

MinIO returns as a **platform primitive** — the Storage Account equivalent alongside Keycloak for Entra ID and OpenBao for Key Vault — following the shape #531 used for Keycloak and Postgres: same compose layout, same secrets plumbing, same local override story.

It also ends a live inconsistency: `storage.hill90.com` has resolved to the VPS throughout, so the platform has been advertising an object store that nothing served.

### Relevance to the app-arch lane

**hill90-app has its own `docker-compose.minio.yml`, which this supersedes.** That lane is currently deciding whether the app keeps its own object store or consumes Hill90's; this PR is what makes "consume Hill90's" the available answer. The S3 API stays on the internal network, reachable as `http://minio:9000`, which is how a tenant would consume it.

## OIDC is wired. SSO is not, and cannot be

**MinIO removed the management console from the AGPL community build in May 2025.** Verified by running releases side by side against a real Keycloak with identical configuration:

| Release | Console `loginStrategy` |
|---|---|
| `RELEASE.2025-04-22` | **`redirect`** — working Keycloak button |
| `RELEASE.2025-05-24` → `2025-09-07` | `form`, `redirectRules: null` |

So the console is **root-credential form login only**, no matter how OIDC is configured. Pinning the April release to keep the button was rejected: freezing an internet-facing service fifteen months behind on security updates is a bad trade.

What OIDC *does* provide is the **S3/STS path**, verified end to end: a Keycloak user with realm role `admin` exchanged a token via `AssumeRoleWithWebIdentity` for temporary credentials and wrote a 29-byte object. A `viewer` user could read but not write. **Do not describe this as SSO.**

Env var names came from `mc admin config set identity_openid --env` on the pinned image, not from documentation — the community docs URL now redirects to AIStor's.

## There is no consumer today

Stated because it is the most likely thing to be misread later: Loki uses `filesystem` storage, Tempo a `local` backend, and `backup.sh` has no S3 target. The primitive exists so consumers can arrive — the same reasoning that restored Keycloak and Postgres. The `MINIO_*` and `VAULT_MINIO_*` keys already in SOPS were orphans of the extracted application and are live again rather than newly minted.

## Certificate path (#538)

`storage.hill90.com` has never issued a certificate — not because ACME was broken, but because no router existed, so nothing ever asked. This adds the router and therefore triggers the **first issuance**.

The resolver is **not hardcoded**; it inherits `ADMIN_CERT_RESOLVER`, so the now-live Cloudflare DNS-01 path applies. The runbook has a watched-issuance procedure with rollback, because a failed first issuance means Traefik serves its default certificate.

## Audit findings, all fixed

A subagent audit found four production defects:

1. **`deploy.sh teardown minio` was broken** — pasted from the wrong block, never set `project_name`, and clobbered `$stack`. It skipped the backup, removed nothing, and exited 0 announcing success.
2. **`mc ready` has no timeout** — still retrying at 90s. Inside a deploy that blocks until CI's six-hour default *while holding the `deploy-prod` concurrency group*.
3. **`mc ready` is unauthenticated** — returns "ready" for bogus credentials, so the credential gate could not detect a wrong root password. Both now use `timeout 30 … mc admin info`.
4. **Empty root credentials silently started MinIO on `minioadmin:minioadmin`** with only a WARN. Now `${VAR:?…}`, which fails the deploy.

Plus four tests that passed against the exact violation they guard (a 2024 pin slipping past a 2025-only regex; a router named something other than `minio-api`; a commented-out call; alternation in a docs assertion). All re-tested by re-running the auditor's mutations.

## Verification

Cold from an empty stack: 15 containers, all health checks green, 10/10 Prometheus targets including `minio`. **325 bats / 29 pytest / shellcheck / five repo checks** pass.

## Risks

- Merging deploys MinIO to production. `deploy.sh minio` runs `minio.sh apply` (non-fatal) to provision the `admin`/`editor`/`viewer` policies; without them federated logins are rejected with "no policy found". Root access is unaffected either way.
- `prod_minio-data` was never deleted in #495, so production may find existing objects. Root credentials are reused rather than rotated for that reason — verified safe by starting a volume initialised with one credential under another.
- First certificate issuance for `storage.hill90.com`; watch it rather than assume it.

## Not done

- **MinIO console SSO** — impossible on a current release, as above.
- **Production verification** — Jon should confirm the console loads and the certificate is trusted after deploy.
