### PR TITLE
fix(local): let Traefik accept the app stack's routers

### DIFF
--- a/platform/edge/traefik.local.yml
+++ b/platform/edge/traefik.local.yml
@@ -87,6 +87,11 @@ providers:
     # These are literals rather than ${VAR} on purpose: Traefik v2.11 does no
     # environment interpolation in the static config file, so a placeholder
     # here is matched as the literal string and silently matches nothing.
+    #
+    # CONFLICT WARNING: branch feat/restore-minio also appends to this same line,
+    # adding `hill90-local-storage`. Whichever merges second must keep both
+    # clauses -- dropping either silently 404s that stack's hostnames, with no
+    # error anywhere.
     constraints: "Label(`com.docker.compose.project`,`hill90-local-edge`) || Label(`com.docker.compose.project`,`hill90-local-observability`) || Label(`com.docker.compose.project`,`hill90-local-identity`) || Label(`com.docker.compose.project`,`hill90-local-platform`) || Label(`com.docker.compose.project`,`hill90-local-db`) || Label(`com.docker.compose.project`,`hill90-local`)"
 
   file:

--- a/platform/edge/traefik.local.yml
+++ b/platform/edge/traefik.local.yml
@@ -87,7 +87,7 @@ providers:
     # These are literals rather than ${VAR} on purpose: Traefik v2.11 does no
     # environment interpolation in the static config file, so a placeholder
     # here is matched as the literal string and silently matches nothing.
-    constraints: "Label(`com.docker.compose.project`,`hill90-local-edge`) || Label(`com.docker.compose.project`,`hill90-local-observability`) || Label(`com.docker.compose.project`,`hill90-local-identity`) || Label(`com.docker.compose.project`,`hill90-local-platform`) || Label(`com.docker.compose.project`,`hill90-local-db`)"
+    constraints: "Label(`com.docker.compose.project`,`hill90-local-edge`) || Label(`com.docker.compose.project`,`hill90-local-observability`) || Label(`com.docker.compose.project`,`hill90-local-identity`) || Label(`com.docker.compose.project`,`hill90-local-platform`) || Label(`com.docker.compose.project`,`hill90-local-db`) || Label(`com.docker.compose.project`,`hill90-local`)"
 
   file:
     directory: /etc/traefik/dynamic


### PR DESCRIPTION
## Summary

