### PR TITLE
docs: what Hill90 must provide for a tenant app deployment, and the ordered plan to do it

### DIFF
--- a/docs/decisions/app-tenancy-on-the-vps.md
+++ b/docs/decisions/app-tenancy-on-the-vps.md
@@ -472,13 +472,16 @@ healthcheck, not because they are failing.
 
 ## Known-unverified
 
-- **No issuance was attempted.** That HTTP-01 will succeed for `api`, `ai`,
-  `hill90.com` and `www` is inferred from it having succeeded for
-  `auth.hill90.com` through the same resolver on the same host, plus the live
-  port-80 and challenge-path probes. It is a strong inference, not an
-  observation. The first real test is the first deploy.
-- **Cloudflare proxy status is inferred from resolution**, not read from the
-  Cloudflare API. No API token was loaded for this assessment.
+- **No issuance was attempted**, and it cannot be without a router, which
+  requires a deploy. Every *input* to HTTP-01 has since been verified per-host
+  rather than inferred from symmetry — record type, proxy status, CAA at three
+  levels, multi-resolver agreement, the redirect exemption on the challenge
+  path, and the ACME account — and `api`/`ai` are indistinguishable from
+  `auth.hill90.com`, which holds a certificate from the same resolver. See
+  [tenant-app-deployment.md](../runbooks/tenant-app-deployment.md) §1. The act
+  itself remains unperformed; the first real test is the first deploy.
+- ~~Cloudflare proxy status is inferred from resolution~~ — **resolved.** Read
+  from the Cloudflare API: every A record in the zone is `proxied=false`.
 - **Firewall rules were not enumerated.** `firewall-cmd --list-ports` returned
   nothing over the SSH chain. Ports 80 and 443 are known reachable because they
   were reached from the public internet, which is the property that matters.

