### PR TITLE
feat(auth): platform-realm.json carries the tenant's clients, so local can prove tenancy

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -126,6 +126,24 @@ KC_ADMIN_PASSWORD=admin
 # VAULT_OIDC_CLIENT_SECRET in .local-vault/local.enc.env. Disposable locally.
 VAULT_OIDC_CLIENT_SECRET=local-rehearsal-secret-0123456789
 
+# --- The tenant's OIDC clients in realm platform ------------------------------
+# platform-realm.json carries hill90-ui and hill90-api so a LOCAL platform
+# Keycloak can serve the tenant the same way production's does. That is what
+# makes local prove TENANCY and not merely the realm design.
+#
+# The client's redirect URI and web origin stay at their PRODUCTION values in
+# platform-realm.json; local.sh appends the local callback to the running client
+# instead, the same delta it already applies to hill90-vault. The secret is
+# disposable locally, but it must equal the
+# AUTH_KEYCLOAK_SECRET the tenant's local stack holds or the token exchange fails
+# with invalid_client — the same failure that cost this estate a night in
+# production.
+HILL90_UI_CLIENT_SECRET=local-tenant-ui-secret-0123456789
+
+# Where the tenant's local UI listens, used only to add its OIDC callback to the
+# running hill90-ui client. Must match hill90-app's local UI port (its PORT_UI).
+TENANT_UI_PORT=13000
+
 # --- Keycloak SSO for the platform services (issue #530) ---------------------
 # Keycloak's public base URL and realm, as the OTHER services must reach it.
 # Production defaults to https://auth.hill90.com and the 'platform' realm.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,8 +174,22 @@ the migration run — but say "nothing worth preserving", not "empty".
   `hill90admin` and `testuser01` in platform realm `platform`, and the same three in
   realm `hill90` on the tenant's own Keycloak.
 - **`app-postgres` is still running and still serving.** See above.
-- **Local is half-drifted**, and is being fixed in the tenant's lane. **Local parity
-  lands before anything is retired.**
+- **Local parity — this platform's half is done; the tenant's is not.**
+  `platform-realm.json` now carries `hill90-ui` and `hill90-api`, mirroring
+  production literally, so a **local** platform Keycloak can serve a tenant the way
+  production's does. Proven by importing the realm into a real Keycloak and reading
+  the token a user would get: `resource_access.hill90-ui.roles = ['admin']`,
+  `aud` includes `hill90-api`, and no `realm_roles` claim —
+  `scripts/checks/realm-tenant-serves-test.sh`, `Verified 2026-07-30 02:41 UTC`.
+  **What remains is the tenant's side:** its local stack still points at its own
+  `app-keycloak`, so local proves the realm design and not yet the tenancy.
+  **Local parity lands before anything is retired**, because a broken local stack
+  would otherwise have nothing to fall back to.
+- **`HILL90_UI_CLIENT_SECRET` has no production value in the store yet.** It only
+  bites on a FIRST import — the live realm already has the client — so a **VPS
+  rebuild** is the case that depends on it, and it must equal the value hill90-app
+  holds. `check_env_surface.py` deliberately allows it no default: a fallback would
+  import a *known* secret for the client fronting hill90.com and say nothing.
 - **Keycloak event storage is off** — `events_enabled=false` on both `master` and
   `platform`, `Verified 2026-07-30 02:07 UTC`. That is why "has anyone actually
   logged in?" cannot be answered from the host: sessions live in Infinispan, not the

--- a/deploy/compose/prod/docker-compose.auth.yml
+++ b/deploy/compose/prod/docker-compose.auth.yml
@@ -39,6 +39,16 @@ services:
       # secret is randomly generated and can never match the value setup-oidc
       # reads from SOPS, so OIDC login fails with invalid_client.
       - VAULT_OIDC_CLIENT_SECRET=${VAULT_OIDC_CLIENT_SECRET}
+      # The tenant's hill90-ui client secret, same mechanism as the vault one
+      # above. Matters only on a FIRST import: the live realm already has the
+      # client, and `start --import-realm` ignores an existing realm. This is
+      # what a VPS rebuild depends on.
+      #
+      # The client's redirect URI and web origin are the LITERAL production
+      # values in platform-realm.json. Local does not parameterise them — it
+      # appends its callback to the running client, the same delta local.sh
+      # already applies to hill90-vault.
+      - HILL90_UI_CLIENT_SECRET=${HILL90_UI_CLIENT_SECRET}
       - KC_BOOTSTRAP_ADMIN_USERNAME=${KC_ADMIN_USERNAME}
       - KC_BOOTSTRAP_ADMIN_PASSWORD=${KC_ADMIN_PASSWORD}
       - JAVA_OPTS_APPEND=-Xms256m -Xmx768m

--- a/infra/secrets/prod.enc.env.example
+++ b/infra/secrets/prod.enc.env.example
@@ -64,6 +64,13 @@ DB_NAME=hill90
 # provisioner, which is idempotent.
 HILL90_APP_DB_PASSWORD=REPLACE_WITH_SECURE_PASSWORD
 
+# --- Tenant OIDC clients in realm platform -----------------------------------
+# hill90-ui's client secret, substituted into platform-realm.json at import.
+# MUST equal the value hill90-app holds, or the tenant cannot sign in after a
+# realm re-import. The live realm is already configured, so this matters at
+# rebuild time.
+HILL90_UI_CLIENT_SECRET=REPLACE_WITH_SECURE_SECRET
+
 # --- Platform identity provider (Keycloak) -----------------------------------
 KC_ADMIN_USERNAME=admin
 KC_ADMIN_PASSWORD=REPLACE_WITH_SECURE_PASSWORD

--- a/platform/auth/keycloak/platform-realm.json
+++ b/platform/auth/keycloak/platform-realm.json
@@ -25,7 +25,19 @@
       {
         "name": "admin"
       }
-    ]
+    ],
+    "client": {
+      "hill90-ui": [
+        {
+          "name": "user",
+          "description": "App user (client-scoped)"
+        },
+        {
+          "name": "admin",
+          "description": "App admin (client-scoped)"
+        }
+      ]
+    }
   },
   "smtpServer": {
     "host": "smtp.hostinger.com",
@@ -73,6 +85,54 @@
           }
         }
       ]
