### PR TITLE
feat(db): let the platform's Postgres host a tenant's databases

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,16 @@ complication is real and is not the Keycloak steps repeated: this platform's
 health check asserts *platform-only databases*, so that boundary has to be
 revisited deliberately rather than worked around.
 
+> **That boundary was revisited on 2026-07-30, and this platform can now host a
+> tenant.** `scripts/provision-tenant-db.sh` creates a least-privilege tenant role
+> with tenant-owned databases, and the local check asserts **tenant isolation**
+> instead — an application database owned by the platform role still fails, by
+> name. See
+> [tenant-databases-on-platform-postgres.md](docs/decisions/tenant-databases-on-platform-postgres.md).
+> The capability exists; **it is not in use.** Nothing points at this Postgres and
+> `app-postgres` is untouched, so the move itself is still ahead. Note also that
+> the check was only ever a *local dev* check, never production enforcement.
+
 **This is greenfield, not a migration.** hill90-app reached the VPS for the first
 time on 2026-07-29 and its realm holds two accounts created hours earlier that
 have never been used. There is no accumulated state. Export, import, rollback and

--- a/docs/decisions/2026-07-29-morning-brief.md
+++ b/docs/decisions/2026-07-29-morning-brief.md
@@ -104,6 +104,22 @@ Hill90's Postgres asserts *platform-only databases* — a check written to fail 
 application databases appear there. Consolidating data means that boundary has to
 be revisited deliberately, not worked around.
 
+> **Amended 2026-07-30 — the complication is now handled, and the move is not.**
+> Hill90 gained `scripts/provision-tenant-db.sh`: a least-privilege tenant role,
+> tenant-owned databases, and `PUBLIC` revoked so a tenant cannot open `keycloak`.
+> The check now asserts **tenant isolation** and still fails on an application
+> database owned by the platform role. Two corrections to the paragraph above:
+> that check is a **local dev check**, not production enforcement, and nothing in
+> the deploy path consults it. See
+> [tenant-databases-on-platform-postgres.md](tenant-databases-on-platform-postgres.md).
+>
+> What is left is the move itself: point the app at the platform, migrate nothing
+> (this is greenfield), and only then retire `app-postgres`. One thing found while
+> proving it will bite during that work — a least-privilege tenant cannot install
+> `uuid-ossp` or `vector`, which the app's migrations create, so the platform
+> installs them. It works today only because the app's `DB_USER` is a superuser in
+> its own Postgres.
+
 ### 1.3 MinIO — OPEN, and the state is reversed
 
 This one genuinely is undecided, and it is the mirror image of the other two:

--- a/docs/decisions/platform-primitives.md
+++ b/docs/decisions/platform-primitives.md
@@ -78,6 +78,18 @@ Platform realms ship with Hill90; application realms ship with the application.
 `keycloak` plus `hill90_api`, `hill90_akm` and `hill90_litellm`. Only the first
 is a platform concern. Application databases belong with the application.
 
+> **Amended 2026-07-30.** That rule is about the *bootstrap*, and it stands:
+> `init.sh` stays platform-only, and a database in it still means a platform
+> service owns it. It is not a rule against hosting a tenant. Azure Database for
+> PostgreSQL hosts other people's databases — that is the capability being
+> mirrored — so the platform now provisions tenant databases through a
+> control-plane operation instead, owned by a least-privilege tenant role and
+> closed to the platform's own data. See
+> [tenant-databases-on-platform-postgres.md](tenant-databases-on-platform-postgres.md).
+> "Application databases belong with the application" was the right conclusion
+> from the wrong reading of it: the app's databases belong to the *app*, not in the
+> *platform's bootstrap*, and those are different claims.
+
 **Platform-to-platform SSO is legitimate; platform-to-infrastructure is not.**
 OpenBao authenticating humans against Keycloak is exactly what the pairing is
 for, and is restored. Wiring **Grafana, Portainer or Traefik** to Keycloak is