- Adds `hill90-local` — the app stack's Compose project — to the Docker provider `constraints` in `platform/edge/traefik.local.yml`, so local Traefik stops dropping the app's routers.
- Local-only. `platform/edge/traefik.yml.tmpl` (production) has no `constraints` key at all and is untouched by this PR.
- Adds a conflict warning above the line, because `feat/restore-minio` (#556) appends `hill90-local-storage` to the same string.

The constraints clause was added so a developer Mac would not pick up routers from unrelated stacks. Its own comment says `hill90-local is the app stack ... Without this clause its routers are dropped and every app hostname returns 404` — but `hill90-local` was never actually in the list. The comment described the intent; the value did not implement it.

## Issue

- Unblocks the app-arch lane's local bring-up. No Hill90 issue.

## Validation Evidence

**Infra/Deploy —** the nine app containers all carry the label this PR allowlists:

```
$ docker ps --format '{{.Names}}\t{{.Label "com.docker.compose.project"}}'
hill90-ai         hill90-local
hill90-api        hill90-local
hill90-keycloak   hill90-local
hill90-knowledge  hill90-local
hill90-litellm    hill90-local
hill90-mcp        hill90-local
hill90-minio      hill90-local
hill90-postgres   hill90-local
hill90-ui         hill90-local
```

Config parses and the allowlist reads as intended — six projects, the five Hill90 local stacks plus the app:

```
hill90-local-edge  hill90-local-observability  hill90-local-identity
hill90-local-platform  hill90-local-db  hill90-local
```

`bats tests/scripts/traefik-config.bats` — **28/28 pass**, including `tailscale-only allows only the Tailscale CGNAT range` and `no admin route relies on basic auth alone for network scoping`.

**Routing, verified live through the local Traefik** (`hill90dev-traefik`, port 80 published on `127.0.0.1:8080`):

```
app.localtest.me/         200  len=7387            UI serving
api.localtest.me/health   200  {"status":"healthy","service":"api"}
storage.localtest.me/     200  server=MinIO Console
ai.localtest.me/mcp       404  server=uvicorn      MCP answering, its own 404
```

## Correction to the reported symptom

The lane note said no routed surface is reachable and that both `ui` and `api` return 404. That is no longer true — this fix is already loaded in the running local Traefik, and all four routed surfaces respond.

The two remaining 404s are **not Traefik**, and are worth naming so nobody chases them:

- `api.localtest.me/` returns Express's `Cannot GET /` (139 bytes). The API has no route at `/`; `/health` returns 200. Routed correctly.
- `ai.localtest.me/mcp` returns 404 with `server: uvicorn` — the MCP container answering after `stripprefix`. Its rule is `Host(...) && PathPrefix(/mcp)`, so a bare `/` correctly does not match.

Traefik's own 404 is the bare-text `404 page not found`. Neither of those is it. The distinguishing check is the body, not the status code.

## Merge order

`feat/restore-minio` (#556) edits this same single line to add `hill90-local-storage`. **Whichever merges second must keep both clauses.** Dropping either silently 404s that stack's hostnames with no error logged anywhere — which is the failure mode this PR exists to fix, so it would be a poor one to reintroduce.

## Notes — two incidental findings, and the pattern behind them

Neither is fixed here; both were found while tracing this one. They matter less individually than as instances of a family.

**1. `deploy.sh verify infra` can only ever time out.** It runs `docker exec traefik wget -qO- http://localhost:8080/api/overview`, but the static config sets `api.insecure: false`, so nothing listens on 8080:

```
$ ssh deploy@<vps> 'docker exec traefik wget -qO- http://localhost:8080/api/overview'
wget: can't connect to remote host: Connection refused
```

Worth being precise about the scope: the **dashboard router is fine.** It reaches `api@internal` over `websecure` behind `auth@file` + `tailscale-only@file`, which is the supported secure path, and it works — `https://traefik.hill90.com/api/overview` returns 401, i.e. the router matched and basic auth challenged. Only the verify probe's port-8080 assumption is wrong. Nothing currently reaches it: `deploy.yml` routes `db`, `auth`, `vault` and `observability` through `reusable-deploy-service.yml`, and `infra` is not among them. So it is a check that would fail the moment anyone relied on it.

**2. An orphan `cors` middleware.** `platform/edge/dynamic/middlewares.yml` still defines `cors` with `accessControlAllowOriginList: ["https://hill90.com"]`. Nothing references it — it survived the app strip. Harmless, but it is app-specific routing policy sitting in platform config.

**The pattern.** Both belong to a family this repo has now produced at least six times: **configuration that is present, plausible, and inert.** It is the failure mode with the worst signal, because reviewing the file makes it look handled.

| Instance | Why it did nothing |
|---|---|
| `ACME_CA_SERVER` as a CLI flag / env var | A mounted static config file wins; Traefik discarded both. Fixed by `render-traefik-config.sh`. |
| `${VAR}` inside the static config | Traefik v2.11 does no interpolation — matched as a literal, silently matching nothing. |
| `LabelRegexp` in constraints | v3-only; on v2.11 it drops every container. |
| **This PR** — `constraints` missing `hill90-local` | Comment said the app was allowlisted; the value did not include it. |
| `verify infra` probing `:8080` | `api.insecure: false` — nothing listens. |
| `cors` middleware | Defined, referenced by nothing. |

There is a seventh worth flagging separately, because it is the worst kind: **`traefik.local.yml` cites `scripts/checks/check_local_parity.py` twice as the guard against local/prod drift, and that file does not exist.**

```
$ find . -name "check_local_parity*"
(no output)
$ grep -rn "check_local_parity" .
platform/edge/traefik.local.yml:14:# scripts/checks/check_local_parity.py guards the two against structural drift.
platform/edge/traefik.local.yml:67:# ... (checked by scripts/checks/check_local_parity.py).
```

An inert setting fails quietly. A **claimed guard that does not exist** actively buys trust it cannot honour — and in this case it is cited as the thing that would have caught exactly the class of drift this PR is fixing.

The generalisable fix is not to chase each instance but to make the class loud: assert that referenced things exist. `traefik-config.bats` already does this for certificate resolver names, on the stated principle that *resolver names are a contract*. The same assertion shape extends to referenced middlewares, referenced check scripts, and Compose project names in constraints.

I'd suggest that as a follow-up issue rather than folding it into this PR.

## Test plan

- [x] `bats tests/scripts/traefik-config.bats` — 28/28 pass
- [x] `python3 scripts/checks/check_md_links.py` — pass
- [x] `bash scripts/checks/check_destructive_commands.sh` — pass
- [x] Live routing verified through local Traefik (four surfaces above)
- [x] Production config confirmed untouched — `traefik.yml.tmpl` has no `constraints` key
- [ ] CI checks pass

**Do not merge** — held for review alongside #556, which touches the same line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
