### PR TITLE
docs: record the realm-naming factor and the tenancy test result

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,17 @@ or in the existing `platform` realm — one Keycloak does not mean one realm.
 **Not started:** no migration has happened, and the platform Keycloak has no
 `hill90` realm to consolidate into. Export before delete, never the reverse.
 
+One technical input to the realm question, recorded neutrally because it is
+Jon's call and not a recommendation: the tenant hardcodes a fallback issuer of
+`https://auth.hill90.com/realms/hill90` in two places
+(`services/api/src/app.ts:105`, `services/mcp/app/main.py:17`). That realm
+returns 404 on this platform's Keycloak today, so a blank `KEYCLOAK_ISSUER`
+currently fails loudly. **If the consolidated realm is named `hill90`, that
+fallback silently becomes correct**, and from then on a blank issuer is
+indistinguishable from working configuration. Naming the realm something else,
+or removing the fallbacks, would keep the failure loud. This is a factor, not an
+argument for either option.
+
 **Postgres is still two instances** — this platform's `postgres` and the
 tenant's `app-postgres`, on separate volumes. **No decision has been recorded.**
 Consolidating data is not obviously the same move as consolidating identity:
@@ -113,8 +124,11 @@ gh workflow run deploy.yml -f service=all
 ```
 
 - Platform baseline is **13 containers, 0 unhealthy**. A tenant's containers sit
-  alongside them and are not part of that count — verify the baseline after any
-  tenant action.
+  alongside them and are not part of that count. **Verify the baseline after any
+  tenant action — a degraded baseline is the stop-everything signal.** The
+  tenancy contract has been tested in both directions: on 2026-07-29 the tenant
+  was torn down to a single container and redeployed, and this platform held at
+  exactly 13 with all shared networks intact throughout.
 - Public: `hill90.com` (the tenant's UI), `auth.hill90.com` (this platform's
   Keycloak, realm `platform`). Tailscale-only: `traefik`, `portainer`,
   `grafana`, `vault`.


### PR DESCRIPTION
Follow-up to #561, which merged before this landed. Two additions to the platform's orientation file, both verified tonight.

## Plan

**1. The realm-naming factor**, recorded as a *factor* and explicitly not a recommendation — the decision is Jon's.

The tenant hardcodes a fallback issuer `https://auth.hill90.com/realms/hill90` in two places. That realm returns **404** on this platform's Keycloak today, so a blank `KEYCLOAK_ISSUER` fails loudly. **If the consolidated realm is named `hill90`, that fallback silently becomes correct**, and from then on a blank issuer is indistinguishable from working configuration. Naming the realm otherwise, or removing the fallbacks, keeps the failure loud.

**2. The tenancy contract has been tested in both directions.** The baseline fast-fact now states plainly that a degraded baseline is the stop-everything signal, and records that on 2026-07-29 the tenant was torn down to a single container and redeployed while this platform held at exactly 13 with all shared networks intact.

## Risks

**Low.** One file, documentation only.

- The realm note could be misread as a steer. Mitigated by the closing sentence: *"This is a factor, not an argument for either option."*
- **Merging fires nothing** — `git diff --name-only` is `CLAUDE.md` alone, and no path in `deploy.yml`'s push filter is touched. Checked, because that is invariant #1 in this very file.

## Rollback

`git revert d3599986`. One commit, one file.

## Validation Evidence

### The fallback claim, verified in the tenant's source

```
services/api/src/app.ts:105
  const issuer = opts.issuer || process.env.KEYCLOAK_ISSUER || 'https://auth.hill90.com/realms/hill90';
services/mcp/app/main.py:17
  KEYCLOAK_ISSUER = os.environ.get("KEYCLOAK_ISSUER", "https://auth.hill90.com/realms/hill90")
```

### That the realm 404s today, so the failure is currently loud

```
platform Keycloak  auth.hill90.com/realms/{master,platform,hill90}  -> 200 / 200 / 404
tenant   Keycloak  app-auth.hill90.com/realms/{master,hill90,platform} -> 200 / 200 / 404
```

### The tenancy test, verified independently at 2026-07-29 06:09 UTC

```
running: 23   unhealthy: 0   app: 10   baseline: 13
hill90.com                 -> 200
hill90.com/api/auth/signin -> 200   providers: ['keycloak']
users in the tenant's hill90 realm: 2   (survived teardown + redeploy)
```

### Symlink re-checked after the edit and after the cherry-pick

```
$ git ls-files -s AGENTS.md
120000 681311eb… 0  AGENTS.md
resolves: YES | first line via link: # Hill90 — agent orientation | byte count matches target: yes
```

Worth stating: a cherry-pick is a plausible way to turn a symlink back into a regular file, so it was re-verified rather than assumed.

### Invariants that had to survive, confirmed present

`one Keycloak does not mean one realm` — 1 occurrence. `No decision has been recorded` (Postgres) — 1 occurrence. No password, username or credential anywhere in the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
