### PR TITLE
fix(backup): stop the SQL dump failing silently, and cover the tenant database

### DIFF
--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -31,6 +31,7 @@ Commands:
 
 Services with backups:
   db             PostgreSQL SQL dump + data volume tar
+  app-db         hill90-app tenant: SQL dump + data volume tar
   vault          OpenBao secrets data (volume tar)
   infra          Traefik certificates + Portainer data (volume tar)
   observability  Grafana dashboards + Prometheus data (volume tar)
@@ -38,6 +39,62 @@ Services with backups:
 Environment variables:
   BACKUP_DIR    Override backup root (default: ${BACKUP_ROOT})
 EOF
+}
+
+# ---------------------------------------------------------------------------
+# sops resolution
+#
+# THIS IS THE INCIDENT. /etc/crontab sets PATH=/sbin:/bin:/usr/sbin:/usr/bin and
+# sops is installed to /usr/local/bin, so under cron `sops` was "command not
+# found". Its stderr went to /dev/null, DB_USER came back empty, the SQL dump
+# was skipped with a warning, the volume tar still ran, and the script exited 0.
+# Three consecutive nightly backups held a tar and no dump while cron reported
+# success. The same command worked by hand, which is why it survived.
+#
+# Resolve by PATH first, then by the known install location.
+# ---------------------------------------------------------------------------
+
+resolve_sops() {
+    if command -v sops >/dev/null 2>&1; then
+        command -v sops
+        return 0
+    fi
+    for candidate in /usr/local/bin/sops /usr/bin/sops /opt/homebrew/bin/sops; do
+        [ -x "$candidate" ] && { printf '%s' "$candidate"; return 0; }
+    done
+    return 1
+}
+
+# ---------------------------------------------------------------------------
+# Artifact verification
+#
+# Two backup directories on the VPS were completely empty and still counted as
+# successful runs. An empty directory must be impossible to report as a backup.
+# ---------------------------------------------------------------------------
+
+verify_artifacts() {
+    local backup_dir="$1"
+    shift
+    local required=("$@")
+
+    [ -d "$backup_dir" ] || die "Backup directory was never created: $backup_dir"
+
+    local found
+    found=$(find "$backup_dir" -type f ! -name '.*.partial' | wc -l | tr -d ' ')
+    [ "$found" -gt 0 ] || die "Backup produced no files at all: $backup_dir"
+
+    local f
+    for f in "${required[@]}"; do
+        [ -f "$backup_dir/$f" ] || die "Expected artifact missing: $backup_dir/$f"
+        [ -s "$backup_dir/$f" ] || die "Expected artifact is empty: $backup_dir/$f"
+    done
+
+    # Nothing that survived should be zero-length.
+    while IFS= read -r f; do
+        [ -s "$f" ] || die "Backup artifact is empty: $f"
+    done < <(find "$backup_dir" -type f ! -name '.*.partial')
+
+    echo "  ✓ verified ${found} artifact(s) in $backup_dir"
 }
 
 # ---------------------------------------------------------------------------
