### PR TITLE
docs: correct five statements the tenant deploy made false

### DIFF
--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -59,7 +59,7 @@ Traefik (edge network)           ┌──────────────�
 **Network Isolation:**
 - **edge network**: Traefik and the services it routes
 - **internal network**: `internal: true`, unreachable from outside the host
-- **agent_internal network**: `internal: true`, retained from the shelved application and currently unused
+- **agent_internal network**: `internal: true`, created by the edge stack and used by the hill90-app tenant (`app-api`, `app-ai`)
 - **Tailscale network**: admin-only surfaces (Traefik dashboard, Portainer, Grafana, OpenBao)
 - **IP Whitelist**: 100.64.0.0/10 (Tailscale CGNAT range) via Traefik middleware
 

--- a/docs/architecture/security.md
+++ b/docs/architecture/security.md
@@ -57,7 +57,7 @@ No service in the current stack sends email. Keycloak was the only sender;
 
 - `hill90_edge`: ingress-facing network for Traefik and the routed services.
 - `hill90_internal`: `internal: true`, unreachable from outside the host; used for private service-to-service traffic.
-- `hill90_agent_internal`: `internal: true`, created by the edge stack. Retained from the shelved application and currently unused by any running container.
+- `hill90_agent_internal`: `internal: true`, created by the edge stack. Attached by the hill90-app tenant's `app-api` and `app-ai` containers.
 - Tailscale-only routes are protected with Traefik middleware and IP allowlists in addition to the firewall. That control depends on Traefik seeing the true client address — see [Network-Layer Client Identity](#network-layer-client-identity).
 
 `docker-compose.infra.yml` is the sole owner of all three networks; the

--- a/docs/decisions/app-tenancy-on-the-vps.md
+++ b/docs/decisions/app-tenancy-on-the-vps.md
@@ -1,7 +1,9 @@
 # What Hill90 Must Provide for a Tenant App Deployment on the VPS
 
-**Status:** assessment — no change made, nothing deployed
+**Status:** assessment, since acted on — hill90-app deployed as a tenant on
+2026-07-29 and consumes the networks described here
 **Recorded:** 2026-07-27
+**Updated:** 2026-07-29
 **Scope:** the Hill90 side only. The app-side work is tracked in
 `hill90-app` under
 [docs/decisions/running-the-app-on-hill90-infra.md](https://github.com/jonhill90/hill90-app/blob/main/docs/decisions/running-the-app-on-hill90-infra.md).

--- a/docs/reference/deployment.md
+++ b/docs/reference/deployment.md
@@ -136,7 +136,7 @@ gh workflow run deploy.yml -f service=all             # everything in order
 
 - **hill90_edge** — ingress-facing; Traefik and the services it routes
 - **hill90_internal** — `internal: true`, private service-to-service traffic
-- **hill90_agent_internal** — `internal: true`, retained from the shelved application and currently unused
+- **hill90_agent_internal** — `internal: true`, used by the hill90-app tenant (`app-api`, `app-ai`)
 
 ## Traefik Dashboard Authentication
 

--- a/docs/runbooks/tenant-app-deployment.md
+++ b/docs/runbooks/tenant-app-deployment.md
@@ -1,13 +1,19 @@
 # Deploying hill90-app to the VPS — What Would Have to Happen
 
-**Status:** plan — nothing here has been executed
+**Status:** partially executed — Phase A complete; `ui`, `db`, `auth` and `api`
+deployed 2026-07-29 from hill90-app's own pipeline
 **Recorded:** 2026-07-27
+**Updated:** 2026-07-29
 **Companion to:** [app-tenancy-on-the-vps.md](../decisions/app-tenancy-on-the-vps.md),
 which establishes what Hill90 provides. This turns that into an ordered
 procedure.
 
-Nothing in this document was run against production. The evidence below comes
-from read-only probes.
+The plan below was written from read-only probes and has since been partly
+carried out. What is now deployed and healthy: `ui`, `db`, `auth`, `api`.
+`knowledge` is crash-looping and `ai` is unhealthy — the `knowledge` fix is
+merged to hill90-app's `main` but not yet deployed. `mcp` and `minio` have never
+been deployed. Deploys run from hill90-app's GitHub Actions pipeline over SSH,
+never from a workstation.
 
 ## Bottom line
 


### PR DESCRIPTION
hill90-app was deployed to this VPS as a tenant on 2026-07-29, from its own GitHub Actions pipeline. Five statements in these docs describe the world before that and are now false. This corrects those five and nothing else.

## Plan

Six edits across five files — the five identified, plus one sentence that could not be left behind without contradicting the header two lines above it.

| File | Line | Claim | Verdict |
|---|---|---|---|
| `docs/runbooks/tenant-app-deployment.md` | 3 | status header | false |
| `docs/runbooks/tenant-app-deployment.md` | 9-10 | "Nothing in this document was run against production." | false — same claim, same file |
| `docs/decisions/app-tenancy-on-the-vps.md` | 3 | status header | false |
| `docs/architecture/overview.md` | 62 | `agent_internal` "currently unused" | false |
| `docs/architecture/security.md` | 60 | `agent_internal` "currently unused" | false |
| `docs/reference/deployment.md` | 139 | `agent_internal` "currently unused" | false |

Every one was re-checked against `origin/main` before editing. None was dropped — all six are false as written.

What replaces them is deliberately narrow. `ui`, `db`, `auth` and `api` are deployed and healthy. `knowledge` is crash-looping, `ai` is unhealthy, and the `knowledge` fix is merged to hill90-app's `main` but **not deployed**. `mcp` and `minio` have never been deployed. None of that is described as working.

The Keycloak/Postgres duplication is not touched anywhere in this PR. Two of each run today — the `platform` realm on Hill90, the `hill90` realm on the app — and whether that consolidates is open and not mine to answer.

## Risks

**Low.** Documentation only, in one directory.

- **Does merging fire a production deploy?** No. `.github/workflows/deploy.yml:6-13` filters pushes to `platform/auth/keycloak/**`, `platform/data/postgres/**`, `platform/observability/**` and four `deploy/compose/prod/*.yml` files. `docs/**` is not among them. This was worth checking explicitly — the tenant runbook's own §4.5 records an unattended path-filtered deploy as a risk, and a Hill90 PR was once held for exactly that.
- **Staleness in the other direction.** `knowledge` and `ai` are actively being fixed. The text says they are not working, which is true now and will need one more edit when they are — that is the correct failure direction for a doc.
- **Collision.** None. `git diff --name-only` is five paths, all under `docs/`. Nothing under `scripts/`, `.github/`, `deploy/` or `platform/`.

## Rollback

`git revert 9d11b7fe`. One commit, five files, documentation only, no runtime effect.

## Validation Evidence

### The three network claims, tested against the host

```
$ docker network inspect hill90_agent_internal --format "{{range .Containers}}{{.Name}} {{end}}"
app-api app-ai
```

"Currently unused by any running container" is false in all three files.

### Deployment state at the time of writing (2026-07-29 05:25 UTC)

```
app-ai           Up 20 minutes (unhealthy)
app-api          Up 24 minutes (healthy)
app-docker-proxy Up 24 minutes (healthy)
app-keycloak     Up 29 minutes (healthy)
app-knowledge    Restarting (3) 6 seconds ago
app-litellm      Up 21 minutes (healthy)
app-postgres     Up 30 minutes (healthy)
app-ui           Up 31 minutes (healthy)
```

### Before and after, each false sentence

**`docs/runbooks/tenant-app-deployment.md:3`**

> `**Status:** plan — nothing here has been executed`

becomes

> `**Status:** partially executed — Phase A complete; `ui`, `db`, `auth` and `api` deployed 2026-07-29 from hill90-app's own pipeline`

**`docs/runbooks/tenant-app-deployment.md:9-10`**

> `Nothing in this document was run against production. The evidence below comes from read-only probes.`

becomes

> `The plan below was written from read-only probes and has since been partly carried out. What is now deployed and healthy: `ui`, `db`, `auth`, `api`. `knowledge` is crash-looping and `ai` is unhealthy — the `knowledge` fix is merged to hill90-app's `main` but not yet deployed. `mcp` and `minio` have never been deployed. Deploys run from hill90-app's GitHub Actions pipeline over SSH, never from a workstation.`

**`docs/decisions/app-tenancy-on-the-vps.md:3`**

> `**Status:** assessment — no change made, nothing deployed`

becomes

> `**Status:** assessment, since acted on — hill90-app deployed as a tenant on 2026-07-29 and consumes the networks described here`

**`docs/architecture/overview.md:62`**

> `- **agent_internal network**: `internal: true`, retained from the shelved application and currently unused`

becomes

> `- **agent_internal network**: `internal: true`, created by the edge stack and used by the hill90-app tenant (`app-api`, `app-ai`)`

**`docs/architecture/security.md:60`**

> `- `hill90_agent_internal`: `internal: true`, created by the edge stack. Retained from the shelved application and currently unused by any running container.`

becomes

> `- `hill90_agent_internal`: `internal: true`, created by the edge stack. Attached by the hill90-app tenant's `app-api` and `app-ai` containers.`

**`docs/reference/deployment.md:139`**

> `- **hill90_agent_internal** — `internal: true`, retained from the shelved application and currently unused`

becomes

> `- **hill90_agent_internal** — `internal: true`, used by the hill90-app tenant (`app-api`, `app-ai`)`

### Residual scan

```
$ grep -rIn "currently unused\|nothing here has been executed\|nothing deployed\|Nothing in this document was run" docs/
  NONE
```

### Blast radius

```
$ git diff --name-only
docs/architecture/overview.md
docs/architecture/security.md
docs/decisions/app-tenancy-on-the-vps.md
docs/reference/deployment.md
docs/runbooks/tenant-app-deployment.md
```

## Noted, not fixed

`docs/runbooks/tenant-app-deployment.md` is still titled *"What Would Have to Happen"*, which now reads oddly for a procedure that has partly happened. Retitling is outside this PR's scope and would churn inbound links; flagging it for whoever does the next pass rather than expanding this one.

Neither this repo nor hill90-app has a `CLAUDE.md` or an `AGENTS.md`. That is a separate creation, not a correction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
