### PR TITLE
docs: who owns a tenant's credential to a platform-owned object

### DIFF
--- a/docs/decisions/app-tenancy-on-the-vps.md
+++ b/docs/decisions/app-tenancy-on-the-vps.md
@@ -457,6 +457,14 @@ deploy workflows, which do not verify `infra`. Worth fixing separately.
 Nothing in the "Provided today ✗" column is a Hill90 capability gap except the
 deploy tooling. The rest are naming decisions that belong to the app.
 
+**Credentials to platform-owned objects are part of this contract.** When the
+platform owns the object — a Postgres role, an OIDC client in realm `platform` —
+this repository's store owns the credential and the tenant holds a replica. The
+reason is this contract rather than a preference: a rebuild path that depends on
+reaching into a tenant's private secret store is not satisfiable by this repository
+alone, which inverts the tenancy relationship. See
+[tenant-credential-ownership.md](tenant-credential-ownership.md).
+
 ## VPS baseline, captured during this assessment
 
 Unchanged from the app repo's Phase 0 baseline, re-verified read-only:

--- a/docs/decisions/tenant-credential-ownership.md
+++ b/docs/decisions/tenant-credential-ownership.md
@@ -1,0 +1,121 @@
+# Who owns a tenant's credential to a platform-owned object
+
+**Status:** decided, recorded 2026-07-30. Generalises a rule that had been settled
+twice in a row, once per credential, without being written down as a rule.
+
+**Relates to:**
+[app-tenancy-on-the-vps.md](app-tenancy-on-the-vps.md) (the tenancy contract),
+[tenant-databases-on-platform-postgres.md](tenant-databases-on-platform-postgres.md)
+(where the same question was answered for the database role)
+
+## The rule
+
+**When the platform owns the object, the platform's store owns the credential to
+it, and the tenant holds a replica.**
+
+A tenant's database role lives in the platform's Postgres. A tenant's OIDC client
+lives in the platform's Keycloak realm. In both cases the object is the platform's,
+so `infra/secrets/prod.enc.env` in *this* repository is authoritative and the
+tenant's own store holds a copy that it consumes.
+
+| Credential | Object it opens | Authoritative store | Tenant's key |
+|---|---|---|---|
+| `HILL90_APP_DB_PASSWORD` | role `hill90_app` in the platform Postgres | Hill90 | `PLATFORM_DB_PASSWORD` (planned) |
+| `HILL90_UI_CLIENT_SECRET` | client `hill90-ui` in realm `platform` | Hill90 | `AUTH_KEYCLOAK_SECRET` |
+
+## Why not the tenant
+
+The tenant would own the credential to a client in **someone else's realm**, and
+this platform could not rebuild the VPS without reaching into the tenant's secret
+store. That inverts the tenancy contract: the whole point of
+[app-tenancy-on-the-vps.md](app-tenancy-on-the-vps.md) is that the platform's
+obligations are narrow, explicit, and satisfiable without knowing anything about a
+particular tenant. A rebuild path that depends on a tenant's private store is not
+satisfiable by this repository alone.
+
+That is the reason, not a preference for symmetry.
+
+## Why not "Keycloak is the only source"
+
+There is a genuinely good competing option, and it was not dismissed lightly:
+**let Keycloak mint the client secret and have the tenant fetch it** with
+`bash scripts/keycloak.sh client-secret hill90-ui`. Nothing extra is stored, and
+every additional copy of a secret is a drift opportunity — the drift that cost this
+estate a night when the `hill90-ui` secret in the store and the one in Keycloak
+disagreed.
+
+Note the asymmetry that makes it tempting here but not for the database: for a
+database role, this platform **must** know the password because it sets it with
+`CREATE ROLE … PASSWORD`. For an OIDC client, Keycloak can generate the secret
+itself, and there is already a first-class read path. So storing it here adds a copy
+without adding capability.
+
+**It loses on disaster recovery, decisively.** Hill90's SOPS store exists so the VPS
+can be rebuilt from nothing. Under "Keycloak is the only source", a rebuild mints a
+*fresh* secret; the tenant's stored value is stale the instant the realm imports, and
+login is broken until a human re-fetches it and re-encrypts. That turns "restore and
+go" into "restore, then debug an `invalid_client`". Under this rule the rebuild
+restores the same secret and the tenant keeps working with no action at all.
+
+## The mitigation for two copies
+
+Two stores holding one secret is a real hazard, so name the owner and provide a
+reconciliation rather than pretending one copy is enough:
+
+- **Hill90's store is authoritative.** If the two disagree, Hill90's value wins.
+- **Reconciling means pushing the authoritative value**, never generating a new one.
+  For the database that is re-running `provision-tenant-db.sh`, which resets the role
+  password idempotently. For the OIDC client it means writing the stored secret onto
+  the client — see the warning below before doing it.
+
+## Two hazards, both specific to filling `HILL90_UI_CLIENT_SECRET`
+
+`Verified 2026-07-30 03:31 UTC:` the key is **absent** from
+`infra/secrets/prod.enc.env` — not empty, not a placeholder, not present. The live
+realm holds a working secret and `hill90-app` holds the match; that pair is what
+makes login work today.
+
+**1. A freshly generated value would be a landmine with a long fuse.** Whatever is
+written into this store must *equal* the live secret. A new random value changes
+nothing immediately — and then breaks login at the next realm import, which may be
+months later during a rebuild, with nothing connecting cause to effect.
+
+**2. "Reconciling" by writing onto the live client breaks login immediately.** The
+tenant holds the current value; overwriting the client's secret invalidates it at
+once. This is why `keycloak.sh tenant-clients` **never rewrites an existing client's
+secret** — absent client, secret required; present client, credentials untouched.
+
+The safe order is: read the live value, write it into this store, verify by hash
+against the tenant's copy, change nothing live.
+
+## The gap that remains, and it fails open
+
+`platform-realm.json` declares `"secret": "${HILL90_UI_CLIENT_SECRET}"`. **Measured,
+not predicted** — importing the real realm file into a throwaway Keycloak with the
+variable unset:
+
+```
+secret length : 26
+is the literal ${HILL90_UI_CLIENT_SECRET}: True
+```
+
+Keycloak does not error and does not generate a random secret. It stores the
+**literal string** `${HILL90_UI_CLIENT_SECRET}` as the client secret. So a rebuild
+performed while this store is missing the key produces two problems, and the second
+is worse than the first:
+
+1. The tenant's login fails with `invalid_client` — the exact failure of 2026-07-29.
+2. The client secret of the confidential client fronting `hill90.com` becomes a
+   **known, guessable string published in a public repository.**
+
+`keycloak.sh tenant-clients` does **not** repair this: the client exists, so it takes
+the "present" branch and deliberately leaves the secret alone. The fail-closed design
+that protects production is also what stops it fixing this. **Any guard has to sit at
+the import path, which is currently unguarded**, and `check_env_surface.py`
+deliberately exempts this key from the have-a-default rule — correctly, since a
+default would bake a *known* secret into every deploy, but the exemption does nothing
+about the unset case at import.
+
+Filling the key removes hazard 1 and 2 together. Adding an import-time guard is worth
+doing regardless of which store is authoritative, because failing open and silently is
+the property to remove.

