### PR TITLE
docs: prepare the Keycloak admin rotation, and record the day's three credential exposures

### DIFF
--- a/docs/decisions/2026-07-30-credential-exposures.md
+++ b/docs/decisions/2026-07-30-credential-exposures.md
@@ -1,0 +1,90 @@
+# Three credential exposures in one day, and the shape they share
+
+**Recorded 2026-07-30.** Brief by intent. The point of writing it down is the shared
+shape and the fix, not the incidents.
+
+## What happened
+
+| # | Credential | Exposed where | By | Status |
+|---|---|---|---|---|
+| 1 | **Production Keycloak `master`-realm admin password** (`KC_ADMIN_PASSWORD`) | agent transcript, in a remote `bash` error line | agent (Hill90 lane) | **still valid**, rotation prepared and awaiting Jon — [../runbooks/keycloak-admin-rotation.md](../runbooks/keycloak-admin-rotation.md) |
+| 2 | **Tenant Postgres role credential** (`hill90_app`) | truncated `docker inspect` output | operator | rotated within the hour |
+| 3 | **A local probe user's password**, hardcoded in a committed script | `scripts/checks/tenant-login-local-test.sh` | agent (Hill90 lane) | fixed in this change — generated at runtime |
+
+Exposure 1 is the serious one, and not because of the value's length. The account
+administers every realm: it can mint users, grant the realm `admin` role that confers
+Grafana Admin and OpenBao access, and read or rewrite any client secret. It also sits
+behind a **publicly reachable** admin console —
+`https://auth.hill90.com/admin/master/console/` returns `200`, and that Traefik router
+carries no middleware, unlike Traefik, Portainer, Grafana and Vault which are
+Tailscale-only. Severity comes from the combination, not the leak alone.
+
+Exposure 3 is small — the password only ever authenticated two users the script
+itself creates and deletes, in a local realm — but invariant 7 says secrets do not
+live in the tree, and a literal password in a committed file is a literal password in
+a committed file.
+
+## The shape
+
+**A value that had to be handled ended up in output that gets retained.**
+
+None of the three was a case of storing a secret in the wrong place, or of a weak
+secret, or of a missing control. In every case the value was correctly stored, and
+then something *printed* it — a `docker inspect`, a shell error message, a test
+fixture. The retention is the mechanism: transcripts, logs and git history all keep
+what was printed.
+
+The mechanism of exposure 1 is worth being concrete about, because it was not a
+`print` statement:
+
+```
+printf '%s\n%s\n' "$USER" "$PASSWORD" | ssh deploy@vps 'bash -s' <<'REMOTE' … REMOTE
+```
+
+The heredoc claimed `ssh`'s stdin, so the piped credentials never reached the script —
+they were handed to the remote shell **as commands**. Remote `bash` tried to execute
+the password as a filename and echoed it back inside its own error text. Nothing
+printed the secret on purpose; a plumbing mistake turned it into a command name, and
+the error handler did the rest.
+
+## The fix that works, and it is not "be careful"
+
+The operator's fix for exposure 2 is the instructive one: it did not try to stop
+people running `docker inspect`. **It made the safe way to answer the question the
+easy one.** That generalises, so apply the same test here.
+
+**What was I actually trying to find out?** Whether a human had completed a sign-in.
+I wanted live session counts from the Keycloak admin API, which needs an admin token,
+so I hand-rolled one.
+
+**Was there already a redacted path? Yes, and I bypassed it.** `scripts/keycloak.sh`
+`kc_login` passes the admin password via `KC_CLI_PASSWORD` and `docker exec -e`
+*specifically* so it never appears in argv, with a comment saying why, and it prints
+nothing. Every step of the rotation runbook uses that pattern. The safe path existed
+in the very file I had been editing; my ad-hoc command went around it.
+
+So the honest finding is not "the tooling was missing" but "the tooling did not cover
+the question I had". Two follow-ups fall out, neither done here:
+
+1. **Add a read-only `keycloak.sh sessions`** (proposed, not built) that reports
+   session counts per client and per user. It would answer "has anyone signed in?"
+   without anybody minting an admin token by hand. This is the direct analogue of the
+   `docker inspect` fix: the question was legitimate, so give it a safe answer.
+2. **Turn on Keycloak login events.** `events_enabled=false` on both realms
+   (`Verified 2026-07-30 02:07 UTC`), which is *why* the question needed the admin
+   API at all — sessions live in Infinispan and `event_entity` is empty. With events
+   stored, the most-asked question in this estate becomes a database query and needs
+   no privileged credential. Already noted in `CLAUDE.md`.
+
+## One thing that did work
+
+Every one of the three was caught and reported immediately by the person who caused
+it, and exposure 2 was rotated inside the hour. That is the control that actually
+held today, and it held three times out of three.
+
+## See also
+
+- [../runbooks/keycloak-admin-rotation.md](../runbooks/keycloak-admin-rotation.md) —
+  the prepared rotation, including a rehearsed break-glass
+- [tenant-credential-ownership.md](tenant-credential-ownership.md) — who owns which
+  credential, decided the same day

