### PR TITLE
fix(deploy): say what to do when the preflight is not on the box yet

### DIFF
--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -71,10 +71,17 @@ jobs:
       - name: Deploy infrastructure
         run: |
           echo "Deploying infrastructure services..."
+          # Existence check before the call: the preflight ships in this repository
+          # and is absent from the box until one deploy includes it, so calling it
+          # directly dies at exit 127 with no explanation. Message is byte-identical
+          # across all four deploy workflows and pinned by
+          # tests/scripts/preflight-checkout.bats — see the fuller note in
+          # reusable-deploy-service.yml for why this is not shared code.
           ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
             deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
             "cd /opt/hill90/app && \
              git fetch origin && \
+             { [ -f scripts/preflight-checkout.sh ] || { echo '::error::scripts/preflight-checkout.sh is missing from /opt/hill90/app on the VPS. It ships in this repository, so it exists on the box only AFTER one deploy that includes it. Fix: ssh to the VPS as deploy, run cd /opt/hill90/app && git pull, then re-run this workflow. Do not remove the guard to get past this.'; exit 1; }; } && \
              bash scripts/preflight-checkout.sh && \
              git reset --hard origin/main && \
              export SOPS_AGE_KEY_FILE=/opt/hill90/secrets/keys/keys.txt && \

--- a/.github/workflows/reusable-deploy-service.yml
+++ b/.github/workflows/reusable-deploy-service.yml
@@ -69,11 +69,39 @@ jobs:
           # deploy.sh automatically runs pre-deploy backup for stateful services
           # (vault, observability) before the down/up cycle.
           echo "Deploying ${{ inputs.service }}..."
+          # The preflight ships in THIS repository, so it does not exist on
+          # /opt/hill90/app until one deploy has included it. Without this check
+          # bash fails with exit 127 and no explanation — verified on 2026-07-29,
+          # when the script was absent from the box and the checkout was four
+          # commits behind main, so every deploy would have died that way.
+          #
+          # Halting is correct; halting silently is not. hill90-app hit this first
+          # and its fix is ported here.
+          #
+          # WHY THIS IS DUPLICATED IN FOUR WORKFLOWS RATHER THAN SHARED:
+          #   * The check has to be INLINE in the remote command. Its whole job is
+          #     to report that the repository's own scripts/ is not on the box, so
+          #     it cannot live in scripts/ — that is the condition it detects.
+          #   * A composite action cannot help: this runs in the REMOTE shell over
+          #     ssh, not on the runner.
+          #   * deploy-infra, vault-init and vault-reinitialize do not call this
+          #     reusable workflow (verified: zero `uses:` references), so there is
+          #     no shared path to hang it on.
+          #   * Two sites wrap the remote command in double quotes and two in
+          #     single quotes, so even a shared snippet needs per-site quoting.
+          #     The MESSAGE is byte-identical anyway — it deliberately contains no
+          #     quote characters of either kind, which is what lets one string
+          #     survive both.
+          #
+          # Drift is prevented by a test, not an abstraction:
+          # tests/scripts/preflight-checkout.bats holds the canonical message and
+          # fails if any of the four differs.
           ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
             deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
             "cd /opt/hill90/app && \
              git fetch origin && \
              git diff --stat HEAD origin/main && \
+             { [ -f scripts/preflight-checkout.sh ] || { echo '::error::scripts/preflight-checkout.sh is missing from /opt/hill90/app on the VPS. It ships in this repository, so it exists on the box only AFTER one deploy that includes it. Fix: ssh to the VPS as deploy, run cd /opt/hill90/app && git pull, then re-run this workflow. Do not remove the guard to get past this.'; exit 1; }; } && \
              bash scripts/preflight-checkout.sh && \
              git reset --hard origin/main && \
              export SOPS_AGE_KEY_FILE=/opt/hill90/secrets/keys/keys.txt && \

--- a/.github/workflows/vault-init.yml
+++ b/.github/workflows/vault-init.yml
@@ -112,9 +112,15 @@ jobs:
 
       - name: Sync host checkout to main
         run: |
+          # Existence check before the call: the preflight ships in this repository
+          # and is absent from the box until one deploy includes it, so calling it
+          # directly dies at exit 127 with no explanation. Message is byte-identical
+          # across all four deploy workflows and pinned by
+          # tests/scripts/preflight-checkout.bats — see the fuller note in
+          # reusable-deploy-service.yml for why this is not shared code.
           ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
             deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
-            'cd /opt/hill90/app && git fetch origin && bash scripts/preflight-checkout.sh && git reset --hard origin/main'
+            'cd /opt/hill90/app && git fetch origin && { [ -f scripts/preflight-checkout.sh ] || { echo "::error::scripts/preflight-checkout.sh is missing from /opt/hill90/app on the VPS. It ships in this repository, so it exists on the box only AFTER one deploy that includes it. Fix: ssh to the VPS as deploy, run cd /opt/hill90/app && git pull, then re-run this workflow. Do not remove the guard to get past this."; exit 1; }; } && bash scripts/preflight-checkout.sh && git reset --hard origin/main'
 
       # Writes the unseal key and root token to 0600 files owned by deploy.
       # Prints neither.