--- a/docs/decisions/app-tenancy-on-the-vps.md
+++ b/docs/decisions/app-tenancy-on-the-vps.md
@@ -1,0 +1,492 @@
+# What Hill90 Must Provide for a Tenant App Deployment on the VPS
+
+**Status:** assessment — no change made, nothing deployed
+**Recorded:** 2026-07-27
+**Scope:** the Hill90 side only. The app-side work is tracked in
+`hill90-app` under
+[docs/decisions/running-the-app-on-hill90-infra.md](https://github.com/jonhill90/hill90-app/blob/main/docs/decisions/running-the-app-on-hill90-infra.md).
+
+## Context
+
+`hill90-app` is a tenant of Hill90, not a peer. Its
+`deploy/compose/prod/*.yml` declare `hill90_edge` and `hill90_internal` as
+`external: true`, and Hill90's `deploy/compose/prod/docker-compose.infra.yml`
+is what creates them. Nothing in that repo can start until Hill90's infra is
+up.
+
+That makes "can the app be deployed to the VPS" partly a Hill90 question. This
+document answers the Hill90 half: what the platform already provides, what it
+does not, and what has to be built or decided before a first tenant deploy is
+possible.
+
+Every claim below was verified by running a command on 2026-07-27. Where
+something is inferred rather than observed, it says so. **No change was made to
+production and nothing was deployed.** Every VPS command used was read-only.
+
+## Answers, in short
+
+| Question | Answer |
+|---|---|
+| Do the app's hostnames have DNS? | **Yes**, all of them, and they point where they should. But none are managed by Hill90's DNS tooling. |
+| Do they have certificates? | **`auth` yes, the rest no.** No Hill90 change is needed — HTTP-01 is proven working and issues on first router. |
+| Does Traefik need configuration? | **Essentially no.** Production has no provider constraints, so it discovers tenant containers automatically. One middleware reference is undefined and must be resolved. |
+| Does deploy tooling know about tenants? | **No.** The concept does not exist in either repo. It needs building, and the recommendation is to build it in `hill90-app`, not here. |
+
+The blockers that remain are name collisions, not platform capability. Hill90
+already provides almost everything a tenant deployment needs.
+
+## 1. DNS and certificates
+
+### The records exist and are correct
+
+The VPS public address is `76.13.26.69`:
+
+```
+$ dig +short srv1264324.hstgr.cloud @1.1.1.1
+76.13.26.69
+```
+
+Every hostname the app's prod compose files ask for resolves, and each resolves
+to the address matching its intended exposure:
+
+```
+$ for h in hill90.com www.hill90.com api.hill90.com ai.hill90.com \
+           auth.hill90.com litellm.hill90.com storage.hill90.com; do
+      printf "%-24s %s\n" "$h" "$(dig +short A $h @1.1.1.1 | tr '\n' ' ')"
+  done
+hill90.com               76.13.26.69
+www.hill90.com           hill90.com. 76.13.26.69
+api.hill90.com           76.13.26.69
+ai.hill90.com            76.13.26.69
+auth.hill90.com          76.13.26.69
+litellm.hill90.com       100.88.29.112
+storage.hill90.com       100.88.29.112
+```
+
+The public five point at the VPS public IP; `litellm` and `storage` point at
+the Tailscale address, which is consistent with their compose labels applying
+`tailscale-only@file`. So the DNS layer is not a blocker for any app hostname.
+
+They are also **not Cloudflare-proxied**. A proxied record answers with a
+Cloudflare anycast address, not the origin; these answer with the origin. That
+matters because it is what leaves HTTP-01 unobstructed. This is inferred from
+the resolution above rather than read from the Cloudflare API — no token was
+loaded for this assessment.
+
+### But Hill90's DNS tooling does not know they exist
+
+`scripts/cloudflare.sh` writes an explicit allowlist and nothing else
+(`scripts/cloudflare.sh:54-62`):
+
+```bash
+MANAGED_RECORDS=(
+    "@:vps"
+    "remote:tailscale"
+    "vps:tailscale"
+    "portainer:tailscale"
+    "traefik:tailscale"
+    "grafana:tailscale"
+    "vault:tailscale"
+)
+```
+
+None of `www`, `api`, `ai`, `auth`, `litellm` or `storage` appear. The script's
+safety contract states that anything not named there "is invisible to it — it
+is never read for comparison and never written". So:
+
+- No Hill90 code path created these records. They predate the app strip or were
+  set by hand.
+- `cloudflare.sh dns verify` will report all-clear while an app record is
+  missing or wrong, because it only checks the seven it manages.
+- A VPS rebuild that re-runs `cloudflare.sh dns sync` restores the seven managed
+  records and **not** the app's. That is a real gap in
+  [vps-rebuild.md](../runbooks/vps-rebuild.md)'s coverage once the app is live.
+
+Extending `MANAGED_RECORDS` is a small change, but it widens the set of records
+a script can write, so it belongs in its own reviewed change rather than folded
+into a deploy. It is not a blocker for a first deploy — the records are already
+correct.
+
+### Certificates: one issued, four not, and no Hill90 change required
+
+Read directly from Traefik's ACME stores on the VPS:
+
+```
+$ ssh deploy@100.88.29.112 'docker exec traefik cat /letsencrypt/acme.json'
+ resolver: letsencrypt
+    auth.hill90.com
+
+$ ssh deploy@100.88.29.112 'docker exec traefik cat /letsencrypt/acme-dns.json'
+ resolver: letsencrypt-dns
+    portainer.hill90.com
+    grafana.hill90.com
+    vault.hill90.com
+    traefik.hill90.com
+```
+
+Confirmed from outside, against the origin:
+
+| Hostname | Certificate served |
+|---|---|
+| `auth.hill90.com` | `CN=auth.hill90.com`, issuer `Let's Encrypt YR2`, valid 2026-07-26 → 2026-10-24 |
+| `hill90.com` | `CN=TRAEFIK DEFAULT CERT` |
+| `www.hill90.com` | `CN=TRAEFIK DEFAULT CERT` |
+| `api.hill90.com` | `CN=TRAEFIK DEFAULT CERT` |
+| `ai.hill90.com` | `CN=TRAEFIK DEFAULT CERT` |
+
+`TRAEFIK DEFAULT CERT` is the self-signed placeholder Traefik serves when no
+router matches the SNI. It confirms both facts at once: no certificate, and no
+router.
+
+**The important finding is that HTTP-01 already works on this Traefik.**
+`auth.hill90.com` sits in `acme.json`, which is the storage for the
+`letsencrypt` resolver, and that resolver's only challenge is
+`httpChallenge` on the `web` entrypoint (`platform/edge/traefik.yml.tmpl`).
+So the path is not theoretical — it has issued a production certificate on this
+host, on this Traefik version, through this firewall.
+
+The preconditions are still in place. Port 80 is reachable from the public
+internet, and the ACME challenge path is exempt from the HTTPS redirect:
+
+```
+$ curl -sI http://api.hill90.com/.well-known/acme-challenge/x | head -1
+HTTP/1.1 404 Not Found
+$ curl -sI http://api.hill90.com/anything | head -1
+HTTP/1.1 308 Permanent Redirect
+```
+
+The 404 is Traefik's ACME handler answering with no challenge pending; the 308
+is the `web` entrypoint's global redirect. If the redirect swallowed the
+challenge path, both would be 308 and HTTP-01 would be impossible. It does not.
+
+**Therefore: `api`, `ai`, `hill90.com` and `www` need no Hill90 action to get
+certificates.** They issue automatically the first time a router carrying
+`tls.certresolver=letsencrypt` appears for them, which the app's compose labels
+already do (`docker-compose.api.yml:135`, `docker-compose.ui.yml:46`,
+`docker-compose.mcp.yml:46`). The resolver names the app requests —
+`letsencrypt` and `letsencrypt-dns` — are both defined here, and the template
+notes that resolver names are a contract precisely so this keeps holding.
+
+Two things to respect rather than fix:
+
+- **Rate limits.** 50 certificates per registered domain per week, 5 failed
+  validations per hostname per hour. Four new hostnames is well inside that. A
+  crash-looping deploy that repeatedly fails validation is not — that is 5
+  attempts before a lockout, and it is the realistic way to hit it.
+- **The records must stay unproxied and port 80 must stay open.** Both are true
+  today and neither is asserted by any check in this repo.
+
+### `auth.hill90.com` is contested, and that is the real certificate finding
+
+Hill90's own Keycloak owns `auth.hill90.com` today — it holds the certificate,
+it is running, and it is routed. The app's `docker-compose.auth.yml:56` declares
+`Host(`auth.hill90.com`)` for *its* Keycloak.
+
+This is not a certificate problem. It is the hostname half of the collision set
+described in §2 below, and it cannot be resolved by anything in the certificate
+layer.
+
+## 2. Traefik configuration
+
+**Short answer: production Traefik needs no configuration change to route to
+containers it does not yet know about.** It will discover them automatically.
+Three details qualify that.
+
+### Discovery already works, and it works because production has no constraints
+
+The production static config (`platform/edge/traefik.yml.tmpl`, and verified in
+the live container) sets:
+
+```yaml
+providers:
+  docker:
+    endpoint: "unix:///var/run/docker.sock"
+    exposedByDefault: false
+    network: hill90_edge
+```
+
+There is no `constraints` key. The Docker provider reads the socket directly,
+so it sees every container on the host regardless of which Compose project or
+which repository started it. A tenant container with `traefik.enable=true` on
+`hill90_edge` is routed with no Hill90-side change at all.
+
+This is deliberate and documented — the local config *does* carry constraints,
+and says why (`platform/edge/traefik.local.yml:72-89`): a developer Mac has
+neighbouring stacks on the same socket, and "production has no such neighbours,
+so it does not need this and does not have it". Deploying a tenant makes
+production have neighbours for the first time. The current behaviour is what
+the app needs, so nothing changes now, but the stated premise is no longer
+true and that comment will mislead the next reader.
+
+Traefik itself is attached only to `edge`
+(`deploy/compose/prod/docker-compose.infra.yml:47-48`), which is the network the
+app's routed services join. The network exists on the VPS, along with the other
+two the app declares external:
+
+```
+$ ssh deploy@100.88.29.112 'docker network ls --format "{{.Name}}"'
+hill90_agent_internal
+hill90_edge
+hill90_internal
+hill90-prod-platform_default
+```
+
+`hill90_agent_sandbox` and `hill90_docker_proxy` are absent, correctly — the app
+creates those itself.
+
+### `traefik.docker.network` is not needed on the VPS
+
+The app's containers are multi-homed (`edge` plus `internal`, and for some
+`agent_internal`), which normally forces an explicit
+`traefik.docker.network` label so Traefik picks the right IP. Here the
+provider-level `network: hill90_edge` supplies that default globally, and on the
+VPS `NETWORK_PREFIX` is unset so `hill90_edge` is the real name. No label is
+required.
+
+This is a VPS-specific answer. Locally the same key reads `hill90dev_edge` and
+the parity check enforces that it tracks `NETWORK_PREFIX`, which is the app
+repo's problem, not this one.
+
+### `mcp-strip@file` is referenced by the app and does not exist here
+
+This is the one required decision on the Traefik side.
+
+`hill90-app/deploy/compose/prod/docker-compose.mcp.yml:48` sets:
+
+```
+traefik.http.routers.mcp.middlewares=mcp-strip@file
+```
+
+Hill90 defines six file middlewares, and that is not one of them. Verified both
+in the repo and in the running container:
+
+```
+$ ssh deploy@100.88.29.112 \
+    'docker exec traefik grep -E "^    [a-z-]+:" /etc/traefik/dynamic/middlewares.yml'
+    security-headers:
+    rate-limit:
+    auth:
+    tailscale-only:
+    compress:
+    cors:
+```
+
+A router naming a middleware that is defined nowhere does not fall back to no
+middleware — Traefik puts the router into an error state and it serves nothing.
+So `ai.hill90.com/mcp` would fail even with DNS, certificate and container all
+correct.
+
+The other two file middlewares the app references are present: `rate-limit@file`
+(`docker-compose.ui.yml:48`) and `tailscale-only@file`
+(`docker-compose.ai.yml:55`).
+
+**Recommendation: the app declares `mcp-strip` as a label, not Hill90 as a
+file.** Hill90 removed it during the strip because it is an app concern — a path
+prefix strip for one app's routes — and re-adding it would put app-specific
+routing knowledge back into platform config. The app's local overlay already
+declares it as a label, so the pattern exists and works; it needs carrying into
+the prod compose file. That change belongs to the app-arch lane.
+
+### One leftover worth noting
+
+`platform/edge/dynamic/middlewares.yml` still defines a `cors` middleware whose
+`accessControlAllowOriginList` is `https://hill90.com` — the app's origin.
+Nothing references it. It is harmless, but it is app-specific config surviving in
+platform config, which is exactly what the `mcp-strip` recommendation above
+argues against. Candidate for cleanup, not a blocker.
+
+### The collisions Traefik will not protect against
+
+Traefik router names are global across the whole Docker provider. Comparing the
+two repos:
+
+| Router name | Hill90 | hill90-app |
+|---|---|---|
+| `keycloak` | ✓ (`docker-compose.auth.yml`) | ✓ (`docker-compose.auth.yml`) |
+| `minio-console` | ✓ **once PR #556 merges** | ✓ (`docker-compose.minio.yml`) |
+| `traefik`, `portainer`, `grafana`, `vault` | ✓ | — |
+| `api`, `ui`, `mcp`, `litellm` | — | ✓ |
+
+Two containers defining the same router name means one silently wins, and which
+one is not deterministic across restarts. Combined with `container_name` and
+hostname collisions, the full contested set is:
+
+| Name | Container | Router | Hostname | Status |
+|---|---|---|---|---|
+| Keycloak | `keycloak` | `keycloak` | `auth.hill90.com` | contested **today** |
+| Postgres | `postgres` | — | — | contested **today** |
+| postgres-exporter | `postgres-exporter` | — | — | contested **today** |
+| MinIO | `minio` | `minio-console` | `storage.hill90.com` | contested **once PR #556 merges** |
+
+The MinIO row is new information for the app lane. `hill90-app`'s decision
+record states "Hill90 runs no MinIO — nothing to dedup", which was true when
+written. PR #556 restores MinIO on `feat/restore-minio` with
+`container_name: ${CONTAINER_PREFIX:-}minio`, router `minio-console` and
+`Host(`${MINIO_HOST:-storage}.${BASE_DOMAIN:-hill90.com}`)` — the same three
+names the app uses. That PR is open and deliberately held; this changes nothing
+about whether to merge it, but the app lane should stop treating MinIO as
+uncontested.
+
+The container-name collisions fail safe: Docker refuses to start a second
+container with an existing name, so the app's `auth` and `db` stacks cannot
+start on the VPS at all. The router-name collision does **not** fail safe, and
+the hostname collision does not either.
+
+## 3. Deploy tooling
+
+**Short answer: no. Neither repo has any concept of deploying a tenant
+application, and it has to be built.**
+
+### Hill90's deploy CLI is closed over its own stacks
+
+`scripts/deploy.sh` accepts a fixed set of verbs (`scripts/deploy.sh:14-33`,
+dispatched at `:518`):
+
+```
+Commands:
+  infra    Deploy infrastructure (Traefik, Portainer)
+  db       Deploy PostgreSQL (platform database)
+  auth     Deploy Keycloak (platform identity provider)
+  vault    Deploy OpenBao secrets management
+  observability  Deploy observability stack
+  teardown Stop and remove a stack's containers and networks
+  verify   Run post-deploy readiness check for a service
+  backup   Run pre-deploy backup for a service
+```
+
+Anything else exits non-zero. More structurally, every code path computes its
+compose file as `deploy/compose/${env}/docker-compose.${stack}.yml` — a fixed
+layout inside this repository. There is no parameter, environment variable or
+code path by which it deploys a compose file from anywhere else. `cmd_teardown`
+(`:461`) and `cmd_verify` (`:50`) both carry the same closed allowlist.
+
+The CI side matches. `.github/workflows/deploy.yml` filters on four compose
+files and three `platform/` subtrees, and its `workflow_dispatch` choice list is
+`[all, db, auth, vault, observability]`. Every deploy workflow checks out this
+repository only; none clones a second one. Adding a tenant is a new workflow,
+not a new path-filter entry.
+
+### The app side has nothing at all
+
+```
+$ ls hill90-app/scripts
+local.sh  provision-akm-db.sh  provision-litellm-db.sh
+$ ls hill90-app/scripts/deploy.sh
+ls: scripts/deploy.sh: No such file or directory
+$ ls hill90-app/infra/secrets
+ls: cannot access 'infra/secrets': No such file or directory
+```
+
+No deploy script, no secrets store, no age key, no vault AppRole. The app has a
+local development path and nothing else. So the gap is not "Hill90 lacks a
+tenant verb" — it is that the entire deploy path for the app is unbuilt.
+
+### Recommendation: build it in `hill90-app`, not here
+
+Extending Hill90's `deploy.sh` with a `tenant` verb is the smaller-looking
+change and the wrong one.
+
+Every safety property in that script is written around stacks it owns: the
+vault-first/SOPS-fallback authentication resolves against
+`infra/secrets/${env}.enc.env` and a per-service Hill90 AppRole; `backup.sh`
+knows the volume names of the five platform stacks; `cmd_teardown` maps stacks
+to Compose project names so that a `down` cannot reach into a neighbouring
+stack. A tenant verb would need a second secrets source, a second compose root,
+a second backup inventory and a second project-name map — at which point it is
+a second script living inside the first one, sharing only the parts that make it
+dangerous.
+
+The tenancy contract Hill90 actually offers is narrow and already met: the three
+external networks, the edge proxy with its resolvers and middlewares, and the
+host. A tenant deploy script belongs with the tenant, and should depend on that
+contract rather than extend the tooling that provides it.
+
+What Hill90 could usefully add instead is a **preflight the tenant can call** —
+a read-only assertion that the three networks exist, Traefik is up, and the
+required file middlewares are defined. That is a genuine platform
+responsibility, it is small, and it converts the failure mode from the app's
+observed "network hill90_edge declared as external, but could not be found"
+into a named contract violation. It is not a blocker for a first deploy.
+
+### An existing check that cannot pass
+
+Not caused by the tenant work, but it sits directly in the path any tenant
+tooling would copy. `deploy.sh verify infra` runs:
+
+```bash
+docker exec traefik wget -qO- http://localhost:8080/api/overview
+```
+
+Traefik's static config sets `api.insecure: false`, so nothing listens on 8080.
+Observed:
+
+```
+$ ssh deploy@100.88.29.112 'docker exec traefik wget -qO- http://localhost:8080/api/overview'
+wget: can't connect to remote host: Connection refused
+```
+
+That check can only ever time out and exit 1. It is not currently reached by the
+deploy workflows, which do not verify `infra`. Worth fixing separately.
+
+## What Hill90 must provide — the contract
+
+| Requirement | Provided today | Action |
+|---|---|---|
+| `hill90_edge` exists | ✓ | none |
+| `hill90_internal` exists | ✓ | none |
+| `hill90_agent_internal` exists | ✓ | none |
+| Traefik discovers tenant containers | ✓ (no provider constraints) | none |
+| Traefik resolves the right IP for multi-homed containers | ✓ (`network: hill90_edge`) | none |
+| `letsencrypt` resolver (HTTP-01) | ✓ proven, issued `auth` | none |
+| `letsencrypt-dns` resolver (DNS-01) | ✓ proven, four certs | none |
+| Port 80 open, ACME path unredirected | ✓ | none |
+| DNS for `hill90.com`, `www`, `api`, `ai` | ✓ resolves, unproxied | none to deploy; add to `MANAGED_RECORDS` separately |
+| `rate-limit@file` | ✓ | none |
+| `tailscale-only@file` | ✓ | none |
+| `security-headers@file` | ✓ (entrypoint-wide) | none |
+| `mcp-strip@file` | ✗ | app declares it as a label |
+| `auth.hill90.com` free for the app | ✗ Hill90's Keycloak holds it | naming decision, app lane |
+| Container names `keycloak`, `postgres`, `postgres-exporter` free | ✗ | naming decision, app lane |
+| Container name `minio`, router `minio-console`, host `storage` free | ✗ once PR #556 merges | naming decision, app lane |
+| Tenant deploy tooling | ✗ | build in `hill90-app`; optionally add a preflight here |
+| Tenant secrets store | ✗ (app has none) | app lane |
+| Observability of tenant containers | partial — `cadvisor` scrapes all containers; no app-specific Prometheus job | not a blocker |
+
+Nothing in the "Provided today ✗" column is a Hill90 capability gap except the
+deploy tooling. The rest are naming decisions that belong to the app.
+
+## VPS baseline, captured during this assessment
+
+Unchanged from the app repo's Phase 0 baseline, re-verified read-only:
+
+```
+13 containers, 0 unhealthy
+cadvisor grafana keycloak loki node-exporter openbao portainer
+postgres postgres-exporter prometheus promtail tempo traefik
+
+hill90_edge members: keycloak openbao grafana portainer prometheus traefik
+```
+
+`portainer` and `traefik` report no health status because they declare no
+healthcheck, not because they are failing.
+
+## Known-unverified
+
+- **No issuance was attempted.** That HTTP-01 will succeed for `api`, `ai`,
+  `hill90.com` and `www` is inferred from it having succeeded for
+  `auth.hill90.com` through the same resolver on the same host, plus the live
+  port-80 and challenge-path probes. It is a strong inference, not an
+  observation. The first real test is the first deploy.
+- **Cloudflare proxy status is inferred from resolution**, not read from the
+  Cloudflare API. No API token was loaded for this assessment.
+- **Firewall rules were not enumerated.** `firewall-cmd --list-ports` returned
+  nothing over the SSH chain. Ports 80 and 443 are known reachable because they
+  were reached from the public internet, which is the property that matters.
+- **Router-name collision behaviour is asserted from Traefik's documented
+  model**, not reproduced. Reproducing it would mean starting a colliding
+  container in production, which was out of scope.
+- **Whether the app's `internal`-only services need egress** was not assessed
+  here. Hill90's `internal` network is `internal: true`, so anything needing
+  outbound must also attach to `edge`. The app repo has this documented in its
+  local overlay and has not yet hit it in prod.
+- **No tenant preflight was written.** The recommendation in §3 is a proposal.

