### PR TITLE
feat(auth): reconcile the tenant's clients onto an existing realm, and prove a login

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,6 +174,18 @@ the migration run — but say "nothing worth preserving", not "empty".
   `hill90admin` and `testuser01` in platform realm `platform`, and the same three in
   realm `hill90` on the tenant's own Keycloak.
 - **`app-postgres` is still running and still serving.** See above.
+- **Declaring a client in `platform-realm.json` does NOT put it in a realm that
+  already exists.** `start --import-realm` is `IGNORE_EXISTING`, so the file is read
+  only on first boot — `keycloak.sh`'s own header says so, and #584 shipped clients
+  into it with no reconcile path, which made the change inert on production and on
+  every existing local stack. Use `bash scripts/keycloak.sh tenant-clients`; it is
+  idempotent and **never rewrites an existing client's secret**, because production's
+  `hill90-ui` secret is live and correct while `HILL90_UI_CLIENT_SECRET` has no
+  production value.
+- **A local dev account needs `email`, `firstName` and `lastName`.** The realm carries
+  Keycloak's default Verify Profile action, so a user without them is diverted to
+  `required-action?execution=VERIFY_PROFILE` and the login never completes. It looks
+  like rejected credentials and is not.
 - **Local parity — this platform's half is done; the tenant's is not.**
   `platform-realm.json` now carries `hill90-ui` and `hill90-api`, mirroring
   production literally, so a **local** platform Keycloak can serve a tenant the way
@@ -181,6 +193,11 @@ the migration run — but say "nothing worth preserving", not "empty".
   the token a user would get: `resource_access.hill90-ui.roles = ['admin']`,
   `aud` includes `hill90-api`, and no `realm_roles` claim —
   `scripts/checks/realm-tenant-serves-test.sh`, `Verified 2026-07-30 02:41 UTC`.
+  A **completed authorization-code login** against the running local platform
+  Keycloak now backs that up — form, credentials, code, token exchange — with the
+  token carrying `resource_access.hill90-ui.roles = ['admin']`, `aud` including
+  `hill90-api`, no `admin` in `realm_access.roles`, and a roleless user refused:
+  `scripts/checks/tenant-login-local-test.sh`, `Verified 2026-07-30 03:17 UTC`.
   **What remains is the tenant's side:** its local stack still points at its own
   `app-keycloak`, so local proves the realm design and not yet the tenancy.
   **Local parity lands before anything is retired**, because a broken local stack

