### PR TITLE
chore(secrets): register the tenant's Postgres credential, and record the production provisioning

### DIFF
--- a/docs/decisions/tenant-databases-on-platform-postgres.md
+++ b/docs/decisions/tenant-databases-on-platform-postgres.md
@@ -1,9 +1,64 @@
 # Hosting a tenant's databases on the platform's Postgres
 
-**Status:** capability added 2026-07-30. **The tenant has not moved.** The AI app
-still runs its own `app-postgres`, and nothing in this change deletes, migrates or
-points anything at the platform. This adds the ability; using it is a separate
-decision and a separate change in `hill90-app`.
+**Status:** capability added 2026-07-30, and **provisioned on production the same
+day** (see "On the real instance" below). **The tenant has not moved.** The AI app
+still runs its own `app-postgres` and still serves from it; nothing here deletes,
+migrates or repoints anything. The databases now exist on the platform and are
+empty, waiting for the app to be repointed — a separate change in `hill90-app`.
+
+## On the real instance — `Verified 2026-07-30 01:57 UTC`
+
+Provisioned against the production platform Postgres with the merged script
+(sha256 `e3983b4c…`, checksum-matched on the host before running), `--dry-run`
+first. Role `hill90_app`; databases `hill90_api`, `hill90_akm`, `hill90_litellm`.
+
+```
+hill90          | owner=hill90      | public_connect=false | acl=hill90=CTc/hill90
+hill90_akm      | owner=hill90_app  | public_connect=false | acl=hill90_app=CTc/hill90_app
+hill90_api      | owner=hill90_app  | public_connect=false | acl=hill90_app=CTc/hill90_app
+hill90_litellm  | owner=hill90_app  | public_connect=false | acl=hill90_app=CTc/hill90_app
+keycloak        | owner=hill90      | public_connect=false | acl=hill90=CTc/hill90
+postgres        | owner=hill90      | public_connect=false | acl=hill90=CTc/hill90
+
+hill90      | super=true  | createdb=true  | createrole=true
+hill90_app  | super=false | createdb=false | createrole=false
+```
+
+Both halves proven over the network from a container on `hill90_internal`, not by
+`docker exec`. The tenant reached `hill90_api`, `hill90_akm` and `hill90_litellm`;
+it was refused on `hill90`, `keycloak`, `postgres` and `template1` with
+`FATAL: permission denied for database … User does not have CONNECT privilege.`
+
+**The revokes did not disturb the platform**, and the proof is live consumers
+rather than an argument: after them, `keycloak` and `postgres-exporter` were still
+connected over the network as `hill90` (`pg_stat_activity` shows `keycloak` from
+`172.19.0.12` and `hill90` from `172.19.0.11`), Keycloak still served realms
+`master, platform`, Grafana returned `200` with `"database": "ok"`, and the
+platform held at 13 containers, 0 unhealthy. The reason it is safe is that every
+consumer of this Postgres connects as `hill90`, a superuser, and superusers bypass
+ACL checks entirely.
+
+The narrowed health check was run against the real database list, and both of its
+failure branches were driven there and repaired: opening a tenant database to
+`PUBLIC` (caught), and leaving a platform database open to `PUBLIC` while a tenant
+exists (caught, then fixed by `--harden-only`). `template0` was used for the
+second probe because `datallowconn=false` makes it unconnectable regardless.
+
+### Two name collisions that block a naive repoint
+
+The app's own Postgres holds `hill90`, `hill90_akm`, `hill90_api`,
+`hill90_litellm`, `keycloak` and `postgres`. Two of those **cannot be recreated on
+the platform under the same names**:
+
+- **`keycloak`** — the app's Keycloak store. The platform's identity database has
+  that exact name. This is the volume collision of #4 in a different costume.
+  Nothing needs moving if the app stops shipping its own Keycloak, which is the
+  settled direction, but it must not be moved as-is.
+- **`hill90`** — `POSTGRES_DB` for `app-postgres`, and also the platform's own
+  database name.
+
+The provisioner refuses both by name, so the mistake fails loudly rather than
+silently mounting the app on top of platform data.
 
 **Relates to:** [platform-primitives.md](platform-primitives.md),
 [app-tenancy-on-the-vps.md](app-tenancy-on-the-vps.md)