--- a/docs/decisions/app-tenancy-on-the-vps.md
+++ b/docs/decisions/app-tenancy-on-the-vps.md
@@ -457,6 +457,14 @@ deploy workflows, which do not verify `infra`. Worth fixing separately.
 Nothing in the "Provided today ✗" column is a Hill90 capability gap except the
 deploy tooling. The rest are naming decisions that belong to the app.
 
+**Credentials to platform-owned objects are part of this contract.** When the
+platform owns the object — a Postgres role, an OIDC client in realm `platform` —
+this repository's store owns the credential and the tenant holds a replica. The
+reason is this contract rather than a preference: a rebuild path that depends on
+reaching into a tenant's private secret store is not satisfiable by this repository
+alone, which inverts the tenancy relationship. See
+[tenant-credential-ownership.md](tenant-credential-ownership.md).
+
 ## VPS baseline, captured during this assessment
 
 Unchanged from the app repo's Phase 0 baseline, re-verified read-only:

--- a/docs/decisions/tenant-credential-ownership.md
+++ b/docs/decisions/tenant-credential-ownership.md
@@ -1,0 +1,121 @@
+# Who owns a tenant's credential to a platform-owned object
+
+**Status:** decided, recorded 2026-07-30. Generalises a rule that had been settled
+twice in a row, once per credential, without being written down as a rule.
+
+**Relates to:**
+[app-tenancy-on-the-vps.md](app-tenancy-on-the-vps.md) (the tenancy contract),
+[tenant-databases-on-platform-postgres.md](tenant-databases-on-platform-postgres.md)
+(where the same question was answered for the database role)
+
+## The rule
+
+**When the platform owns the object, the platform's store owns the credential to
+it, and the tenant holds a replica.**
+
+A tenant's database role lives in the platform's Postgres. A tenant's OIDC client
+lives in the platform's Keycloak realm. In both cases the object is the platform's,
+so `infra/secrets/prod.enc.env` in *this* repository is authoritative and the
+tenant's own store holds a copy that it consumes.
+
+| Credential | Object it opens | Authoritative store | Tenant's key |
+|---|---|---|---|
+| `HILL90_APP_DB_PASSWORD` | role `hill90_app` in the platform Postgres | Hill90 | `PLATFORM_DB_PASSWORD` (planned) |
+| `HILL90_UI_CLIENT_SECRET` | client `hill90-ui` in realm `platform` | Hill90 | `AUTH_KEYCLOAK_SECRET` |
+
+## Why not the tenant
+
+The tenant would own the credential to a client in **someone else's realm**, and
+this platform could not rebuild the VPS without reaching into the tenant's secret
+store. That inverts the tenancy contract: the whole point of
+[app-tenancy-on-the-vps.md](app-tenancy-on-the-vps.md) is that the platform's
+obligations are narrow, explicit, and satisfiable without knowing anything about a
+particular tenant. A rebuild path that depends on a tenant's private store is not
+satisfiable by this repository alone.
+
+That is the reason, not a preference for symmetry.
+
+## Why not "Keycloak is the only source"
+
+There is a genuinely good competing option, and it was not dismissed lightly:
+**let Keycloak mint the client secret and have the tenant fetch it** with
+`bash scripts/keycloak.sh client-secret hill90-ui`. Nothing extra is stored, and
+every additional copy of a secret is a drift opportunity — the drift that cost this
+estate a night when the `hill90-ui` secret in the store and the one in Keycloak
+disagreed.
+
+Note the asymmetry that makes it tempting here but not for the database: for a
+database role, this platform **must** know the password because it sets it with
+`CREATE ROLE … PASSWORD`. For an OIDC client, Keycloak can generate the secret
+itself, and there is already a first-class read path. So storing it here adds a copy
+without adding capability.
+
+**It loses on disaster recovery, decisively.** Hill90's SOPS store exists so the VPS
+can be rebuilt from nothing. Under "Keycloak is the only source", a rebuild mints a
+*fresh* secret; the tenant's stored value is stale the instant the realm imports, and
+login is broken until a human re-fetches it and re-encrypts. That turns "restore and
+go" into "restore, then debug an `invalid_client`". Under this rule the rebuild
+restores the same secret and the tenant keeps working with no action at all.
+
+## The mitigation for two copies
+
+Two stores holding one secret is a real hazard, so name the owner and provide a
+reconciliation rather than pretending one copy is enough:
+
+- **Hill90's store is authoritative.** If the two disagree, Hill90's value wins.
+- **Reconciling means pushing the authoritative value**, never generating a new one.
+  For the database that is re-running `provision-tenant-db.sh`, which resets the role
+  password idempotently. For the OIDC client it means writing the stored secret onto
+  the client — see the warning below before doing it.
+
+## Two hazards, both specific to filling `HILL90_UI_CLIENT_SECRET`
+
+`Verified 2026-07-30 03:31 UTC:` the key is **absent** from
+`infra/secrets/prod.enc.env` — not empty, not a placeholder, not present. The live
+realm holds a working secret and `hill90-app` holds the match; that pair is what
+makes login work today.
+
+**1. A freshly generated value would be a landmine with a long fuse.** Whatever is
+written into this store must *equal* the live secret. A new random value changes
+nothing immediately — and then breaks login at the next realm import, which may be
+months later during a rebuild, with nothing connecting cause to effect.
+
+**2. "Reconciling" by writing onto the live client breaks login immediately.** The
+tenant holds the current value; overwriting the client's secret invalidates it at
+once. This is why `keycloak.sh tenant-clients` **never rewrites an existing client's
+secret** — absent client, secret required; present client, credentials untouched.
+
+The safe order is: read the live value, write it into this store, verify by hash
+against the tenant's copy, change nothing live.
+
+## The gap that remains, and it fails open
+
+`platform-realm.json` declares `"secret": "${HILL90_UI_CLIENT_SECRET}"`. **Measured,
+not predicted** — importing the real realm file into a throwaway Keycloak with the
+variable unset:
+
+```
+secret length : 26
+is the literal ${HILL90_UI_CLIENT_SECRET}: True
+```
+
+Keycloak does not error and does not generate a random secret. It stores the
+**literal string** `${HILL90_UI_CLIENT_SECRET}` as the client secret. So a rebuild
+performed while this store is missing the key produces two problems, and the second
+is worse than the first:
+
+1. The tenant's login fails with `invalid_client` — the exact failure of 2026-07-29.
+2. The client secret of the confidential client fronting `hill90.com` becomes a
+   **known, guessable string published in a public repository.**
+
+`keycloak.sh tenant-clients` does **not** repair this: the client exists, so it takes
+the "present" branch and deliberately leaves the secret alone. The fail-closed design
+that protects production is also what stops it fixing this. **Any guard has to sit at
+the import path, which is currently unguarded**, and `check_env_surface.py`
+deliberately exempts this key from the have-a-default rule — correctly, since a
+default would bake a *known* secret into every deploy, but the exemption does nothing
+about the unset case at import.
+
+Filling the key removes hazard 1 and 2 together. Adding an import-time guard is worth
+doing regardless of which store is authoritative, because failing open and silently is
+the property to remove.