--- a/scripts/checks/tenant-login-local-test.sh
+++ b/scripts/checks/tenant-login-local-test.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# Complete a REAL authorization-code login against the LOCAL PLATFORM Keycloak as
+# the tenant's client, and read the resulting token.
+#
+# Requires a running local platform stack; exits 0 with SKIP if there is none, so
+# it is safe to run anywhere. It creates two throwaway users and deletes them.
+#
+# Not an example-token generator and not a form that rendered: this walks the
+# actual flow — auth endpoint, login form POST, authorization code, token
+# exchange — because "the form appeared" is the exact error that let a broken
+# client secret sit unnoticed for a day.
+#
+# Two users, deliberately:
+#   localdev     holds hill90-ui:admin  -> must be authorised
+#   localnorole  holds no client role   -> must be REFUSED
+# Without the second, this would only show authorisation is permissive.
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+ENVF="${ENVF:-$ROOT/.env.local}"
+envget() { grep -E "^$1=" "$ENVF" 2>/dev/null | tail -n1 | cut -d= -f2-; }
+
+KC="${KC_CONTAINER:-$(envget CONTAINER_PREFIX)keycloak}"
+REALM="${KC_REALM:-$(envget KC_REALM)}"; REALM="${REALM:-platform}"
+BASE="${KC_PUBLIC_URL:-http://$(envget AUTH_HOST).$(envget BASE_DOMAIN):$(envget HTTP_PORT)}"
+UI_REDIRECT="http://localhost:$(envget TENANT_UI_PORT)/api/auth/callback/keycloak"
+SECRET=$(envget HILL90_UI_CLIENT_SECRET)
+ADMIN_U=$(envget KC_ADMIN_USERNAME)
+ADMIN_P=$(envget KC_ADMIN_PASSWORD)
+PW='LocalProbe!2026'
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; BOLD='\033[1m'; NC='\033[0m'
+pass=0; fail=0
+ok()  { echo -e "  ${GREEN}✓${NC} $1"; pass=$((pass+1)); }
+bad() { echo -e "  ${RED}✗${NC} $1"; fail=$((fail+1)); }
+
+docker inspect "$KC" >/dev/null 2>&1 \
+  || { echo "SKIP: ${KC} is not running. Bring the local platform up first: bash scripts/local.sh up"; exit 0; }
+
+kc() { docker exec "$KC" /opt/keycloak/bin/kcadm.sh "$@"; }
+KC_CLI_PASSWORD="$ADMIN_P" docker exec -e KC_CLI_PASSWORD "$KC" \
+  /opt/keycloak/bin/kcadm.sh config credentials --server http://127.0.0.1:8080 \
+  --realm master --user "$ADMIN_U" >/dev/null 2>&1 || { echo "kcadm login failed"; exit 2; }
+
+mkuser() {
+  local u="$1"
+  kc delete "users/$(kc get users -r $REALM -q "username=$u" --fields id --format csv --noquotes 2>/dev/null | tr -d '\r' | head -1)" -r $REALM >/dev/null 2>&1 || true
+  # email/firstName/lastName are REQUIRED, not decoration: the realm has
+  # Keycloak's default Verify Profile action, so a user missing them is diverted
+  # to required-action?execution=VERIFY_PROFILE instead of completing the login.
+  # That is what silently broke the first run of this script.
+  kc create users -r $REALM -s "username=$u" -s enabled=true -s emailVerified=true \
+     -s "email=${u}@localtest.me" -s "firstName=${u}" -s "lastName=Probe" >/dev/null 2>&1
+  local id; id=$(kc get users -r $REALM -q "username=$u" --fields id --format csv --noquotes 2>/dev/null | tr -d '\r' | head -1)
+  kc set-password -r $REALM --userid "$id" --new-password "$PW" >/dev/null 2>&1
+  echo "$id"
+}
+
+cleanup() {
+  for u in localdev localnorole; do
+    local id; id=$(kc get users -r $REALM -q "username=$u" --fields id --format csv --noquotes 2>/dev/null | tr -d '\r' | head -1)
+    [ -n "$id" ] && kc delete "users/$id" -r $REALM >/dev/null 2>&1
+  done
+  echo "  (probe users removed)"
+}
+trap cleanup EXIT
+
+echo -e "${BOLD}Setting up two users${NC}"
+ID_ADMIN=$(mkuser localdev)
+mkuser localnorole >/dev/null
+kc add-roles -r $REALM --uid "$ID_ADMIN" --cclientid hill90-ui --rolename admin >/dev/null 2>&1 \
+  && ok "localdev holds hill90-ui:admin" || bad "could not assign hill90-ui:admin"
+ok "localnorole holds no client role (the refusal control)"
+
+# --------------------------------------------------------------------------
+# login USER -> prints the access token, or empty on failure
+# --------------------------------------------------------------------------
+login() {
+  local user="$1" jar; jar=$(mktemp)
+  local enc_redirect auth_url
+  enc_redirect=$(python3 -c "import urllib.parse,sys;print(urllib.parse.quote(sys.argv[1],safe=''))" "$UI_REDIRECT")
+  auth_url="${BASE}/realms/${REALM}/protocol/openid-connect/auth?client_id=hill90-ui&response_type=code&scope=openid&redirect_uri=${enc_redirect}&state=probe123"
+  # 1. the login page, keeping cookies
+  local form_action
+  curl -s -c "$jar" -b "$jar" -L "$auth_url" -o "${jar}.html"
+  # grep/sed, not an inline python regex: inside a single-quoted python -c a
+  # r"...\"..." pattern is a LITERAL backslash-quote and silently never matches,
+  # which is what broke the first version of this script.
+  form_action=$(grep -oE 'action="[^"]+"' "${jar}.html" | head -1 \
+                | sed -e 's/^action="//' -e 's/"$//' -e 's/&amp;/\&/g')
+  if [ -z "$form_action" ]; then rm -f "$jar" "${jar}.html"; echo ""; return; fi
+  # 2. submit credentials -> 302 carrying ?code=
+  local loc
+  loc=$(curl -s -c "$jar" -b "$jar" -o /dev/null -D - \
+        --data-urlencode "username=${user}" --data-urlencode "password=${PW}" \
+        --data-urlencode "credentialId=" "$form_action" | tr -d '\r' | awk '/^[Ll]ocation:/{print $2}' | tail -1)
+  rm -f "$jar" "${jar}.html"
+  local code; code=$(printf '%s' "$loc" | python3 -c '
+import sys,urllib.parse
+q=urllib.parse.urlparse(sys.stdin.read().strip()).query
+print(urllib.parse.parse_qs(q).get("code",[""])[0])')
+  [ -n "$code" ] || { echo ""; return; }
+  # 3. exchange the code for tokens — the step "the form rendered" never reaches
+  curl -s -X POST "${BASE}/realms/${REALM}/protocol/openid-connect/token" \
+    -d grant_type=authorization_code -d "code=${code}" \
+    --data-urlencode "redirect_uri=${UI_REDIRECT}" \
+    -d client_id=hill90-ui --data-urlencode "client_secret=${SECRET}" \
+    | python3 -c 'import sys,json; print(json.load(sys.stdin).get("access_token",""))' 2>/dev/null
+}
+
+claims() {
+  python3 -c '
+import sys, json, base64
+t=sys.stdin.read().strip()
+if not t: print("{}"); raise SystemExit
+p=t.split(".")[1]; p+="="*(-len(p)%4)
+print(json.dumps(json.loads(base64.urlsafe_b64decode(p))))'
+}
+
+echo ""
+echo -e "${BOLD}A completed login: form -> credentials -> code -> TOKEN EXCHANGE${NC}"
+AT=$(login localdev)
+if [ -n "$AT" ]; then
+  ok "localdev completed the full code flow and received an access token"
+else
+  bad "localdev could not complete the flow"
+fi
+C=$(printf '%s' "$AT" | claims)
+echo "$C" | python3 -c '
+import sys, json
+c=json.load(sys.stdin)
+print("      iss                            =", c.get("iss"))
+print("      aud                            =", c.get("aud"))
+print("      azp                            =", c.get("azp"))
+print("      resource_access.hill90-ui.roles=", (c.get("resource_access") or {}).get("hill90-ui",{}).get("roles"))
+print("      realm_access.roles             =", (c.get("realm_access") or {}).get("roles"))
+print("      realm_roles claim present      =", "realm_roles" in c)'
+
+if [ -z "$AT" ]; then
+  bad "no token, so the claim assertions below cannot pass (they must not pass vacuously)"
+else
+echo "$C" | python3 -c 'import sys,json; c=json.load(sys.stdin); sys.exit(0 if (c.get("resource_access") or {}).get("hill90-ui",{}).get("roles")==["admin"] else 1)' \
+  && ok "the token carries resource_access.hill90-ui.roles = ['''admin''']" \
+  || bad "resource_access.hill90-ui.roles is not ['''admin''']"
+echo "$C" | python3 -c 'import sys,json; c=json.load(sys.stdin); a=c.get("aud"); a=a if isinstance(a,list) else [a]; sys.exit(0 if "hill90-api" in a else 1)' \
+  && ok "aud includes hill90-api — the api will accept it" || bad "aud does not include hill90-api"
+echo "$C" | python3 -c 'import sys,json; c=json.load(sys.stdin); r=(c.get("realm_access") or {}).get("roles") or []; sys.exit(0 if "admin" not in r else 1)' \
+  && ok "realm_access.roles does NOT contain admin — realm_roles authorises nothing" \
+  || bad "realm_access.roles contains admin — the privilege hole is OPEN"
+echo "$C" | python3 -c 'import sys,json; sys.exit(0 if "realm_roles" not in json.load(sys.stdin) else 1)' \
+  && ok "no realm_roles claim at all" || bad "a realm_roles claim is present"
+fi
+
+echo ""
+echo -e "${BOLD}The refusal control: a user WITHOUT the client role${NC}"
+AT2=$(login localnorole)
+[ -n "$AT2" ] && ok "localnorole can authenticate (it should — authn is not authz)" \
+              || bad "localnorole could not authenticate at all"
+C2=$(printf '%s' "$AT2" | claims)
+echo "$C2" | python3 -c '
+import sys, json
+c=json.load(sys.stdin)
+print("      resource_access.hill90-ui      =", (c.get("resource_access") or {}).get("hill90-ui"))
+print("      realm_access.roles             =", (c.get("realm_access") or {}).get("roles"))'
+if [ -z "$AT2" ]; then
+  bad "no token for localnorole, so the refusal assertion cannot pass vacuously"
+else
+echo "$C2" | python3 -c '
+import sys, json
+c=json.load(sys.stdin)
+roles=(c.get("resource_access") or {}).get("hill90-ui",{}).get("roles") or []
+sys.exit(0 if "admin" not in roles and "user" not in roles else 1)' \
+  && ok "it carries NO hill90-ui role — every app permission check returns empty, so it is denied" \
+  || bad "it carries a hill90-ui role it was never granted"
+fi
+
+echo ""
+if [ "$fail" -eq 0 ]; then
+  echo -e "${GREEN}${BOLD}All ${pass} assertions passed against the local platform Keycloak.${NC}"; exit 0
+fi
+echo -e "${RED}${BOLD}${fail} failed, ${pass} passed.${NC}"; exit 1

--- a/scripts/keycloak.sh
+++ b/scripts/keycloak.sh
@@ -44,6 +44,10 @@ Usage: keycloak.sh <command>
 
 Commands:
   apply                  Ensure realm roles and SSO clients exist and are correct
+  tenant-clients         Reconcile the TENANT's clients (hill90-ui, hill90-api).
+                         platform-realm.json imports only on first boot, so this
+                         is how they reach a realm that already exists. Never
+                         rewrites an existing client's secret.
   status                 Show the realm, its clients and their redirect URIs
   client-secret <id>     Print a client's secret (for wiring another service)
   help                   Show this help message
@@ -323,6 +327,178 @@ for c in json.load(sys.stdin):
 ' 2>/dev/null || true
 }
 