+    },
+    {
+      "clientId": "hill90-ui",
+      "secret": "${HILL90_UI_CLIENT_SECRET}",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "publicClient": false,
+      "bearerOnly": false,
+      "standardFlowEnabled": true,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "fullScopeAllowed": true,
+      "redirectUris": [
+        "https://hill90.com/api/auth/callback/keycloak"
+      ],
+      "webOrigins": [
+        "https://hill90.com"
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "roles",
+        "profile",
+        "email"
+      ],
+      "protocolMappers": [
+        {
+          "name": "hill90-api-audience",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "config": {
+            "included.client.audience": "hill90-api",
+            "access.token.claim": "true",
+            "id.token.claim": "false"
+          }
+        }
+      ]
+    },
+    {
+      "clientId": "hill90-api",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "publicClient": false,
+      "bearerOnly": true,
+      "standardFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "fullScopeAllowed": true
     }
   ]
 }

--- a/platform/vault/secrets-schema.yaml
+++ b/platform/vault/secrets-schema.yaml
@@ -151,6 +151,15 @@ runtime_secrets:
     vault_path: secret/tenants/hill90-app/database
     compose_refs: []
 
+  # The tenant's OIDC client secret for hill90-ui in realm platform. Substituted
+  # into platform-realm.json at import, exactly like VAULT_OIDC_CLIENT_SECRET.
+  # It bites only on a FIRST import — the live realm already has the client — so
+  # a VPS rebuild is what depends on it being present and CORRECT.
+  - key: HILL90_UI_CLIENT_SECRET
+    vault_path: secret/tenants/hill90-app/oidc
+    compose_refs:
+      - docker-compose.auth.yml
+
 # SOPS-only secrets: bootstrap/infrastructure keys that have no vault
 # KV mapping. These must exist in prod.enc.env.example but are not
 # expected in vault.

--- a/scripts/checks/check_env_surface.py
+++ b/scripts/checks/check_env_surface.py
@@ -69,6 +69,11 @@ SENSITIVE = {
     "KC_ADMIN_PASSWORD",
     "VAULT_OIDC_CLIENT_SECRET",
     "GRAFANA_OIDC_CLIENT_SECRET",
+    # The tenant's hill90-ui client secret, substituted into platform-realm.json
+    # at import. A fallback would be worse than a missing value: the realm would
+    # import with a KNOWN client secret for the client that fronts hill90.com,
+    # and nothing would report it. Fail closed instead.
+    "HILL90_UI_CLIENT_SECRET",
 }
 
 # Consumed by scripts rather than by compose substitution.