@@ -99,17 +156,27 @@ backup_db() {
     # Load secrets here rather than depending on the caller's ordering.
     local db_user="${DB_USER:-}"
     if [ -z "$db_user" ] && [ -f "${PROJECT_ROOT}/infra/secrets/prod.enc.env" ]; then
-        db_user=$(sops -d "${PROJECT_ROOT}/infra/secrets/prod.enc.env" 2>/dev/null \
-                  | grep '^DB_USER=' | cut -d= -f2- || true)
+        local sops_bin
+        if sops_bin="$(resolve_sops)"; then
+            db_user=$("$sops_bin" -d "${PROJECT_ROOT}/infra/secrets/prod.enc.env" 2>/dev/null \
+                      | grep '^DB_USER=' | cut -d= -f2- || true)
+        else
+            die "sops is not installed or not resolvable (PATH=$PATH).
+Under cron, PATH is /sbin:/bin:/usr/sbin:/usr/bin and sops lives in
+/usr/local/bin — this is exactly how the SQL dump silently stopped running."
+        fi
     fi
 
     # pg_isready is NOT an authentication check — it exits 0 for any role name,
     # including one that does not exist and including the empty string. Prove
     # the credentials work by running a query.
+    # These used to be warnings. A backup that produces no dump and still reports
+    # success manufactures false confidence, which is worse than an error: the
+    # operator believes they have a restore path and does not.
     if [ -z "$db_user" ]; then
-        warn "DB_USER could not be resolved — skipping SQL dump (volume tar still taken)"
+        die "DB_USER could not be resolved — refusing to report a backup with no SQL dump"
     elif ! docker exec postgres psql -U "$db_user" -tAc 'SELECT 1' >/dev/null 2>&1; then
-        warn "Cannot authenticate to PostgreSQL as '${db_user}' — skipping SQL dump (volume tar still taken)"
+        die "Cannot authenticate to PostgreSQL as '${db_user}' — refusing to report a backup with no SQL dump"
     else
         # Never leave a truncated dump behind claiming to be a backup: write to
         # a temp file, check the exit status AND that it is non-empty, and only
@@ -120,12 +187,67 @@ backup_db() {
             echo "  ✓ SQL dump saved to $backup_dir/database.sql ($(wc -c < "$backup_dir/database.sql") bytes)"
         else
             rm -f "$backup_dir/.database.sql.partial"
-            warn "pg_dumpall failed or produced an empty dump — no SQL backup was taken"
+            die "pg_dumpall failed or produced an empty dump — refusing to report success"
         fi
     fi
 
     # Volume tar (full data directory backup). Runs regardless of the dump.
     backup_volume "prod_postgres-data" "$backup_dir/postgres-data.tar.gz" || true
+
+    verify_artifacts "$backup_dir" "database.sql"
+}
+
+# ---------------------------------------------------------------------------
+# Tenant database backup — hill90-app
+#
+# prod_app-postgres-data had never been backed up by anything. This repo's
+# backup.sh only knew prod_postgres-data, and hill90-app has no backup script of
+# its own. That volume holds the app's Keycloak realm and its user accounts, AKM
+# knowledge, chat history and LiteLLM data.
+#
+# The user is read from the running container rather than from a secrets store,
+# because the app's store lives in the app's repository and is not present here.
+# A tar of a live PGDATA is crash-consistent at best; pg_dumpall is the artifact
+# that restores cleanly, so both are taken and the dump is required.
+# ---------------------------------------------------------------------------
+
+backup_app_db() {
+    local backup_dir="$1"
+    mkdir -p "$backup_dir"
+
+    local container="${APP_PG_CONTAINER:-app-postgres}"
+
+    echo "Backing up the hill90-app tenant database..."
+
+    if ! docker inspect "$container" >/dev/null 2>&1; then
+        die "Container '${container}' not found — the tenant's database cannot be backed up.
+If the tenant is deliberately not deployed, run the other services explicitly
+rather than letting this report success."
+    fi
+
+    local app_user="${APP_DB_USER:-}"
+    if [ -z "$app_user" ]; then
+        app_user=$(docker inspect "$container" \
+                   --format '{{range .Config.Env}}{{println .}}{{end}}' 2>/dev/null \
+                   | grep '^POSTGRES_USER=' | cut -d= -f2- || true)
+    fi
+    [ -n "$app_user" ] || die "Could not determine the tenant database user from ${container}"
+
+    docker exec "$container" psql -U "$app_user" -tAc 'SELECT 1' >/dev/null 2>&1 \
+        || die "Cannot authenticate to ${container} as '${app_user}' — refusing to report a backup with no SQL dump"
+
+    if docker exec "$container" pg_dumpall -U "$app_user" > "$backup_dir/.app-database.sql.partial" 2>/dev/null \
+       && [ -s "$backup_dir/.app-database.sql.partial" ]; then
+        mv "$backup_dir/.app-database.sql.partial" "$backup_dir/app-database.sql"
+        echo "  ✓ SQL dump saved to $backup_dir/app-database.sql ($(wc -c < "$backup_dir/app-database.sql") bytes)"
+    else
+        rm -f "$backup_dir/.app-database.sql.partial"
+        die "pg_dumpall against ${container} failed or produced an empty dump — refusing to report success"
+    fi
+
+    backup_volume "prod_app-postgres-data" "$backup_dir/app-postgres-data.tar.gz" || true
+
+    verify_artifacts "$backup_dir" "app-database.sql"
 }
 
 backup_infra() {
@@ -163,8 +285,8 @@ cmd_backup() {
 
     # Validate service before constructing any paths
     case "$service" in
-        db|vault|infra|observability) ;;
-        *) die "Unknown service for backup: $service. Use: db, vault, infra, observability" ;;
+        db|app-db|vault|infra|observability) ;;
+        *) die "Unknown service for backup: $service. Use: db, app-db, vault, infra, observability" ;;
     esac
 
     local timestamp