+# ---------------------------------------------------------------------------
+# The tenant's clients
+#
+# platform-realm.json declares hill90-ui and hill90-api, but `start --import-realm`
+# uses IGNORE_EXISTING: the file is read ONLY on first boot. So declaring them
+# there does nothing to a realm that already exists — production's, or any
+# developer's local stack that was up before the declaration landed. That is the
+# same trap deploy.sh:399 records for the SSO clients, and the reason this
+# reconcile exists.
+#
+# Two things this deliberately does NOT do:
+#
+#   1. It never rewrites an existing client's secret. Production's hill90-ui holds
+#      a live secret that works, and HILL90_UI_CLIENT_SECRET has no production
+#      value in the store yet. Reconciling the secret would break every login and
+#      look like a service fault. Absent client -> secret required; present client
+#      -> credentials untouched.
+#
+#   2. It never adds a realm-roles mapper, and REMOVES one if it finds it. Every
+#      other client here gets one; these two must not. This realm grants Grafana
+#      Admin and OpenBao off the REALM role `admin`, and the app reads
+#      resource_access.<client>.roles precisely so an app admin does not inherit
+#      infrastructure admin. resource_access comes from the built-in `roles`
+#      client scope, so no per-client mapper is needed at all.
+# ---------------------------------------------------------------------------
+
+ensure_client_roles() {
+    local uuid="$1"; shift
+    local existing role
+    existing=$(kc get "clients/${uuid}/roles" -r "$KC_REALM" --fields name --format csv --noquotes 2>/dev/null | tr -d '\r')
+    for role in "$@"; do
+        if echo "$existing" | grep -qx "$role"; then
+            echo "    = client role ${role}"
+        else
+            kc create "clients/${uuid}/roles" -r "$KC_REALM" -s "name=${role}" >/dev/null 2>&1 \
+                && echo "    + client role ${role}" \
+                || warn "could not create client role ${role}"
+        fi
+    done
+}
+
+ensure_audience_mapper() {
+    local uuid="$1" audience="$2"
+    local found
+    found=$(kc get "clients/${uuid}/protocol-mappers/models" -r "$KC_REALM" 2>/dev/null | python3 -c '
+import json, sys
+try:
+    ms = json.load(sys.stdin)
+except Exception:
+    ms = []
+for m in ms:
+    if m.get("protocolMapper") == "oidc-audience-mapper" \
+       and (m.get("config") or {}).get("included.client.audience") == sys.argv[1]:
+        print(m.get("id", "")); break
+' "$audience" 2>/dev/null)
+    if [ -n "$found" ]; then
+        echo "    = audience mapper (${audience})"
+        return 0
+    fi
+    python3 -c '
+import json, sys
+print(json.dumps({
+    "name": sys.argv[1] + "-audience",
+    "protocol": "openid-connect",
+    "protocolMapper": "oidc-audience-mapper",
+    "config": {
+        "included.client.audience": sys.argv[1],
+        "access.token.claim": "true",
+        "id.token.claim": "false",
+    },
+}))' "$audience" \
+      | docker exec -i "$KC_CONTAINER" /opt/keycloak/bin/kcadm.sh \
+          create "clients/${uuid}/protocol-mappers/models" -r "$KC_REALM" -f - >/dev/null 2>&1 \
+      && echo "    + audience mapper (${audience})" \
+      || warn "could not create the ${audience} audience mapper — the api will reject the UI's tokens"
+}
+
+# The inverse of ensure_realm_roles_mapper: assert ABSENCE, and repair it.
+remove_realm_roles_mapper() {
+    local uuid="$1" client_id="$2"
+    local ids
+    ids=$(kc get "clients/${uuid}/protocol-mappers/models" -r "$KC_REALM" 2>/dev/null | python3 -c '
+import json, sys
+try:
+    ms = json.load(sys.stdin)
+except Exception:
+    ms = []
+for m in ms:
+    if m.get("protocolMapper") in ("oidc-usermodel-realm-role-mapper",
+                                   "oidc-usermodel-role-mapper"):
+        print(m.get("id",""))
+' 2>/dev/null)
+    local id
+    for id in $ids; do
+        [ -n "$id" ] || continue
+        kc delete "clients/${uuid}/protocol-mappers/models/${id}" -r "$KC_REALM" >/dev/null 2>&1
+        warn "REMOVED a realm-roles mapper from ${client_id}. That mapper would let an app role inherit the realm 'admin' grant (Grafana Admin, OpenBao). It must not be there."
+    done
+}
+
+cmd_tenant_clients() {
+    require_running
+    kc_login
+
+    local ui_redirects="${HILL90_UI_REDIRECT_URIS:-https://hill90.com/api/auth/callback/keycloak}"
+    local ui_origins="${HILL90_UI_WEB_ORIGINS:-https://hill90.com}"
+    local ui_secret="${HILL90_UI_CLIENT_SECRET:-}"
+
+    echo "Tenant clients in realm '${KC_REALM}'..."
+
+    # --- hill90-api: bearer-only, no flows, no secret needed ---------------
+    local api_uuid; api_uuid=$(client_uuid "hill90-api")
+    if [ -z "$api_uuid" ]; then
+        python3 -c '
+import json
+print(json.dumps({
+    "clientId": "hill90-api", "protocol": "openid-connect", "enabled": True,
+    "publicClient": False, "bearerOnly": True,
+    "standardFlowEnabled": False, "directAccessGrantsEnabled": False,
+    "serviceAccountsEnabled": False, "fullScopeAllowed": True,
+}))' | docker exec -i "$KC_CONTAINER" /opt/keycloak/bin/kcadm.sh \
+                create clients -r "$KC_REALM" -f - >/dev/null 2>&1
+        api_uuid=$(client_uuid "hill90-api")
+        [ -n "$api_uuid" ] || die "Failed to create client hill90-api"
+        echo "  + hill90-api (bearer-only)"
+    else
+        echo "  = hill90-api"
+    fi
+
+    # --- hill90-ui --------------------------------------------------------
+    local ui_uuid; ui_uuid=$(client_uuid "hill90-ui")
+    if [ -z "$ui_uuid" ]; then
+        [ -n "$ui_secret" ] || die "hill90-ui does not exist and HILL90_UI_CLIENT_SECRET is empty — refusing to create a login client with no secret"
+        python3 -c '
+import json, sys
+print(json.dumps({
+    "clientId": "hill90-ui", "secret": sys.argv[1], "protocol": "openid-connect",
+    "enabled": True, "publicClient": False, "bearerOnly": False,
+    "standardFlowEnabled": True, "directAccessGrantsEnabled": False,
+    "serviceAccountsEnabled": False, "fullScopeAllowed": True,
+    "redirectUris": sys.argv[2].split(","), "webOrigins": sys.argv[3].split(","),
+    "defaultClientScopes": ["web-origins", "acr", "roles", "profile", "email"],
+}))' "$ui_secret" "$ui_redirects" "$ui_origins" \
+          | docker exec -i "$KC_CONTAINER" /opt/keycloak/bin/kcadm.sh \
+                create clients -r "$KC_REALM" -f - >/dev/null 2>&1
+        ui_uuid=$(client_uuid "hill90-ui")
+        [ -n "$ui_uuid" ] || die "Failed to create client hill90-ui"
+        echo "  + hill90-ui (confidential)"
+    else
+        # Reconcile URLs and flags only. NOT the secret — see the header.
+        python3 -c '
+import json, sys
+print(json.dumps({
+    "standardFlowEnabled": True, "directAccessGrantsEnabled": False,
+    "publicClient": False, "bearerOnly": False, "fullScopeAllowed": True,
+    "redirectUris": sys.argv[1].split(","), "webOrigins": sys.argv[2].split(","),
+    "defaultClientScopes": ["web-origins", "acr", "roles", "profile", "email"],
+}))' "$ui_redirects" "$ui_origins" \
+          | docker exec -i "$KC_CONTAINER" /opt/keycloak/bin/kcadm.sh \
+                update "clients/${ui_uuid}" -r "$KC_REALM" -f - >/dev/null 2>&1
+        echo "  = hill90-ui (URLs and flags reconciled; secret untouched)"
+    fi
+
+    ensure_client_roles "$ui_uuid" user admin
+    ensure_audience_mapper "$ui_uuid" "hill90-api"
+    remove_realm_roles_mapper "$ui_uuid" "hill90-ui"
+    remove_realm_roles_mapper "$api_uuid" "hill90-api"
+
+    echo ""
+    success "Tenant clients reconciled in realm '${KC_REALM}'."
+}
+
 cmd_client_secret() {
     [ -n "${1:-}" ] || die "Usage: keycloak.sh client-secret <clientId>"
     require_running
@@ -340,6 +516,7 @@ main() {
     local cmd="${1:-help}"; shift || true
     case "$cmd" in
         apply)          cmd_apply "$@" ;;
+        tenant-clients) cmd_tenant_clients "$@" ;;
         status)         cmd_status "$@" ;;
         client-secret)  cmd_client_secret "$@" ;;
         help|-h|--help) usage ;;