@@ -79,6 +84,11 @@ SCRIPT_ONLY = {
     "VOLUME_PREFIX_BARE",
     "HTTP_PORT",
     "HTTPS_PORT",
+    # Where the TENANT's local UI listens. Read by scripts/local.sh to append that
+    # callback to the running hill90-ui client, so a local platform Keycloak can
+    # serve the tenant. No compose ${VAR}: this platform does not run the tenant's
+    # UI, it only has to know the URL Keycloak must accept a redirect to.
+    "TENANT_UI_PORT",
     # Portainer stores its OAuth configuration in its own database, applied
     # through its API by scripts/portainer.sh — there is no compose ${VAR} to
     # reference, but the value still has to be documented and kept in SOPS.

--- a/scripts/checks/check_realm_tenant_clients.py
+++ b/scripts/checks/check_realm_tenant_clients.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""Pin the tenant clients in platform-realm.json to the shape production runs.
+
+WHY THIS EXISTS
+===============
+
+A tenant of this platform authenticates against realm `platform`, and its
+authorisation depends on ONE claim: `resource_access.hill90-ui.roles`. That claim
+is emitted by Keycloak's built-in `roles` client scope. Nothing logs a warning if
+it stops being emitted — the token still validates, the login still succeeds, and
+every permission check silently returns empty. A user sees an app with no
+permissions and no error.
+
+So three things are asserted here, and each one has a specific way of going wrong:
+
+1. `hill90-ui` keeps `roles` in its `defaultClientScopes`. Left implicit, the
+   claim depends on the realm's default-client-scope list, which is edited
+   elsewhere and for other reasons.
+
+2. `hill90-ui` has NO realm-roles mapper. This is the inversion worth
+   understanding, because the obvious instinct is backwards:
+
+   `scripts/keycloak.sh` gives every PLATFORM client a realm-roles mapper, and
+   `hill90-vault` deliberately uses claim `realm_roles` because
+   `vault.sh setup-oidc` binds `{"realm_roles": ["admin"]}`. That is correct FOR
+   THE PLATFORM'S OWN CLIENTS.
+
+   For the tenant it would be a privilege hole. The `platform` realm grants
+   Grafana Admin and OpenBao access off the REALM role `admin`. The app reads
+   client roles precisely so that an app admin does not inherit infrastructure
+   admin — `services/api/src/middleware/keycloak-config.ts` says there is
+   deliberately no fallback to `realm_roles` for that reason. Adding a
+   realm-roles mapper here would re-open what the client-role design closed.
+
+3. The audience mapper for `hill90-api` survives. Without it the api rejects the
+   UI's tokens on audience validation.
+
+Plus the do-not-clobber assertions: `hill90-vault` must still be present with its
+`realm_roles` mapper intact, because adding to this file must not disturb it.
+
+Every expected value was read from the LIVE platform realm on 2026-07-30, not
+invented.
+
+Usage: python3 scripts/checks/check_realm_tenant_clients.py [path-to-realm.json]
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_REALM = ROOT / "platform" / "auth" / "keycloak" / "platform-realm.json"
+
+# The claim the tenant's services actually read. Changing this string means the
+# app changed; go and check it before editing.
+TENANT_ROLES_CLAIM = "resource_access.hill90-ui.roles"
+
+# Mapper types that would put REALM roles into a tenant token.
+REALM_ROLE_MAPPERS = {
+    "oidc-usermodel-realm-role-mapper",
+    "oidc-usermodel-role-mapper",
+}
+
+
+def fail(problems: list[str], msg: str) -> None:
+    problems.append(msg)
+
+
+def check(realm: dict) -> list[str]:
+    problems: list[str] = []
+    clients = {c.get("clientId"): c for c in realm.get("clients", [])}
+
+    # ---- the tenant's clients exist -------------------------------------
+    for cid in ("hill90-ui", "hill90-api"):
+        if cid not in clients:
+            fail(problems, f"client '{cid}' is missing — a tenant cannot authenticate without it")
+    if problems:
+        return problems
+
+    ui = clients["hill90-ui"]
+    api = clients["hill90-api"]
+
+    # ---- 1. the roles scope is pinned -----------------------------------
+    scopes = ui.get("defaultClientScopes")
+    if scopes is None:
+        fail(
+            problems,
+            "hill90-ui has no explicit defaultClientScopes. "
+            f"{TENANT_ROLES_CLAIM} then depends on the realm's default list; pin it.",
+        )
+    elif "roles" not in scopes:
+        fail(
+            problems,
+            "hill90-ui's defaultClientScopes does not include 'roles', so "
+            f"{TENANT_ROLES_CLAIM} is never emitted and every permission check "
+            "silently returns empty.",
+        )
+
+    # ---- 2. no realm-roles mapper on the tenant client ------------------
+    for m in ui.get("protocolMappers", []) or []:
+        if m.get("protocolMapper") in REALM_ROLE_MAPPERS:
+            claim = (m.get("config") or {}).get("claim.name", "<unset>")
+            fail(
+                problems,
+                f"hill90-ui has a realm-roles mapper ('{m.get('name')}' -> claim "
+                f"'{claim}'). That is correct for hill90-vault and WRONG here: the "
+                "platform realm grants Grafana Admin and OpenBao off realm role "
+                "'admin', and the app reads client roles specifically so an app "
+                "admin does not inherit infrastructure admin.",
+            )
+
+    # ---- 3. the audience mapper survives --------------------------------
+    aud = [
+        m for m in (ui.get("protocolMappers") or [])
+        if m.get("protocolMapper") == "oidc-audience-mapper"
+        and (m.get("config") or {}).get("included.client.audience") == "hill90-api"
+    ]
+    if not aud:
+        fail(
+            problems,
+            "hill90-ui has no audience mapper including 'hill90-api'. The api "
+            "validates audience, so its tokens would be rejected.",
+        )
+    else:
+        cfg = aud[0].get("config") or {}
+        if cfg.get("access.token.claim") != "true":
+            fail(problems, "the hill90-api audience mapper does not set access.token.claim=true")
+
+    # ---- the client roles the app assigns -------------------------------
+    ui_roles = {r.get("name") for r in (realm.get("roles", {}).get("client", {}) or {}).get("hill90-ui", [])}
+    for r in ("user", "admin"):
+        if r not in ui_roles:
+            fail(problems, f"client role 'hill90-ui:{r}' is not defined in roles.client")
+
+    # ---- shape of the two clients, as production runs them --------------
+    if ui.get("publicClient") is not False:
+        fail(problems, "hill90-ui must be a confidential client (publicClient: false), as in production")
+    if ui.get("standardFlowEnabled") is not True:
+        fail(problems, "hill90-ui must have standardFlowEnabled: true")
+    if ui.get("directAccessGrantsEnabled") is not False:
+        fail(
+            problems,
+            "hill90-ui must have directAccessGrantsEnabled: false — production does, "
+            "and enabling it turns a stolen password into a token with no browser involved",
+        )
+    if api.get("bearerOnly") is not True:
+        fail(problems, "hill90-api must be bearerOnly: true, as in production")
+    if api.get("standardFlowEnabled") is not False:
+        fail(problems, "hill90-api must have standardFlowEnabled: false — it is not a login client")
+
+    # ---- do not clobber -------------------------------------------------
+    vault = clients.get("hill90-vault")
+    if vault is None:
+        fail(problems, "hill90-vault has disappeared from the realm file — OpenBao SSO depends on it")
+    else:
+        vault_realm_mappers = [
+            m for m in (vault.get("protocolMappers") or [])
+            if m.get("protocolMapper") in REALM_ROLE_MAPPERS
+            and (m.get("config") or {}).get("claim.name") == "realm_roles"
+        ]
+        if not vault_realm_mappers:
+            fail(
+                problems,
+                "hill90-vault has lost its realm-roles mapper on claim 'realm_roles'. "
+                "vault.sh setup-oidc binds that exact claim; OpenBao SSO breaks without it.",
+            )
+
+    return problems
+
+
+def main() -> int:
+    path = Path(sys.argv[1]) if len(sys.argv) > 1 else DEFAULT_REALM
+    if not path.is_file():
+        print(f"realm file not found: {path}", file=sys.stderr)
+        return 2
+    realm = json.loads(path.read_text())
+    problems = check(realm)
+    if problems:
+        print(f"Tenant client check FAILED for {path.name}:", file=sys.stderr)
+        for p in problems:
+            print(f"  - {p}", file=sys.stderr)
+        return 1
+    print(
+        "Tenant clients pinned: hill90-ui (confidential, roles scope, audience "
+        "mapper, no realm-roles mapper), hill90-api (bearer-only), client roles "
+        "user+admin, hill90-vault intact."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/checks/realm-tenant-serves-test.sh
+++ b/scripts/checks/realm-tenant-serves-test.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+# Prove platform-realm.json actually SERVES the tenant, by importing it into a
+# real Keycloak and generating the access token a user would receive.
+#
+# check_realm_tenant_clients.py asserts the FILE is shaped correctly. That is not
+# the same as asserting Keycloak emits the claim the app reads, which depends on
+# built-in client scopes this repo does not own. So this asks Keycloak itself:
+# import the realm, assign a client role, and read the resulting token.
+#
+# It builds and destroys its own throwaway Keycloak. It never touches a running
+# stack, and it never touches the VPS.
+#
+# Two things bit this test before the realm was ever in question, both recorded
+# here so the next person does not rediscover them:
+#   - the Keycloak 26 image is UBI-micro and ships NO curl, so an in-container
+#     HTTP probe fails while the server is perfectly healthy;
+#   - the realm ships sslRequired=external, correct for production, so plain HTTP
+#     returns 403 "HTTPS required" until it is relaxed — which is exactly what
+#     scripts/local.sh does to the running realm.
+#
+# Usage: bash scripts/checks/realm-tenant-serves-test.sh
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+KC="h90realmtest-kc"
+IMG="quay.io/keycloak/keycloak:26.4.0"
+ADMIN=admin
+# Disposable, for a container that is destroyed at the end of this script.
+ADMIN_PW=throwaway-not-a-real-credential
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; BOLD='\033[1m'; NC='\033[0m'
+pass=0; fail=0
+ok()   { echo -e "  ${GREEN}✓${NC} $1"; pass=$((pass+1)); }
+bad()  { echo -e "  ${RED}✗${NC} $1"; fail=$((fail+1)); }
+
+cleanup() { docker rm -f "$KC" >/dev/null 2>&1 || true; }
+trap cleanup EXIT
+cleanup
+
+echo -e "${BOLD}Importing platform-realm.json into a real Keycloak${NC}"
+docker run -d --name "$KC" -p 18099:8080 \
+  -e KC_BOOTSTRAP_ADMIN_USERNAME="$ADMIN" \
+  -e KC_BOOTSTRAP_ADMIN_PASSWORD="$ADMIN_PW" \
+  -e KC_HTTP_ENABLED=true \
+  -e HILL90_UI_CLIENT_SECRET=local-tenant-ui-secret-0123456789 \
+  -e HILL90_UI_REDIRECT_URI=http://localhost:13000/api/auth/callback/keycloak \
+  -e HILL90_UI_WEB_ORIGIN=http://localhost:13000 \
+  -e VAULT_OIDC_CLIENT_SECRET=throwaway-vault-secret \
+  -e GRAFANA_OIDC_CLIENT_SECRET=throwaway-grafana-secret \
+  -e PORTAINER_OIDC_CLIENT_SECRET=throwaway-portainer-secret \
+  -v "$ROOT/platform/auth/keycloak/platform-realm.json:/opt/keycloak/data/import/platform-realm.json:ro" \
+  "$IMG" start-dev --import-realm >/dev/null
+
+echo "  waiting for Keycloak..."
+# Readiness via kcadm, not curl: the Keycloak 26 image is UBI-micro and ships no
+# curl, so an in-container HTTP probe fails even when the server is fine. And the
+# realm ships sslRequired=external (correct for production), so plain HTTP from
+# the host returns 403 "HTTPS required" until it is relaxed — scripts/local.sh
+# does exactly that on the running realm. Both of those bit this verification
+# before the realm itself was ever in question.
+ready() { docker exec "$KC" /opt/keycloak/bin/kcadm.sh config credentials \
+            --server http://127.0.0.1:8080 --realm master \
+            --user "$ADMIN" --password "$ADMIN_PW" >/dev/null 2>&1; }
+for _ in $(seq 1 60); do ready && break; sleep 2; done
+if ! ready; then
+  echo -e "${RED}Keycloak never came up. Import log:${NC}"
+  docker logs "$KC" 2>&1 | grep -iE "error|warn|import|realm" | tail -25
+  exit 2
+fi
+ok "realm 'platform' imported; kcadm authenticated"
+
+# The same delta local.sh applies, so HTTP discovery is reachable here too.
+docker exec "$KC" /opt/keycloak/bin/kcadm.sh update realms/platform -s sslRequired=NONE >/dev/null 2>&1
+if curl -sf "http://localhost:18099/realms/platform/.well-known/openid-configuration" >/dev/null 2>&1; then
+  ok "OIDC discovery served over HTTP after relaxing sslRequired (as local.sh does)"
+else
+  bad "OIDC discovery still not served over HTTP"
+fi
+
+kc() { docker exec "$KC" /opt/keycloak/bin/kcadm.sh "$@" 2>&1; }
+kc config credentials --server http://localhost:8080 --realm master \
+   --user "$ADMIN" --password "$ADMIN_PW" >/dev/null 2>&1 \
+   || { echo "kcadm login failed"; exit 2; }
+
+# ---------------------------------------------------------------------------
+echo ""
+echo -e "${BOLD}The clients a tenant consumes${NC}"
+CLIENTS=$(kc get clients -r platform --fields clientId 2>/dev/null | tr -d ' \n')
+for c in hill90-ui hill90-api hill90-vault; do
+  echo "$CLIENTS" | grep -q "\"$c\"" && ok "client $c present" || bad "client $c MISSING"
+done
+
+get_field() { kc get "clients?clientId=$1" -r platform 2>/dev/null | python3 -c "
+import sys,json
+d=json.load(sys.stdin)
+if not d: print('MISSING'); raise SystemExit
+v=d[0]
+for k in '$2'.split('.'):
+    v = v.get(k) if isinstance(v,dict) else v
+print(json.dumps(v))
+" 2>/dev/null; }
+
+# These must be PRODUCTION's values verbatim. Local gets its callback appended to
+# the running client by local.sh, which is why the file can mirror prod exactly.
+RU=$(get_field hill90-ui redirectUris)
+[ "$RU" = '["https://hill90.com/api/auth/callback/keycloak"]' ] \
+  && ok "redirectUris mirror production exactly: $RU" \
+  || bad "redirectUris are not production's: $RU"
+WO=$(get_field hill90-ui webOrigins)
+[ "$WO" = '["https://hill90.com"]' ] \
+  && ok "webOrigins mirror production exactly: $WO" \
+  || bad "webOrigins are not production's: $WO"
+
+[ "$(get_field hill90-ui publicClient)" = "false" ] && ok "hill90-ui is confidential" || bad "hill90-ui is not confidential"
+[ "$(get_field hill90-api bearerOnly)" = "true" ]   && ok "hill90-api is bearer-only" || bad "hill90-api is not bearer-only"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo -e "${BOLD}Client roles, and the platform's own client untouched${NC}"
+UI_ID=$(kc get "clients?clientId=hill90-ui" -r platform --fields id 2>/dev/null | python3 -c "import sys,json;print(json.load(sys.stdin)[0]['id'])")
+ROLES=$(kc get "clients/$UI_ID/roles" -r platform --fields name 2>/dev/null | tr -d ' \n')
+for r in user admin; do
+  echo "$ROLES" | grep -q "\"$r\"" && ok "client role hill90-ui:$r exists" || bad "client role hill90-ui:$r MISSING"
+done
+VAULT_MAP=$(kc get "clients?clientId=hill90-vault" -r platform 2>/dev/null | python3 -c "
+import sys,json
+c=json.load(sys.stdin)[0]
+ms=[(m['name'],(m.get('config') or {}).get('claim.name')) for m in c.get('protocolMappers',[])]
+print(ms)
+" 2>/dev/null)
+echo "$VAULT_MAP" | grep -q "realm_roles" \
+  && ok "hill90-vault kept its realm_roles mapper — $VAULT_MAP" \
+  || bad "hill90-vault lost its realm_roles mapper — $VAULT_MAP"
+
+# ---------------------------------------------------------------------------
+# The decisive test: what claims does a user actually GET?
+# ---------------------------------------------------------------------------
+echo ""
+echo -e "${BOLD}The token a user would actually receive${NC}"
+kc create users -r platform -s username=localdev -s enabled=true >/dev/null 2>&1
+UID_=$(kc get "users?username=localdev&exact=true" -r platform --fields id 2>/dev/null | python3 -c "import sys,json;print(json.load(sys.stdin)[0]['id'])")
+kc add-roles -r platform --uid "$UID_" --cclientid hill90-ui --rolename admin >/dev/null 2>&1 \
+  && ok "assigned hill90-ui:admin to a test user" \
+  || bad "could not assign the client role"
+
+TOKEN_JSON=$(kc get "clients/$UI_ID/evaluate-scopes/generate-example-access-token?userId=${UID_}&scope=" -r platform 2>/dev/null)
+echo "$TOKEN_JSON" | python3 -c "
+import sys, json
+raw = sys.stdin.read()
+try:
+    t = json.loads(raw)
+except Exception:
+    print('COULD NOT PARSE:', raw[:400]); raise SystemExit(1)
+ra = (t.get('resource_access') or {}).get('hill90-ui', {}).get('roles')
+aud = t.get('aud')
+realm = (t.get('realm_access') or {}).get('roles')
+print('resource_access.hill90-ui.roles =', ra)
+print('aud                            =', aud)
+print('realm_access.roles             =', realm)
+print('has realm_roles claim          =', 'realm_roles' in t)
+" > /tmp/h90-token-claims.txt 2>&1
+cat /tmp/h90-token-claims.txt | sed 's/^/      /'
+
+CLAIMS=$(cat /tmp/h90-token-claims.txt)
+echo "$CLAIMS" | grep -q "resource_access.hill90-ui.roles = \['admin'\]" \
+  && ok "the claim the app reads is populated: resource_access.hill90-ui.roles = ['admin']" \
+  || bad "resource_access.hill90-ui.roles is NOT what the app expects"
+echo "$CLAIMS" | grep -qE "aud .*hill90-api" \
+  && ok "audience includes hill90-api, so the api will accept the UI's token" \
+  || bad "audience does NOT include hill90-api — the api would reject these tokens"
+echo "$CLAIMS" | grep -q "has realm_roles claim          = False" \
+  && ok "no realm_roles claim on the tenant token — the privilege hole stays closed" \
+  || bad "a realm_roles claim is present on the tenant token"
+
+# ---------------------------------------------------------------------------
+# The local delta local.sh applies. New code, so prove it rather than trust it:
+# it must ADD the local callback and origin while KEEPING production's.
+# ---------------------------------------------------------------------------
+echo ""
+echo -e "${BOLD}The local delta (same kcadm calls scripts/local.sh makes)${NC}"
+UI_LOCAL="http://localhost:13000"
+UI_URIS=$(python3 -c '
+import json, sys
+print(json.dumps(["https://hill90.com/api/auth/callback/keycloak",
+                  sys.argv[1].rstrip("/") + "/api/auth/callback/keycloak"]))' "$UI_LOCAL")
+UI_ORIGINS=$(python3 -c '
+import json, sys
+print(json.dumps(["https://hill90.com", sys.argv[1].rstrip("/")]))' "$UI_LOCAL")
+CID=$(docker exec "$KC" /opt/keycloak/bin/kcadm.sh get clients -r platform \
+        -q clientId=hill90-ui --fields id --format csv --noquotes 2>/dev/null | tr -d '\r')
+if [ -n "$CID" ] && docker exec "$KC" /opt/keycloak/bin/kcadm.sh update "clients/${CID}" \
+     -r platform -s "redirectUris=${UI_URIS}" -s "webOrigins=${UI_ORIGINS}" >/dev/null 2>&1; then
+  ok "delta applied via kcadm (client id resolved by the same csv/noquotes call local.sh uses)"
+else
+  bad "delta failed — local.sh would warn and the tenant's local login would be rejected"
+fi
+RU2=$(get_field hill90-ui redirectUris)
+echo "$RU2" | grep -q "localhost:13000/api/auth/callback/keycloak" \
+  && ok "local callback present after the delta" || bad "local callback missing: $RU2"
+echo "$RU2" | grep -q "https://hill90.com/api/auth/callback/keycloak" \
+  && ok "production callback KEPT, not replaced" || bad "production callback was clobbered: $RU2"
+WO2=$(get_field hill90-ui webOrigins)
+echo "$WO2" | grep -q "localhost:13000" \
+  && ok "local web origin present (CORS for NextAuth)" || bad "local web origin missing: $WO2"
+echo "$WO2" | grep -q "https://hill90.com" \
+  && ok "production web origin KEPT" || bad "production web origin was clobbered: $WO2"
+
+echo ""
+if [ "$fail" -eq 0 ]; then
+  echo -e "${GREEN}${BOLD}All ${pass} assertions passed against a real Keycloak.${NC}"; exit 0
+fi
+echo -e "${RED}${BOLD}${fail} failed, ${pass} passed.${NC}"; exit 1

--- a/scripts/local.sh
+++ b/scripts/local.sh
@@ -337,6 +337,39 @@ print(json.dumps([
         warn "Could not add local OIDC callbacks to hill90-vault — 'local.sh vault setup-oidc' logins will fail with 'Invalid parameter: redirect_uri'"
     fi
 
+    # Same shape, third delta: hill90-ui ships production URLs too, and it is the
+    # client the TENANT's local stack authenticates with. Without this, pointing
+    # hill90-app's local UI at this Keycloak fails with
+    # "Invalid parameter: redirect_uri" — so local would prove the realm design
+    # and never the tenancy, which is the gap this delta exists to close.
+    #
+    # webOrigins matters as well as redirectUris: NextAuth's browser-side calls
+    # are rejected by CORS without it, and that failure looks like an auth
+    # problem rather than an origin problem. Production already learned that
+    # distinction the hard way on api.hill90.com.
+    local ui_local; ui_local="http://localhost:$(env_get TENANT_UI_PORT 13000)"
+    local ui_uris_json ui_origins_json
+    ui_uris_json=$(python3 -c '
+import json, sys
+print(json.dumps([
+    "https://hill90.com/api/auth/callback/keycloak",
+    sys.argv[1].rstrip("/") + "/api/auth/callback/keycloak",
+]))' "$ui_local")
+    ui_origins_json=$(python3 -c '
+import json, sys
+print(json.dumps(["https://hill90.com", sys.argv[1].rstrip("/")]))' "$ui_local")
+    local ui_cid
+    ui_cid=$(docker exec "${cpfx}keycloak" /opt/keycloak/bin/kcadm.sh get clients \
+        -r "${KC_PLATFORM_REALM:-platform}" -q clientId=hill90-ui --fields id \
+        --format csv --noquotes 2>/dev/null | tr -d '\r')
+    if [ -n "$ui_cid" ] && docker exec "${cpfx}keycloak" /opt/keycloak/bin/kcadm.sh update \
+        "clients/${ui_cid}" -r "${KC_PLATFORM_REALM:-platform}" \
+        -s "redirectUris=${ui_uris_json}" -s "webOrigins=${ui_origins_json}" >/dev/null 2>&1; then
+        success "Added local callbacks and origin to the hill90-ui client (${ui_local})"
+    else
+        warn "Could not add local callbacks to hill90-ui — pointing the tenant's local UI at this Keycloak will fail with 'Invalid parameter: redirect_uri'"
+    fi
+
     info "Starting the vault stack (openbao)..."
     compose_vault up -d || die "Vault stack failed to start"
 

--- a/tests/checks/test_realm_tenant_clients.py
+++ b/tests/checks/test_realm_tenant_clients.py
@@ -1,0 +1,144 @@
+"""Tests for scripts/checks/check_realm_tenant_clients.py
+
+Invokes the checker as a CLI against mutated copies of the real realm file, the
+same subprocess pattern as test_secrets_schema.py.
+
+Each mutation is a way the tenant's authorisation has actually been at risk of
+breaking silently, so a test that stops catching one of these is worth noticing.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "checks" / "check_realm_tenant_clients.py"
+REALM = ROOT / "platform" / "auth" / "keycloak" / "platform-realm.json"
+
+
+def run(realm: dict) -> subprocess.CompletedProcess:
+    with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as f:
+        json.dump(realm, f)
+        path = f.name
+    try:
+        return subprocess.run(
+            ["python3", str(SCRIPT), path], capture_output=True, text=True, timeout=60
+        )
+    finally:
+        Path(path).unlink(missing_ok=True)
+
+
+@pytest.fixture
+def realm() -> dict:
+    return json.loads(REALM.read_text())
+
+
+def client(realm: dict, cid: str) -> dict:
+    return next(c for c in realm["clients"] if c["clientId"] == cid)
+
+
+def test_the_real_realm_file_passes():
+    result = subprocess.run(
+        ["python3", str(SCRIPT)], capture_output=True, text=True, cwd=ROOT, timeout=60
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_fails_when_the_roles_scope_is_dropped(realm):
+    ui = client(realm, "hill90-ui")
+    ui["defaultClientScopes"] = [s for s in ui["defaultClientScopes"] if s != "roles"]
+    r = run(realm)
+    assert r.returncode == 1
+    assert "roles" in r.stderr and "silently" in r.stderr
+
+
+def test_fails_when_default_client_scopes_are_left_implicit(realm):
+    del client(realm, "hill90-ui")["defaultClientScopes"]
+    r = run(realm)
+    assert r.returncode == 1
+    assert "defaultClientScopes" in r.stderr
+
+
+@pytest.mark.parametrize(
+    "claim", ["realm_access.roles", "realm_roles", "roles"]
+)
+def test_fails_on_any_realm_roles_mapper_whatever_the_claim(realm, claim):
+    """The trap is the mapper TYPE, not the claim string it happens to carry."""
+    client(realm, "hill90-ui").setdefault("protocolMappers", []).append(
+        {
+            "name": "realm-roles",
+            "protocol": "openid-connect",
+            "protocolMapper": "oidc-usermodel-realm-role-mapper",
+            "config": {"claim.name": claim, "access.token.claim": "true"},
+        }
+    )
+    r = run(realm)
+    assert r.returncode == 1
+    assert "realm-roles mapper" in r.stderr
+
+
+def test_fails_when_the_audience_mapper_is_removed(realm):
+    client(realm, "hill90-ui")["protocolMappers"] = []
+    r = run(realm)
+    assert r.returncode == 1
+    assert "audience" in r.stderr
+
+
+def test_fails_when_a_client_role_is_missing(realm):
+    realm["roles"]["client"]["hill90-ui"] = [
+        r for r in realm["roles"]["client"]["hill90-ui"] if r["name"] != "admin"
+    ]
+    r = run(realm)
+    assert r.returncode == 1
+    assert "hill90-ui:admin" in r.stderr
+
+
+def test_fails_when_direct_access_grants_are_enabled(realm):
+    client(realm, "hill90-ui")["directAccessGrantsEnabled"] = True
+    r = run(realm)
+    assert r.returncode == 1
+    assert "directAccessGrantsEnabled" in r.stderr
+
+
+def test_fails_when_the_ui_client_is_made_public(realm):
+    client(realm, "hill90-ui")["publicClient"] = True
+    r = run(realm)
+    assert r.returncode == 1
+    assert "confidential" in r.stderr
+
+
+def test_fails_when_the_api_client_stops_being_bearer_only(realm):
+    client(realm, "hill90-api")["bearerOnly"] = False
+    r = run(realm)
+    assert r.returncode == 1
+    assert "bearerOnly" in r.stderr
+
+
+def test_fails_when_a_tenant_client_is_absent(realm):
+    realm["clients"] = [c for c in realm["clients"] if c["clientId"] != "hill90-api"]
+    r = run(realm)
+    assert r.returncode == 1
+    assert "hill90-api" in r.stderr
+
+
+# ---- do-not-clobber: the additions must not cost the platform its own client ----
+
+
+def test_fails_when_hill90_vault_is_removed(realm):
+    realm["clients"] = [c for c in realm["clients"] if c["clientId"] != "hill90-vault"]
+    r = run(realm)
+    assert r.returncode == 1
+    assert "hill90-vault" in r.stderr and "OpenBao" in r.stderr
+
+
+def test_fails_when_vaults_realm_roles_mapper_is_lost(realm):
+    client(realm, "hill90-vault")["protocolMappers"] = []
+    r = run(realm)
+    assert r.returncode == 1
+    assert "realm_roles" in r.stderr

--- a/tests/checks/test_realm_tenant_serves.py
+++ b/tests/checks/test_realm_tenant_serves.py
@@ -1,0 +1,42 @@
+"""Tests for scripts/checks/realm-tenant-serves-test.sh
+
+The file-shape assertions live in test_realm_tenant_clients.py. These are the ones
+that need a real Keycloak, because the claim the tenant's services read —
+`resource_access.hill90-ui.roles` — is emitted by built-in client scopes this repo
+does not define. Only Keycloak can answer whether it actually appears.
+
+The script builds and destroys its own throwaway Keycloak; it never touches a
+running stack.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "checks" / "realm-tenant-serves-test.sh"
+
+docker_available = shutil.which("docker") is not None and (
+    subprocess.run(["docker", "info"], capture_output=True, timeout=30).returncode == 0
+    if shutil.which("docker")
+    else False
+)
+
+
+def test_script_exists():
+    assert SCRIPT.is_file(), f"missing: {SCRIPT}"
+
+
+@pytest.mark.skipif(not docker_available, reason="needs a reachable docker daemon")
+def test_the_realm_serves_the_tenant():
+    result = subprocess.run(
+        ["bash", str(SCRIPT)], capture_output=True, text=True, cwd=ROOT, timeout=900
+    )
+    assert result.returncode == 0, (
+        "the platform realm does not serve the tenant correctly:\n"
+        f"{result.stdout}\n{result.stderr}"
+    )

--- a/tests/scripts/platform-services.bats
+++ b/tests/scripts/platform-services.bats
@@ -65,15 +65,53 @@ assert 'hill90-vault' in [c['clientId'] for c in r.get('clients', [])]
   [ "$status" -eq 0 ]
 }
 
-@test "the platform realm contains no application clients" {
-  # hill90-ui and hill90-api belong to the extracted application, which is one
-  # tenant among several and brings its own realm.
+@test "the platform realm's client list is exactly the deliberate allowlist" {
+  # SUPERSEDED ASSERTION, recorded rather than deleted quietly.
+  #
+  # This test used to assert the OPPOSITE: that hill90-ui and hill90-api must NOT
+  # appear here, "because the extracted application is one tenant among several
+  # and brings its own realm". That was the realm-per-consumer shape in
+  # docs/decisions/platform-primitives.md, and it was retracted — the settled
+  # decision is ONE Keycloak and ONE realm, the existing `platform`, with the
+  # tenant's clients inside it. The live realm has had both clients since
+  # 2026-07-30, so the old assertion contradicted production.
+  #
+  # The guard is kept with teeth rather than dropped: the client list is an
+  # ALLOWLIST, so a new client cannot accumulate here without someone editing this
+  # line and thinking about it. That is what the original test was really for.
+  #
+  # grafana and portainer are deliberately absent — scripts/keycloak.sh creates
+  # those at deploy time, they were never in this file.
   run python3 -c "
 import json
 r = json.load(open('platform/auth/keycloak/platform-realm.json'))
-ids = [c['clientId'] for c in r.get('clients', [])]
-bad = [i for i in ids if i in ('hill90-ui', 'hill90-api')]
-assert not bad, bad
+ids = sorted(c['clientId'] for c in r.get('clients', []))
+expected = sorted(['hill90-vault', 'hill90-ui', 'hill90-api'])
+assert ids == expected, f'unexpected client list: {ids} != {expected}'
+"
+  [ "$status" -eq 0 ]
+}
+
+@test "the tenant's clients carry no realm-role mapper" {
+  # The reason the tenant's clients are allowed in this realm at all is that they
+  # use CLIENT roles. This realm grants Grafana Admin and OpenBao off the REALM
+  # role 'admin', so a realm-role mapper on a tenant client would hand an
+  # application admin infrastructure administration.
+  #
+  # Asserted here as well as in scripts/checks/check_realm_tenant_clients.py
+  # because this is the file that reviews the realm's separation properties.
+  run python3 -c "
+import json
+r = json.load(open('platform/auth/keycloak/platform-realm.json'))
+bad = []
+for c in r.get('clients', []):
+    if c['clientId'] not in ('hill90-ui', 'hill90-api'):
+        continue
+    for m in c.get('protocolMappers', []) or []:
+        if m.get('protocolMapper') in ('oidc-usermodel-realm-role-mapper',
+                                       'oidc-usermodel-role-mapper'):
+            bad.append((c['clientId'], m.get('name')))
+assert not bad, f'realm-role mapper on a tenant client: {bad}'
 "
   [ "$status" -eq 0 ]
 }


### PR DESCRIPTION
Local proved the realm **design** and not the **tenancy**, because a local platform
Keycloak had no `hill90-ui` or `hill90-api` to serve. It does now. Retiring
`app-keycloak` was gated on this.

## No structural blocker — saying it early, as asked

The issuer is **byte-identical** whether Keycloak is reached through Traefik on the
browser path or via the internal `keycloak` alias from a container on the shared
network:

```
browser path   http://auth.localtest.me:8080/realms/platform/...  -> issuer http://auth.localtest.me:8080/realms/platform
internal alias http://keycloak:8080/realms/platform/...           -> issuer http://auth.localtest.me:8080/realms/platform
```

So the tenant's existing split-horizon handling (`KC_HOSTNAME_BACKCHANNEL_DYNAMIC`,
`KEYCLOAK_INTERNAL_ISSUER`) transfers unchanged. And there is **no DNS-alias
collision**, which was worth checking given invariant 4: the tenant's service key is
`app-keycloak`, this platform's is `keycloak`, so the two aliases coexist.

## Two premises in your brief were wrong, and the second inverts the trap

**`platform-realm.json` did not already carry `grafana` and `portainer`** — only
`hill90-vault`. The other two are created by `scripts/keycloak.sh` at deploy time.
Nothing was clobbered either way, and I checked **after** the edit, not just before:
`hill90-vault` is byte-identical to `main` and keeps its `realm_roles` mapper.

**The `realm_roles` trap now runs the other way.** The app no longer reads a custom
claim. `services/api/src/middleware/keycloak-config.ts` reads
`resource_access.<client>.roles` — the *standard* claim — and states there is
deliberately no fallback to `realm_roles` because the platform realm grants Grafana
Admin and OpenBao off realm role `admin`. Production confirms it: `hill90-ui` carries
**exactly one mapper**, the audience mapper, and no realm-roles mapper at all.

`keycloak.sh:154`'s `realm_access.roles` default never touches these clients — it is
applied to `grafana`, `portainer` and `hill90-vault`, and vault deliberately passes
`realm_roles`. So the danger is not *getting* the default. It is **adding** a
realm-roles mapper here, which would reopen exactly what client roles closed. The
check asserts its absence for that reason.

## Mirrors production, read rather than invented

| | production (read 2026-07-30) | realm file |
|---|---|---|
| `hill90-ui` | confidential, standard flow, direct grants **off**, `fullScopeAllowed` | same |
| mappers on `hill90-ui` | one: `hill90-api-audience` | same, and no other is permitted |
| client roles | `user` / `admin` with those descriptions | verbatim |
| `hill90-api` | bearer-only, no flows | same |
| redirect / origin | `https://hill90.com/...` | **literal**, not parameterised |

## I reverted my own first design, because this repo already had the answer

My first version parameterised the redirect URI and web origin through two new
environment variables. Then I found `local.sh`'s existing idiom: **production values
stay in the realm file and local appends a delta to the running client** — it already
does this for `hill90-vault`, with the comment *"production values are the defaults,
local adds deltas"*.

That is strictly better here: it makes the file mirror production **literally**, which
is what you asked for, and it removed both new variables. So I reverted and added the
third delta for `hill90-ui`. It sets `webOrigins` as well as `redirectUris`, because
NextAuth's browser-side calls fail CORS without it — and that failure reads as an auth
problem rather than an origin problem, which this estate has already paid for once on
`api.hill90.com`.

## What pins it, and what proves it

**Pins the file** — `scripts/checks/check_realm_tenant_clients.py`, 14 table-driven
tests. Each case is a real way this breaks *silently*: the `roles` scope dropped from
`defaultClientScopes`; `defaultClientScopes` left implicit; a realm-role mapper of
**any** claim name; the audience mapper removed; a missing client role; direct grants
enabled; the UI made public; the api no longer bearer-only; and the two do-not-clobber
cases on `hill90-vault`.

**Proves Keycloak agrees** — asserting the file is shaped right is not asserting the
claim is emitted, which depends on built-in client scopes this repo does not own. So
`scripts/checks/realm-tenant-serves-test.sh` imports the realm into a throwaway
Keycloak, assigns `hill90-ui:admin` to a test user, and reads the token Keycloak
generates:

```
resource_access.hill90-ui.roles = ['admin']
aud                            = ['hill90-api', 'account']
realm_access.roles             = ['offline_access', 'uma_authorization', 'default-roles-platform']
has realm_roles claim          = False
```

That last line and the `realm_access` line are the privilege boundary, measured on a
token rather than argued from config.

```
All 21 assertions passed against a real Keycloak.
```

Including the local delta itself, since it was new code: local callback added,
**production callback kept**, same for the origin.

`47 passed` in `tests/checks/` (was 45). `check_env_surface.py`,
`check_secrets_schema.py`, `check_md_links.py`, `check_realm_tenant_clients.py` all
clean. No throwaway containers left behind.

## Two gotchas that cost me time, recorded in the script so they cost nobody else

- The **Keycloak 26 image ships no `curl`** (UBI-micro), so an in-container HTTP probe
  fails while the server is perfectly healthy. My first two runs reported "realm never
  came up" while the logs said `Realm 'platform' imported` / `Import finished
  successfully`. The realm was never the problem; the probe was.
- The realm ships **`sslRequired=external`**, correct for production, so plain HTTP
  returns `403 HTTPS required` until relaxed — which is exactly what `local.sh` already
  does to the running realm.

## `HILL90_UI_CLIENT_SECRET` — registered, no production value yet

Same mechanism as `VAULT_OIDC_CLIENT_SECRET`. It bites **only on a first import**, so a
**VPS rebuild** is the case that depends on it, and its value must equal what
`hill90-app` holds. It is deliberately exempt from the default-value rule in
`check_env_surface.py`: a fallback would import a *known* secret for the client fronting
`hill90.com` and report nothing.

## What I need from the tenant's side — coordination, not a change I made

`hill90-app` was not touched (read-only greps and queries). To join the two locally, its
local stack needs to point at this platform's Keycloak instead of `app-keycloak`:

- `AUTH_KEYCLOAK_ISSUER` / `KEYCLOAK_ISSUER` → `http://auth.localtest.me:8080/realms/platform`
- `KEYCLOAK_INTERNAL_ISSUER` → `http://keycloak:8080/realms/platform`
- `AUTH_KEYCLOAK_ID` → `hill90-ui`, and `AUTH_KEYCLOAK_SECRET` = this platform's
  `HILL90_UI_CLIENT_SECRET` from `.env.local` (they must match, or the exchange fails
  `invalid_client` — the production failure repeated locally)
- its local UI must stay on the port `TENANT_UI_PORT` names (13000), since that is the
  callback this platform adds

**One parity gap I did not close on my own initiative:** production's platform realm
ships **no users**, and mirroring that means a local platform realm has no login out of
the box, whereas the tenant's own local realm bakes in a `dev` account. Adding a local
dev user is a decision about the shared realm file, so I have left it to you rather than
quietly diverging from production.

Hill90 stayed at 13 containers locally and on the VPS; the VPS was read-only throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)