--- a/.github/workflows/vault-reinitialize.yml
+++ b/.github/workflows/vault-reinitialize.yml
@@ -170,9 +170,15 @@ jobs:
 
       - name: Sync host checkout to main
         run: |
+          # Existence check before the call: the preflight ships in this repository
+          # and is absent from the box until one deploy includes it, so calling it
+          # directly dies at exit 127 with no explanation. Message is byte-identical
+          # across all four deploy workflows and pinned by
+          # tests/scripts/preflight-checkout.bats — see the fuller note in
+          # reusable-deploy-service.yml for why this is not shared code.
           ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
             deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
-            'cd /opt/hill90/app && git fetch origin && bash scripts/preflight-checkout.sh && git reset --hard origin/main'
+            'cd /opt/hill90/app && git fetch origin && { [ -f scripts/preflight-checkout.sh ] || { echo "::error::scripts/preflight-checkout.sh is missing from /opt/hill90/app on the VPS. It ships in this repository, so it exists on the box only AFTER one deploy that includes it. Fix: ssh to the VPS as deploy, run cd /opt/hill90/app && git pull, then re-run this workflow. Do not remove the guard to get past this."; exit 1; }; } && bash scripts/preflight-checkout.sh && git reset --hard origin/main'
 
       # ---- The destructive part ---------------------------------------------
 

--- a/tests/scripts/preflight-checkout.bats
+++ b/tests/scripts/preflight-checkout.bats
@@ -120,3 +120,90 @@ setup() {
   [[ "$output" == *"1 commits behind"* ]]
   [[ "$output" != *"AHEAD"* ]]
 }
+
+# ---------------------------------------------------------------------------
+# The guard must fail LEGIBLY when it is not on the box yet.
+#
+# The preflight ships in this repository, so it exists on /opt/hill90/app only
+# AFTER one deploy that includes it. Until then every deploy path that calls it
+# dies at `bash: scripts/preflight-checkout.sh: No such file or directory`,
+# exit 127, with nothing saying what to do. Verified on 2026-07-29: the script is
+# absent from the box and the checkout is at #563, four commits behind main, so
+# this is the live state and not a hypothetical.
+#
+# Halting is correct — it is the fail-closed direction. Halting without an
+# explanation is not. hill90-app solved this first; these tests port it back.
+#
+# The message must be BYTE-IDENTICAL in all four workflows so it is greppable.
+# The four sites cannot share an abstraction (see the comment in the
+# implementation), so a test is what keeps them in step.
+# ---------------------------------------------------------------------------
+
+DEPLOY_WORKFLOWS=(
+  ".github/workflows/reusable-deploy-service.yml"
+  ".github/workflows/deploy-infra.yml"
+  ".github/workflows/vault-init.yml"
+  ".github/workflows/vault-reinitialize.yml"
+)
+
+# The canonical text lives here, once. The implementation must match it exactly.
+# It deliberately contains NO quote characters of either kind: two of the four
+# call sites wrap the remote command in double quotes and two in single quotes,
+# so any quote in the message would have to differ per site and stop being
+# greppable.
+EXPECTED_MESSAGE='::error::scripts/preflight-checkout.sh is missing from /opt/hill90/app on the VPS. It ships in this repository, so it exists on the box only AFTER one deploy that includes it. Fix: ssh to the VPS as deploy, run cd /opt/hill90/app && git pull, then re-run this workflow. Do not remove the guard to get past this.'
+
+@test "every deploy path checks the preflight exists before running it" {
+  cd "$BATS_TEST_DIRNAME/../.."
+  for wf in "${DEPLOY_WORKFLOWS[@]}"; do
+    grep -q -- "-f scripts/preflight-checkout.sh" "$wf" \
+      || { echo "no existence check in $wf — a missing script will exit 127 with no explanation"; return 1; }
+  done
+}
+
+@test "the missing-preflight message is byte-identical in all four workflows" {
+  cd "$BATS_TEST_DIRNAME/../.."
+  for wf in "${DEPLOY_WORKFLOWS[@]}"; do
+    grep -qF -- "$EXPECTED_MESSAGE" "$wf" \
+      || { echo "message missing or altered in $wf"; return 1; }
+  done
+}
+
+@test "the message contains no quote characters — it must survive both quotings" {
+  # Two sites embed the remote command in "..." and two in '...'. A quote in the
+  # message would need escaping that differs per site, which is how four copies
+  # stop being greppable.
+  [[ "$EXPECTED_MESSAGE" != *"'"* ]]
+  [[ "$EXPECTED_MESSAGE" != *'"'* ]]
+}
+
+@test "the message names the exact command that fixes it" {
+  # The reader is someone whose deploy just failed. A diagnosis without a command
+  # is a fifteen-minute detour.
+  [[ "$EXPECTED_MESSAGE" == *"git pull"* ]]
+  [[ "$EXPECTED_MESSAGE" == *"/opt/hill90/app"* ]]
+}
+
+@test "the existence check runs BEFORE the script is invoked, in each workflow" {
+  cd "$BATS_TEST_DIRNAME/../.."
+  for wf in "${DEPLOY_WORKFLOWS[@]}"; do
+    check_line=$(grep -n -- "-f scripts/preflight-checkout.sh" "$wf" | head -1 | cut -d: -f1)
+    run_line=$(grep -n -- "bash scripts/preflight-checkout.sh" "$wf" | head -1 | cut -d: -f1)
+    [ -n "$check_line" ] || { echo "no existence check in $wf"; return 1; }
+    [ -n "$run_line" ]   || { echo "no invocation in $wf"; return 1; }
+    # Same line is fine (a one-liner chains both); after is not.
+    [ "$check_line" -le "$run_line" ] \
+      || { echo "$wf checks for the script AFTER trying to run it"; return 1; }
+  done
+}
+
+@test "the guard is still fail-closed — it exits rather than skipping the preflight" {
+  cd "$BATS_TEST_DIRNAME/../.."
+  for wf in "${DEPLOY_WORKFLOWS[@]}"; do
+    # The whole point is halting. A check that warns and continues would deploy
+    # with no preflight at all, which is worse than the 127 it replaces.
+    line=$(grep -- "-f scripts/preflight-checkout.sh" "$wf" | head -1)
+    [[ "$line" == *"exit 1"* ]] \
+      || { echo "$wf checks for the script but does not exit when it is absent"; return 1; }
+  done
+}