--- a/scripts/local.sh
+++ b/scripts/local.sh
@@ -337,37 +337,28 @@ print(json.dumps([
         warn "Could not add local OIDC callbacks to hill90-vault — 'local.sh vault setup-oidc' logins will fail with 'Invalid parameter: redirect_uri'"
     fi
 
-    # Same shape, third delta: hill90-ui ships production URLs too, and it is the
-    # client the TENANT's local stack authenticates with. Without this, pointing
-    # hill90-app's local UI at this Keycloak fails with
-    # "Invalid parameter: redirect_uri" — so local would prove the realm design
-    # and never the tenancy, which is the gap this delta exists to close.
+    # The tenant's clients need more than a URL delta: platform-realm.json is
+    # imported ONLY on first boot, so on any stack that existed before those
+    # clients were declared they are simply absent — this local stack included.
+    # keycloak.sh tenant-clients reconciles them idempotently, and takes the
+    # local URLs so the callback this platform must accept is the tenant's.
     #
-    # webOrigins matters as well as redirectUris: NextAuth's browser-side calls
-    # are rejected by CORS without it, and that failure looks like an auth
-    # problem rather than an origin problem. Production already learned that
-    # distinction the hard way on api.hill90.com.
+    # webOrigins matters as much as redirectUris: NextAuth's browser-side calls
+    # are rejected by CORS without it, and that failure reads as an auth problem
+    # rather than an origin one. Production already learned that distinction the
+    # hard way on api.hill90.com.
     local ui_local; ui_local="http://localhost:$(env_get TENANT_UI_PORT 13000)"
-    local ui_uris_json ui_origins_json
-    ui_uris_json=$(python3 -c '
-import json, sys
-print(json.dumps([
-    "https://hill90.com/api/auth/callback/keycloak",
-    sys.argv[1].rstrip("/") + "/api/auth/callback/keycloak",
-]))' "$ui_local")
-    ui_origins_json=$(python3 -c '
-import json, sys
-print(json.dumps(["https://hill90.com", sys.argv[1].rstrip("/")]))' "$ui_local")
-    local ui_cid
-    ui_cid=$(docker exec "${cpfx}keycloak" /opt/keycloak/bin/kcadm.sh get clients \
-        -r "${KC_PLATFORM_REALM:-platform}" -q clientId=hill90-ui --fields id \
-        --format csv --noquotes 2>/dev/null | tr -d '\r')
-    if [ -n "$ui_cid" ] && docker exec "${cpfx}keycloak" /opt/keycloak/bin/kcadm.sh update \
-        "clients/${ui_cid}" -r "${KC_PLATFORM_REALM:-platform}" \
-        -s "redirectUris=${ui_uris_json}" -s "webOrigins=${ui_origins_json}" >/dev/null 2>&1; then
-        success "Added local callbacks and origin to the hill90-ui client (${ui_local})"
+    if KC_CONTAINER="${cpfx}keycloak" \
+       KC_REALM="$(env_get KC_REALM platform)" \
+       KC_ADMIN_USERNAME="$(env_get KC_ADMIN_USERNAME admin)" \
+       KC_ADMIN_PASSWORD="$(env_get KC_ADMIN_PASSWORD admin)" \
+       HILL90_UI_CLIENT_SECRET="$(env_get HILL90_UI_CLIENT_SECRET "")" \
+       HILL90_UI_REDIRECT_URIS="https://hill90.com/api/auth/callback/keycloak,${ui_local}/api/auth/callback/keycloak" \
+       HILL90_UI_WEB_ORIGINS="https://hill90.com,${ui_local}" \
+           bash "$SCRIPT_DIR/keycloak.sh" tenant-clients >/dev/null 2>&1; then
+        success "Tenant clients reconciled on the local platform realm (callback ${ui_local})"
     else
-        warn "Could not add local callbacks to hill90-ui — pointing the tenant's local UI at this Keycloak will fail with 'Invalid parameter: redirect_uri'"
+        warn "Could not reconcile the tenant clients — pointing the tenant's local stack at this Keycloak will fail. Run: bash scripts/keycloak.sh tenant-clients"
     fi
 
     info "Starting the vault stack (openbao)..."

--- a/tests/checks/test_tenant_login_local.py
+++ b/tests/checks/test_tenant_login_local.py
@@ -1,0 +1,64 @@
+"""Tests for scripts/checks/tenant-login-local-test.sh
+
+This is the only check in the suite that needs a RUNNING local platform stack, so
+it skips rather than fails when there isn't one — including in CI. The realm's
+shape and the claims Keycloak emits are covered without a stack by
+test_realm_tenant_clients.py and test_realm_tenant_serves.py; what this adds is a
+completed authorization-code login against the local platform Keycloak, with a
+refusal control.
+
+Run it locally after `bash scripts/local.sh up`.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "checks" / "tenant-login-local-test.sh"
+
+
+def _local_keycloak() -> str | None:
+    """The local platform Keycloak container, if one is running."""
+    if not shutil.which("docker"):
+        return None
+    env_local = ROOT / ".env.local"
+    prefix = ""
+    if env_local.is_file():
+        for line in env_local.read_text().splitlines():
+            if line.startswith("CONTAINER_PREFIX="):
+                prefix = line.split("=", 1)[1].strip()
+    name = f"{prefix}keycloak"
+    r = subprocess.run(
+        ["docker", "inspect", "-f", "{{.State.Running}}", name],
+        capture_output=True, text=True, timeout=30,
+    )
+    return name if r.returncode == 0 and r.stdout.strip() == "true" else None
+
+
+def test_script_exists():
+    assert SCRIPT.is_file(), f"missing: {SCRIPT}"
+
+
+@pytest.mark.skipif(
+    _local_keycloak() is None,
+    reason="no local platform Keycloak running (bash scripts/local.sh up)",
+)
+def test_a_tenant_user_can_complete_a_login_and_a_roleless_one_is_refused():
+    result = subprocess.run(
+        ["bash", str(SCRIPT)], capture_output=True, text=True, cwd=ROOT, timeout=600
+    )
+    # The script exits 0 with a SKIP line if the stack vanished between the
+    # fixture check and the run; treat that as a skip rather than a false pass.
+    if "SKIP:" in result.stdout:
+        pytest.skip(result.stdout.strip())
+    assert result.returncode == 0, (
+        "the local platform Keycloak did not serve the tenant correctly:\n"
+        f"{result.stdout}\n{result.stderr}"
+    )
+    # Guard against a vacuous pass: the assertions must actually have run.
+    assert "assertions passed" in result.stdout, result.stdout


### PR DESCRIPTION
## First, a gap in #584 that I should have caught

**Declaring the clients in `platform-realm.json` did nothing to any realm that
already existed.** `start --import-realm` is `IGNORE_EXISTING` — and
`keycloak.sh`'s own header says so in as many words. The running local platform
realm had:

```
account account-console admin-cli broker grafana hill90-vault portainer
realm-management security-admin-console
```

No `hill90-ui`, no `hill90-api`. Production is masked only because its clients
already exist. So "local can prove tenancy" was true for a *fresh* local and false
for every existing one — including the stack I was about to test with. I shipped
clients into a file whose header warns that doing so changes nothing, and no
reconcile path.

`keycloak.sh tenant-clients` is that path. Idempotent, with two deliberate refusals:

- **It never rewrites an existing client's secret.** Production's `hill90-ui` holds a
  live working secret; `HILL90_UI_CLIENT_SECRET` has no production value. Reconciling
  credentials would break every login and present as a service fault. Absent client →
  secret required; present client → credentials untouched.
- **It never adds a realm-roles mapper, and removes one if it finds it**, loudly.
  Every other client here gets one; these two must not.

`local.sh`'s third delta is replaced by a call to it, so a fresh local converges via
the import and an existing local via the reconcile.

## The completed login — form, credentials, code, token exchange

Against the **running local platform Keycloak**, not a throwaway and not an
example-token generator:

```
localdev
  iss                             = http://auth.localtest.me:8080/realms/platform
  azp                             = hill90-ui
  aud                             = ['hill90-api', 'account']
  resource_access.hill90-ui.roles = ['admin']
  realm_access.roles              = ['offline_access','uma_authorization','default-roles-platform']
  realm_roles claim present       = False

localnorole
  authenticates successfully (authn is not authz)
  resource_access.hill90-ui       = None

All 9 assertions passed against the local platform Keycloak.
```

`realm_access.roles` carrying no `admin`, and no `realm_roles` claim at all, is the
privilege boundary measured on a real token. `localnorole` is the **refusal control** —
without it this would only show authorisation is permissive.

## What is NOT proven, and needs you

**I could not complete a browser login through to an authenticated app page**, because
that needs `hill90-app` changes and pane 1 is live there. What I proved is the full
OIDC exchange against the platform Keycloak — the step behind the form, which is the
one that was skipped last time — but *not* the app's own page, and I am not going to
describe it as if I had.

The join is two values in the app's local stack, which is already on realm `platform`,
just on its own Keycloak:

```
now:  AUTH_KEYCLOAK_ISSUER=http://app-auth.localtest.me:8080/realms/platform
      KEYCLOAK_INTERNAL_ISSUER=http://app-keycloak:8080/realms/platform

needs: AUTH_KEYCLOAK_ISSUER=http://auth.localtest.me:8080/realms/platform
       KEYCLOAK_INTERNAL_ISSUER=http://keycloak:8080/realms/platform
       AUTH_KEYCLOAK_SECRET = this platform's HILL90_UI_CLIENT_SECRET from .env.local
```

`AUTH_KEYCLOAK_ID` is already `hill90-ui`, and the UI port already matches the callback
this platform registers. **No structural blocker:** the issuer is byte-identical on
both the browser path and the internal alias, so the app's existing split-horizon
handling transfers.

Once that lands, the two remaining proofs are the app's to give: a browser login
through to an authenticated page, and the api returning 403 for `localnorole`.

## Three of my own errors, each of which produced a convincing wrong answer

- **Inside a single-quoted `python3 -c`, `r"...\"..."` is a literal backslash-quote.**
  My form-action regex never matched, so the login "failed" for a reason with nothing
  to do with Keycloak. Now grep/sed, with a comment saying why.
- **The first version's claim assertions passed on an empty token.** A test that goes
  green when nothing happened is exactly the disease we have spent two days removing.
  Every assertion is now guarded on a token existing, and the pytest wrapper asserts
  the output actually contains assertion results.
- **Verify Profile.** The realm carries Keycloak's default action, so a user without
  `email`/`firstName`/`lastName` is diverted to
  `required-action?execution=VERIFY_PROFILE` and never completes. It presents as
  rejected credentials. This lands on any local dev account someone creates, so it is
  recorded in `CLAUDE.md`.

## Verification

`49 passed` in `tests/checks/` (was 47), `345` bats, `check_realm_tenant_clients.py`,
`check_env_surface.py`, `check_secrets_schema.py`, `check_md_links.py` all clean.
`shellcheck --severity=error scripts/*.sh` clean, and the new script is clean at
warning level too.

The login test **skips** rather than fails without a local stack, so CI stays green
and cannot pass vacuously. Nothing else in the local realm was disturbed: `grafana`,
`portainer` and `hill90-vault` are all still present, both probe users were deleted,
and the realm has no leftover users.

Local platform 13 containers; the VPS was not touched at all this round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)