--- a/docs/decisions/tenant-databases-on-platform-postgres.md
+++ b/docs/decisions/tenant-databases-on-platform-postgres.md
@@ -1,0 +1,148 @@
+# Hosting a tenant's databases on the platform's Postgres
+
+**Status:** capability added 2026-07-30. **The tenant has not moved.** The AI app
+still runs its own `app-postgres`, and nothing in this change deletes, migrates or
+points anything at the platform. This adds the ability; using it is a separate
+decision and a separate change in `hill90-app`.
+
+**Relates to:** [platform-primitives.md](platform-primitives.md),
+[app-tenancy-on-the-vps.md](app-tenancy-on-the-vps.md)
+
+## The question
+
+Postgres is this platform's counterpart to Azure Database for PostgreSQL. A
+managed database service hosts other people's databases — that is the entire
+capability. This platform's Postgres could not: it had exactly one login role,
+`hill90`, a superuser and the owner of every database, and a local health check
+that treated any database it did not recognise as a fault.
+
+So there were two ways to give the app a database on the platform, and both were
+wrong:
+
+1. **Give the app the `hill90` role.** It is a superuser. The tenant would have
+   read and write access to `keycloak` — every user, credential and session in
+   the platform's identity provider — and the ability to drop it.
+2. **Have the platform create and own the app's databases.** This is what
+   [#495](https://github.com/jonhill90/Hill90/pull/495) deleted Postgres over:
+   application databases in the platform bootstrap are what made Postgres look
+   like an application dependency in the first place.
+
+## The decision
+
+**A role per tenant, least privilege, and the databases owned by that role.**
+
+- One login role per tenant: `LOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE
+  NOINHERIT NOREPLICATION NOBYPASSRLS`.
+- The tenant's databases are **owned by the tenant role**, which also owns their
+  `public` schema, so the tenant needs no grant from the platform to create its
+  own tables.
+- `PUBLIC` is revoked on every database — the tenant's and the platform's. This
+  is the step that makes the boundary real rather than nominal, and it is easy to
+  miss: Postgres grants `CONNECT` to `PUBLIC` on every new database by default,
+  so a freshly created tenant role can open `keycloak` on day one without any
+  grant at all.
+- Provisioning is a **control-plane operation**, `scripts/provision-tenant-db.sh`,
+  not a line in the bootstrap. `platform/data/postgres/init.sh` stays
+  platform-only, so #495's rule is intact: a database there still means a
+  platform service owns it. It also would not have worked — `init.sh` runs only
+  on an empty data volume, and production's is not empty.
+
+### Flagged for overrule: how much privilege the tenant gets
+
+**`NOCREATEDB` is a judgement call and it is the one to argue with.** With it, a
+tenant cannot create its own databases; every new one is a platform operation and
+someone has to run the script. Without it, the tenant self-serves, and the cost is
+that it can also create databases nobody asked for on a shared server.
+
+Least privilege was chosen because the alternative to a *narrow* tenant role was
+never a *slightly wider* one — it was the `hill90` superuser. If self-service
+matters more than the narrow grant, `CREATEDB` is a one-word change to
+`ROLE_ATTRS` in the provisioner, and the isolation test asserts the current
+behaviour, so flipping it will fail loudly and tell you exactly what you changed.
+
+### The tenant's password is not stored here
+
+The provisioner reads it from `TENANT_DB_PASSWORD` and never writes it — not to
+disk, not to this repo's secret store, not to the terminal. The platform *sets*
+the credential; the tenant keeps its own copy in its own store.
+
+This is deliberate. Two stores holding one secret is exactly how the app's
+Keycloak client secret drifted out of agreement with Keycloak and cost a night of
+diagnosis. One owner per secret.
+
+## What broke that had to be fixed alongside
+
+**A least-privilege tenant cannot install extensions.** The app's migrations run
+`CREATE EXTENSION IF NOT EXISTS "uuid-ossp"` and `CREATE EXTENSION IF NOT EXISTS
+vector` (`services/knowledge/app/db/migrations/001`, `011`, `012` in
+`hill90-app`). Neither is a trusted extension, so a non-superuser cannot create
+either, and the app's first migration would have failed against the platform. It
+works today only because the app's `DB_USER` is a superuser in the app's own
+Postgres.
+
+The provisioner installs both, so the app's `IF NOT EXISTS` finds them present
+and does nothing. This is the same shape as a managed service, where the provider
+installs from an allowlist. **It is also a constraint on the app:** any future
+extension has to be added to the provisioner, and the failure will surface as a
+migration error, not as a permissions message.
+
+## The health check was narrowed, not deleted
+
+`scripts/local.sh` asserted "platform-only databases": anything other than
+`postgres`, `keycloak` and the owner's database failed. Correct guard, wrong
+condition once tenancy is the point — it fails on the legitimate case.
+
+It now asserts **tenant isolation**, and the fault it used to catch still fails,
+by name:
+
+| Condition | Result |
+|---|---|
+| No tenant databases | pass — "platform databases only" |
+| Tenant database owned by an unprivileged role, closed to `PUBLIC` | pass, and it is listed with its owner |
+| Application database owned by the platform role | **fail** — named as the #495 drift |
+| Tenant database owned by a superuser | **fail** |
+| Tenant database granting `CONNECT` to `PUBLIC` | **fail** |
+| A tenant exists and a platform database still grants `CONNECT` to `PUBLIC` | **fail**, with the repair command |
+
+Worth being clear about what this check is, because it has been described as a
+production boundary: it is a **local development check**. It is not enforcement,
+and nothing in the deploy path consults it. `hill90-app`'s `deploy.sh` mentions
+platform-only databases in a summary string only.
+
+## Why the tests are shaped the way they are
+
+`docker exec postgres psql -U some_role` **proves nothing about a role's
+privileges**. The platform's `pg_hba.conf` is `trust` for local socket and
+`127.0.0.1` connections, so an in-container `psql` succeeds with no password, the
+wrong password, or for a role whose password was never set. Only a connection
+arriving over the container network reaches the `scram-sha-256` line.
+
+So every assertion in `scripts/checks/tenant-db-isolation-test.sh` is made from a
+second container over a docker network, and one of them deliberately uses the
+wrong password: if that connection ever succeeds, `pg_hba` has been loosened and
+every other assertion in the file is worthless.
+
+## Rollback
+
+Nothing here is destructive and nothing runs automatically. To undo the capability
+on a given Postgres:
+
+```sql
+-- per tenant database
+DROP DATABASE hill90_api;               -- only if the tenant is not using it
+-- then the role
+DROP ROLE hill90_app;
+-- and, to restore Postgres' default openness (not recommended)
+GRANT CONNECT ON DATABASE keycloak TO PUBLIC;
+```
+
+Reverting the code is a plain `git revert`; the narrowed health check goes back to
+failing on any non-platform database, which is correct behaviour for a Postgres
+with no tenants on it.
+
+## See also
+
+- [platform-primitives.md](platform-primitives.md) — why Postgres is a platform
+  service and not an application dependency
+- [app-tenancy-on-the-vps.md](app-tenancy-on-the-vps.md) — the tenancy contract
+- [../runbooks/tenant-app-deployment.md](../runbooks/tenant-app-deployment.md) — the deployment sequence

--- a/docs/runbooks/tenant-app-deployment.md
+++ b/docs/runbooks/tenant-app-deployment.md
@@ -293,9 +293,15 @@ Owned by the app-arch lane. Nothing else can start until these land.
     chose. If it is vault, this needs an AppRole and a policy, which is a Hill90
     change.
 
-11. **[CARE] Provision the app's databases** in the app's own Postgres, not
-    Hill90's. Hill90's health check asserts platform-only databases and is
-    written to fail if app databases appear there — that boundary is deliberate.
+11. **[CARE] Provision the app's databases** in the app's own Postgres. That is
+    still what this sequence does, and it is unchanged.
+
+    *Amended 2026-07-30:* the reason given here — "Hill90's health check asserts
+    platform-only databases" — is no longer the reason. That check now asserts
+    tenant isolation and accepts a properly provisioned tenant; Hill90 gained
+    `scripts/provision-tenant-db.sh` for exactly this. Putting the app's
+    databases on the platform is a real option, and a separate decision. See
+    [../decisions/tenant-databases-on-platform-postgres.md](../decisions/tenant-databases-on-platform-postgres.md).
 
 12. **[RISK] Deploy `ui` alone, and stop.** This is the certificate experiment
     and the first live routing test in one. `ui` is the right first service: it

--- a/scripts/checks/tenant-db-isolation-test.sh
+++ b/scripts/checks/tenant-db-isolation-test.sh
@@ -1,0 +1,325 @@
+#!/usr/bin/env bash
+# Integration test: does the tenant privilege boundary on platform Postgres
+# actually hold?
+#
+# This test exists because the obvious way to check a Postgres role — `docker
+# exec postgres psql -U role` — proves NOTHING about that role's password or its
+# network privileges. The platform's pg_hba.conf is:
+#
+#     local  all all              trust
+#     host   all all 127.0.0.1/32 trust
+#     host   all all all          scram-sha-256
+#
+# The first two lines mean an in-container psql authenticates by trust: it would
+# succeed with no password, with the wrong password, and for a role whose
+# password was never set. Only a connection arriving over the container network
+# hits the scram-sha-256 line. So every assertion here is made from a SECOND
+# container, over the network, and never with `docker exec` into the server.
+#
+# It builds its own throwaway Postgres from the same image and the same platform
+# bootstrap the real stack uses, so it never touches a running stack, and asserts
+# both halves of the boundary: the tenant role reaches the databases it owns, and
+# is refused on the platform's own.
+#
+# Usage: bash scripts/checks/tenant-db-isolation-test.sh [--keep]
+#        --keep   leave the throwaway containers up for inspection
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# Throwaway names, deliberately unlike anything a stack creates. Nothing here
+# may collide with hill90*-* (a running stack) or with another pane's scratch
+# containers.
+NET="h90tenanttest-net"
+PG="h90tenanttest-db"
+IMAGE="pgvector/pgvector:pg16"
+
+PLATFORM_ROLE="hill90"
+PLATFORM_PASSWORD="platform-pw-not-a-secret"
+TENANT_ROLE="hill90_app"
+TENANT_PASSWORD="tenant-pw-not-a-secret-0123456789"
+OTHER_TENANT_ROLE="hill90_other"
+OTHER_TENANT_PASSWORD="other-pw-not-a-secret-0123456789"
+
+TENANT_DBS=(hill90_api hill90_akm hill90_litellm)
+# Every database the tenant role must NOT be able to open. `template1` is in the
+# list because it is connectable by default and is nobody's idea of tenant data.
+PLATFORM_DBS=(hill90 keycloak postgres template1)
+
+KEEP=0
+[ "${1:-}" = "--keep" ] && KEEP=1
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; BOLD='\033[1m'; NC='\033[0m'
+
+pass_count=0
+fail_count=0
+
+cleanup() {
+    if [ "$KEEP" -eq 1 ]; then
+        echo -e "${YELLOW}--keep: leaving ${PG} and ${NET} up.${NC}" >&2
+        return
+    fi
+    docker rm -f "$PG" >/dev/null 2>&1 || true
+    docker network rm "$NET" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+fatal() { echo -e "${RED}FATAL: $*${NC}" >&2; exit 2; }
+
+# --------------------------------------------------------------------------
+# Assertions. Every one runs psql in a throwaway client container on the same
+# docker network, so authentication goes through pg_hba's scram-sha-256 line.
+# --------------------------------------------------------------------------
+
+# net_psql ROLE PASSWORD DB SQL -> prints combined output, returns psql's status
+net_psql() {
+    local role="$1" password="$2" db="$3" sql="$4"
+    docker run --rm --network "$NET" -e PGPASSWORD="$password" "$IMAGE" \
+        psql -h "$PG" -U "$role" -d "$db" -v ON_ERROR_STOP=1 -tAc "$sql" 2>&1
+}
+
+expect_ok() {
+    local label="$1" role="$2" password="$3" db="$4" sql="$5" out
+    if out=$(net_psql "$role" "$password" "$db" "$sql"); then
+        echo -e "  ${GREEN}✓${NC} ${label}"
+        pass_count=$((pass_count + 1))
+    else
+        echo -e "  ${RED}✗${NC} ${label} — expected success, got:"
+        echo "$out" | sed 's/^/        /'
+        fail_count=$((fail_count + 1))
+    fi
+}
+
+# expect_refused LABEL ROLE PASSWORD DB SQL EXPECTED_SUBSTRING
+# Fails if the command succeeds, and also fails if it is refused for the wrong
+# reason — "connection refused" is not "permission denied", and a test that
+# accepts either would pass against a Postgres that is merely down.
+expect_refused() {
+    local label="$1" role="$2" password="$3" db="$4" sql="$5" expect="$6" out
+    if out=$(net_psql "$role" "$password" "$db" "$sql"); then
+        echo -e "  ${RED}✗${NC} ${label} — expected refusal, but it SUCCEEDED: ${out}"
+        fail_count=$((fail_count + 1))
+    elif echo "$out" | grep -qiF "$expect"; then
+        echo -e "  ${GREEN}✓${NC} ${label}"
+        pass_count=$((pass_count + 1))
+    else
+        echo -e "  ${RED}✗${NC} ${label} — refused, but not for the expected reason"
+        echo "        expected to contain: ${expect}"
+        echo "$out" | sed 's/^/        got: /'
+        fail_count=$((fail_count + 1))
+    fi
+}
+
+expect_equals() {
+    local label="$1" role="$2" password="$3" db="$4" sql="$5" want="$6" out
+    out=$(net_psql "$role" "$password" "$db" "$sql" || true)
+    if [ "$(echo "$out" | tr -d '[:space:]')" = "$want" ]; then
+        echo -e "  ${GREEN}✓${NC} ${label}"
+        pass_count=$((pass_count + 1))
+    else
+        echo -e "  ${RED}✗${NC} ${label} — wanted '${want}', got '${out}'"
+        fail_count=$((fail_count + 1))
+    fi
+}
+
+# --------------------------------------------------------------------------
+# Fixture
+# --------------------------------------------------------------------------
+
+command -v docker >/dev/null 2>&1 || fatal "docker is not available"
+docker info >/dev/null 2>&1 || fatal "docker daemon is not reachable"
+
+INIT_SH="$PROJECT_ROOT/platform/data/postgres/init.sh"
+[ -f "$INIT_SH" ] || fatal "platform bootstrap not found: $INIT_SH"
+
+PROVISIONER="$PROJECT_ROOT/scripts/provision-tenant-db.sh"
+
+echo -e "${BOLD}Tenant database isolation on platform Postgres${NC}"
+echo ""
+
+cleanup
+docker network create "$NET" >/dev/null
+docker run -d --name "$PG" --network "$NET" \
+    -e POSTGRES_USER="$PLATFORM_ROLE" \
+    -e POSTGRES_PASSWORD="$PLATFORM_PASSWORD" \
+    -e POSTGRES_DB="$PLATFORM_ROLE" \
+    -v "$INIT_SH:/docker-entrypoint-initdb.d/init.sh:ro" \
+    "$IMAGE" >/dev/null
+
+echo "  waiting for the throwaway Postgres to accept connections..."
+# -h 127.0.0.1, not the Unix socket. The image's entrypoint runs the bootstrap
+# against a temporary server with listen_addresses='' and then shuts it down, so
+# a socket-based pg_isready goes green *during* init and then the server
+# disappears underneath the test. Only TCP proves the real server is up.
+pg_ready() { docker exec "$PG" pg_isready -h 127.0.0.1 -U "$PLATFORM_ROLE" >/dev/null 2>&1; }
+for _ in $(seq 1 90); do
+    pg_ready && break
+    sleep 1
+done
+pg_ready || fatal "throwaway Postgres never became ready: $(docker logs "$PG" 2>&1 | tail -20)"
+
+# Sanity-check the fixture itself: the platform bootstrap must NOT have created
+# the tenant databases. If it did, this test would be proving the wrong thing.
+for db in "${TENANT_DBS[@]}"; do
+    if docker exec "$PG" psql -U "$PLATFORM_ROLE" -tAc \
+        "SELECT 1 FROM pg_database WHERE datname='$db'" | grep -q 1; then
+        fatal "fixture is wrong: the platform bootstrap created ${db}. Platform bootstrap must stay platform-only (#495)."
+    fi
+done
+echo -e "  ${GREEN}✓${NC} fixture: platform bootstrap created no tenant databases"
+echo ""
+
+# --------------------------------------------------------------------------
+# The thing under test
+# --------------------------------------------------------------------------
+
+echo -e "${BOLD}Provisioning${NC}"
+[ -x "$PROVISIONER" ] || [ -f "$PROVISIONER" ] \
+    || fatal "provisioner not found: $PROVISIONER"
+
+TENANT_DB_PASSWORD="$TENANT_PASSWORD" bash "$PROVISIONER" \
+    --container "$PG" --role "$TENANT_ROLE" "${TENANT_DBS[@]}" \
+    || fatal "provisioner failed"
+
+# A second tenant, so cross-tenant isolation is tested and not assumed.
+TENANT_DB_PASSWORD="$OTHER_TENANT_PASSWORD" bash "$PROVISIONER" \
+    --container "$PG" --role "$OTHER_TENANT_ROLE" other_probe \
+    || fatal "provisioner failed for the second tenant"
+echo ""
+
+# --------------------------------------------------------------------------
+# Half one: the tenant reaches what it owns
+# --------------------------------------------------------------------------
+
+echo -e "${BOLD}The tenant role reaches its own databases (over the network)${NC}"
+for db in "${TENANT_DBS[@]}"; do
+    expect_ok "connect and query ${db}" \
+        "$TENANT_ROLE" "$TENANT_PASSWORD" "$db" "SELECT 1"
+done
+for db in "${TENANT_DBS[@]}"; do
+    expect_ok "create and drop a table in ${db}" \
+        "$TENANT_ROLE" "$TENANT_PASSWORD" "$db" \
+        "CREATE TABLE isolation_probe (id int); DROP TABLE isolation_probe"
+done
+# The app's own migrations run CREATE EXTENSION (uuid-ossp, vector). A
+# least-privilege tenant cannot install an extension, so the platform must have
+# installed them already or the app breaks on first migration.
+for db in "${TENANT_DBS[@]}"; do
+    expect_equals "uuid-ossp and vector are present in ${db}" \
+        "$TENANT_ROLE" "$TENANT_PASSWORD" "$db" \
+        "SELECT count(*) FROM pg_extension WHERE extname IN ('uuid-ossp','vector')" \
+        "2"
+done
+echo ""
+
+# --------------------------------------------------------------------------
+# Half two: the tenant is refused where it must be
+# --------------------------------------------------------------------------
+
+echo -e "${BOLD}The tenant role is refused on platform databases${NC}"
+for db in "${PLATFORM_DBS[@]}"; do
+    expect_refused "cannot connect to ${db}" \
+        "$TENANT_ROLE" "$TENANT_PASSWORD" "$db" "SELECT 1" \
+        "permission denied for database"
+done
+echo ""
+
+echo -e "${BOLD}The tenant role has no platform-level power${NC}"
+expect_refused "cannot create a database" \
+    "$TENANT_ROLE" "$TENANT_PASSWORD" "${TENANT_DBS[0]}" \
+    "CREATE DATABASE should_not_exist" "permission denied to create database"
+expect_refused "cannot create a role" \
+    "$TENANT_ROLE" "$TENANT_PASSWORD" "${TENANT_DBS[0]}" \
+    "CREATE ROLE should_not_exist LOGIN" "permission denied to create role"
+expect_refused "cannot read pg_authid (other roles' password hashes)" \
+    "$TENANT_ROLE" "$TENANT_PASSWORD" "${TENANT_DBS[0]}" \
+    "SELECT rolname FROM pg_authid" "permission denied for table pg_authid"
+expect_equals "is not a superuser" \
+    "$TENANT_ROLE" "$TENANT_PASSWORD" "${TENANT_DBS[0]}" \
+    "SELECT usesuper FROM pg_user WHERE usename = current_user" "f"
+echo ""
+
+echo -e "${BOLD}Authentication is real, not trust${NC}"
+# If this passes with the wrong password, pg_hba has been loosened and every
+# other assertion in this file is worthless.
+expect_refused "the wrong password is rejected over the network" \
+    "$TENANT_ROLE" "wrong-password" "${TENANT_DBS[0]}" "SELECT 1" \
+    "password authentication failed"
+echo ""
+
+echo -e "${BOLD}Tenants are isolated from each other${NC}"
+for db in "${TENANT_DBS[@]}"; do
+    expect_refused "a second tenant cannot connect to ${db}" \
+        "$OTHER_TENANT_ROLE" "$OTHER_TENANT_PASSWORD" "$db" "SELECT 1" \
+        "permission denied for database"
+done
+expect_refused "the first tenant cannot connect to the second tenant's database" \
+    "$TENANT_ROLE" "$TENANT_PASSWORD" "other_probe" "SELECT 1" \
+    "permission denied for database"
+echo ""
+
+# --------------------------------------------------------------------------
+# The boundary must not have broken the platform
+# --------------------------------------------------------------------------
+
+echo -e "${BOLD}The platform still works${NC}"
+for db in hill90 keycloak postgres; do
+    expect_ok "the platform role still reaches ${db} over the network" \
+        "$PLATFORM_ROLE" "$PLATFORM_PASSWORD" "$db" "SELECT 1"
+done
+expect_ok "keycloak's uuid-ossp extension is intact" \
+    "$PLATFORM_ROLE" "$PLATFORM_PASSWORD" keycloak \
+    "SELECT 1 FROM pg_extension WHERE extname = 'uuid-ossp'"
+echo ""
+
+# --------------------------------------------------------------------------
+# Idempotence — this will be run again on a Postgres that already has tenants
+# --------------------------------------------------------------------------
+
+echo -e "${BOLD}Re-running the provisioner is safe${NC}"
+if TENANT_DB_PASSWORD="$TENANT_PASSWORD" bash "$PROVISIONER" \
+    --container "$PG" --role "$TENANT_ROLE" "${TENANT_DBS[@]}" >/dev/null 2>&1; then
+    echo -e "  ${GREEN}✓${NC} second run succeeds"
+    pass_count=$((pass_count + 1))
+else
+    echo -e "  ${RED}✗${NC} second run failed — the provisioner is not idempotent"
+    fail_count=$((fail_count + 1))
+fi
+expect_ok "the tenant still reaches its database after a re-run" \
+    "$TENANT_ROLE" "$TENANT_PASSWORD" "${TENANT_DBS[0]}" "SELECT 1"
+
+# The guard that matters most: the provisioner must refuse to touch a platform
+# database even when told to.
+echo ""
+echo -e "${BOLD}The provisioner refuses to provision a platform database${NC}"
+for db in keycloak postgres hill90; do
+    if TENANT_DB_PASSWORD="$TENANT_PASSWORD" bash "$PROVISIONER" \
+        --container "$PG" --role "$TENANT_ROLE" "$db" >/dev/null 2>&1; then
+        echo -e "  ${RED}✗${NC} it accepted '${db}' as a tenant database"
+        fail_count=$((fail_count + 1))
+    else
+        echo -e "  ${GREEN}✓${NC} refuses '${db}'"
+        pass_count=$((pass_count + 1))
+    fi
+done
+# And it must refuse to hand a tenant the platform's own login role.
+if TENANT_DB_PASSWORD="$TENANT_PASSWORD" bash "$PROVISIONER" \
+    --container "$PG" --role "$PLATFORM_ROLE" tenant_probe >/dev/null 2>&1; then
+    echo -e "  ${RED}✗${NC} it accepted the platform role '${PLATFORM_ROLE}' as a tenant role"
+    fail_count=$((fail_count + 1))
+else
+    echo -e "  ${GREEN}✓${NC} refuses the platform's own role as a tenant role"
+    pass_count=$((pass_count + 1))
+fi
+
+# --------------------------------------------------------------------------
+
+echo ""
+if [ "$fail_count" -eq 0 ]; then
+    echo -e "${GREEN}${BOLD}All ${pass_count} assertions passed.${NC}"
+    exit 0
+fi
+echo -e "${RED}${BOLD}${fail_count} assertion(s) failed, ${pass_count} passed.${NC}"
+exit 1

--- a/scripts/local.sh
+++ b/scripts/local.sh
@@ -603,22 +603,7 @@ cmd_health() {
     check_exec "Postgres accepting connections" "${cp}postgres" \
         pg_isready -U "$(env_get DB_USER hill90)" || failed=1
 
-    # Guard the reason Postgres was deleted in #495: if application databases
-    # reappear here, Postgres has drifted back into being an app dependency.
-    local appdbs
-    # An ALLOWLIST, not a hill90_* prefix match: a database called `litellm` is
-    # just as much an application database, and a denylist silently passes it.
-    appdbs=$(docker exec "${cp}postgres" psql -U "$(env_get DB_USER hill90)" -tAc \
-        "SELECT datname FROM pg_database
-          WHERE datistemplate = false
-            AND datname NOT IN ('postgres', 'keycloak', '$(env_get DB_USER hill90)')" \
-        2>/dev/null | tr -d '\r' | tr '\n' ' ')
-    if [ -n "${appdbs// /}" ]; then
-        echo "  ${RED}✗${NC} Platform-only databases — found non-platform databases: ${appdbs}"
-        failed=1
-    else
-        echo "  ${GREEN}✓${NC} Platform-only databases (only postgres, keycloak and the owner role's database)"
-    fi
+    check_tenant_db_isolation "$cp" || failed=1
 
     # The realm must actually serve OIDC discovery over the local scheme; a
     # healthy container proves nothing if sslRequired still rejects plain HTTP.
@@ -632,6 +617,90 @@ cmd_health() {
         warn "Some checks failed. 'bash scripts/local.sh logs' for detail."
         return 1
     fi
+}
+
+# Tenant isolation on the platform database.
+#
+# This replaces a check that asserted "platform-only databases": any database
+# other than postgres, keycloak and the owner's was a failure. That was the right
+# guard for the reason Postgres was deleted in #495 — application databases in
+# the platform bootstrap made Postgres look like an application dependency — but
+# it also fails on the legitimate case, which is a tenant's databases provisioned
+# by scripts/provision-tenant-db.sh. Postgres is the platform's managed database
+# service (docs/decisions/platform-primitives.md); hosting a tenant is what it is
+# for.
+#
+# So the check is narrowed, not removed. The fault it caught still fails: an
+# application database owned by the platform's own role is exactly the drift
+# #495 was about, and it is now reported with that name. What is newly allowed is
+# a database owned by an unprivileged tenant role and closed to PUBLIC.
+#
+# Note what this is and is not: a LOCAL development check. It is not enforcement,
+# and nothing in the deploy path consults it.
+check_tenant_db_isolation() {
+    local cp="$1"
+    local admin_role rows db owner owner_is_super public_connect
+    local tenant_dbs="" open_platform_dbs="" problems=0
+    admin_role="$(env_get DB_USER hill90)"
+
+    rows=$(docker exec "${cp}postgres" psql -U "$admin_role" -tAc \
+        "SELECT d.datname || '|' || pg_get_userbyid(d.datdba) || '|' ||
+                (SELECT r.rolsuper::text FROM pg_roles r WHERE r.oid = d.datdba) || '|' ||
+                has_database_privilege('public', d.datname, 'CONNECT')::text
+           FROM pg_database d ORDER BY 1" 2>/dev/null | tr -d '\r')
+
+    if [ -z "$rows" ]; then
+        echo "  ${RED}✗${NC} Tenant isolation — could not enumerate databases"
+        return 1
+    fi
+
+    while IFS='|' read -r db owner owner_is_super public_connect; do
+        [ -n "$db" ] || continue
+        case "$db" in
+            postgres|keycloak|template0|template1|"$admin_role")
+                # A platform database. It must not be reachable by PUBLIC once a
+                # tenant role exists on this server, or the tenant can open it.
+                [ "$public_connect" = "true" ] && \
+                    open_platform_dbs="${open_platform_dbs}${db} "
+                continue
+                ;;
+        esac
+
+        # Everything else is a tenant database, and has to look like one.
+        if [ "$owner" = "$admin_role" ]; then
+            echo "  ${RED}✗${NC} Tenant isolation — '${db}' is owned by the platform role '${admin_role}'. This is the #495 drift: an application database created by the platform. Provision it with scripts/provision-tenant-db.sh instead."
+            problems=1
+        elif [ "$owner_is_super" = "true" ]; then
+            echo "  ${RED}✗${NC} Tenant isolation — '${db}' is owned by '${owner}', which is a SUPERUSER. A tenant role must not be one."
+            problems=1
+        elif [ "$public_connect" = "true" ]; then
+            echo "  ${RED}✗${NC} Tenant isolation — '${db}' grants CONNECT to PUBLIC, so every other tenant on this server can open it. Re-run scripts/provision-tenant-db.sh."
+            problems=1
+        else
+            tenant_dbs="${tenant_dbs}${db}(${owner}) "
+        fi
+    done <<EOF
+$rows
+EOF
+
+    if [ -z "${tenant_dbs// /}" ] && [ "$problems" -eq 0 ]; then
+        echo "  ${GREEN}✓${NC} Tenant isolation — platform databases only (postgres, keycloak, ${admin_role}); no tenants provisioned"
+        return 0
+    fi
+
+    # Only meaningful once a tenant exists: before that, PUBLIC CONNECT on the
+    # platform's own databases has nobody to grant anything to, and reporting it
+    # would make a clean single-purpose Postgres look broken.
+    if [ -n "${tenant_dbs// /}" ] && [ -n "${open_platform_dbs// /}" ]; then
+        echo "  ${RED}✗${NC} Tenant isolation — a tenant exists, but these platform databases still grant CONNECT to PUBLIC: ${open_platform_dbs}— run 'bash scripts/provision-tenant-db.sh --harden-only'"
+        problems=1
+    fi
+
+    if [ "$problems" -eq 0 ]; then
+        echo "  ${GREEN}✓${NC} Tenant isolation — tenant databases are tenant-owned and closed to PUBLIC: ${tenant_dbs}"
+        return 0
+    fi
+    return 1
 }
 
 check_http() {

--- a/scripts/provision-tenant-db.sh
+++ b/scripts/provision-tenant-db.sh
@@ -1,0 +1,262 @@
+#!/usr/bin/env bash
+# Provision a tenant's databases on the platform's Postgres.
+#
+# Postgres here is the open-source counterpart to Azure Database for PostgreSQL
+# (docs/decisions/platform-primitives.md). A managed database service does not
+# bake its tenants into the server image; it exposes a control-plane operation
+# that creates a login and some databases. This script is that operation.
+#
+# That is why nothing here goes into platform/data/postgres/init.sh. That file
+# stays platform-only — #495 deleted Postgres partly because application
+# databases in the bootstrap made it look like an application dependency, and
+# adding a database there still means "a PLATFORM service owns this". It also
+# would not work: init.sh runs only on an empty data volume, and production's is
+# not empty.
+#
+# What a tenant gets:
+#   - one login role: NOSUPERUSER, NOCREATEDB, NOCREATEROLE, NOREPLICATION
+#   - the databases it asked for, OWNED by that role, with PUBLIC revoked
+#   - the extensions its migrations expect, installed by the platform because a
+#     least-privilege role cannot install them itself
+#
+# What a tenant does not get: any access to a platform database. The default
+# `PUBLIC` CONNECT privilege on every existing database is revoked, which is the
+# step that makes the boundary real — without it a tenant role can open
+# `keycloak` on day one.
+#
+# Usage:
+#   TENANT_DB_PASSWORD=... bash scripts/provision-tenant-db.sh \
+#       --role hill90_app [--container postgres] [--extension vector] \
+#       [--dry-run] <database> [<database>...]
+#
+#   TENANT_DB_PASSWORD=... bash scripts/provision-tenant-db.sh --harden-only
+#
+# The password is read from TENANT_DB_PASSWORD and is never written to disk, to
+# this repo's secret store, or to the terminal. The tenant owns its own copy of
+# that credential in its own secret store; this platform only sets it. Two stores
+# holding the same secret is how the tenant's Keycloak client secret drifted.
+
+set -euo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/_common.sh"
+
+CONTAINER="${CONTAINER_PREFIX:-}postgres"
+ADMIN_ROLE="${DB_USER:-hill90}"
+TENANT_ROLE=""
+EXTENSIONS=()
+DATABASES=()
+DRY_RUN=0
+HARDEN_ONLY=0
+
+# Databases that are never a tenant's, whatever the caller says. `template1` is
+# here because it is connectable by default; `template0` because it is a
+# database name and mistakes are cheap to prevent.
+reserved_dbs() {
+    printf '%s\n' postgres template0 template1 keycloak "$ADMIN_ROLE"
+}
+
+usage() {
+    sed -n '2,40p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+    exit "${1:-1}"
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --container)   CONTAINER="$2"; shift 2 ;;
+        --role)        TENANT_ROLE="$2"; shift 2 ;;
+        --admin-role)  ADMIN_ROLE="$2"; shift 2 ;;
+        --extension)   EXTENSIONS+=("$2"); shift 2 ;;
+        --dry-run)     DRY_RUN=1; shift ;;
+        --harden-only) HARDEN_ONLY=1; shift ;;
+        -h|--help)     usage 0 ;;
+        -*)            die "unknown option: $1" ;;
+        *)             DATABASES+=("$1"); shift ;;
+    esac
+done
+
+# The app's migrations run `CREATE EXTENSION IF NOT EXISTS` for both of these
+# (services/knowledge/app/db/migrations/001 and 011/012 in hill90-app). Neither
+# is a trusted extension, so a NOSUPERUSER tenant cannot create them and the
+# first migration would fail. The platform installs them; the app's statement
+# then finds them present and does nothing.
+[[ ${#EXTENSIONS[@]} -eq 0 ]] && EXTENSIONS=("uuid-ossp" "vector")
+
+require_command docker
+
+# ---------------------------------------------------------------------------
+# psql plumbing
+#
+# Reads go through -tAc. Writes go in on stdin, never in argv: `docker exec`
+# arguments are visible in `ps` on the host, and the role password is one of
+# them.
+# ---------------------------------------------------------------------------
+
+psql_read() {
+    local db="$1" sql="$2"
+    docker exec "$CONTAINER" psql -U "$ADMIN_ROLE" -d "$db" -tAc "$sql" 2>/dev/null | tr -d '\r'
+}
+
+psql_exec() {
+    local db="$1"
+    if [[ $DRY_RUN -eq 1 ]]; then
+        sed "s/PASSWORD '[^']*'/PASSWORD '<redacted>'/" | sed "s/^/    [dry-run ${db}] /"
+        return 0
+    fi
+    docker exec -i "$CONTAINER" psql -v ON_ERROR_STOP=1 -U "$ADMIN_ROLE" -d "$db" >/dev/null
+}
+
+# Postgres has no CREATE DATABASE ... IF NOT EXISTS and no way to run it inside a
+# DO block, so the \gexec trick is the only idempotent form. Same shape as
+# platform/data/postgres/init.sh, deliberately.
+sql_literal() { printf "%s" "${1//\'/\'\'}"; }
+sql_ident()   { printf '"%s"' "${1//\"/\"\"}"; }
+
+# ---------------------------------------------------------------------------
+# Preconditions
+# ---------------------------------------------------------------------------
+
+docker inspect -f '{{.State.Running}}' "$CONTAINER" 2>/dev/null | grep -q true \
+    || die "container '$CONTAINER' is not running"
+
+psql_read postgres "SELECT 1" | grep -q 1 \
+    || die "cannot query Postgres in '$CONTAINER' as '$ADMIN_ROLE'"
+
+harden_platform_databases() {
+    # The step that makes the boundary real. Every database Postgres creates
+    # grants CONNECT to PUBLIC by default, so a tenant role can open the
+    # platform's databases the moment it exists. Revoke that, and grant the
+    # platform role explicitly rather than leaving it to rely on PUBLIC.
+    #
+    # Safe for the platform itself: the platform role is a superuser and the
+    # owner of these databases, and ACL checks are bypassed for superusers.
+    # Verified by the "the platform still works" assertions in
+    # scripts/checks/tenant-db-isolation-test.sh.
+    info "Revoking the default PUBLIC access on platform databases..."
+    local db
+    while read -r db; do
+        psql_read postgres "SELECT 1 FROM pg_database WHERE datname='$(sql_literal "$db")'" \
+            | grep -q 1 || continue
+        psql_exec postgres <<-SQL
+			REVOKE ALL ON DATABASE $(sql_ident "$db") FROM PUBLIC;
+			GRANT ALL ON DATABASE $(sql_ident "$db") TO $(sql_ident "$ADMIN_ROLE");
+		SQL
+        echo "    hardened: ${db}"
+    done < <(reserved_dbs)
+}
+
+if [[ $HARDEN_ONLY -eq 1 ]]; then
+    [[ ${#DATABASES[@]} -eq 0 ]] || die "--harden-only takes no database arguments"
+    harden_platform_databases
+    success "Platform databases hardened."
+    exit 0
+fi
+
+[[ -n "$TENANT_ROLE" ]] || die "--role is required"
+[[ ${#DATABASES[@]} -gt 0 ]] || die "at least one database name is required"
+
+[[ "$TENANT_ROLE" =~ ^[a-z][a-z0-9_]{2,62}$ ]] \
+    || die "invalid tenant role name '$TENANT_ROLE' (want ^[a-z][a-z0-9_]{2,62}\$)"
+[[ "$TENANT_ROLE" != "$ADMIN_ROLE" ]] \
+    || die "'$TENANT_ROLE' is the platform's own role. A tenant must never be given it — it is a superuser over the platform's data."
+
+# Refuse to hand a tenant any existing superuser or role-creating login.
+existing_attrs=$(psql_read postgres \
+    "SELECT rolsuper::text || ' ' || rolcreaterole::text || ' ' || rolcreatedb::text
+       FROM pg_roles WHERE rolname = '$(sql_literal "$TENANT_ROLE")'")
+if [[ -n "$existing_attrs" && "$existing_attrs" != "false false false" ]]; then
+    die "role '$TENANT_ROLE' already exists with elevated attributes (super createrole createdb = $existing_attrs). Refusing to reuse it as a tenant role."
+fi
+
+TENANT_DB_PASSWORD="${TENANT_DB_PASSWORD:-}"
+[[ -n "$TENANT_DB_PASSWORD" ]] || die "TENANT_DB_PASSWORD is not set"
+[[ ${#TENANT_DB_PASSWORD} -ge 16 ]] \
+    || die "TENANT_DB_PASSWORD is shorter than 16 characters"
+[[ "$TENANT_DB_PASSWORD" != *$'\n'* ]] \
+    || die "TENANT_DB_PASSWORD contains a newline"
+
+for db in "${DATABASES[@]}"; do
+    [[ "$db" =~ ^[a-z][a-z0-9_]{2,62}$ ]] \
+        || die "invalid database name '$db' (want ^[a-z][a-z0-9_]{2,62}\$)"
+    if reserved_dbs | grep -qxF "$db"; then
+        die "'$db' is a platform database. A tenant database cannot be named that — see docs/decisions/platform-primitives.md."
+    fi
+    # The dangerous case the name check alone would miss: an existing database
+    # owned by the platform role. Changing its owner to a tenant is how you hand
+    # over platform data by accident.
+    owner=$(psql_read postgres \
+        "SELECT pg_get_userbyid(datdba) FROM pg_database WHERE datname = '$(sql_literal "$db")'")
+    if [[ -n "$owner" && "$owner" != "$TENANT_ROLE" ]]; then
+        die "database '$db' already exists and is owned by '$owner', not '$TENANT_ROLE'. Refusing to change the owner of an existing database."
+    fi
+done
+
+# ---------------------------------------------------------------------------
+# The tenant login role
+# ---------------------------------------------------------------------------
+
+info "Provisioning tenant role '${TENANT_ROLE}' in '${CONTAINER}'..."
+
+# NOINHERIT so a future GRANT of some group role to this one does not silently
+# widen it; the tenant would have to SET ROLE explicitly.
+ROLE_ATTRS="LOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE NOINHERIT NOREPLICATION NOBYPASSRLS"
+if [[ -n "$existing_attrs" ]]; then
+    psql_exec postgres <<-SQL
+		ALTER ROLE $(sql_ident "$TENANT_ROLE") ${ROLE_ATTRS} PASSWORD '$(sql_literal "$TENANT_DB_PASSWORD")';
+	SQL
+    echo "    role updated (password reset, attributes reasserted)"
+else
+    psql_exec postgres <<-SQL
+		CREATE ROLE $(sql_ident "$TENANT_ROLE") ${ROLE_ATTRS} PASSWORD '$(sql_literal "$TENANT_DB_PASSWORD")';
+	SQL
+    echo "    role created"
+fi
+
+# ---------------------------------------------------------------------------
+# The tenant's databases
+# ---------------------------------------------------------------------------
+
+for db in "${DATABASES[@]}"; do
+    psql_exec postgres <<-SQL
+		SELECT 'CREATE DATABASE $(sql_ident "$db") OWNER $(sql_ident "$TENANT_ROLE")'
+		WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = '$(sql_literal "$db")')\gexec
+	SQL
+
+    # Only this tenant may open it. Without the REVOKE, every other tenant role
+    # on this server could connect via the default PUBLIC grant.
+    psql_exec postgres <<-SQL
+		REVOKE ALL ON DATABASE $(sql_ident "$db") FROM PUBLIC;
+		GRANT ALL ON DATABASE $(sql_ident "$db") TO $(sql_ident "$TENANT_ROLE");
+	SQL
+
+    # The database owner is not automatically the owner of its `public` schema.
+    # Set it, so the tenant can create objects there without any grant from us.
+    psql_exec "$db" <<-SQL
+		ALTER SCHEMA public OWNER TO $(sql_ident "$TENANT_ROLE");
+	SQL
+
+    for ext in "${EXTENSIONS[@]}"; do
+        psql_exec "$db" <<-SQL
+			CREATE EXTENSION IF NOT EXISTS $(sql_ident "$ext");
+		SQL
+    done
+
+    if [[ $DRY_RUN -eq 0 ]]; then
+        actual_owner=$(psql_read postgres \
+            "SELECT pg_get_userbyid(datdba) FROM pg_database WHERE datname = '$(sql_literal "$db")'")
+        [[ "$actual_owner" == "$TENANT_ROLE" ]] \
+            || die "post-check failed: '$db' is owned by '$actual_owner', expected '$TENANT_ROLE'"
+    fi
+    echo "    ${db}: owned by ${TENANT_ROLE}, PUBLIC revoked, extensions ${EXTENSIONS[*]}"
+done
+
+harden_platform_databases
+
+if [[ $DRY_RUN -eq 1 ]]; then
+    warn "Dry run — nothing was changed."
+    exit 0
+fi
+
+success "Tenant '${TENANT_ROLE}' provisioned: ${DATABASES[*]}"
+echo "" >&2
+info "The privilege boundary is asserted by:"
+info "  bash scripts/checks/tenant-db-isolation-test.sh"

--- a/tests/checks/test_tenant_db_isolation.py
+++ b/tests/checks/test_tenant_db_isolation.py
@@ -1,0 +1,51 @@
+"""Tests for scripts/checks/tenant-db-isolation-test.sh
+
+The assertions themselves live in the shell script, because they have to be made
+over a docker network from a second container — an in-container `psql` would
+authenticate by trust and prove nothing about a role's password. This wrapper
+exists so `make test` runs them.
+
+The script builds and destroys its own throwaway Postgres. It never touches a
+running stack.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "checks" / "tenant-db-isolation-test.sh"
+
+docker_available = shutil.which("docker") is not None and (
+    subprocess.run(
+        ["docker", "info"], capture_output=True, timeout=30
+    ).returncode
+    == 0
+    if shutil.which("docker")
+    else False
+)
+
+
+def test_script_exists():
+    assert SCRIPT.is_file(), f"missing: {SCRIPT}"
+
+
+@pytest.mark.skipif(
+    not docker_available, reason="needs a reachable docker daemon"
+)
+def test_tenant_privilege_boundary_holds():
+    result = subprocess.run(
+        ["bash", str(SCRIPT)],
+        capture_output=True,
+        text=True,
+        cwd=ROOT,
+        timeout=600,
+    )
+    assert result.returncode == 0, (
+        "tenant isolation assertions failed:\n"
+        f"{result.stdout}\n{result.stderr}"
+    )


### PR DESCRIPTION
## Decide this first — the one judgement call

**The tenant role is `NOCREATEDB`.** It cannot create its own databases; every new
one is a platform operation someone has to run. Overrule this if self-service
matters more than the narrow grant — it is a one-word change to `ROLE_ATTRS` in
`scripts/provision-tenant-db.sh`, and the isolation test asserts the current
behaviour, so flipping it fails loudly and names what changed.

Least privilege was chosen because the alternative to a *narrow* tenant role was
never a *slightly wider* one — it was the `hill90` superuser, which has read,
write and drop over the platform's own Keycloak store.

## What this does

Postgres is this platform's counterpart to Azure Database for PostgreSQL and it
could not host a tenant. One login role (`hill90`, superuser, owner of
everything) and a local health check that failed on any database it did not
recognise.

- **`scripts/provision-tenant-db.sh`** — a control-plane operation, not a
  bootstrap line. One least-privilege login role per tenant
  (`NOSUPERUSER NOCREATEDB NOCREATEROLE NOINHERIT NOREPLICATION NOBYPASSRLS`),
  tenant-owned databases, tenant-owned `public` schema, `PUBLIC` revoked
  everywhere. Idempotent. Refuses to name a platform database as a tenant's,
  refuses to change an existing database's owner, refuses the platform's own role.
- **`platform/data/postgres/init.sh` is untouched.** #495's rule holds: a database
  there still means a platform service owns it. It also would not have worked —
  it runs only on an empty data volume, and production's is not empty.
- **`scripts/local.sh` narrowed, not deleted.** It asserted "platform-only
  databases"; it now asserts *tenant isolation*. The fault it caught still fails,
  by name.

**This adds the capability and does not use it.** Nothing points at this Postgres
and `app-postgres` is untouched.

*Rebased onto #579, which landed mid-work.* `main` now records **"`app-postgres`
goes"** as settled, with this exact boundary named as the complication to revisit
deliberately. So this is not a separate open question — it is that complication,
handled. The conflict resolution attaches the amendments to the new §1.2 wording
rather than reinstating the superseded "no decision recorded" text. **What is still
ahead is the move itself:** point the app at the platform, migrate nothing, and
only then retire `app-postgres`.

## The step that actually makes the boundary real

Postgres grants `CONNECT` to `PUBLIC` on every new database. Without revoking it,
a freshly created tenant role can open `keycloak` on day one with no grant at all.
The provisioner revokes it on the platform's databases too, and there is a
`--harden-only` mode to re-run that alone.

## Two things that surfaced while proving it

**A least-privilege tenant cannot install extensions.** The app's migrations run
`CREATE EXTENSION IF NOT EXISTS "uuid-ossp"` and `... vector`
(`services/knowledge/app/db/migrations/001`, `011`, `012`). Neither is trusted, so
a non-superuser cannot create either and the app's first migration would have
failed against the platform. It works today only because the app's `DB_USER` is a
superuser in its own Postgres. The provisioner installs both. **Constraint on the
app:** a future extension must be added to the provisioner, and it will surface as
a migration error rather than a permissions message.

**`docker exec psql` proves nothing about a role.** `pg_hba.conf` is `trust` for
the local socket and `127.0.0.1`, so an in-container `psql` succeeds with no
password, the wrong password, or for a role whose password was never set. Only a
connection over the container network reaches `scram-sha-256`. Every assertion in
the test is therefore made from a second container, and one deliberately uses the
wrong password — if that ever succeeds, `pg_hba` has been loosened and the rest of
the file is worthless.

## Validation

Written failing first. Before the provisioner existed, `tenant-db-isolation-test.sh`
stopped at `FATAL: provisioner not found` with the fixture assertion already
passing. With it: **32/32**, and the suite is `31 passed` including it.

The test builds its own throwaway Postgres from the same image and the same
platform bootstrap, and destroys it. It never touches a running stack. It runs in
CI (`pytest tests/checks/`), skipped if no docker daemon.

Both halves, run against the **live local platform Postgres** from a separate
container over `hill90dev_internal`:

```
### HALF ONE — tenant role reaches its own databases, over the network
hill90_api       hill90_app connected to hill90_api
hill90_akm       hill90_app connected to hill90_akm
hill90_litellm   hill90_app connected to hill90_litellm

### HALF TWO — the same role refused on platform databases
hill90           FATAL:  permission denied for database "hill90"
                 DETAIL:  User does not have CONNECT privilege.
keycloak         FATAL:  permission denied for database "keycloak"
postgres         FATAL:  permission denied for database "postgres"
template1        FATAL:  permission denied for database "template1"

### auth is scram, not trust — wrong password
wrong-pw         FATAL:  password authentication failed for user "hill90_app"

### the platform itself is unaffected
hill90           platform role ok in hill90
keycloak         platform role ok in keycloak
postgres         platform role ok in postgres
```

Also asserted by the suite: cross-tenant isolation (a second tenant refused on the
first's databases and vice versa), no `CREATE DATABASE`, no `CREATE ROLE`, no
`pg_authid` read, not a superuser, extensions present, `CREATE TABLE` in its own
database works, idempotent re-run, and the provisioner refusing `keycloak`,
`postgres`, `hill90` and the platform's own role.

Every branch of the narrowed health check, proven live:

```
✓ Tenant isolation — platform databases only (postgres, keycloak, hill90); no tenants provisioned
✗ Tenant isolation — 'drift_probe' is owned by the platform role 'hill90'. This is the #495 drift...
✓ Tenant isolation — tenant databases are tenant-owned and closed to PUBLIC: hill90_akm(hill90_app) hill90_api(hill90_app) hill90_litellm(hill90_app)
✗ Tenant isolation — 'hill90_akm' grants CONNECT to PUBLIC, so every other tenant on this server can open it...
✗ Tenant isolation — a tenant exists, but these platform databases still grant CONNECT to PUBLIC: keycloak — run 'bash scripts/provision-tenant-db.sh --harden-only'
```

CI on this branch: **`completed success`**, and the isolation test ran rather than
skipping — `test_tenant_privilege_boundary_holds PASSED`, `31 passed in 23.39s`
([run](https://github.com/jonhill90/Hill90/actions/runs/30505335155)). All local
checks were re-run after the rebase.

Static checks: `check_md_links.py` pass, `check_env_surface.py` pass,
`check_volume_names.py` pass, `check_destructive_commands.sh` pass, `bash -n` pass,
`shellcheck` clean apart from SC1091/SC2001 informational.

Keycloak stayed `healthy` and OIDC discovery stayed `HTTP 200` after `PUBLIC` was
revoked on its database. Container count unchanged; no throwaway containers left
behind.

## Local dev side effect, left in place deliberately

`hill90dev-postgres` now has `hill90_app` plus `hill90_api`, `hill90_akm`,
`hill90_litellm`, and `PUBLIC` revoked on its platform databases — that is the
evidence above. Nothing consumes them; the app's local stack still uses
`app-postgres`. To undo:

```sql
DROP DATABASE hill90_api; DROP DATABASE hill90_akm; DROP DATABASE hill90_litellm;
DROP ROLE hill90_app;
```

The password used is a locally generated throwaway, never written into the repo.

## Risks

| Risk | Mitigation |
|---|---|
| `REVOKE ... FROM PUBLIC` on a platform database locks out a platform service | Only the superuser owner uses them, and superusers bypass ACL checks. Asserted in both directions; Keycloak verified healthy afterwards. |
| A *future* platform database defaults to `PUBLIC` `CONNECT` and a tenant can open it | The narrowed check fails on exactly this once a tenant exists, and prints `--harden-only`. |
| The app's migrations need an extension the provisioner does not install | Surfaces as a migration failure, not a permission error. Called out in the decision record as a standing constraint. |
| `ALTER ROLE ... PASSWORD` reaching a server log | Default `log_statement` is `none`. The password is passed on stdin, never in `docker exec` argv, which is visible in host `ps`. |
| Nothing enforces this in production | Stated plainly: the health check is a **local dev check**. Real enforcement would be a deploy-time guard, and is not in this PR. |

## Rollback

`git revert`. The narrowed check returns to failing on any non-platform database,
which is correct for a Postgres with no tenants. Undoing the SQL is the block
above; the decision record has the same commands.

## Out of scope, per the standing limits

`app-postgres` and the `prod_app-*` volumes are untouched, no deploy was run, and
no production Postgres was modified. Removing the tenant's own database is not in
scope until the app is proven against the platform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