--- a/docs/runbooks/tenant-app-deployment.md
+++ b/docs/runbooks/tenant-app-deployment.md
@@ -1,0 +1,406 @@
+# Deploying hill90-app to the VPS — What Would Have to Happen
+
+**Status:** plan — nothing here has been executed
+**Recorded:** 2026-07-27
+**Companion to:** [app-tenancy-on-the-vps.md](../decisions/app-tenancy-on-the-vps.md),
+which establishes what Hill90 provides. This turns that into an ordered
+procedure.
+
+Nothing in this document was run against production. The evidence below comes
+from read-only probes.
+
+## Bottom line
+
+**The app has no deployment path because one was never built, not because
+Hill90 cannot host it.** That is the honest headline, and it should be said
+before anyone attempts a deploy and discovers it step by step.
+
+Two questions were open. Both are now settled:
+
+- **Can `ai` and `api` get certificates?** **Yes.** Every precondition for
+  HTTP-01 is verified, and every one of them is identical to `auth.hill90.com`,
+  which already holds a certificate from the same resolver. This is no longer an
+  assumption of symmetry — the symmetry was measured. See §1.
+- **Can Hill90's deploy tooling deploy a tenant?** **No, and neither can
+  hill90-app's, because it has none.** This needs building. See §2.
+
+The platform side is in better shape than the tooling side. Of the sixteen
+things a tenant deploy needs from Hill90, thirteen already exist. What is
+missing is the deploy path itself and a set of naming decisions.
+
+## 1. The certificate question, settled
+
+The concern was that `ai` and `api` are public hosts, so they need HTTP-01,
+whereas the hosts that demonstrably have certificates today — `portainer`,
+`grafana`, `vault`, `traefik` — are Tailscale-only and went through DNS-01. A
+different challenge type is a different failure surface, and assuming symmetry
+with the DNS-01 hosts would prove nothing.
+
+That framing is right, but it points at the wrong comparator. **`auth.hill90.com`
+is the correct one: it is public, and it holds a certificate issued through
+HTTP-01 on this Traefik.**
+
+```
+$ ssh deploy@<vps> 'docker exec traefik cat /letsencrypt/acme.json'
+resolver: letsencrypt          <- httpChallenge on entrypoint web
+  auth.hill90.com
+
+$ ssh deploy@<vps> 'docker exec traefik cat /letsencrypt/acme-dns.json'
+resolver: letsencrypt-dns      <- dnsChallenge, cloudflare
+  portainer.hill90.com  grafana.hill90.com  vault.hill90.com  traefik.hill90.com
+```
+
+So HTTP-01 is a proven path on this host, not a theoretical one. The remaining
+question is narrow and answerable: **does `api` or `ai` differ from `auth` in any
+way that HTTP-01 depends on?** Each dependency was checked separately.
+
+| Precondition | `auth` (has cert) | `api` | `ai` | Method |
+|---|---|---|---|---|
+| Resolves to the VPS | 76.13.26.69 | 76.13.26.69 | 76.13.26.69 | `dig` |
+| Record type | A | A | A | `dig` — no CNAME indirection |
+| Cloudflare proxy | `proxied=false` | `proxied=false` | `proxied=false` | Cloudflare API |
+| Resolver agreement | 4/4 | 4/4 | 4/4 | 1.1.1.1, 8.8.8.8, 9.9.9.9, 208.67.222.222 |
+| CAA restriction | none | none | none | `dig CAA` at FQDN, apex and TLD |
+| Port 80 reachable | yes | yes | yes | `curl` from off-network |
+| ACME path exempt from redirect | 404 | 404 | 404 | see below |
+| Other paths redirected | 301 | 301 | 301 | see below |
+| ACME account | valid, prod LE, acct `3571664055` | same account | same account | `acme.json` |
+| Resolver defined | `letsencrypt` | `letsencrypt` | `letsencrypt-dns` (litellm) / `letsencrypt` (mcp) | `traefik.yml.tmpl` |
+
+The decisive measurement is the last pair, run per-host against the VPS:
+
+```
+$ for h in auth api ai hill90.com www; do ... done
+  auth.hill90.com      acme=404 other=301
+  api.hill90.com       acme=404 other=301
+  ai.hill90.com        acme=404 other=301
+  hill90.com           acme=404 other=301
+  www.hill90.com       acme=404 other=301
+```
+
+The `web` entrypoint redirects everything permanently to `websecure` — except
+`/.well-known/acme-challenge/`, which Traefik's ACME handler intercepts and
+answers 404 when no token is pending. **If that exemption were missing, the
+challenge would be redirected to HTTPS, Let's Encrypt would not follow it, and
+HTTP-01 would be impossible.** It is present, and it is present identically for
+every one of the five hostnames. `api` and `ai` are indistinguishable from the
+host that already works.
+
+Two further checks that could each have been a silent blocker:
+
+- **CAA.** No CAA record exists at `api.hill90.com`, `ai.hill90.com`,
+  `hill90.com`, or `com`. An unnoticed CAA record is a classic cause of
+  "inexplicable" issuance failure, and it can differ per subdomain. There is
+  none, so no CA is restricted.
+- **Cloudflare proxy status**, read from the API rather than inferred from
+  resolution: every A record in the zone is `proxied=false`. A proxied record
+  would put Cloudflare in the path on port 80 and change the validation
+  entirely.
+
+`www.hill90.com` is a CNAME to the apex, also unproxied. HTTP-01 handles CNAMEs
+without special treatment.
+
+### What is still not proven, and what the real risk is
+
+**No certificate was issued, because issuance requires a router to exist, which
+requires a deploy.** Every input to HTTP-01 has been verified; the act itself
+has not been performed. That is the honest limit of this analysis.
+
+The residual risk is therefore not "will HTTP-01 work" — it is **rate limits if
+something else goes wrong**. Let's Encrypt allows 5 failed validations per
+hostname per hour and 50 certificates per registered domain per week. Four new
+hostnames is trivially inside the weekly limit. A crash-looping container that
+Traefik keeps re-requesting for is not: that is five attempts before an hour-long
+lockout, and it is the realistic way this bites.
+
+**Mitigation, and it is the one genuinely valuable precaution in this whole
+plan:** issue against the Let's Encrypt **staging** CA first. The mechanism
+already exists and is deliberate — `ACME_CA_SERVER` has no default,
+`render-traefik-config.sh` refuses to render without it, and
+`ACME_REQUIRE_PRODUCTION=1` exists to prevent the opposite mistake. Staging has
+far looser limits, so a broken first deploy costs nothing.
+
+The cost of that path is real and must be understood before choosing it:
+switching CAs means Traefik will **not** reissue certificates it considers
+valid, so returning to production requires clearing the ACME stores — and
+`acme-dns.json` holds all four DNS-01 certificates in one file. Staging-testing
+the app's HTTP-01 certificates therefore risks the *working* infra certificates
+if the stores are cleared carelessly. `docs/architecture/certificates.md` covers
+the recovery.
+
+Given that trade, the recommendation is: **go straight to production ACME, but
+deploy one service first** (`ui` at `hill90.com`), confirm the certificate, and
+only then bring up the rest. One hostname's worth of rate limit is a cheaper
+experiment than a CA switch.
+
+## 2. The deploy tooling question, settled
+
+**Hill90's deploy tooling cannot deploy a tenant application, and hill90-app has
+no deploy tooling at all. This has to be built. It is the single largest piece
+of unstarted work, and it is the actual reason the app has no deployment path.**
+
+### Hill90's side is closed over its own stacks
+
+`scripts/deploy.sh` takes a fixed verb set — `infra`, `db`, `auth`, `vault`,
+`observability`, `teardown`, `verify`, `backup` — and the dispatcher rejects
+anything else. More structurally, every path computes its compose file as
+`deploy/compose/${env}/docker-compose.${stack}.yml`, a fixed layout inside this
+repository. There is no parameter, environment variable or code path that points
+it at a compose file from elsewhere. `cmd_teardown` and `cmd_verify` carry the
+same closed allowlist independently.
+
+CI matches: every deploy workflow checks out this repository only, and
+`deploy.yml`'s `workflow_dispatch` choice list is `[all, db, auth, vault,
+observability]`. Adding a tenant is a new workflow, not a path-filter entry.
+
+### The app's side is empty
+
+```
+$ ls hill90-app/scripts
+local.sh  provision-akm-db.sh  provision-litellm-db.sh
+$ ls hill90-app/scripts/deploy.sh
+No such file or directory
+$ ls hill90-app/infra/secrets
+No such file or directory
+```
+
+No deploy script, no secrets store, no age key, no vault AppRole, no CI deploy
+workflow. `RESURRECTION.md` §2 states this plainly and has been right the whole
+time: "The deploy tooling — `scripts/deploy.sh`, the `Makefile` targets, and the
+per-service GitHub Actions deploy workflows all stayed in Hill90."
+
+And there is no checkout on the host. `/opt/hill90/app` is a **Hill90** clone
+despite the name:
+
+```
+$ ssh deploy@<vps> 'cd /opt/hill90/app && git remote -v'
+origin  https://github.com/jonhill90/Hill90.git
+```
+
+### Where it should be built, and why not here
+
+**Build it in `hill90-app`.** Extending Hill90's `deploy.sh` with a `tenant`
+verb looks smaller and is the wrong shape.
+
+Every safety property in that script is written around stacks it owns. The
+vault-first/SOPS-fallback path authenticates with a per-service Hill90 AppRole
+against `infra/secrets/${env}.enc.env`. `backup.sh` knows the volume names of
+the five platform stacks. `cmd_teardown` maps stacks to Compose project names
+specifically so a `down` cannot reach into a neighbouring stack — and the repo
+bans `--remove-orphans` for the same reason. A tenant verb needs a second
+secrets source, a second compose root, a second backup inventory and a second
+project-name map. At that point it is a second script living inside the first,
+sharing only the parts that make it dangerous.
+
+The tenancy contract Hill90 offers is narrow and already met: three external
+networks, an edge proxy with working resolvers and middlewares, and a host with
+capacity. A tenant's deploy script should depend on that contract, not extend
+the tooling that provides it.
+
+**What Hill90 should add is one small thing: a read-only preflight** the tenant
+calls before deploying — assert the three networks exist, Traefik is running,
+and the file middlewares the tenant references are defined. That converts the
+app's observed failure
+
+```
+network hill90_edge declared as external, but could not be found
+```
+
+into a named contract violation, and it is a genuine platform responsibility.
+It is not a blocker; it is the cheapest thing on this list.
+
+## 3. The ordered plan
+
+Risk labels: **[SAFE]** reversible, no production impact. **[CARE]** touches
+production but fails safe. **[RISK]** can break a working Hill90 surface —
+named individually in §4.
+
+### Phase A — app-side prerequisites (no VPS contact)
+
+Owned by the app-arch lane. Nothing else can start until these land.
+
+1. **[SAFE] Resolve the name collisions.** Four contested names, in `container_name`,
+   Traefik router name, and hostname. This is a design decision, not a rename:
+   whether the app's data plane should sit on its own network rather than
+   `hill90_internal` is part of it.
+
+   | Name | Container | Router | Hostname |
+   |---|---|---|---|
+   | Keycloak | `keycloak` | `keycloak` | `auth.hill90.com` |
+   | Postgres | `postgres` | — | — |
+   | postgres-exporter | `postgres-exporter` | — | — |
+   | MinIO | `minio` | `minio-console` | `storage.hill90.com` |
+
+   The MinIO row becomes contested when #556 merges; it is not today.
+   `postgres-exporter` should be deleted rather than renamed — Hill90 owns
+   observability and already runs one.
+
+   *Verify:* no name in the app's prod compose appears in Hill90's, checked
+   across all three namespaces.
+
+2. **[SAFE] Fix `mcp-strip`.** The app's `docker-compose.mcp.yml` references
+   `mcp-strip@file`, which Hill90 does not define. A router naming an undefined
+   middleware does not degrade — it errors and serves nothing. Declare it as a
+   label, as the local overlay already does.
+
+   *Verify:* the prod compose has no `@file` reference Hill90 does not define.
+   Currently the app references three; two exist.
+
+3. **[SAFE] Parameterise the five network names.** 23 literals across nine files.
+   Three are Hill90's (`edge`, `internal`, `agent_internal`); two are the app's
+   own (`agent_sandbox`, `docker_proxy`) and need it too, because
+   `services/api` attaches agent containers by name.
+
+4. **[SAFE] Build the deploy script and the secrets store.** §2. This is the
+   long pole. It needs, at minimum: a compose root, a secrets source, a
+   dependency-ordered bring-up, a per-service readiness check, and a teardown
+   that cannot reach outside its own project.
+
+5. **[SAFE] Fix the two dead provision scripts.** Both `source` a
+   `scripts/_common.sh` that was never extracted, so both die at line 7 under
+   `set -e`. `provision-akm-db.sh` additionally pipes a heredoc into
+   `docker exec` without `-i`. Fix the missing file first — it masks the other.
+
+### Phase B — Hill90-side preparation
+
+6. **[SAFE] Add a tenant preflight** to Hill90 (§2). Read-only.
+
+7. **[SAFE] Add the app's hostnames to `cloudflare.sh`'s `MANAGED_RECORDS`.**
+   The records are already correct, so this changes nothing today. It matters
+   for VPS rebuild: `dns sync` currently restores seven records and not the
+   app's, and `dns verify` reports all-clear while an app record is wrong.
+   Do this as its own reviewed change — it widens the set of records a script
+   can write, which is the property `cloudflare.sh`'s safety contract exists to
+   constrain.
+
+8. **[CARE] Decide who owns `auth.hill90.com`.** Hill90's Keycloak holds it and
+   the certificate today. It cannot be shared. Until this is decided the app's
+   auth stack cannot be deployed at all — see §4.1.
+
+### Phase C — first deploy
+
+9. **[CARE] Get the app onto the host.** Clone to a path that is not
+   `/opt/hill90/app` — that is Hill90's checkout despite the name. Capacity is
+   not a constraint: 187G free of 199G, 12G RAM available of 15G.
+
+10. **[CARE] Seed the app's secrets**, by whatever mechanism Phase A step 4
+    chose. If it is vault, this needs an AppRole and a policy, which is a Hill90
+    change.
+
+11. **[CARE] Provision the app's databases** in the app's own Postgres, not
+    Hill90's. Hill90's health check asserts platform-only databases and is
+    written to fail if app databases appear there — that boundary is deliberate.
+
+12. **[RISK] Deploy `ui` alone, and stop.** This is the certificate experiment
+    and the first live routing test in one. `ui` is the right first service: it
+    has no dependency on the contested Keycloak, and `hill90.com` is currently
+    unrouted so there is nothing to displace.
+
+    *Verify:* `curl -sI https://hill90.com` returns a real certificate rather
+    than `CN=TRAEFIK DEFAULT CERT`; `acme.json` gains `hill90.com`; the four
+    existing DNS-01 certificates are untouched.
+
+    **Stop here and confirm before continuing.** This single step answers the
+    only genuinely unproven question in this document.
+
+13. **[RISK] Deploy the remainder in dependency order.** `api` must precede `ai`
+    and `knowledge` — it is the sole creator of `agent_sandbox` and
+    `docker_proxy`, which those two consume as external.
+
+    Order: `db` → `auth` → `api` → `ai`, `knowledge`, `mcp` → `minio`.
+
+14. **[SAFE] Verify the Hill90 baseline is unchanged.** 13 containers, 0
+    unhealthy; `auth.hill90.com`, `grafana`, `portainer`, `vault` and `traefik`
+    all still serving. Run this after *every* step above, not only at the end.
+
+## 4. Risk register — the steps that can break production
+
+### 4.1 Deploying the app's auth stack can take down infra admin SSO — **highest**
+
+`auth.hill90.com` is Hill90's Keycloak, and it is the identity provider for
+Grafana, Portainer and Vault SSO. The app declares the same hostname *and* the
+same Traefik router name (`keycloak`).
+
+The `container_name` collision fails safe — Docker refuses a duplicate name, so
+the stack cannot start. **The router-name collision does not.** If the container
+is renamed but the router is not, two containers define a router called
+`keycloak` and Traefik picks one non-deterministically across restarts. The
+losing router is not logged as an error; it is simply absent.
+
+The failure mode is: infra SSO breaks at an unpredictable time, for a reason
+that appears nowhere, triggered by an unrelated restart.
+
+*Do not deploy the app's auth stack until §3 step 1 is complete and verified
+across all three namespaces.*
+
+### 4.2 There is no staging step — anything that starts is immediately public
+
+Production Traefik sets no provider `constraints`, so the Docker provider picks
+up **every** container on the socket regardless of Compose project. The moment a
+container starts with `traefik.enable=true` and a `Host` rule, it is live on the
+public internet. There is no dry-run, no disabled state, no review gate.
+
+This is exactly the property that makes the tenant model work with no Traefik
+configuration — and the same property means a mistake is instantly exposed.
+Bring services up one at a time.
+
+### 4.3 The `postgres` network alias collides silently on shared networks
+
+Observed locally: two containers aliased `postgres` on one network made DNS
+return both addresses, and Keycloak resolved to the wrong instance and failed
+authentication with `FATAL: password authentication failed for user "hill90"` —
+a message that reads as a secrets problem and is not.
+
+Because DNS returns both, it is non-deterministic and will intermittently
+succeed, which is the worst available failure mode. If the app's data plane
+shares `hill90_internal`, this reaches production.
+
+### 4.4 Certificate rate limits, if a deploy crash-loops
+
+5 failed validations per hostname per hour. See §1. Mitigated by step 12's
+one-service-first approach.
+
+### 4.5 Merging anything under the deploy workflow's path filter fires an
+unattended production deploy
+
+`deploy.yml` triggers on push to `main` for `platform/auth/keycloak/**`,
+`platform/data/postgres/**`, `platform/observability/**`, and four compose
+files. This is how PR #556 came to be held — it touches
+`platform/observability/prometheus/prometheus.yml`. Any Hill90-side change in
+this plan needs the same check before merge.
+
+### 4.6 Observability cardinality
+
+`cadvisor` scrapes every container on the host, so nine new containers appear in
+Prometheus without configuration. That is desirable, but it is a step change in
+series count on a stack sized for 13 containers. Low severity; worth watching
+rather than pre-empting.
+
+## 5. What this plan does not cover
+
+- **Whether the app works.** No routed surface of the app has ever been reached
+  in production, and nothing here proves the app is correct — only that it can
+  be deployed and reached.
+- **Data migration.** The app's databases would be provisioned empty. Whether
+  anything needs restoring into them is not addressed.
+- **`services/cli` and `services/discord-bot`**, which per `RESURRECTION.md` §6
+  have never been part of any automated deploy.
+- **Rollback.** Hill90's `rollback.sh` knows its own stacks only, with the same
+  closed allowlist as `deploy.sh`. A tenant rollback path is part of the tooling
+  that needs building, and is not designed here.
+
+## 6. Evidence
+
+Every command in this document was read-only. Commands shown against the VPS were
+run over `ssh -i ~/.ssh/remote.hill90.com deploy@100.88.29.112`.
+
+- Certificate stores: `docker exec traefik cat /letsencrypt/acme.json`,
+  `/letsencrypt/acme-dns.json`
+- DNS: `dig` against 1.1.1.1, 8.8.8.8, 9.9.9.9, 208.67.222.222; CAA at FQDN,
+  apex and TLD
+- Cloudflare proxy status: `GET /zones/{id}/dns_records`, token from SOPS
+- Port 80 / ACME path: `curl` from off-network against 76.13.26.69 with explicit
+  `Host` headers
+- Host capacity: `df -h /`, `free -h`
+- Tooling: `scripts/deploy.sh`, `.github/workflows/deploy.yml`,
+  `ls hill90-app/scripts`