### PR DESCRIPTION
All four deploy workflows call `scripts/preflight-checkout.sh` directly. The script ships in this repository, so it does not exist on `/opt/hill90/app` until one deploy has included it — which means **right now every deploy path dies at**

```
bash: scripts/preflight-checkout.sh: No such file or directory   (exit 127)
```

with nothing saying what to do. **Verified on the host rather than inferred:** the file is absent from `/opt/hill90/app` and the checkout is at `b50b3a1` (#563), four commits behind main. This is the live state, not a hypothetical.

## Plan

Halting is the right direction — it is fail-closed, and #566 recorded the caveat deliberately. Halting *without an explanation* is not. `hill90-app` hit this first; its fix is ported back. Each site now tests for the file and emits an actionable `::error::` naming the exact command, before invoking it.

**The message is byte-identical in all four**, and contains **no quote character of either kind**. That is not incidental: two sites wrap the remote command in double quotes and two in single quotes, so any quote would need different escaping per site and would stop being one greppable string.

### Four copies rather than one shared guard

Chosen for reasons, not convenience:

- **The check must be inline in the remote command.** Its entire job is to report that this repository's `scripts/` directory is not on the box — so it cannot live in `scripts/`. That is the condition it detects.
- **A composite action cannot help.** This runs in the *remote* shell over ssh, not on the runner.
- **Three of the four do not route through `reusable-deploy-service.yml`.** Verified: zero `uses:` references. A guard living only there would leave `vault-init` and `vault-reinitialize` — the most destructive workflows — unguarded. That is the case your brief anticipated, and it is real.
- **Two quoting styles** mean even a shared snippet needs per-site adaptation.

**Drift is prevented by a test rather than an abstraction.** The canonical message lives once, in `tests/scripts/preflight-checkout.bats`, and a test fails if any of the four differs.

## Risks

- Four copies can still drift *in the surrounding shell* — the test pins the message and the ordering, not the whole fragment.
- The `::error::` annotation depends on the remote's stdout reaching the runner log, which it does over ssh; if a future site redirected output, the annotation would be lost while the exit code still worked.
- It does not fix the underlying bootstrap need. The first deploy still requires one manual `git pull` on the box — it just now says so.

## Rollback

Revert. The four workflows return to calling the script directly and the guard becomes a bare 127 again.

## Validation Evidence

**Test first.** Six tests written before the change, run against it: **4 failed, 2 passed.** The two that passed assert properties of the canonical message *constant* — that it has no quotes, and that it names a command — so they constrain the spec rather than the implementation, and passing early is correct for them rather than vacuous.

**Beyond grep, the behaviour was simulated in both quoting styles** by extracting the exact fragment each workflow sends to the remote shell and running it against a directory with and without the script:

```
script absent, double-quoted site    message printed, exit 1    (not 127)
script absent, single-quoted site    message printed, exit 1    (not 127)
script present, both sites           guard transparent, exit 0
```

Both printed **byte-identical** text — the proof that one unquoted string survives both embeddings.

```
bats --recursive tests/scripts/      344 passed, 0 failed    (338 on main + 6)
all four workflow YAML files         parse
mutation: message altered in one     test 14 fails, naming vault-init.yml
```

**No fifth site:** the set of workflows containing `reset --hard origin/main` and the set calling the preflight are the same four, so no reset path is unguarded.

**A correction to my own reporting during this work:** an earlier full-suite run showed 74 passing / 270 failing and I nearly reported it as pre-existing breakage. It was my error — Hill90's tests use paths relative to the repository root (`vps.bats` runs `bash scripts/vps.sh`) and I had invoked bats from another directory. From the repository root the suite is green both before and after.

**Not deployed.** The first deploy after this merges still needs the one manual `git pull` the message now describes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