--- a/docs/decisions/tenant-databases-on-platform-postgres.md
+++ b/docs/decisions/tenant-databases-on-platform-postgres.md
@@ -142,6 +142,12 @@ secret is exactly how the app's Keycloak client secret drifted out of agreement
 with Keycloak and cost a night of diagnosis. The mitigation is a declared owner and
 an idempotent reconciliation command, not pretending one copy is enough.
 
+> **Generalised 2026-07-30.** The same question came up again for the `hill90-ui`
+> OIDC client secret and got the same answer for the same reason, so the rule is now
+> written down once instead of re-argued per credential:
+> [tenant-credential-ownership.md](tenant-credential-ownership.md). Read that before
+> deciding where a *third* tenant credential lives — MinIO is the likely next one.
+
 ## What broke that had to be fixed alongside
 
 **A least-privilege tenant cannot install extensions.** The app's migrations run


### PR DESCRIPTION
The question had been answered twice — the tenant's database role, then the
`hill90-ui` client secret — and never written down as a rule. Now one record, with
both existing decisions pointing at it, so a third credential is not re-argued from
scratch. MinIO is the likely next one.

**No secret was filled. No live client was touched.** `HILL90_UI_CLIENT_SECRET` is
still absent from `infra/secrets/prod.enc.env` (verified `0` chars after these edits).