### PR DESCRIPTION
## Summary

Two documents. Nothing was executed, nothing deployed; every VPS command was read-only.

- **`docs/decisions/app-tenancy-on-the-vps.md`** — what Hill90 must provide for `hill90-app` to deploy on the VPS.
- **`docs/runbooks/tenant-app-deployment.md`** — that assessment turned into an ordered procedure, with the risky steps named.

`hill90-app` declares `hill90_edge` and `hill90_internal` as `external: true`, so whether it can deploy is partly a Hill90 question.

## The two things this settles

### 1. Can `ai` and `api` get certificates? **Yes.**

The concern was that assuming symmetry with the hosts that *do* have certificates proves nothing, because those four — `portainer`, `grafana`, `vault`, `traefik` — are Tailscale-only and went through DNS-01. That is right, but it points at the wrong comparator. **`auth.hill90.com` is public and holds a certificate issued through HTTP-01 on this Traefik**:

```
acme.json      (letsencrypt, httpChallenge):  auth.hill90.com
acme-dns.json  (letsencrypt-dns):             portainer, grafana, vault, traefik
```

So rather than assume, each dependency of HTTP-01 was checked per-host:

| Precondition | `auth` (has cert) | `api` | `ai` |
|---|---|---|---|
| Resolves to VPS | 76.13.26.69 | 76.13.26.69 | 76.13.26.69 |
| Record type | A | A | A |
| Cloudflare proxy | `proxied=false` | `proxied=false` | `proxied=false` |
| Resolver agreement | 4/4 | 4/4 | 4/4 |
| CAA restriction | none | none | none |
| ACME account | valid, prod LE `3571664055` | same | same |