--- a/docs/decisions/tenant-databases-on-platform-postgres.md
+++ b/docs/decisions/tenant-databases-on-platform-postgres.md
@@ -142,6 +142,12 @@ secret is exactly how the app's Keycloak client secret drifted out of agreement
 with Keycloak and cost a night of diagnosis. The mitigation is a declared owner and
 an idempotent reconciliation command, not pretending one copy is enough.
 
+> **Generalised 2026-07-30.** The same question came up again for the `hill90-ui`
+> OIDC client secret and got the same answer for the same reason, so the rule is now
+> written down once instead of re-argued per credential:
+> [tenant-credential-ownership.md](tenant-credential-ownership.md). Read that before
+> deciding where a *third* tenant credential lives — MinIO is the likely next one.
+
 ## What broke that had to be fixed alongside
 
 **A least-privilege tenant cannot install extensions.** The app's migrations run

--- a/docs/runbooks/keycloak-admin-rotation.md
+++ b/docs/runbooks/keycloak-admin-rotation.md
@@ -1,0 +1,220 @@
+# Rotating the Keycloak `master`-realm admin password
+
+**Prepared 2026-07-30, not executed.** Written because production
+`KC_ADMIN_PASSWORD` was exposed in an agent transcript and is still valid — see
+[../decisions/2026-07-30-credential-exposures.md](../decisions/2026-07-30-credential-exposures.md).
+Rotating it is Jon's call.
+
+Every step below was **rehearsed against the local platform Keycloak**
+(`quay.io/keycloak/keycloak:26.4.0`, the same image production runs) and the local
+state was restored afterwards. Where something could not be verified locally, it
+says so.
+
+---
+
+## Read this first: the env-variable route does not work
+
+`docker-compose.auth.yml` sets `KC_BOOTSTRAP_ADMIN_USERNAME` and
+`KC_BOOTSTRAP_ADMIN_PASSWORD` from the store. **Those apply only on FIRST
+startup, when the realm has no admin.** Changing them in SOPS and redeploying
+`auth` does nothing to the existing admin account — Keycloak starts cleanly, logs
+nothing unusual, and the old password keeps working.
+
+Somebody will try that route and conclude the rotation "didn't take". It is not a
+rotation at all. **This is an admin-API change plus a SOPS update.**
+
+The order matters in one direction only: change Keycloak first or the store first,
+but until both are done `keycloak.sh` and the `auth` deploy's SSO reconcile step
+will fail to authenticate. That step is deliberately non-fatal, so nothing breaks —
+it just stops reconciling until the pair agrees.
+
+---
+
+## 1. Rotate the password in Keycloak
+
+Get the admin user's id, then set the new password. `kcadm` inside the container
+talks to `127.0.0.1:8080`, which is exempt from `sslRequired`, so this works
+regardless of TLS settings.
+
+```bash
+ssh deploy@<vps>
+
+# Authenticate. The password goes through the ENVIRONMENT, not argv — this is the
+# pattern scripts/keycloak.sh:100 uses, and the reason it uses it.
+KC_CLI_PASSWORD='<current admin password>' \
+  docker exec -e KC_CLI_PASSWORD keycloak /opt/keycloak/bin/kcadm.sh \
+    config credentials --server http://127.0.0.1:8080 --realm master --user admin
+
+ID=$(docker exec keycloak /opt/keycloak/bin/kcadm.sh \
+       get users -r master -q username=admin --fields id \
+       --format csv --noquotes | tr -d '\r')
+
+docker exec keycloak /opt/keycloak/bin/kcadm.sh \
+  set-password -r master --userid "$ID" --new-password '<new password>'
+```
+
+**Caveat, stated rather than hidden:** `--new-password` puts the value in the
+container's argv, readable via `/proc` for the duration of the call. On this host
+that is not an escalation — anyone who can read `/proc` is `deploy` or `root`, and
+`deploy` already holds the age key to the whole secrets store. If you want to avoid
+it anyway, the Admin REST API accepts the value in a request body
+(`PUT /admin/realms/master/users/{id}/reset-password`, `--data-binary @-` from
+stdin). **I could not verify that variant locally** — the `master` realm ships
+`sslRequired=external`, so plain-HTTP admin calls return
+`403 {"error":"invalid_request","error_description":"HTTPS required"}`; only
+`platform` is relaxed locally. On production, where `auth.hill90.com` is HTTPS, it
+would work.
+
+## 2. Update the store, and the vault path
+
+```bash
+make secrets-update KEY=KC_ADMIN_PASSWORD VALUE='<new password>'
+```
+
+Schema path is `secret/auth/config` (`platform/vault/secrets-schema.yaml`), so the
+OpenBao copy needs the same value if vault is being kept in step.
+
+Confirm without printing it:
+
+```bash
+make secrets-get KEY=KC_ADMIN_PASSWORD | tr -d '\n' | shasum -a 256 | cut -c1-12
+```
+
+## 3. Verify — BOTH halves
+
+"The new one works" is not "the old one stopped working". Check both.
+
+```bash
+# new value: expect success
+KC_CLI_PASSWORD='<new password>' docker exec -e KC_CLI_PASSWORD keycloak \
+  /opt/keycloak/bin/kcadm.sh config credentials \
+  --server http://127.0.0.1:8080 --realm master --user admin && echo ACCEPTED
+
+# OLD value: expect failure
+KC_CLI_PASSWORD='<old password>' docker exec -e KC_CLI_PASSWORD keycloak \
+  /opt/keycloak/bin/kcadm.sh config credentials \
+  --server http://127.0.0.1:8080 --realm master --user admin \
+  && echo "STILL VALID — ROTATION DID NOT TAKE" || echo REFUSED
+```
+
+Rehearsed locally, both halves observed:
+
+```
+after rotation:
+  new pw -> OK
+  OLD pw -> REFUSED
+```
+
+Then confirm the store and Keycloak agree, by using the store's value:
+
+```bash
+KC_ADMIN_PASSWORD="$(make secrets-get KEY=KC_ADMIN_PASSWORD)" \
+  bash scripts/keycloak.sh status
+```
+
+## 4. Blast-radius checks, AFTER the rotation
+
+**Expected impact is nil**, and that is a claim to test rather than assume. None of
+the SSO consumers use the admin credential — Grafana uses
+`GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET`, Portainer `PORTAINER_OIDC_CLIENT_SECRET`,
+OpenBao `VAULT_OIDC_CLIENT_SECRET`, and `KC_ADMIN*` appears in neither `vault.sh`
+nor `portainer.sh`. A user-password change cannot alter a client secret. Check each
+anyway, and note none of these checks needs the admin credential:
+
+| Service | Check | Expected |
+|---|---|---|
+| Grafana | `curl -s -D - -o /dev/null https://grafana.hill90.com/login/generic_oauth` | `302` with `Location:` pointing at `auth.hill90.com/realms/platform` |
+| Portainer | `curl -s https://portainer.hill90.com/api/settings/public` | `AuthenticationMethod: 3` (OAuth) and an `OAuthLoginURI` containing `realms/platform` |
+| OpenBao | `curl -s -X POST https://vault.hill90.com/v1/auth/oidc/oidc/auth_url -d '{"role":"","redirect_uri":"https://vault.hill90.com/ui/vault/auth/oidc/oidc/callback"}'` | JSON `data.auth_url` containing `realms/platform` |
+| The app | complete a sign-in at `hill90.com` | reaches an authenticated page |
+
+Verification status of those checks, honestly:
+
+- **Grafana — verified locally.** Returned `302` to
+  `http://auth.localtest.me:8080/realms/platform...`.
+- **Portainer — shape verified, not the value.** Locally it reports
+  `AuthenticationMethod: 1` (internal) with no `OAuthLoginURI`, because local
+  Portainer SSO was never applied. Production should report `3`.
+- **OpenBao — not verified.** The local OpenBao is uninitialized and sealed
+  (`initialized: false, sealed: true`), so the OIDC method does not exist there and
+  the endpoint 404s. The check is correct in shape; it is untested.
+
+Also confirm the realm's clients are untouched — five plus the built-ins:
+
+```bash
+docker exec keycloak /opt/keycloak/bin/kcadm.sh get clients -r platform \
+  --fields clientId --format csv --noquotes | sort
+# expect: grafana, hill90-api, hill90-ui, hill90-vault, portainer + Keycloak built-ins
+```
+
+---
+
+## 5. Rollback — and yes, there is a break-glass
+
+**This is the section that matters**, because getting the rotation wrong means
+losing the admin API for the realm that fronts every infra surface.
+
+### If you still have a working admin session
+
+Set the password back with the step-1 command. Nothing else to undo — no restart, no
+config change, no client touched.
+
+### If the admin path is lost entirely
+
+**There is a break-glass, and it needs no downtime.** Keycloak 26.4.0 ships
+`kc.sh bootstrap-admin user`, which writes an admin directly to the database.
+
+**It cannot run inside the live container.** Rehearsed, and it fails:
+
+```
+ERROR: Unable to start the management interface on 0.0.0.0:9000
+ERROR: Address already in use
+```
+
+Run it from a **sidecar** against the same database instead — the same shape this
+estate already proved for the realm export. Rehearsed locally, and it worked with the
+server left running:
+
+```bash
+docker run --rm --network hill90_internal \
+  -e KC_DB=postgres \
+  -e KC_DB_URL="jdbc:postgresql://postgres:5432/keycloak" \
+  -e KC_DB_USERNAME='<DB_USER>' -e KC_DB_PASSWORD='<DB_PASSWORD>' \
+  -e BG_PW='<break-glass password>' \
+  quay.io/keycloak/keycloak:26.4.0 \
+  bootstrap-admin user --username breakglass --password:env BG_PW
+```
+
+Then authenticate as `breakglass` against the running server, fix the real admin,
+and **delete the break-glass account**:
+
+```bash
+BG=$(docker exec keycloak /opt/keycloak/bin/kcadm.sh get users -r master \
+       -q username=breakglass --fields id --format csv --noquotes | tr -d '\r')
+docker exec keycloak /opt/keycloak/bin/kcadm.sh delete "users/$BG" -r master
+```
+
+Rehearsal confirmed the whole path, including that the account authenticates against
+the live server and that deleting it leaves `master` with only `admin`.
+
+**Note `--password:env`**, not `--password`. It reads the value from an environment
+variable so it never appears in argv — the same discipline as step 1.
+
+### What makes this genuinely low-risk
+
+There is exactly **one** login account in `master` (`admin`), so there is no second
+admin to fall back on — which is why the sidecar matters. It is worth considering a
+standing second admin account as a follow-up, but that is a decision, not part of
+this rotation.
+
+---
+
+## Do not
+
+- **Do not** change the env vars and redeploy expecting a rotation. See the top.
+- **Do not** write the new value onto any *client* secret. Client secrets are
+  unrelated to the admin user, and overwriting one breaks that service's SSO
+  immediately.
+- **Do not** recreate the Keycloak container or its volume. The realm lives in
+  Postgres; a fresh volume is not a rotation, it is a rebuild, and
+  `platform-realm.json` imports only on first boot.

