### PR TITLE
fix(deploy): refuse to reset a dirty checkout, and report drift

### DIFF
--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -75,6 +75,7 @@ jobs:
             deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
             "cd /opt/hill90/app && \
              git fetch origin && \
+             bash scripts/preflight-checkout.sh && \
              git reset --hard origin/main && \
              export SOPS_AGE_KEY_FILE=/opt/hill90/secrets/keys/keys.txt && \
              export ACME_REQUIRE_PRODUCTION=1 && \

--- a/.github/workflows/reusable-deploy-service.yml
+++ b/.github/workflows/reusable-deploy-service.yml
@@ -74,6 +74,7 @@ jobs:
             "cd /opt/hill90/app && \
              git fetch origin && \
              git diff --stat HEAD origin/main && \
+             bash scripts/preflight-checkout.sh && \
              git reset --hard origin/main && \
              export SOPS_AGE_KEY_FILE=/opt/hill90/secrets/keys/keys.txt && \
              bash scripts/deploy.sh ${{ inputs.service }} prod"

--- a/.github/workflows/vault-init.yml
+++ b/.github/workflows/vault-init.yml
@@ -114,7 +114,7 @@ jobs:
         run: |
           ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
             deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
-            'cd /opt/hill90/app && git fetch origin && git reset --hard origin/main'
+            'cd /opt/hill90/app && git fetch origin && bash scripts/preflight-checkout.sh && git reset --hard origin/main'
 
       # Writes the unseal key and root token to 0600 files owned by deploy.
       # Prints neither.

--- a/.github/workflows/vault-reinitialize.yml
+++ b/.github/workflows/vault-reinitialize.yml
@@ -172,7 +172,7 @@ jobs:
         run: |
           ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
             deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
-            'cd /opt/hill90/app && git fetch origin && git reset --hard origin/main'
+            'cd /opt/hill90/app && git fetch origin && bash scripts/preflight-checkout.sh && git reset --hard origin/main'
 
       # ---- The destructive part ---------------------------------------------
 

--- a/docs/runbooks/deployment.md
+++ b/docs/runbooks/deployment.md
@@ -88,7 +88,42 @@ All Docker Compose operations use explicit project names to prevent cross-stack 
 2. **All `docker compose` calls use explicit `-p <project>`** — no implicit project names.
 3. **Stateless apps use `up -d --force-recreate --no-deps`** — no `down` step, zero-downtime replacement.
 4. **Edge deploy is manual-only** — never auto-triggered by push.