@@ -173,6 +295,7 @@ cmd_backup() {
 
     case "$service" in
         db)            backup_db "$backup_dir" ;;
+        app-db)        backup_app_db "$backup_dir" ;;
         vault)         backup_vault "$backup_dir" ;;
         infra)         backup_infra "$backup_dir" ;;
         observability) backup_observability "$backup_dir" ;;
@@ -188,14 +311,34 @@ cmd_backup_all() {
     echo "================================"
     echo ""
 
-    for svc in db vault infra observability; do
-        cmd_backup "$svc"
+    # Run every service even if one fails, then fail the job at the end.
+    #
+    # Aborting on the first failure would be worse than the bug being fixed: the
+    # tenant's database is legitimately absent whenever the tenant is torn down
+    # (which happened during a teardown test on 2026-07-29), and `set -e` would
+    # then skip vault, infra and observability entirely. One missing service must
+    # not cost the other four their backups — but it must still turn the run red.
+    local failed=()
+    for svc in db app-db vault infra observability; do
+        if ! ( cmd_backup "$svc" ); then
+            failed+=("$svc")
+            warn "Backup FAILED for: $svc (continuing with the remaining services)"
+        fi
         echo ""
     done
 
     echo "================================"
-    echo "Full Backup Complete!"
+    if [ ${#failed[@]} -eq 0 ]; then
+        echo "Full Backup Complete!"
+        echo "================================"
+        return 0
+    fi
+
+    echo "Full Backup INCOMPLETE"
     echo "================================"
+    die "These services produced no usable backup: ${failed[*]}
+The other services were backed up. This exits non-zero deliberately — a partial
+backup must not be reported as success."
 }
 
 cmd_restore() {

--- a/tests/scripts/backup.bats
+++ b/tests/scripts/backup.bats
@@ -138,3 +138,150 @@
   run bash scripts/backup.sh restore db /tmp/nonexistent-path-$$
   [ "$status" -eq 1 ]
 }
+
+# ---------------------------------------------------------------------------
+# Regression tests for the silent SQL-dump failure and the missing app coverage.
+#
+# Root cause of the live incident: /etc/crontab sets
+# PATH=/sbin:/bin:/usr/sbin:/usr/bin, sops lives in /usr/local/bin, so under
+# cron `sops -d` was "command not found". stderr was discarded, DB_USER came
+# back empty, the SQL dump was skipped with a warning, the volume tar still ran
+# and the script exited 0. Three consecutive nightly backups contained a tar and
+# no dump while cron reported success.
+#
+# These tests stub docker and sops so they run in CI without a live stack.
+# ---------------------------------------------------------------------------
+
+setup_stubs() {
+  STUB_BIN="$BATS_TEST_TMPDIR/bin"
+  mkdir -p "$STUB_BIN"
+
+  cat > "$STUB_BIN/docker" <<'EOF'
+#!/usr/bin/env bash
+# stub: psql auth check succeeds; pg_dumpall/pg_dump emit plausible SQL
+case "$*" in
+  *pg_dumpall*|*pg_dump*) echo "-- PostgreSQL database dump"; echo "CREATE ROLE hill90;"; exit 0 ;;
+  *psql*SELECT\ 1*)       echo "1"; exit 0 ;;
+  *"volume ls"*)          echo "prod_postgres-data"; echo "prod_app-postgres-data"; exit 0 ;;
+  *inspect*)              exit 0 ;;
+  *run*)                  exit 0 ;;
+  *)                      exit 0 ;;
+esac
+EOF
+  chmod +x "$STUB_BIN/docker"
+
+  cat > "$STUB_BIN/sops" <<'EOF'
+#!/usr/bin/env bash
+echo "DB_USER=hill90"
+echo "DB_PASSWORD=stub"
+exit 0
+EOF
+  chmod +x "$STUB_BIN/sops"
+}
+
+@test "backup db FAILS when the SQL dump cannot be taken, rather than warning" {
+  setup_stubs
+  # sops absent from PATH — exactly the cron condition that caused the incident.
+  rm -f "$STUB_BIN/sops"
+  run env PATH="$STUB_BIN:/usr/bin:/bin" \
+      BACKUP_DIR="$BATS_TEST_TMPDIR/backups" DB_USER= \
+      bash scripts/backup.sh backup db
+  [ "$status" -ne 0 ]
+  [[ "$output" != *"✓ Backup complete"* ]]
+}
+
+@test "backup db FAILS when the dump would be empty" {
+  setup_stubs
+  cat > "$STUB_BIN/docker" <<'EOF'
+#!/usr/bin/env bash
+case "$*" in
+  *pg_dumpall*|*pg_dump*) exit 0 ;;   # exits 0 but writes nothing
+  *psql*SELECT\ 1*)       echo "1"; exit 0 ;;
+  *)                      exit 0 ;;
+esac
+EOF
+  chmod +x "$STUB_BIN/docker"
+  run env PATH="$STUB_BIN:/usr/bin:/bin" \
+      BACKUP_DIR="$BATS_TEST_TMPDIR/backups" \
+      bash scripts/backup.sh backup db
+  [ "$status" -ne 0 ]
+}
+
+@test "backup db resolves sops by absolute path, not only via PATH" {
+  run grep -nE "/usr/local/bin/sops|command -v sops|SOPS_BIN" scripts/backup.sh
+  [ "$status" -eq 0 ]
+}
+
+@test "backup.sh covers the app's postgres volume" {
+  run grep -n "prod_app-postgres-data" scripts/backup.sh
+  [ "$status" -eq 0 ]
+}
+
+@test "backup app-db produces a real SQL dump of the tenant database, not only a tar" {
+  setup_stubs
+  run env PATH="$STUB_BIN:/usr/bin:/bin" \
+      BACKUP_DIR="$BATS_TEST_TMPDIR/backups" APP_DB_USER=hill90 \
+      bash scripts/backup.sh backup app-db
+  [ "$status" -eq 0 ]
+  dump="$(find "$BATS_TEST_TMPDIR/backups" -name 'app-database.sql' | head -1)"
+  [ -n "$dump" ]
+  [ -s "$dump" ]
+}
+
+@test "backup app-db FAILS when the tenant database cannot be dumped" {
+  setup_stubs
+  cat > "$STUB_BIN/docker" <<'EOF'
+#!/usr/bin/env bash
+case "$*" in
+  *pg_dumpall*|*pg_dump*) exit 1 ;;   # dump fails
+  *psql*SELECT\ 1*)       echo "1"; exit 0 ;;
+  *)                      exit 0 ;;
+esac
+EOF
+  chmod +x "$STUB_BIN/docker"
+  run env PATH="$STUB_BIN:/usr/bin:/bin" \
+      BACKUP_DIR="$BATS_TEST_TMPDIR/backups" APP_DB_USER=hill90 \
+      bash scripts/backup.sh backup app-db
+  [ "$status" -ne 0 ]
+}
+
+@test "backup.sh verifies artifacts are non-empty before reporting success" {
+  run grep -nE "verify_artifacts|assert_non_empty" scripts/backup.sh
+  [ "$status" -eq 0 ]
+}
+
+@test "a successful db backup produces a non-empty dump and exits 0" {
+  setup_stubs
+  run env PATH="$STUB_BIN:/usr/bin:/bin" \
+      BACKUP_DIR="$BATS_TEST_TMPDIR/backups" \
+      bash scripts/backup.sh backup db
+  [ "$status" -eq 0 ]
+  dump="$(find "$BATS_TEST_TMPDIR/backups" -name 'database.sql' | head -1)"
+  [ -n "$dump" ]
+  [ -s "$dump" ]
+}
+
+@test "backup-all continues past a failing service and still exits non-zero" {
+  setup_stubs
+  # Tenant container absent — the state during any teardown of the app.
+  cat > "$STUB_BIN/docker" <<'EOF'
+#!/usr/bin/env bash
+case "$*" in
+  *inspect\ app-postgres*) exit 1 ;;                 # tenant not deployed
+  *pg_dumpall*|*pg_dump*)  echo "-- dump"; echo "CREATE ROLE hill90;"; exit 0 ;;
+  *psql*SELECT\ 1*)        echo "1"; exit 0 ;;
+  *)                       exit 0 ;;
+esac
+EOF
+  chmod +x "$STUB_BIN/docker"
+  run env PATH="$STUB_BIN:/usr/bin:/bin" \
+      BACKUP_DIR="$BATS_TEST_TMPDIR/backups" \
+      bash scripts/backup.sh backup-all
+  # Fails overall...
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"app-db"* ]]
+  # ...but the platform database was still backed up.
+  dump="$(find "$BATS_TEST_TMPDIR/backups" -name 'database.sql' | head -1)"
+  [ -n "$dump" ]
+  [ -s "$dump" ]
+}