--- a/scripts/checks/tenant-login-local-test.sh
+++ b/scripts/checks/tenant-login-local-test.sh
@@ -27,7 +27,12 @@ UI_REDIRECT="http://localhost:$(envget TENANT_UI_PORT)/api/auth/callback/keycloa
 SECRET=$(envget HILL90_UI_CLIENT_SECRET)
 ADMIN_U=$(envget KC_ADMIN_USERNAME)
 ADMIN_P=$(envget KC_ADMIN_PASSWORD)
-PW='LocalProbe!2026'
+# Generated per run, never committed. It only ever authenticates the two users this
+# script creates and deletes, so a literal would be low-risk — but invariant 7 says
+# secrets do not live in the tree, and a hardcoded one here was counted as the third
+# credential exposure of 2026-07-30. Cheaper to generate it than to argue the
+# exception. Mixed case, digit and symbol, so any password policy accepts it.
+PW="Probe-$(openssl rand -hex 16)-9!"
 
 RED='\033[0;31m'; GREEN='\033[0;32m'; BOLD='\033[1m'; NC='\033[0m'
 pass=0; fail=0


### PR DESCRIPTION
**Nothing executed.** Production `KC_ADMIN_PASSWORD` is untouched and still valid
(sha256 `07800425eb77…`, re-confirmed after these edits). Rotating it is Jon's call.