## The rule

When the platform owns the object, the platform's store owns the credential and the
tenant holds a replica.

| Credential | Object it opens | Authoritative | Tenant's key |
|---|---|---|---|
| `HILL90_APP_DB_PASSWORD` | role `hill90_app` in the platform Postgres | Hill90 | `PLATFORM_DB_PASSWORD` (planned) |
| `HILL90_UI_CLIENT_SECRET` | client `hill90-ui` in realm `platform` | Hill90 | `AUTH_KEYCLOAK_SECRET` |

## Why not the tenant — the reason, not the preference

The tenant would hold the credential to a client in **someone else's realm**, and this
platform could not rebuild the VPS without reaching into the tenant's private store.
That inverts the tenancy contract, whose whole point is that this platform's
obligations are satisfiable without knowing anything about a particular tenant. It is
recorded in the contract doc as well, because it is a property of the contract rather
than a secrets-management style choice.

## Why not "Keycloak is the only source" — recorded, not dismissed

Genuinely the strongest competing option: Keycloak can mint the secret and
`keycloak.sh client-secret hill90-ui` can read it, so storing it here adds a copy
without adding capability — and every copy is a drift opportunity, which is precisely
what cost a night when the store and Keycloak disagreed.

There is a real asymmetry worth noting: for a database role the platform **must** know
the password because it sets it with `CREATE ROLE … PASSWORD`; for an OIDC client it
need not.

**It loses on disaster recovery.** Hill90's store exists so the VPS can be rebuilt
from nothing. Under that option a rebuild mints a *fresh* secret, the tenant's copy is
stale the instant the realm imports, and login is broken until a human re-fetches and
re-encrypts — "restore and go" becomes "restore, then debug `invalid_client`".

## The two hazards you named, recorded because both are silent

1. **A freshly generated value is a landmine with a long fuse.** It changes nothing
   immediately, then breaks login at the next realm import — possibly months later
   during a rebuild, with nothing connecting cause to effect.
2. **"Reconciling" by writing onto the live client breaks login at once.** Which is
   why `keycloak.sh tenant-clients` never rewrites an existing client's secret:
   absent client → secret required; present client → credentials untouched.

Safe order: read the live value, write it into this store, verify by hash against the
tenant's copy, change nothing live.

## And the gap — measured, not predicted

I imported the real realm file into a throwaway Keycloak with the variable unset:

```
secret length : 26
is the literal ${HILL90_UI_CLIENT_SECRET}: True
```

Keycloak does not error and does not generate a random secret — it stores the
**literal string**. So a rebuild in today's state produces two problems, and the
second is worse than the first:

1. Login fails with `invalid_client` — the exact failure of 2026-07-29.
2. The client secret of the confidential client fronting `hill90.com` becomes a
   **known, guessable string published in a public repository.**

`tenant-clients` does not repair this, deliberately: the client exists, so it leaves
the secret alone. The guard has to sit at the import path, which fails open and
silently today. `check_env_surface.py`'s exemption from the have-a-default rule is
still correct — a default would bake a *known* secret into every deploy — but it does
nothing about the unset case at import.

`check_md_links.py` clean. Both cross-links verified present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)