### PR DESCRIPTION
Backups have been silently broken for at least three days, and the tenant's database has never been backed up by anything. Both are live tonight and neither is migration-specific.

## Root cause, reproduced on the host

`/etc/crontab` sets `PATH=/sbin:/bin:/usr/sbin:/usr/bin`. `sops` installs to `/usr/local/bin`. Under cron, `sops` is **command not found** — its stderr goes to `/dev/null`, `DB_USER` comes back empty, the dump is skipped with a warning, the volume tar still runs, and the script exits **0**.

It works by hand and fails from cron. That is why it survived three nights.

```
$ env -i PATH=/sbin:/bin:/usr/sbin:/usr/bin bash -c "command -v sops"
  sops NOT FOUND on PATH=/usr/bin:/bin
$ command -v sops
  /usr/local/bin/sops
```

## Plan

1. **Resolve `sops` by PATH first, then by known install locations.** Fail loudly if it cannot be found.
2. **A dump that cannot be taken is fatal, not a warning.** A backup reporting success with no dump manufactures false confidence — worse than an error, because the operator believes they have a restore path and does not.
3. **New `app-db` service** covering `prod_app-postgres-data`: a real `pg_dumpall` plus the volume tar. The database user is read from the running container, because the tenant's secrets store lives in the tenant's repository and is not present here.
4. **`verify_artifacts`** — the directory exists, holds at least one file, every required artifact is present and non-empty, and no surviving file is zero-length. Empty directories should have been impossible.