## 1. The rotation runbook — rehearsed, not written from the docs

Every step was run against the **local** platform Keycloak (`26.4.0`, the same image
production runs) and local state was restored afterwards: `master` realm back to one
`admin` account, original password accepted, rehearsal values refused.

**It leads with the trap**, because someone will otherwise hit it and conclude the
rotation didn't take: `KC_BOOTSTRAP_ADMIN_*` applies **only on first startup**.
Changing it in SOPS and redeploying `auth` does nothing — Keycloak starts cleanly,
logs nothing unusual, the old password keeps working. This is an **admin-API change
plus a SOPS update**.

**Verification is both halves.** Rehearsed:

```
after rotation:
  new pw -> OK
  OLD pw -> REFUSED
```

**Blast-radius checks are per service, and none of them needs the admin credential** —
which is the point. Grafana uses `GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET`, Portainer
`PORTAINER_OIDC_CLIENT_SECRET`, OpenBao `VAULT_OIDC_CLIENT_SECRET`; `KC_ADMIN*` appears
in neither `vault.sh` nor `portainer.sh`, and a user-password change cannot alter a
client secret. Expected impact nil — with the command to prove it, and the verification
status stated per check rather than implied:

- **Grafana — verified locally.** `302` to `auth.localtest.me/realms/platform`.
- **Portainer — shape only.** Locally reports `AuthenticationMethod: 1` (internal)
  because local SSO was never applied; production should report `3`.
