### PR TITLE
docs: decision 1.4 is not a yes/no — there are two staged branches

### DIFF
--- a/docs/decisions/2026-07-29-morning-brief.md
+++ b/docs/decisions/2026-07-29-morning-brief.md
@@ -166,14 +166,29 @@ Nothing is blocked by leaving this open.
 
 ### 1.4 Publish the documentation site refresh?
 
-A refresh of [docs.hill90.com](https://docs.hill90.com) is **written, reviewed and
-held unpublished**, on branch `docs/post-deploy-refresh` in `hill90-docs`. It
-corrects the site to eight healthy stacks, the passed detachment test, the proven
-restore, and the Keycloak decision in both halves.
+**Not a yes/no any more — publish the right branch, and not before step 1.**
 
-It is held because the site is the most public surface in the estate and because
-its *merged-but-not-deployed* list will need one touch-up after you deploy
-(§4, step 3). Publishing after that deploy costs nothing and lands accurate.
+There are **two** staged branches in `hill90-docs`, and only one is safe:
+
+| Branch | State |
+|---|---|
+| `docs/post-deploy-refresh` | **Do not publish.** Written before the login failure was known. It tells readers the login form was reachable and gives a *"Sign in with your Keycloak credentials"* instruction that cannot be followed. |
+| `docs/mintlify-login-truth` | **The one to publish.** Same content, plus: every `ai-app` page carries the broken-login finding, the sign-in instruction is corrected, and three pages that named `auth.hill90.com` as the application's identity provider now name `app-auth.hill90.com` — the homelab's is a different realm. |
+
+Both correct the site to eight healthy stacks, the passed detachment test, the
+proven restore, and the Keycloak decision in both halves.
+
+**Two things to do before it goes live**, neither large:
+
+1. **Repair the login (§4, step 1) first, or publish knowing the site says login
+   is broken.** Either is defensible — the site would be accurate in both cases —
+   but publishing first and repairing second means the site is briefly wrong in
+   the reassuring direction, which is the worse way round.
+2. **Touch up the merged-but-not-deployed list after you deploy** (§4, step 3),
+   which is a one-line edit.
+
+The site is the most public surface in the estate, which is why this is the one
+place where publishing something stale costs more than waiting.
 
 ---
 


### PR DESCRIPTION
The brief named `docs/post-deploy-refresh` as the thing to publish. **That branch would push a falsehood onto the most public surface in the estate** — the exact one the last hour was spent removing everywhere else.

## What I found

| Branch | State |
|---|---|
| `docs/post-deploy-refresh` | **Do not publish.** Written before the login failure was known. Says the login form was reachable; `quickstart.mdx:29` instructs *"Sign in with your Keycloak credentials to access the dashboard."* |
| `docs/mintlify-login-truth` | **Safe.** Every `ai-app` page carries the finding, the sign-in instruction is corrected, and three pages naming `auth.hill90.com` as the app's IdP now say `app-auth.hill90.com`. |

My earlier fix covered `ai-app/overview.mdx` only — **not enough**, because someone trying to sign in opens the quickstart or the authentication page, and both still read as a working flow.

## Also corrected, and wrong independently of the outage

Three pages named `auth.hill90.com` as the application's identity provider. That is the **homelab's** Keycloak serving a different realm; the app's is `app-auth.hill90.com`. Precisely the confusion this estate has spent the week untangling.

## 1.4 is no longer a yes/no

It now says: repair the login first, **or** publish knowing the site says login is broken — both defensible, but publishing first and repairing second leaves the site briefly wrong *in the reassuring direction*, which is the worse way round. Plus the one-line touch-up after deploying.

Verified: every `ai-app` page carries the finding; zero followable sign-in instructions remain; anchors resolve across 19 pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