### A regression this almost introduced

Adding `app-db` to `backup-all` under `set -e` means that whenever the tenant is torn down — **which happened during the teardown test earlier tonight** — the first failure aborts the loop and `vault`, `infra` and `observability` never run. One absent service must not cost the other four their backups.

`backup-all` now runs each service in a subshell, collects failures, and dies at the end. The run still goes red; the other backups still happen. I found this by reading my own change against tonight's events, not from a test failure.

## Risks

- **`backup-all` now exits non-zero when any service fails.** That is the point, but it changes cron's exit status from always-0 to sometimes-1. Nothing consumes that status today beyond the log.
- **Pre-deploy backups can now fail.** `deploy.sh` calls `backup.sh` behind `|| warn "Pre-deploy backup failed (continuing deploy)"`, so a deploy is not blocked — it warns, as before.
- **The `app-db` dump adds ~0.5 MB and a few seconds** to the nightly run.
- **Not fixed here:** the Ansible-managed cron entry could also set `PATH`. Fixing it at the script level is the more robust layer — it works regardless of how the script is invoked — but the cron entry remains a reasonable belt-and-braces follow-up.

## Rollback

`git revert 3ad15a41`. Two files, no data touched, no schema, no retention change.

## Validation Evidence

### The tests fail before and pass after