The decisive measurement is the redirect exemption. The `web` entrypoint permanently redirects everything to `websecure` **except** `/.well-known/acme-challenge/`, which Traefik's ACME handler intercepts. Were that missing, Let's Encrypt would be redirected to HTTPS and HTTP-01 would be impossible:

```
auth.hill90.com      acme=404 other=301
api.hill90.com       acme=404 other=301
ai.hill90.com        acme=404 other=301
hill90.com           acme=404 other=301
www.hill90.com       acme=404 other=301
```

`api` and `ai` are indistinguishable from the host that already works.

Two checks that could each have been a silent blocker: **no CAA record** exists at the FQDN, apex, or TLD — a classic cause of inexplicable issuance failure, and it can differ per subdomain. And proxy status was read from the **Cloudflare API** rather than inferred from resolution: every A record in the zone is `proxied=false`.

**Still unproven:** issuance itself, which needs a router, which needs a deploy. So the residual risk is not whether HTTP-01 works — it is **rate limits if a deploy crash-loops** (5 failed validations per hostname per hour).

The runbook recommends deploying `ui` alone first rather than switching to the staging CA. Staging has looser limits, but returning to production means clearing the ACME stores, and `acme-dns.json` holds all four *working* infra certificates in one file. One hostname's rate limit is a cheaper experiment than risking those.