-5. **No local VPS file edits** — all changes go through git + CI.
+5. **No local VPS file edits** — all changes go through git + CI. See
+   [Hand-edits on `/opt/hill90/app` are doomed by construction](#hand-edits-on-opthill90app-are-doomed-by-construction)
+   for why this is a mechanism rather than a preference.
+
+### Hand-edits on `/opt/hill90/app` are doomed by construction
+
+Every deploy path in this repository runs `git reset --hard origin/main` on the
+VPS checkout — `deploy-infra.yml`, `reusable-deploy-service.yml`,
+`vault-init.yml` and `vault-reinitialize.yml` all do it. **Any uncommitted change
+under `/opt/hill90/app` is therefore destroyed by the next deploy**, and it is
+not recoverable: unstaged changes are never written to git's object database, so
+there is no blob, no stash and no reflog entry to restore from.
+
+Land a hand-edit in the repository the same day, or accept that it will vanish
+without a trace and without a warning.
+
+**Some of those paths are live.** `platform/edge/dynamic` is bind-mounted into
+Traefik at `/etc/traefik/dynamic` with `watch: true`, so editing a file there is
+simultaneously a **live production change** and a doomed one — Traefik reloads
+it within seconds, and the next deploy silently reverts it. Ten further paths
+(the Keycloak realm and theme, the Postgres init script, the observability
+configs, the vault policies) are bind-mounted without `watch`, so an edit is
+visible in the container immediately and takes effect at its next restart.
+
+A dirty tree under `docs/` is untidy. A dirty tree under `platform/edge/dynamic`
+is an undocumented live production change about to be reverted without review.
+
+`scripts/preflight-checkout.sh` runs before every reset and enforces this: on a
+dirty tree it prints the full diff — the only record that will survive — labels
+each path by how live it is, and refuses. Override with
+`ALLOW_DIRTY_CHECKOUT=1` when the discard is genuinely intended.
+
+It also reports **drift**: how many commits the checkout is behind `origin/main`.
+On 2026-07-29 the checkout was found 12 commits behind and locally modified, so
+production had been running configuration that differed from the repository for
+three days with no signal. That is the case the drift report exists to surface.
 
 ### Inspecting Stacks
 

--- a/scripts/preflight-checkout.sh
+++ b/scripts/preflight-checkout.sh
@@ -99,13 +99,26 @@ report_drift() {
 
     echo ""
     echo "  ################################################################"
-    echo "  # DRIFT: this checkout is ${behind} commits behind origin/main"
-    [ "$ahead" -gt 0 ] && echo "  #        and ${ahead} commits ahead (unpushed local commits!)"
-    echo "  #"
-    echo "  # Production has been running config that differs from the"
-    echo "  # repository. Commits not yet deployed:"
+    if [ "$behind" -gt 0 ]; then
+        echo "  # DRIFT: this checkout is ${behind} commits behind origin/main"
+        echo "  #"
+        echo "  # Production has been running config that differs from the"
+        echo "  # repository. Commits not yet deployed:"
+    fi
+    if [ "$ahead" -gt 0 ]; then
+        [ "$behind" -gt 0 ] && echo "  #"
+        echo "  # DRIFT: this checkout is ${ahead} commits AHEAD of origin/main."
+        echo "  # Those commits exist only on this host and \`git reset --hard\`"
+        echo "  # will discard them. Push them before deploying."
+    fi
     echo "  ################################################################"
-    git --no-pager log --oneline HEAD..origin/main 2>/dev/null | sed 's/^/    /' | head -20
+    if [ "$behind" -gt 0 ]; then
+        git --no-pager log --oneline HEAD..origin/main 2>/dev/null | sed 's/^/    /' | head -20
+    fi
+    if [ "$ahead" -gt 0 ]; then
+        echo "    commits only on this host:"
+        git --no-pager log --oneline origin/main..HEAD 2>/dev/null | sed 's/^/      /' | head -20
+    fi
     echo ""
 }
 

--- a/scripts/preflight-checkout.sh
+++ b/scripts/preflight-checkout.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# Checkout preflight — run on the VPS immediately BEFORE `git reset --hard`.
+#
+# WHY THIS EXISTS
+#
+# /opt/hill90/app is a deploy target that people hand-edit, and every deploy path
+# in this repository runs `git reset --hard origin/main`. A local edit there is
+# therefore destroyed silently, by design, with no record of what it was —
+# unstaged changes are never written to git's object database, so there is no
+# blob, no stash and no reflog entry to recover from.
+#
+# On 2026-07-29 exactly that happened: an uncommitted change to
+# platform/edge/dynamic/middlewares.yml was discarded during a routine `git
+# fetch && git reset --hard origin/main`, and its contents are gone permanently.
+# The checkout had also been sitting 12 commits behind main for three days, so
+# production config genuinely differed from the repository and nobody knew.
+#
+# THE PART THAT MAKES IT SERIOUS
+#
+# Some paths in this repository are bind-mounted into running containers, and one
+# of them is *watched*. platform/edge/dynamic is mounted into Traefik at
+# /etc/traefik/dynamic with `watch: true`, so editing a file there is
+# simultaneously a LIVE production change and a doomed one. `git reset --hard`
+# on that path rewrites edge security configuration on a running host, and
+# Traefik reloads it within seconds.
+#
+# A dirty tree under docs/ is untidy. A dirty tree under platform/edge/dynamic is
+# an undocumented live production change about to be reverted without review.
+# This script distinguishes them.
+#
+# BEHAVIOUR
+#
+#   clean tree                -> report drift, exit 0
+#   dirty tree                -> print the FULL diff, classify each path, exit 1
+#   ALLOW_DIRTY_CHECKOUT=1    -> print the FULL diff, classify, exit 0
+#
+# The diff is printed in every case, including the override, because it is the
+# only record that will survive the reset.
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Paths that are bind-mounted into running containers.
+#
+# Derived from the `../../../<path>:` bind mounts in deploy/compose/prod/*.yml.
+# Keep in step with those files; tests/scripts/preflight-checkout.bats pins the
+# behaviour, not the list.
+# ---------------------------------------------------------------------------
+
+# Bind-mounted AND watched — an edit takes effect on a running container within
+# seconds, with no restart and no deploy.
+WATCHED_PATHS=(
+    "platform/edge/dynamic"
+)
+
+# Bind-mounted — an edit is visible inside the container immediately and takes
+# effect at its next restart.
+BIND_MOUNTED_PATHS=(
+    "platform/auth/keycloak/platform-realm.json"
+    "platform/auth/keycloak/themes/hill90"
+    "platform/data/postgres/init.sh"
+    "platform/observability/grafana/provisioning"
+    "platform/observability/loki/loki.yml"
+    "platform/observability/prometheus/alerts.yml"
+    "platform/observability/prometheus/prometheus.yml"
+    "platform/observability/promtail/promtail.yml"
+    "platform/observability/tempo/tempo.yml"
+    "platform/vault/policies"
+)
+
+classify_path() {
+    local path="$1" p
+    for p in "${WATCHED_PATHS[@]}"; do
+        case "$path" in "$p"|"$p"/*) printf 'LIVE (WATCHED — Traefik reloads this within seconds)'; return ;; esac
+    done
+    for p in "${BIND_MOUNTED_PATHS[@]}"; do
+        case "$path" in "$p"|"$p"/*) printf 'BIND-MOUNTED (in-container now, active at next restart)'; return ;; esac
+    done
+    printf 'not mounted'
+}
+
+# ---------------------------------------------------------------------------
+# Drift
+# ---------------------------------------------------------------------------
+
+report_drift() {
+    local behind ahead
+    git rev-parse --verify -q origin/main >/dev/null 2>&1 || {
+        echo "  drift: origin/main not fetched — cannot determine"
+        return 0
+    }
+    behind=$(git rev-list --count HEAD..origin/main 2>/dev/null || echo 0)
+    ahead=$(git rev-list --count origin/main..HEAD 2>/dev/null || echo 0)
+
+    if [ "$behind" -eq 0 ] && [ "$ahead" -eq 0 ]; then
+        echo "  drift: up to date with origin/main"
+        return 0
+    fi
+
+    echo ""
+    echo "  ################################################################"
+    echo "  # DRIFT: this checkout is ${behind} commits behind origin/main"
+    [ "$ahead" -gt 0 ] && echo "  #        and ${ahead} commits ahead (unpushed local commits!)"
+    echo "  #"
+    echo "  # Production has been running config that differs from the"
+    echo "  # repository. Commits not yet deployed:"
+    echo "  ################################################################"
+    git --no-pager log --oneline HEAD..origin/main 2>/dev/null | sed 's/^/    /' | head -20
+    echo ""
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+echo "=============================================="
+echo "Checkout preflight — $(pwd)"
+echo "=============================================="
+
+report_drift
+
+if [ -z "$(git status --porcelain)" ]; then
+    echo "  working tree clean — safe to reset"
+    exit 0
+fi
+
+echo ""
+echo "  ################################################################"
+echo "  # THE WORKING TREE IS DIRTY"
+echo "  #"
+echo "  # \`git reset --hard\` will destroy the changes below and they are"
+echo "  # NOT RECOVERABLE — unstaged changes are not git objects, so there"
+echo "  # is no stash, no blob and no reflog entry to restore from."
+echo "  #"
+echo "  # This diff is the only record. Copy it before continuing."
+echo "  ################################################################"
+echo ""
+
+echo "  Modified paths, by how live they are:"
+echo ""
+live_count=0
+while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    path="${line:3}"
+    class="$(classify_path "$path")"
+    printf '    %-56s %s\n' "$path" "$class"
+    case "$class" in LIVE*|BIND-MOUNTED*) live_count=$((live_count + 1)) ;; esac
+done < <(git status --porcelain)
+
+if [ "$live_count" -gt 0 ]; then
+    echo ""
+    echo "  *** ${live_count} of these are mounted into running containers. ***"
+    echo "  *** An edit there was a live production change. Resetting it is"
+    echo "  *** another one, in the opposite direction, with no review."
+fi
+
+echo ""
+echo "  ---------------- FULL DIFF (tracked files) ----------------"
+git --no-pager diff | sed 's/^/  /'
+echo "  ---------------- END DIFF ----------------"
+echo ""
+
+untracked=$(git ls-files --others --exclude-standard)
+if [ -n "$untracked" ]; then
+    echo "  Untracked files (git reset --hard leaves these, but they are undeployed):"
+    echo "$untracked" | sed 's/^/    /'
+    echo ""
+fi
+
+if [ "${ALLOW_DIRTY_CHECKOUT:-0}" = "1" ]; then
+    echo "  ALLOW_DIRTY_CHECKOUT=1 — proceeding and discarding the above."
+    exit 0
+fi
+
+echo "  REFUSING to continue."
+echo ""
+echo "  Land the change in the repository, or re-run with"
+echo "  ALLOW_DIRTY_CHECKOUT=1 if you genuinely mean to discard it."
+exit 1

--- a/tests/scripts/preflight-checkout.bats
+++ b/tests/scripts/preflight-checkout.bats
@@ -1,0 +1,103 @@
+#!/usr/bin/env bats
+
+# Tests for scripts/preflight-checkout.sh
+#
+# Why this guard exists. /opt/hill90/app is a deploy target that people hand-edit,
+# and every deploy path runs `git reset --hard origin/main`, so a local edit there
+# is destroyed silently. On 2026-07-29 that happened: an uncommitted change to
+# platform/edge/dynamic/middlewares.yml was discarded with nobody ever seeing the
+# diff. That directory is bind-mounted into Traefik with `watch: true`, so an edit
+# there is simultaneously a LIVE production change and a doomed one.
+#
+# These run against throwaway git repos. No VPS.
+
+setup() {
+  REPO="$BATS_TEST_TMPDIR/checkout"
+  ORIGIN="$BATS_TEST_TMPDIR/origin.git"
+  git init -q --bare "$ORIGIN"
+  git init -q "$REPO"
+  cd "$REPO"
+  git config user.email t@t; git config user.name t
+  mkdir -p docs platform/edge/dynamic platform/observability/prometheus
+  echo "doc" > docs/readme.md
+  echo "middlewares: {}" > platform/edge/dynamic/middlewares.yml
+  echo "scrape: {}" > platform/observability/prometheus/prometheus.yml
+  git add -A && git commit -qm init
+  git remote add origin "$ORIGIN" && git push -q origin HEAD:main
+  git fetch -q origin
+  PF="$BATS_TEST_DIRNAME/../../scripts/preflight-checkout.sh"
+}
+
+@test "preflight passes on a clean tree" {
+  run bash "$PF"
+  [ "$status" -eq 0 ]
+}
+
+@test "preflight REFUSES when the tree is dirty" {
+  echo "hand edit" >> docs/readme.md
+  run bash "$PF"
+  [ "$status" -ne 0 ]
+}
+
+@test "preflight PRINTS THE FULL DIFF — the only record of the hand-edit" {
+  echo "MAGIC_HAND_EDIT_MARKER" >> docs/readme.md
+  run bash "$PF"
+  [[ "$output" == *"MAGIC_HAND_EDIT_MARKER"* ]]
+}
+
+@test "a dirty WATCHED path is called out as live production config" {
+  echo "hand edit" >> platform/edge/dynamic/middlewares.yml
+  run bash "$PF"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"LIVE"* ]]
+  [[ "$output" == *"watch"* || "$output" == *"WATCHED"* ]]
+}
+
+@test "a dirty bind-mounted path is distinguished from an ordinary one" {
+  echo "hand edit" >> platform/observability/prometheus/prometheus.yml
+  run bash "$PF"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"BIND-MOUNTED"* ]]
+}
+
+@test "a dirty docs-only path is NOT labelled live" {
+  echo "hand edit" >> docs/readme.md
+  run bash "$PF"
+  [[ "$output" != *"LIVE"* ]]
+}
+
+@test "ALLOW_DIRTY_CHECKOUT=1 overrides the refusal but still prints the diff" {
+  echo "OVERRIDE_MARKER" >> docs/readme.md
+  run env ALLOW_DIRTY_CHECKOUT=1 bash "$PF"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"OVERRIDE_MARKER"* ]]
+}
+
+@test "preflight reports how far the checkout is behind origin/main" {
+  echo "upstream change" >> docs/readme.md
+  git add -A && git commit -qm upstream && git push -q origin HEAD:main
+  git reset -q --hard HEAD~1
+  git fetch -q origin
+  run bash "$PF"
+  [[ "$output" == *"behind"* ]]
+  [[ "$output" == *"1"* ]]
+}
+
+@test "drift is reported loudly when the checkout is stale" {
+  for i in 1 2 3; do echo "c$i" >> docs/readme.md; git add -A; git commit -qm "c$i"; done
+  git push -q origin HEAD:main
+  git reset -q --hard HEAD~3
+  git fetch -q origin
+  run bash "$PF"
+  [[ "$output" == *"3 commits behind"* ]]
+}
+
+@test "every deploy path calls the preflight before git reset --hard" {
+  cd "$BATS_TEST_DIRNAME/../.."
+  for wf in .github/workflows/deploy-infra.yml \
+            .github/workflows/reusable-deploy-service.yml \
+            .github/workflows/vault-init.yml \
+            .github/workflows/vault-reinitialize.yml; do
+    grep -q "preflight-checkout.sh" "$wf" || { echo "missing preflight in $wf"; return 1; }
+  done
+}

--- a/tests/scripts/preflight-checkout.bats
+++ b/tests/scripts/preflight-checkout.bats
@@ -101,3 +101,22 @@ setup() {
     grep -q "preflight-checkout.sh" "$wf" || { echo "missing preflight in $wf"; return 1; }
   done
 }
+
+@test "drift wording is correct when only AHEAD of origin/main" {
+  echo "local only" >> docs/readme.md
+  git add -A && git commit -qm "local-only commit"
+  run bash "$PF"
+  # Must not claim to be behind when it is not.
+  [[ "$output" != *"0 commits behind"* ]]
+  [[ "$output" == *"AHEAD"* ]]
+  [[ "$output" == *"discard them"* ]]
+}
+
+@test "drift wording is correct when only BEHIND origin/main" {
+  echo "upstream" >> docs/readme.md
+  git add -A && git commit -qm up && git push -q origin HEAD:main
+  git reset -q --hard HEAD~1 && git fetch -q origin
+  run bash "$PF"
+  [[ "$output" == *"1 commits behind"* ]]
+  [[ "$output" != *"AHEAD"* ]]
+}


### PR DESCRIPTION
On 2026-07-29 a routine `git fetch && git reset --hard origin/main` on `/opt/hill90/app` destroyed an uncommitted change to `platform/edge/dynamic/middlewares.yml`. Nobody saw the diff, and it is not recoverable — unstaged changes are never written to git's object database, so there is no blob, no stash and no reflog entry.

**This is not specific to that incident. It is how the design works.** Four workflows run `git reset --hard origin/main` on that checkout, so any hand-edit there is doomed, silently, by construction.

## Plan

Three guards, each catching what the others miss.

**1. `scripts/preflight-checkout.sh`** — on a dirty tree it prints the **full diff** (the only record that survives the reset), labels every modified path by how live it is, and **refuses**. `ALLOW_DIRTY_CHECKOUT=1` overrides and still prints the diff. It also reports drift against `origin/main`.

**2. All four deploy paths call it** immediately before the reset: `deploy-infra.yml`, `reusable-deploy-service.yml`, `vault-init.yml`, `vault-reinitialize.yml`.

**3. `docs/runbooks/deployment.md`** — invariant 5 already said *"No local VPS file edits"* and gave **no reason**. It now states the mechanism, because a rule with its reason written down survives and an asserted one does not.

### Three tiers, not two

You asked for "dirty in a watched path" vs "dirty in docs". Reading the actual bind mounts in `deploy/compose/prod/*.yml` turned up a middle tier, so the script reports three:

| Tier | Paths | Meaning |
|---|---|---|
| **LIVE (WATCHED)** | `platform/edge/dynamic` | Traefik mounts it at `/etc/traefik/dynamic` with `watch: true` — an edit is a live production change, reloaded within seconds |
| **BIND-MOUNTED** | 10 paths — Keycloak realm + theme, Postgres init, 5 observability configs, vault policies | visible in the container now, active at next restart |
| **not mounted** | docs, scripts, tests | doomed, but inert |

## Risks

- **A deploy against a dirty checkout now fails where it used to succeed.** That is the point. The override exists for the deliberate case, and every deploy that has ever succeeded ran against a clean tree, so nothing that works today changes.
- **The preflight runs from the checkout it is about to validate**, so it must already exist there — it will be absent on the first deploy after merge. `bash scripts/preflight-checkout.sh` would fail with 127 and, because the workflows chain with `&&`, the deploy would stop rather than proceed unguarded. Failing closed is the right direction, but the first deploy after this merges needs one manual `git pull` on the box, or it will halt. **Flagging this explicitly — it is the one operational sharp edge in the change.**
- **A dirty tree is not a rare state** on a box people hand-edit; expect this to fire.

## Rollback

`git revert` the two commits. The script is additive; reverting the workflow lines restores the previous behaviour exactly.

## Validation Evidence

### Tests fail before, pass after

12 bats tests in `tests/scripts/preflight-checkout.bats`, running against throwaway git repos — **no VPS required**. Against current `main` all failed with exit 127, since the script did not exist.

```
ok 1  preflight passes on a clean tree
ok 2  preflight REFUSES when the tree is dirty
ok 3  preflight PRINTS THE FULL DIFF — the only record of the hand-edit
ok 4  a dirty WATCHED path is called out as live production config
ok 5  a dirty bind-mounted path is distinguished from an ordinary one
ok 6  a dirty docs-only path is NOT labelled live
ok 7  ALLOW_DIRTY_CHECKOUT=1 overrides the refusal but still prints the diff
ok 8  preflight reports how far the checkout is behind origin/main
ok 9  drift is reported loudly when the checkout is stale
ok 10 every deploy path calls the preflight before git reset --hard
ok 11 drift wording is correct when only AHEAD of origin/main
ok 12 drift wording is correct when only BEHIND origin/main
```

**338 pass, 0 fail** across the whole `tests/scripts/` suite. `shellcheck --severity=error scripts/*.sh` clean. All four workflow YAMLs still parse under `yaml.safe_load`.

### Tonight's incident, replayed against the guard

A throwaway clone with the same file dirtied:

```
  ################################################################
  # THE WORKING TREE IS DIRTY
  #
  # `git reset --hard` will destroy the changes below and they are
  # NOT RECOVERABLE — unstaged changes are not git objects, so there
  # is no stash, no blob and no reflog entry to restore from.
  #
  # This diff is the only record. Copy it before continuing.
  ################################################################

  Modified paths, by how live they are:

    platform/edge/dynamic/middlewares.yml    LIVE (WATCHED — Traefik reloads this within seconds)

  *** 1 of these are mounted into running containers. ***
  *** An edit there was a live production change. Resetting it is
  *** another one, in the opposite direction, with no review.

  ---------------- FULL DIFF (tracked files) ----------------
  +      # hand-edit applied during an incident, never committed
  ---------------- END DIFF ----------------

  REFUSING to continue.
EXIT=1
```

That diff is exactly what was lost tonight, and the guard prints it before anything is destroyed.

### A defect the repro found in the guard's own output

The first replay printed `DRIFT: 0 commits behind origin/main` inside an alarming block, because the drift block was gated on `behind == 0 && ahead == 0`. Behind and ahead are now reported separately and only when true, and being **ahead** gets its own warning — `git reset --hard` discards commits that exist only on that host, which is a second way to lose work on this checkout. Two tests pin the wording.

I would rather report that I broke my own output and fixed it than ship a guard whose first real firing reads as nonsense.

### Not verified

Nothing here has run on the VPS, deliberately — no deploy was triggered, nothing under `/opt/hill90/app` was touched, and Traefik was not restarted. The guard's behaviour is proven against throwaway repos and by the replay above. Its behaviour *in the workflow* will first be exercised on the next real deploy, subject to the bootstrap caveat under Risks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
