### PR TITLE
docs: record what changed in the backup story, and the live preflight caveat

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,9 @@ nothing. It is a **platform**: it hosts tenants but is not the application.
   path if ACME goes wrong.
 - [`docs/decisions/`](docs/decisions/) — why things are the way they are.
   [`app-tenancy-on-the-vps.md`](docs/decisions/app-tenancy-on-the-vps.md) defines
-  what this platform offers a tenant.
+  what this platform offers a tenant;
+  [`tenant-checkout-hazard.md`](docs/decisions/tenant-checkout-hazard.md) records
+  why the tenant needs its own checkout guard and why its risk is the smaller one.
 - [`CONTRIBUTING.md`](CONTRIBUTING.md) — conventions and the deploy rules.
 - Published pages: [docs.hill90.com](https://docs.hill90.com).
 

--- a/docs/runbooks/deployment.md
+++ b/docs/runbooks/deployment.md
@@ -115,10 +115,22 @@ visible in the container immediately and takes effect at its next restart.
 A dirty tree under `docs/` is untidy. A dirty tree under `platform/edge/dynamic`
 is an undocumented live production change about to be reverted without review.
 
+> **Live as of 2026-07-29 07:45 UTC: the VPS checkout does not yet have this
+> script.** `/opt/hill90/app` is at `b50b3a1` (#563) and two commits behind, so
+> `bash scripts/preflight-checkout.sh` will exit 127 and — because the deploy
+> chains with `&&` — **the next deploy will halt rather than run unguarded.**
+> That is the safe direction, but it needs one `git pull` on the box first. The
+> preflight lives in the checkout it validates, so this is a one-time bootstrap
+> cost, not a recurring one.
+
 `scripts/preflight-checkout.sh` runs before every reset and enforces this: on a
 dirty tree it prints the full diff — the only record that will survive — labels
 each path by how live it is, and refuses. Override with
 `ALLOW_DIRTY_CHECKOUT=1` when the discard is genuinely intended.
+
+The tenant has the same hazard on `/opt/hill90-app` and no guard yet; the
+analysis, including the finding that nothing there is live-watched, is in
+[`docs/decisions/tenant-checkout-hazard.md`](../decisions/tenant-checkout-hazard.md).
 
 It also reports **drift**: how many commits the checkout is behind `origin/main`.
 On 2026-07-29 the checkout was found 12 commits behind and locally modified, so
@@ -146,6 +158,10 @@ Backups are stored at `/opt/hill90/backups/<service>/<timestamp>/` on the VPS.
 A daily cron job runs `backup-all` at 03:00 UTC. Weekly prune at 04:00 Sunday
 removes backups older than 7 days. Logs at `/opt/hill90/backups/cron.log`.
 
+`backup-all` covers `db`, `app-db`, `vault`, `infra` and `observability`. It runs
+every service even if one fails and then exits non-zero, so one absent service
+does not cost the other four their backups — but the run still goes red.
+
 Cron is configured by Ansible (`01-system-prep.yml`) during VPS bootstrap.
 To verify on VPS: `crontab -l -u deploy | grep hill90`
 
@@ -157,6 +173,7 @@ make backup                    # or: bash scripts/backup.sh backup-all
 
 # Backup a specific service
 make backup-db                 # or: bash scripts/backup.sh backup db
+bash scripts/backup.sh backup app-db   # the hill90-app tenant's database
 make backup-vault              # or: bash scripts/backup.sh backup vault
 make backup-infra              # or: bash scripts/backup.sh backup infra
 make backup-observability      # or: bash scripts/backup.sh backup observability
@@ -172,6 +189,51 @@ bash scripts/backup.sh prune 14 # Keep 14 days instead
 # Restore from backup
 make backup-restore SERVICE=db BACKUP_PATH=/opt/hill90/backups/db/20260222_120000
 ```
+
+### What changed on 2026-07-29, and why it matters
+
+Two defects were found and fixed together (#563). Both had been true for days and
+neither produced an error.
+
+**The SQL dump had silently stopped running.** `/etc/crontab` sets
+`PATH=/sbin:/bin:/usr/sbin:/usr/bin` and `sops` installs to `/usr/local/bin`, so
+under cron the decrypt was *command not found*. Its stderr went to `/dev/null`,
+`DB_USER` came back empty, the dump was skipped with a warning, the volume tar
+still ran, and the job exited 0. Three consecutive nightly backups held a tar and
+no `database.sql`. The same command worked by hand, which is why it survived.
+
+**The tenant's database had never been backed up by anything.**
+`prod_app-postgres-data` holds hill90-app's Keycloak realm and its user accounts,
+AKM knowledge, chat history and LiteLLM data. This script knew only
+`prod_postgres-data`, and hill90-app has no backup script of its own.
+
+What is now different:
+
+- `sops` is resolved by absolute path, not by `PATH` alone.
+- A dump that cannot be taken is **fatal**, not a warning. A backup that reports
+  success with no dump manufactures false confidence, which is worse than an
+  error — the operator believes they have a restore path and does not.
+- Artifacts are checked non-empty before success is reported. Two backup
+  directories on this host were completely empty and had still counted as
+  successful runs.
+- `app-db` covers the tenant: a real `pg_dumpall` plus the volume tar.
+
+**The restore is proven, not assumed.** On 2026-07-29 the tenant dump was
+restored into a throwaway Postgres container and both user accounts came back
+with their correct realm roles. That was the first restore this estate had ever
+performed. Verified artifacts from that run:
+
+| Artifact | Bytes |
+|---|---|
+| `/opt/hill90/backups/db/20260729_065934/database.sql` | 322,299 |
+| `/opt/hill90/backups/app-db/20260729_065944/app-database.sql` | 532,513 |
+| `/opt/hill90/backups/app-db/20260729_065944/app-postgres-data.tar.gz` | 17,347,196 |
+
+A tar of a live `PGDATA` is crash-consistent at best; the `pg_dumpall` is the
+artifact that restores cleanly. Both are taken and the dump is required.
+
+Not covered by any backup: object storage, agent state, and
+`/opt/hill90/agentbox-configs`, which is a host path outside every checkout.
 
 ### What Gets Backed Up
 


### PR DESCRIPTION
Hill90's own docs had less attention than the app's tonight, and the backup story changed materially underneath them.

**Re-verified at 2026-07-29 07:45 UTC before writing:** 23 running, 0 unhealthy, baseline exactly 13, `hill90.com` 200, `app-auth.hill90.com` 302, `auth.hill90.com/realms/platform` 200, both backup directories present with non-empty artifacts.

## Plan

**1. The backup story** — `docs/runbooks/deployment.md` listed the commands but conveyed none of the history. It now records that the SQL dump had silently stopped running (cron's `PATH` lacks `/usr/local/bin`, so `sops` was *command not found*, stderr discarded, dump skipped, job exit 0), that `prod_app-postgres-data` had never been backed up by anything, what is now different, and that **the restore is proven** — the tenant dump was restored into a throwaway container on 2026-07-29 and both accounts came back with their correct realm roles. Artifact sizes are listed so a reader can tell a real backup from an empty directory.

`app-db` added to the manual command list. The scheduled-backup section now states that `backup-all` runs every service even if one fails and then exits non-zero.

It also states what **no** backup covers: object storage, agent state, and `/opt/hill90/agentbox-configs`.

**2. The deploy path** — #564 added the preflight, and one thing about it is live right now.

**3. Discoverability** — `docs/decisions/tenant-checkout-hazard.md` was reachable only by knowing it existed. There is no decisions index in this repo; discovery is by cross-link, so it is now linked from `CLAUDE.md`'s decisions pointer and from the hand-edits section of the deployment runbook.

## The operationally live item

**The VPS checkout does not yet have #564's preflight script**, so the next deploy will halt:

```
$ cd /opt/hill90/app
preflight present: NO
behind origin/main: 2
working tree: 0 modified
HEAD: b50b3a1  (#563)
```

`bash scripts/preflight-checkout.sh` will exit 127, and because the deploy chains with `&&` the run stops rather than proceeding unguarded. That is the safe direction and it is a one-time bootstrap cost — the preflight lives in the checkout it validates — but it will surprise whoever deploys next, so it is a blockquote in the runbook rather than a footnote.

I did **not** pull the box to pre-empt it. That would be a production change outside the scope of a docs PR, and the last time I ran `git reset --hard` there I destroyed something.

## Risks

**Low.** Two documentation files, no code, no workflow, no script.

- The blockquote goes stale the moment someone pulls the box. It is explicitly timestamped and scoped as one-time, so its expiry is visible.
- Everything else is history, which does not decay.

## Rollback

`git revert d17452cd`. Two files.

## Validation Evidence

### Host state at the moment of writing

```
2026-07-29 07:45 UTC
running: 23   unhealthy: 0   app: 10   baseline: 13
hill90.com 200 · app-auth.hill90.com 302 · auth.hill90.com/realms/platform 200

  532513  app-database.sql
17347196  app-postgres-data.tar.gz
  322299  database.sql
10282251  postgres-data.tar.gz
```

### Link check — the repo's own tool, covering the two new cross-links

```
$ python3 scripts/checks/check_md_links.py
Markdown link check passed: no missing local links found.
```

### The `AGENTS.md` symlink survives a `CLAUDE.md` edit

Checked because editing the target is a plausible way to break it:

```
120000 681311eb… 0  AGENTS.md
via link: # Hill90 — agent orientation | bytes match target: yes
```

### Constraints, checked not asserted

```
"one Keycloak does not mean one realm"      CLAUDE.md: 1 — intact
"No decision has been recorded" (Postgres)  CLAUDE.md: 1 — intact
credential added                            none
```

No claim is made about the realm choice or repository visibility; both remain Jon's alone and neither has been made.

### Scope

```
$ git diff --name-only
CLAUDE.md
docs/runbooks/deployment.md
```

Nothing in `hill90-app` was touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
