### PR TITLE
docs: add agent orientation (CLAUDE.md, AGENTS.md symlinked)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,123 @@
+# Hill90 — agent orientation
+
+*(`AGENTS.md` and `CLAUDE.md` are the same file — one is a symlink, so there is
+no second copy to drift.)*
+
+Read this first. It is deliberately short; follow the links only when you need
+them.
+
+**What this is:** the homelab infrastructure for a single VPS — Traefik at the
+edge, Keycloak for identity, Postgres, OpenBao, the LGTM observability stack,
+Tailscale for private access, and Ansible plus GitHub Actions to rebuild it from
+nothing. It is a **platform**: it hosts tenants but is not the application.
+[hill90-app](https://github.com/jonhill90/hill90-app) is its first tenant.
+
+## Where to look
+
+- [`docs/runbooks/`](docs/runbooks/) — the operational procedures. Start with
+  [`deployment.md`](docs/runbooks/deployment.md); [`vps-rebuild.md`](docs/runbooks/vps-rebuild.md)
+  and [`disaster-recovery.md`](docs/runbooks/disaster-recovery.md) are the ones
+  you hope not to need.
+- [`docs/reference/`](docs/reference/) — the flag-level detail behind those
+  procedures.
+- [`docs/architecture/`](docs/architecture/) — how the pieces fit, plus
+  [`certificates.md`](docs/architecture/certificates.md), which is the recovery
+  path if ACME goes wrong.
+- [`docs/decisions/`](docs/decisions/) — why things are the way they are.
+  [`app-tenancy-on-the-vps.md`](docs/decisions/app-tenancy-on-the-vps.md) defines
+  what this platform offers a tenant.
+- [`CONTRIBUTING.md`](CONTRIBUTING.md) — conventions and the deploy rules.
+- Published pages: [docs.hill90.com](https://docs.hill90.com).
+
+## Layout
+
+```
+deploy/compose/prod/    the platform stacks — infra, db, auth, vault, observability
+platform/edge/          Traefik static template + dynamic middlewares
+platform/auth/          Keycloak realm and theme
+platform/observability/ Prometheus, Loki, Tempo, Grafana, exporters
+infra/secrets/          SOPS-encrypted stores; age private keys are gitignored
+scripts/                deploy.sh, backup.sh, _common.sh, checks/
+ansible/                VPS bootstrap
+docs/                   runbooks, reference, architecture, decisions
+```
+
+## Invariants — do not break these without an explicit decision
+
+1. **Merging can deploy to production.** `.github/workflows/deploy.yml` triggers
+   on push to `main` under `platform/auth/keycloak/**`,
+   `platform/data/postgres/**`, `platform/observability/**` and four
+   `deploy/compose/prod/*.yml` files. Check whether a PR touches a filtered path
+   *before* merging it. `docs/**` is not filtered.
+2. **`--remove-orphans` is banned globally**, in every script and workflow, and
+   CI enforces it. It will delete containers belonging to another stack that
+   shares a Compose project name.
+3. **Production Traefik sets no provider `constraints`.** Every container on the
+   socket with `traefik.enable=true` and a `Host` rule is live on the public
+   internet the moment it starts. There is no staging state. Bring services up
+   one at a time.
+4. **`ACME_CA_SERVER` has no default.** `scripts/render-traefik-config.sh`
+   refuses to render without it, and `ACME_REQUIRE_PRODUCTION=1` guards the
+   opposite mistake. Switching CAs means Traefik will not reissue certificates it
+   considers valid, so returning to production requires clearing the ACME
+   stores — and `acme-dns.json` holds all four DNS-01 certificates in one file.
+   Read [`docs/architecture/certificates.md`](docs/architecture/certificates.md)
+   first.
+5. **This repo owns the shared networks.** `docker-compose.infra.yml` and
+   `scripts/deploy.sh` create `hill90_edge`, `hill90_internal` and
+   `hill90_agent_internal`. Tenants consume them as `external: true` and must
+   never create them. Renaming or removing one breaks every tenant silently.
+6. **Readiness checks run a real query, not a liveness probe.** `pg_isready`
+   exits 0 on a Postgres whose credentials are entirely broken; the db check runs
+   `psql -tAc "SELECT 1"` as the real user for exactly that reason. Do not
+   "simplify" it back.
+7. **Secrets come from SOPS or OpenBao, never from a file in the tree.** Age
+   private keys are gitignored; only `.pub` files are committed.
+
+## Ground rules for changing this repo
+
+- **Verify against the host, then date the claim.** Anything perishable —
+  container counts, health, what a tenant is running — carries a
+  `Verified <UTC timestamp>`. A dated claim that has aged is honest; an undated
+  one is just wrong later.
+- **Do not document what you have not run.** A compose file that parses is not a
+  service that starts.
+- A tenant's problems are not automatically this repo's problems. The contract
+  this platform offers is narrow and written down in
+  [`docs/decisions/app-tenancy-on-the-vps.md`](docs/decisions/app-tenancy-on-the-vps.md);
+  widening it is a decision, not a fix.
+
+## Open decisions — do not write these as settled
+
+**One Keycloak is the decision; two are running.** Today the platform runs
+`keycloak` (realms `master`, `platform`) and the tenant runs `app-keycloak`
+(realms `master`, `hill90`) — verified 2026-07-29 05:55 UTC. **Decided:** there
+will be one Keycloak, and the app will stop shipping its own. **Not decided:**
+whether the app's clients land in a new `hill90` realm on the platform Keycloak
+or in the existing `platform` realm — one Keycloak does not mean one realm.
+**Not started:** no migration has happened, and the platform Keycloak has no
+`hill90` realm to consolidate into. Export before delete, never the reverse.
+
+**Postgres is still two instances** — this platform's `postgres` and the
+tenant's `app-postgres`, on separate volumes. **No decision has been recorded.**
+Consolidating data is not obviously the same move as consolidating identity:
+this platform's health check asserts platform-only databases, which is a
+designed boundary.
+
+## Fast facts
+
+```bash
+bash scripts/deploy.sh <infra|db|auth|vault|observability> prod
+bash scripts/deploy.sh verify <service> prod
+gh workflow run deploy.yml -f service=all
+```
+
+- Platform baseline is **13 containers, 0 unhealthy**. A tenant's containers sit
+  alongside them and are not part of that count — verify the baseline after any
+  tenant action.
+- Public: `hill90.com` (the tenant's UI), `auth.hill90.com` (this platform's
+  Keycloak, realm `platform`). Tailscale-only: `traefik`, `portainer`,
+  `grafana`, `vault`.
+- `app-auth.hill90.com` is the **tenant's** Keycloak, not this one.
+- The deploy user on the VPS is `deploy`; the checkout is `/opt/hill90/app`.
+  `/opt/hill90-app` is the tenant's, despite the similar name.


### PR DESCRIPTION
Adds `CLAUDE.md`, with `AGENTS.md` committed as a symlink to it. Net-new — this repo had neither.

## Plan

### A correction to my own inventory

I reported that neither this repo nor Hill90 has these files and that there is "no precedent to mirror." The first half was right; **the second was wrong** — I had only looked in the three target repos. Three others have them:

| Repo | Files | Lines | Shape |
|---|---|---|---|
| **AgentBox** | `CLAUDE.md` + `AGENTS.md` | 99 | `AGENTS.md` is a git symlink (`120000`) |
| **Skills** | `CLAUDE.md` + `AGENTS.md` | 149 | Also symlinked |
| **k8s-homelab** | `CLAUDE.md` | 548 | Embeds a "Current Cluster State" section |

The house style has visibly evolved toward the shortest of the three. This follows **AgentBox**: one file, ~100 lines, sections *what this is / where to look / layout / invariants / ground rules / fast facts*.

### Why a symlink

AgentBox's own note says it: *"one is a symlink, so there is no second copy to drift."* Two files that must agree is precisely the failure mode of the last two days.

### What is in Invariants

These are platform invariants, not the app's:

1. **Merging can deploy to production.** `deploy.yml` triggers on push to `main` under `platform/auth/keycloak/**`, `platform/data/postgres/**`, `platform/observability/**` and four prod compose files. This repo's own runbook records unattended path-filtered deploys as a risk, so it is invariant #1.
2. `--remove-orphans` banned globally, enforced by CI.
3. Production Traefik sets **no provider `constraints`** — anything with `traefik.enable` and a `Host` rule is instantly public. No staging state.
4. `ACME_CA_SERVER` has no default; `render-traefik-config.sh` refuses without it, and switching CAs risks the four DNS-01 certificates that share `acme-dns.json`.
5. **This repo owns the three shared networks** tenants consume as external. Renaming one breaks every tenant silently.
6. The db readiness check runs `psql -tAc "SELECT 1"`, not `pg_isready`, because `pg_isready` passes on entirely broken credentials.
7. Secrets come from SOPS or OpenBao; age private keys are gitignored, only `.pub` is committed.

### Deliberate omissions

- **No "current state" section.** Perishable facts live in README's dated table; this file links to it. k8s-homelab's 548-line file is the counterexample.
- **No credentials**, in a file agents read.
- No architecture re-explanation, roadmap, or CONTRIBUTING duplication — links only.

### Open decisions, recorded as open

The Keycloak paragraph is the approved wording, with its four-part shape intact: **decided** (one Keycloak), **not decided** (which realm), **not started** (no migration; the platform Keycloak has no `hill90` realm), and *export before delete, never the reverse*. It carries the sentence **"one Keycloak does not mean one realm."**

**Postgres carries no decision** — two instances today, no steer, and a note that consolidating data is not obviously the same move as consolidating identity given the platform-only-databases boundary.

## Risks

**Low.** One new file plus a symlink; nothing executable, no workflow, no compose.

- **A broken symlink looks fine in a diff and is inert on disk.** This is the real risk of the change and it is tested below rather than assumed.
- **Staleness.** The file states invariants, which age slowly. The three claims that do age carry UTC timestamps.
- **Duplication drift with README.** Mitigated by not repeating state — the file points at README's table instead.

## Rollback

`git revert` the single commit, or `git rm CLAUDE.md AGENTS.md`. Nothing depends on it.

## Validation Evidence

### The symlink actually resolves — five checks, then a sixth that matters more

```
$ git ls-files -s CLAUDE.md AGENTS.md
120000 681311eb9cf453d0faddf3aacaec7357e97ba8e9 0  AGENTS.md      <- 120000 = symlink
100644 e45a1d2ae797de29af38660174bf0cb9adce4df0 0  CLAUDE.md

$ git cat-file -p :AGENTS.md
CLAUDE.md                                          <- stored target

$ readlink AGENTS.md          -> CLAUDE.md
$ head -1 AGENTS.md           -> # Hill90 — agent orientation
$ wc -c AGENTS.md CLAUDE.md   -> 6870 / 6870
$ ls -Li                      -> same inode 222876210
```

Mode `120000` proves git stored a symlink rather than a text file containing the word `CLAUDE.md` — the usual way this goes wrong. The blob SHA `681311eb…` is byte-identical to AgentBox's `AGENTS.md`, since both store the same link target.

**Fresh-clone test** — the check that matters, because everything above passes in a working tree that already had the file:

```
$ git clone --depth 1 --branch docs/agent-orientation <origin> clonetest
$ cd clonetest
mode in fresh clone: 120000 681311eb… 0  AGENTS.md
readlink:            CLAUDE.md
first line:          # Hill90 — agent orientation
broken?:             NO -- resolves
```

A clone that never saw my working tree materialises a working symlink.

### Merging this deploys nothing — checked against invariant #1

```
$ git diff --cached --name-only | grep -E "^(platform/auth/keycloak/|platform/data/postgres/|platform/observability/|deploy/compose/prod/docker-compose\.(db|auth|vault|observability)\.yml)"
  no filtered path touched — merge is inert
```

### Host state, verified before writing the dated claims

```
2026-07-29 05:57 UTC
running: 21   unhealthy: 0   app: 8   baseline: 13
hill90_edge / hill90_internal / hill90_agent_internal / hill90_agent_sandbox — all present
hill90.com -> 404   (app-ui not yet back from the yank-out redeploy)
app-auth   -> 302
```

Realms, verified separately at 05:55 UTC — platform Keycloak: `master` 200, `platform` 200, `hill90` **404**. App Keycloak: `master` 200, `hill90` 200, `platform` 404. That is the evidence behind "no `hill90` realm to consolidate into."

### What I could not check

Nothing in this PR is executable, so there is no test to run. The claims are either invariants (verified against the files they describe) or timestamped observations (verified against the host, quoted above).

## Update — second commit `f2f08409`

Two additions after the platform's own facts moved.

**The realm-naming factor**, recorded neutrally as a factor and explicitly not a recommendation. The tenant hardcodes a fallback issuer `https://auth.hill90.com/realms/hill90` in `services/api/src/app.ts:105` and `services/mcp/app/main.py:17`. Verified: that realm returns **404** on this platform's Keycloak today, so a blank `KEYCLOAK_ISSUER` fails loudly. If the consolidated realm is *named* `hill90`, that fallback silently becomes correct and a blank issuer stops being distinguishable from working configuration. Naming it otherwise, or deleting the fallbacks, keeps the failure loud. No steer either way — it is Jon's call.

**The tenancy contract has now been tested in both directions.** The baseline fast-fact says plainly that a degraded baseline is the stop-everything signal, and records that on 2026-07-29 the tenant was torn down to a single container and redeployed while this platform held at exactly 13 with all shared networks intact.

Verified independently at 2026-07-29 06:09 UTC:

```
running: 23   unhealthy: 0   app: 10   baseline: 13
hill90.com                 -> 200
hill90.com/api/auth/signin -> 200   providers: ['keycloak']
users in the tenant's hill90 realm: 2   (survived teardown + redeploy)
```

Symlink re-checked after the edit — `AGENTS.md` still mode `120000`, still resolves, byte count through the link matches the edited target.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