Nine tests added to `tests/scripts/backup.bats`, in the bats shape CI already runs. Against `origin/main`'s `backup.sh`:

```
not ok 23 backup db FAILS when the SQL dump cannot be taken, rather than warning
not ok 24 backup db FAILS when the dump would be empty
not ok 25 backup db resolves sops by absolute path, not only via PATH
not ok 26 backup.sh covers the app's postgres volume
not ok 27 backup app-db produces a real SQL dump of the tenant database, not only a tar
not ok 29 backup.sh verifies artifacts are non-empty before reporting success
```

After the fix: **326 pass across `tests/scripts/`, 0 failures.** `shellcheck --severity=error scripts/*.sh` clean.

### A real backup run on the host — not a dry run

Staged at `/tmp/bkverify` with a symlink to the real `infra/`, so the live checkout was never modified. Run under **cron's exact PATH**.

**Control — the current script, reproducing the incident:**

```
WARNING: DB_USER could not be resolved — skipping SQL dump (volume tar still taken)
  Backing up volume prod_postgres-data...
✓ Backup complete: /tmp/bkverify/control/db/20260729_064628
  exit=0
  artifacts: postgres-data.tar.gz          <- no dump, and it says "complete"
```

**Fixed — platform database:**

```
  ✓ SQL dump saved to .../database.sql (322299 bytes)
  ✓ Saved to .../postgres-data.tar.gz
  ✓ verified 2 artifact(s)
✓ Backup complete   exit=0
```

**Fixed — tenant database, the first backup it has ever had:**

```
  ✓ SQL dump saved to .../app-database.sql (532513 bytes)
  ✓ Saved to .../app-postgres-data.tar.gz
  ✓ verified 2 artifact(s)
✓ Backup complete
```

### The dumps are plausible, not merely non-empty

```
platform  322299 bytes  2 databases: hill90 keycloak
tenant    532513 bytes  5 databases: hill90 hill90_akm hill90_api hill90_litellm keycloak
tenant    keycloak user_entity table present  (Jon's two accounts are captured)
both      end with the pg_dumpall trailer     -> COMPLETE
```

My first completeness check reported `TRUNCATED` for both. That was my grep, not the artifacts — `pg_dumpall` writes "database **cluster** dump complete". Corrected and re-checked rather than filed as a defect.

### Nothing was harmed

```
                        before        after
containers              23            23
unhealthy               0             0
existing backup dirs    11            11
live checkout backup.sh mtime 2026-07-26 20:52  (unchanged)
/tmp/bkverify           removed
```

No existing backup was deleted, retention was not touched, the restore path was not touched, and both databases were read only through `pg_dumpall`.

### What I did not verify live

`backup-all`'s continue-past-failure behaviour is proven by test 31, not by a live full run — a real `backup-all` writes five services' artifacts to disk and I did not want to manufacture that volume on the host to prove a control-flow property a test settles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