@@ -60,15 +115,30 @@ matters more than the narrow grant, `CREATEDB` is a one-word change to
 `ROLE_ATTRS` in the provisioner, and the isolation test asserts the current
 behaviour, so flipping it will fail loudly and tell you exactly what you changed.
 
-### The tenant's password is not stored here
+### Where the tenant's password lives — amended 2026-07-30
 
-The provisioner reads it from `TENANT_DB_PASSWORD` and never writes it — not to
-disk, not to this repo's secret store, not to the terminal. The platform *sets*
-the credential; the tenant keeps its own copy in its own store.
+**The provisioner still never writes it.** It reads `TENANT_DB_PASSWORD` and
+persists nothing: not to disk, not to a store, not to the terminal.
 
-This is deliberate. Two stores holding one secret is exactly how the app's
-Keycloak client secret drifted out of agreement with Keycloak and cost a night of
-diagnosis. One owner per secret.
+**But the credential is now stored, in this platform's SOPS store, as
+`HILL90_APP_DB_PASSWORD`** (`infra/secrets/prod.enc.env`, vault path
+`secret/tenants/hill90-app/database`, registered in
+`platform/vault/secrets-schema.yaml` with `compose_refs: []` because no platform
+compose file consumes it). The tenant needs the credential in order to be
+repointed, and a credential that exists only in one operator's terminal is not
+operable.
+
+**This creates the two-copies condition the paragraph below warns about, so name
+the authority explicitly: this store is authoritative.** The platform sets the
+password; when `hill90-app` copies it into its own store, that copy is a replica.
+If they ever disagree, the repair is to re-run the provisioner with the value from
+*here* — it is idempotent and resets the password, which is the same shape as the
+Keycloak client-secret repair.
+
+The original reasoning still stands as the warning it was: two stores holding one
+secret is exactly how the app's Keycloak client secret drifted out of agreement
+with Keycloak and cost a night of diagnosis. The mitigation is a declared owner and
+an idempotent reconciliation command, not pretending one copy is enough.
 
 ## What broke that had to be fixed alongside
 