- **OpenBao — untested.** The local one is `initialized: false, sealed: true`, so the
  OIDC method doesn't exist there and the endpoint 404s.

## The break-glass — the answer to your most important question

**Yes, there is one, and it needs no downtime.** Keycloak 26.4.0 ships
`kc.sh bootstrap-admin`.

It **cannot** run inside the live container. Rehearsed, and it fails:

```
ERROR: Unable to start the management interface on 0.0.0.0:9000
ERROR: Address already in use
```

It **works from a sidecar** against the same database with the server left running —
the same shape this estate already proved for the realm export. Rehearsed end to end:
the recovered account authenticated against the live server, and deleting it left
`master` with only `admin`.

One thing that makes this matter: there is exactly **one** login account in `master`,
so there is no second admin to fall back on. A standing second admin is worth
considering, but that is a decision, not part of a rotation.

## 2. The incident record — brief, and about the shape

| # | Credential | Where | Status |
|---|---|---|---|
| 1 | Production Keycloak `master` admin | agent transcript, in a remote `bash` error line | **still valid**, rotation prepared |
| 2 | Tenant Postgres role | truncated `docker inspect` | rotated within the hour |
| 3 | A local probe password hardcoded in a script I committed | `tenant-login-local-test.sh` | **fixed here** — generated per run |