### 2. Can Hill90's tooling deploy a tenant? **No — and this is the real answer to why the app has no deployment path.**

It has to be built. Saying it plainly beats having someone discover it a step at a time.

`deploy.sh` takes a fixed verb set and every path computes its compose file as `deploy/compose/${env}/docker-compose.${stack}.yml` — a fixed layout inside this repo. No parameter points it elsewhere. Every deploy workflow checks out this repository only.

The app's side is empty:

```
$ ls hill90-app/scripts
local.sh  provision-akm-db.sh  provision-litellm-db.sh
$ ls hill90-app/scripts/deploy.sh   -> No such file or directory
$ ls hill90-app/infra/secrets       -> No such file or directory
```

And there is no checkout on the host — `/opt/hill90/app` is a **Hill90** clone despite the name.

**Recommendation: build it in `hill90-app`, not by extending `deploy.sh`.** Every safety property there — AppRole auth, backup volume inventory, the teardown project-name map that stops a `down` reaching into a neighbouring stack — is written around stacks it owns. A tenant verb needs a second copy of each, at which point it is a second script inside the first, sharing only the parts that make it dangerous. What Hill90 *should* add is a read-only preflight the tenant calls.

## Validation Evidence

**Infra —** all read-only. Certificate stores via `docker exec traefik cat /letsencrypt/*.json`; DNS via `dig` against four resolvers plus CAA at three levels; proxy status via the Cloudflare API; port 80 and the ACME path via `curl` from off-network with explicit `Host` headers; capacity via `df -h` / `free -h` (187G of 199G free, 12G of 15G RAM available — not a constraint).