--- a/infra/secrets/prod.enc.env
+++ b/infra/secrets/prod.enc.env
@@ -80,9 +80,10 @@ GRAFANA_OIDC_CLIENT_SECRET=ENC[AES256_GCM,data:+8J5W0ACzx2I7UmW++j3W2wCz7NytKuns
 PORTAINER_OIDC_CLIENT_SECRET=ENC[AES256_GCM,data:PojT9jxvE6JDxt6MLxuMFz2YgMlB2DgoZW0asBovWyEJGRr8OJhws9wBrxs=,iv:C8CJwS3sfZFY6T5kLsWOspgUqYcJjYWpMs/Awh9QJPQ=,tag:2iQyec8tnxxUhq6peZtsJw==,type:str]
 PORTAINER_ADMIN_PASSWORD=ENC[AES256_GCM,data:wNJ1CM7eZ9ujJVFJuTvQ/7wTfkU=,iv:y/QuT4jfvxH8BMAfrEgDw9Udr+paPRq0Rd7eAh1CjwA=,tag:ptai9mrCwQ0d8sZ8e3xORg==,type:str]
 VAULT_OIDC_CLIENT_SECRET=ENC[AES256_GCM,data:jeGsH9RdREYp+6X43zAOCGEtpmPfM6nWxwjnI2NwS65ccmvH5iYKvnFDEQ==,iv:nLWiu/KMoXzi376LbnGYYFU8TtiwoKlV3ot2USdP4ek=,tag:8vuXo1JPWvhf/CMI5Sa2Ug==,type:str]
+HILL90_APP_DB_PASSWORD=ENC[AES256_GCM,data:/2V/XkIXl9VnSooHlly/xI9O7SpdaYlaQWrGHr/mnkaeVx4M/L/G22Thimd2uSgBECuAUqKDv+bre4ZW6KeeEQ==,iv:KVl0kOOEou70lKeLB1rxVJ99Rdw3JshLiVw/+w2B2so=,tag:9GXz1E5MjcUuaKzeOIa3xw==,type:str]
 sops_age__list_0__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBrRy9IcWFNL2pOZWNxdzEr\nYk80dmdiYkVOa2RJYnM2Z29ucURmR05sQkdnCk9ZN2VmYUJpdVZ3WnljQU9XUXdv\nWFYyL2JERGlMd2hCSFAzNlRnUEdlSDQKLS0tIDdncUI5SkxORFE3dnI0aVloaE9z\nSGh3SnNsYnltNmJteFJUeVU3MWpvaDAKfJ6tZctOxb4xPFjesRxQw1Q8FvB8/Gnx\ncFwQpzTlIFc+uXS895d9ydS1VA5lot8PdbPUKk1/wCcuJR4EFR/elQ==\n-----END AGE ENCRYPTED FILE-----\n
 sops_age__list_0__map_recipient=age1p30vk2qpvlkj5pzh72f0wwvlqgmedvr204nldmpskmptgy9ryg8qg9qd5v
-sops_lastmodified=2026-07-27T02:58:20Z
-sops_mac=ENC[AES256_GCM,data:zj9I/u2sSJ9pfvaypa2f3GUsyaZ8ZBNy1DM4oRCn71h3TWEFztd8C2IdXgSoUvMWe994l+W21jUjCluGO4ETLS09A+4j6kSjRzAYpK+aVrrUBqxviYZJbZJgTyMtEgtwZ7Wqf/DBunOeNY8BQ1t6honCU4Ne1XCZ3HUkxeniKnE=,iv:nr76xyeQiwr7jsYcKVNECn/KG1H+SOnl+wKoJJgT9Bg=,tag:nSb6fL1Li6TcK2zr2CPvAA==,type:str]
+sops_lastmodified=2026-07-30T01:33:11Z
+sops_mac=ENC[AES256_GCM,data:AQTHdPh3XmmhxOIABHD8e9s+ilrPBO/QbpPg2UeQXz/AECAsUdhvFIKvAHk6+tP4zk7eGqIZZ7r17jaQuwRQX0c38RGFR8BRbQ47b8XPP5Px4y5eYFa2BMzbN3/5Fcq8ucNzqCEDT4XMgp4Kzh8XkvXp1QEYEZ9RhjBaYqKXk7o=,iv:+bOmBsqMnCluN7UFsI9hXUBwZ4L5pM+emHbUkP8ainY=,tag:WMuP4hghy4Bh1PZac/xPmQ==,type:str]
 sops_unencrypted_suffix=_unencrypted
 sops_version=3.11.0

--- a/infra/secrets/prod.enc.env.example
+++ b/infra/secrets/prod.enc.env.example
@@ -57,6 +57,13 @@ DB_USER=hill90
 DB_PASSWORD=REPLACE_WITH_SECURE_PASSWORD
 DB_NAME=hill90
 
+# --- Tenant logins on the platform database ----------------------------------
+# The hill90-app tenant's login, created by scripts/provision-tenant-db.sh. No
+# compose file here references it: this platform SETS the credential, and the
+# tenant consumes it from its own repository. Rotating it means re-running the
+# provisioner, which is idempotent.
+HILL90_APP_DB_PASSWORD=REPLACE_WITH_SECURE_PASSWORD
+
 # --- Platform identity provider (Keycloak) -----------------------------------
 KC_ADMIN_USERNAME=admin
 KC_ADMIN_PASSWORD=REPLACE_WITH_SECURE_PASSWORD

--- a/platform/vault/secrets-schema.yaml
+++ b/platform/vault/secrets-schema.yaml
@@ -142,6 +142,15 @@ runtime_secrets:
     vault_path: secret/infra/portainer
     compose_refs: []
 
+  # The hill90-app tenant's login on the platform's Postgres, created by
+  # scripts/provision-tenant-db.sh. compose_refs is empty and stays empty: no
+  # platform compose file consumes this. The platform sets the credential and
+  # the tenant reads it from here, which makes this store the authoritative
+  # copy — see docs/decisions/tenant-databases-on-platform-postgres.md.
+  - key: HILL90_APP_DB_PASSWORD
+    vault_path: secret/tenants/hill90-app/database
+    compose_refs: []
+
 # SOPS-only secrets: bootstrap/infrastructure keys that have no vault
 # KV mapping. These must exist in prod.enc.env.example but are not
 # expected in vault.


### PR DESCRIPTION
Follow-up to #580, which added the capability. **It has now been run against the
real platform Postgres.**

## The key pane 1 needs

**`HILL90_APP_DB_PASSWORD`** in `infra/secrets/prod.enc.env`, 64 hex chars.
Role name is **`hill90_app`**; databases `hill90_api`, `hill90_akm`,
`hill90_litellm` on the platform `postgres` container, reachable on
`hill90_internal` as host `postgres`.

```bash
make secrets-get KEY=HILL90_APP_DB_PASSWORD
```

Registered in `platform/vault/secrets-schema.yaml` at
`secret/tenants/hill90-app/database` with `compose_refs: []` — no platform compose
file consumes it. `check_secrets_schema.py` passes.

**This store is authoritative.** I said in #580 that the password would never be
stored here, and that is now false, so the decision record is corrected rather than
left disagreeing with reality — a credential that exists only in one operator's
terminal is not operable. The original warning is kept, because it is still the
right warning: two stores holding one secret is how the Keycloak client secret
drifted. The mitigation is a declared owner plus an idempotent reconciliation
command (`re-run the provisioner with the value from here`), not pretending one copy
is enough.

## What was done to production

`--dry-run` first. The script was checksum-verified on the host as the merged code
(`e3983b4c…`) before running, and copied to a temp dir rather than pulling the
production checkout, which stays clean at #578. Credential passed over stdin, never
argv. Temp copies removed afterwards and confirmed to contain no secret material.

## Verification, on the real instance

**Final state:**

```
hill90          | owner=hill90      | public_connect=false | acl=hill90=CTc/hill90
hill90_akm      | owner=hill90_app  | public_connect=false | acl=hill90_app=CTc/hill90_app
hill90_api      | owner=hill90_app  | public_connect=false | acl=hill90_app=CTc/hill90_app
hill90_litellm  | owner=hill90_app  | public_connect=false | acl=hill90_app=CTc/hill90_app
keycloak        | owner=hill90      | public_connect=false | acl=hill90=CTc/hill90
postgres        | owner=hill90      | public_connect=false | acl=hill90=CTc/hill90

hill90      | super=true  | createdb=true  | createrole=true
hill90_app  | super=false | createdb=false | createrole=false
```

**Half one — over the network, from a container on `hill90_internal`:**

```
hill90_api      hill90_app@hill90_api  client=172.19.0.22/32
hill90_akm      hill90_app@hill90_akm  client=172.19.0.22/32
hill90_litellm  hill90_app@hill90_litellm  client=172.19.0.22/32
```

**Half two — the same role, same path, refused:**

```
hill90     FATAL:  permission denied for database "hill90"
           DETAIL:  User does not have CONNECT privilege.
keycloak   FATAL:  permission denied for database "keycloak"
           DETAIL:  User does not have CONNECT privilege.
postgres   FATAL:  permission denied for database "postgres"
           DETAIL:  User does not have CONNECT privilege.
template1  FATAL:  permission denied for database "template1"
           DETAIL:  User does not have CONNECT privilege.
```

Plus: `CREATE DATABASE` → `permission denied to create database`; `CREATE ROLE` →
`permission denied to create role`; `pg_authid` → `permission denied for table
pg_authid`; `usesuper` → `f`. And it *can* work inside its own databases —
`CREATE TABLE`/`DROP TABLE` succeeded, `uuid-ossp,vector` present in all three.

**The revokes did not disturb the platform, proven by live consumers rather than by
argument.** After them:

```
keycloak    healthy      realms: master, platform
grafana     healthy      HTTP 200, "database": "ok"
postgres-exporter healthy

pg_stat_activity (network-connected, password-authenticated):
  hill90    | hill90 | 172.19.0.11 | idle     <- postgres-exporter
  keycloak  | hill90 | 172.19.0.12 | idle     <- keycloak

platform containers: 13    app: 10    unhealthy: 0
```

The reason it is safe is the one you found: every consumer connects as `hill90`, a
superuser, and superusers bypass ACL checks entirely.

## The narrowed check, against the real list

The actual `check_tenant_db_isolation` function, run against production:

```
✓ Tenant isolation — tenant databases are tenant-owned and closed to PUBLIC: hill90_akm(hill90_app) hill90_api(hill90_app) hill90_litellm(hill90_app)
```

It does not pass because it is loose. Both failure branches were driven **on the
real instance** and repaired:

```
### PROBE 1 — open a TENANT database to PUBLIC
✗ Tenant isolation — 'hill90_akm' grants CONNECT to PUBLIC, so every other tenant on this server can open it.
  ...restoring
✓ Tenant isolation — tenant databases are tenant-owned and closed to PUBLIC: ...

### PROBE 2 — open a PLATFORM database to PUBLIC while a tenant exists
✗ Tenant isolation — a tenant exists, but these platform databases still grant CONNECT to PUBLIC: template0 — run '... --harden-only'
  ...repairing via the documented command
✓ Tenant isolation — tenant databases are tenant-owned and closed to PUBLIC: ...
```

`template0` was chosen for probe 2 precisely because `datallowconn=false` makes it
unconnectable regardless, so the branch was exercised with zero exposure. No
platform identity database was reopened to test a code path.

## The app is untouched

```
app-postgres: healthy, started 2026-07-29T05:52:07Z, restarts 0
app-api still points at app-postgres: 1 env var match
app's own databases: hill90, hill90_akm, hill90_api, hill90_litellm, keycloak, postgres
hill90.com: 200
```

Nothing was dropped. `app-postgres` and the `prod_app-*` volumes were not touched.
The platform databases now exist and are **empty**, waiting for a repoint.

## Two collisions that would block a naive repoint

The app's Postgres holds `keycloak` and `hill90` — both platform database names.
`keycloak` is the volume collision of invariant #4 in a different costume. The
provisioner refuses both by name, so the mistake fails loudly rather than mounting
the app on top of platform data. If the app stops shipping its own Keycloak, which
is the settled direction, nothing needs moving.

## Rollback

Reversing the platform-side revokes is one `GRANT` per database, and the exact
pre-change ACLs were captured first:

```sql
GRANT CONNECT, TEMPORARY ON DATABASE hill90    TO PUBLIC;  -- was datacl NULL
GRANT CONNECT, TEMPORARY ON DATABASE postgres  TO PUBLIC;  -- was datacl NULL
GRANT CONNECT, TEMPORARY ON DATABASE keycloak  TO PUBLIC;  -- was =Tc/hill90
GRANT CONNECT            ON DATABASE template1 TO PUBLIC;  -- was =c/hill90  (no TEMP)
GRANT CONNECT            ON DATABASE template0 TO PUBLIC;  -- was =c/hill90  (no TEMP)
```

Removing the tenant is `DROP DATABASE` ×3 + `DROP ROLE hill90_app` — **not run, and
out of scope** until the app is proven against the platform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)