### PR TITLE
docs: the import is rehearsed, and do not restore the pg_dump into the platform

### DIFF
--- a/docs/decisions/2026-07-29-morning-brief.md
+++ b/docs/decisions/2026-07-29-morning-brief.md
@@ -4,18 +4,17 @@
 nothing is degraded. The application is deployed and healthy, and for the first
 time it has a backup that has actually been restored.
 
-**One thing is blocked**, and it is a two-command fix — see §3.
+**On the Keycloak migration, everything up to your decision is done and
+rehearsed.** The backup restores. The export was taken against a live
+`app-keycloak` — no downtime — and verified. The import was rehearsed into a
+throwaway and works: all three client secrets present, password hashes intact,
+the role mapper survives. **The only thing left before step 2 is your realm
+decision (§1.1).**
 
-**On the Keycloak migration you are no longer at step 0.** The backup exists and
-has been restored; the realm export exists and has been verified; the export was
-performed against a live `app-keycloak`, so the no-downtime finding is proven by
-execution rather than argument. The only thing between you and the next step is
-your realm decision (§1.1).
-
-Read the first section and stop if that is all you have time for — **except for
-two commands**: both VPS checkouts need pulling before anything deploys. That is
+Read §1 and stop if that is all you have time for — **except for two commands**:
+both VPS checkouts need pulling before anything will deploy, which is
 [§3](#3-do-this-first--two-checkouts-need-pulling-before-anything-deploys).
-Everything else below is either already safe or already recorded.
+Everything else is either already safe or already recorded.
 
 ```
 23 containers running · 0 unhealthy · Hill90 baseline exactly 13 · app 10
@@ -66,17 +65,40 @@ realm hill90 · 2 users, both carrying credentials · 3 clients carrying secrets
 5 realm roles · 2 realm_roles protocol mappers
 ```
 
-Credentials present is what makes it a **restore** rather than a re-creation;
-client secrets present are why it beats the `pg_dump`, which cannot carry them.
+Credentials present is what makes it a **restore** rather than a re-creation.
+
+It beats the `pg_dump` not because the dump lacks the secrets — the dump does
+contain them, in the `client` table — but because it is **the only artifact
+Keycloak can import**. `--import-realm` consumes a realm JSON; a database dump
+can only be restored by replacing a database, which is the destructive path
+described below.
 
 **That file contains credential material. Do not copy it into a repository**, and
 do not move it off the box without deciding where it may live. It is
 `0600 deploy:deploy` in a `0700` directory and should stay that way.
 
-**The import is untested.** Rehearsing it — importing into a throwaway, exporting
-again, and confirming the hashes and all three client secrets come back
-identical — is checklist item 4 in the app's migration runbook and is still open.
-Verified export, unverified import.
+**The import is rehearsed and works** (2026-07-29). Imported into a throwaway
+stack: all three client secrets present, password hashes intact, and the
+`realm_roles` mapper survives on `hill90-ui` pointing at `realm_roles` with no
+competing mapper.
+
+> **Do not use the `pg_dump` as the import vehicle.** It is the obvious
+> shortcut — the backup exists, it contains the realm, it looks sufficient — and
+> it is destructive. That dump is a whole-cluster restore of a *different*
+> Keycloak's database. Its `keycloak` database contains realms `master` and
+> `hill90` and **no `platform` realm**, while the platform's `keycloak` database
+> holds `master` and `platform`, and `platform` is where the `grafana`,
+> `portainer` and `hill90-vault` SSO clients live.
+>
+> It also does not fail cleanly. The dump carries `CREATE DATABASE keycloak` and
+> **no `DROP DATABASE`**, so against an existing database the create fails,
+> `psql` continues past the error by default, and the app's realm rows are then
+> copied *into the live platform database*. The likely outcome is a partially
+> merged identity store rather than a clean overwrite — worse, because it may not
+> fail loudly.
+>
+> The `kc.sh export` artifact is the only valid vehicle. It can be produced from
+> the backup if the live realm is ever unavailable.
 
 **The migration needs no downtime.** `kc.sh export` does not need *this*
 Keycloak stopped — it needs *an* exporter with database access, so a throwaway
@@ -85,8 +107,8 @@ below), not argued.
 
 That removes the main reason to postpone this to a quiet evening — the export
 itself costs nothing. **The `pg_dump` is not a substitute:** only a `kc.sh export`
-artifact carries `clients[].secret`, so a database dump alone cannot reconstitute
-the client secrets.
+artifact is importable: Keycloak's `--import-realm` takes a realm JSON, and a
+database dump can only be applied by replacing a database.
 
 ### 1.2 Does `hill90-app` go public?
 


### PR DESCRIPTION
Two updates, **one correction to a claim I had written**, and the cold-read pass.

## 1. The import is rehearsed and works

Header now leads with it: backup restores, export verified, **import proven** — all three client secrets present, password hashes intact, the `realm_roles` mapper surviving on `hill90-ui` with no competing mapper. *"The only thing left before step 2 is your realm decision."*

## 2. Do not restore the `pg_dump` into the platform Keycloak

In the brief rather than only the runbook, because it is a shortcut a reasonable person reaches for. **Mechanism verified, not repeated:**

```
app dump's keycloak DB    realms: master, hill90        (no platform)
platform keycloak DB      realms: master, platform
platform realm clients    grafana, hill90-vault, portainer
app dump DROP DATABASE    0 occurrences
app dump CREATE DATABASE  keycloak (line 5964)
```

**The failure mode is worse than a clean overwrite.** With no `DROP DATABASE`, the create fails against an existing database, `psql` continues past the error by default, and the app's realm rows are copied *into the live platform database* — a partially merged identity store that may not fail loudly.

## 3. A correction to my own text

The brief said in two places that the export beats the `pg_dump` because the dump **cannot carry client secrets**. **That is false.** The dump does carry them:

```
COPY public.client — 18 rows, 3 containing 20+ char token-like values
```

Three, matching the three clients in the export. The real reason is that the export is **the only artifact Keycloak can import**: `--import-realm` consumes a realm JSON, and a database dump can only be applied by replacing a database. Both occurrences corrected.

I flag this because the claim originated in the framing I was given and I had propagated it twice. The conclusion — use the export, not the dump — is unchanged and now rests on a true reason.

## 4. Cold-read pass

Judged every line against "could he act on this without asking a question".

| Check | Result |
|---|---|
| First thing he reads is what he most needs | yes — nothing broken, then migration status, then the two commands |
| Instructions depending on tonight-only knowledge | none remain |
| Inference stated as fact | **one found and fixed** — the `pg_dump` secrets claim above |
| Earned results described tentatively | none — yank-out *passed*, backup *restores*, import *works*, all stated flatly |
| Decisions decidable without a runbook | yes — each carries its tradeoff inline |

**Cut:** a duplication announcing the blocked deploy twice within ten lines, which reads as two separate problems.

All nine hedges re-verified present. Link check passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)