**Checks —** `check_md_links.py` and `check_destructive_commands.sh` both pass.

## Notes

**The highest-risk step is named explicitly** in the runbook's risk register: deploying the app's auth stack can take down infra admin SSO. `auth.hill90.com` is Hill90's Keycloak and the IdP for Grafana, Portainer and Vault. The `container_name` collision fails safe — Docker refuses a duplicate. The **Traefik router-name collision does not**: two routers named `keycloak` means a non-deterministic winner across restarts, with the loser logged nowhere. Infra SSO would break at an unpredictable time for a reason that appears in no log.

**There is also no staging step.** Production Traefik sets no provider `constraints`, so anything that starts with `traefik.enable=true` and a `Host` rule is immediately live on the public internet. That is the same property that makes the tenant model need no Traefik configuration — and it means a mistake is instantly exposed. Bring services up one at a time.

**PR #556 makes MinIO contested.** It lands `container_name: minio`, router `minio-console` and `Host(storage.hill90.com)` — the same three names the app uses. The app's decision record says "Hill90 runs no MinIO", which was true when written. Changes nothing about merging #556; the app lane just needs to stop treating MinIO as uncontested.

**Two things found but not fixed**, both raised in #557: `deploy.sh verify infra` probes port 8080 while `api.insecure: false`, and an orphan `cors` middleware allowlists `https://hill90.com` with nothing referencing it.

## Test plan

- [x] `python3 scripts/checks/check_md_links.py` — pass
- [x] `bash scripts/checks/check_destructive_commands.sh` — pass
- [x] No production change; all VPS commands read-only
- [ ] CI checks pass

**Do not merge** without review — this records decisions that shape the app lane's naming and tooling work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