**The shape: a value that had to be handled ended up in output that gets retained.**
None was stored wrongly or weak. Something *printed* it, and transcripts, logs and git
history keep what was printed.

Mine was not even a print statement — a heredoc claimed `ssh`'s stdin, so the piped
credentials were handed to the remote shell **as commands**, and `bash` echoed the
password back inside its own `No such file or directory` error.

**Your fix for exposure 2 is the instructive one and it generalises:** it didn't try to
stop people running `inspect`, it made the safe way to answer the question the easy
one. Applying that test to mine:

- **What was I trying to find out?** Whether a human had completed a sign-in.
- **Was there a redacted path? Yes, and I bypassed it.** `keycloak.sh` `kc_login`
  passes the admin password via `KC_CLI_PASSWORD` + `docker exec -e` *specifically* so
  it never reaches argv — in the very file I had been editing.

So the honest finding is not "tooling was missing" but "tooling didn't cover my
question". Two follow-ups, **neither built here**: a read-only `keycloak.sh sessions`
subcommand, and turning on Keycloak login events — `events_enabled=false` on both
realms is *why* the question needed an admin token at all.

## Exposure 3, fixed in this change

`PW='LocalProbe!2026'` in a committed script is now `PW="Probe-$(openssl rand -hex
16)-9!"`. Low-risk either way — it only authenticated two users the script creates and
deletes in a local realm — but invariant 7 says secrets don't live in the tree, and
arguing the exception costs more than generating it. The login proof still passes:
`All 9 assertions passed`.

## Verification

`49 passed` pytest, `345` bats, `check_md_links.py` clean, `shellcheck` clean at
warning level. Local platform 13 containers. **The VPS was not touched** — no rotation,
nothing retired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)