### PR TITLE
test(checks): phase timing for the two Docker-backed checks

### DIFF
--- a/scripts/checks/realm-tenant-serves-test.sh
+++ b/scripts/checks/realm-tenant-serves-test.sh
@@ -24,12 +24,32 @@ set -uo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 KC="h90realmtest-kc"
 IMG="quay.io/keycloak/keycloak:26.4.0"
-ADMIN=admin
+ADMIN="admin"
 # Disposable, for a container that is destroyed at the end of this script.
 ADMIN_PW=throwaway-not-a-real-credential
 
 RED='\033[0;31m'; GREEN='\033[0;32m'; BOLD='\033[1m'; NC='\033[0m'
 pass=0; fail=0
+
+# ---------------------------------------------------------------------------
+# Phase timing.
+#
+# Added because a run of the pytest suite once took 340s against a 66s median and
+# PASSED, and nothing in the output said which part was slow. Timing per phase makes
+# the next outlier attributable instead of a mystery.
+#
+# The pull is timed SEPARATELY and deliberately. Left inside `docker run -d`, a cold
+# image pull is indistinguishable from a slow server boot — and on a fresh CI runner
+# the pull is most of the wall clock. So a cold run and a warm run must read
+# differently here; that difference is the measurement, not noise to smooth away.
+#
+# Whole seconds via `date +%s`: portable to the bash 3.2 that ships with macOS,
+# where EPOCHREALTIME does not exist. Every phase here is seconds-scale, and the
+# readiness phase additionally reports attempts used, which is finer than a clock.
+# ---------------------------------------------------------------------------
+IMG_STATE="unknown"; T_PULL=0; T_START=0; T_READY=0; T_ASSERT=0; READY_TRIES=0
+READY_CAP_TRIES=60; READY_CAP_SLEEP=2
+now() { date +%s; }
 ok()   { echo -e "  ${GREEN}✓${NC} $1"; pass=$((pass+1)); }
 bad()  { echo -e "  ${RED}✗${NC} $1"; fail=$((fail+1)); }
 
@@ -38,6 +58,20 @@ trap cleanup EXIT
 cleanup
 
 echo -e "${BOLD}Importing platform-realm.json into a real Keycloak${NC}"
+
+# PHASE: image. Pull explicitly so its cost is visible rather than folded into start.
+if docker image inspect "$IMG" >/dev/null 2>&1; then
+    IMG_STATE="cached"
+    echo "  image: cached locally (no pull)"
+else
+    IMG_STATE="pulled"
+    echo "  image: not present locally — pulling ${IMG}"
+    _t0=$(now); docker pull -q "$IMG" >/dev/null 2>&1; T_PULL=$(( $(now) - _t0 ))
+    echo "  image: pulled in ${T_PULL}s"
+fi
+
+# PHASE: start.
+_t0=$(now)
 docker run -d --name "$KC" -p 18099:8080 \
   -e KC_BOOTSTRAP_ADMIN_USERNAME="$ADMIN" \
   -e KC_BOOTSTRAP_ADMIN_PASSWORD="$ADMIN_PW" \
@@ -61,13 +95,27 @@ echo "  waiting for Keycloak..."
 ready() { docker exec "$KC" /opt/keycloak/bin/kcadm.sh config credentials \
             --server http://127.0.0.1:8080 --realm master \
             --user "$ADMIN" --password "$ADMIN_PW" >/dev/null 2>&1; }
-for _ in $(seq 1 60); do ready && break; sleep 2; done
+T_START=$(( $(now) - _t0 ))
+echo "  start: container running after ${T_START}s"
+
+# PHASE: ready. The cap is UNCHANGED at 60 attempts x 2s = 120s. Attempts used is
+# reported so headroom is a measured number rather than an estimate — and so a run
+# that nearly exhausted the budget is visible even though it passed.
+_t0=$(now)
+for _ in $(seq 1 "$READY_CAP_TRIES"); do
+  READY_TRIES=$((READY_TRIES + 1))
+  ready && break
+  sleep "$READY_CAP_SLEEP"
+done
+T_READY=$(( $(now) - _t0 ))
 if ! ready; then
-  echo -e "${RED}Keycloak never came up. Import log:${NC}"
+  echo -e "${RED}Keycloak never came up after ${T_READY}s (${READY_TRIES}/${READY_CAP_TRIES} attempts, cap $((READY_CAP_TRIES * READY_CAP_SLEEP))s). Import log:${NC}"
   docker logs "$KC" 2>&1 | grep -iE "error|warn|import|realm" | tail -25
   exit 2
 fi
+echo "  ready: after ${T_READY}s (${READY_TRIES}/${READY_CAP_TRIES} attempts, cap $((READY_CAP_TRIES * READY_CAP_SLEEP))s)"
 ok "realm 'platform' imported; kcadm authenticated"
+_t_assert0=$(now)
 
 # The same delta local.sh applies, so HTTP discovery is reachable here too.
 docker exec "$KC" /opt/keycloak/bin/kcadm.sh update realms/platform -s sslRequired=NONE >/dev/null 2>&1
@@ -204,6 +252,20 @@ echo "$WO2" | grep -q "localhost:13000" \
   && ok "local web origin present (CORS for NextAuth)" || bad "local web origin missing: $WO2"
 echo "$WO2" | grep -q "https://hill90.com" \
   && ok "production web origin KEPT" || bad "production web origin was clobbered: $WO2"
+
+T_ASSERT=$(( $(now) - _t_assert0 ))
+
+echo ""
+echo -e "${BOLD}Phase timing${NC}  (so a slow run says WHICH part was slow)"
+if [ "$IMG_STATE" = "cached" ]; then
+  echo "  image   cached, no pull       (a first run on this host pulls ~500MB and will differ)"
+else
+  echo "  image   pulled in ${T_PULL}s        (cold; a cached run will report 0s here)"
+fi
+echo "  start   ${T_START}s"
+echo "  ready   ${T_READY}s  (${READY_TRIES}/${READY_CAP_TRIES} attempts of a $((READY_CAP_TRIES * READY_CAP_SLEEP))s cap)"
+echo "  asserts ${T_ASSERT}s  (${pass} assertions, each one or more docker exec calls)"
+echo "  total   $(( T_PULL + T_START + T_READY + T_ASSERT ))s accounted for"
 
 echo ""
 if [ "$fail" -eq 0 ]; then

--- a/scripts/checks/tenant-db-isolation-test.sh
+++ b/scripts/checks/tenant-db-isolation-test.sh
@@ -41,6 +41,18 @@ CP="h90tenanttest-"
 PG="${CP}postgres"
 IMAGE="pgvector/pgvector:pg16"
 
+# ---------------------------------------------------------------------------
+# Phase timing. Added after a pytest run took 340s against a 66s median and PASSED,
+# with nothing in the output saying which part was slow. Whole seconds via
+# `date +%s`, which works on the bash 3.2 macOS ships; every phase here is
+# seconds-scale and the readiness phase also reports attempts used, which is finer
+# than a clock. No cap was changed and no retry was added: if a cap turns out to be
+# too tight, that should be learned from this output, not pre-empted.
+# ---------------------------------------------------------------------------
+IMG_STATE="unknown"; T_PULL=0; T_NET=0; T_START=0; T_READY=0; T_ASSERT=0
+READY_TRIES=0; READY_CAP_TRIES=90; READY_CAP_SLEEP=1
+now() { date +%s; }
+
 PLATFORM_ROLE="hill90"
 PLATFORM_PASSWORD="platform-pw-not-a-secret"
 TENANT_ROLE="hill90_app"
@@ -145,7 +157,27 @@ echo -e "${BOLD}Tenant database isolation on platform Postgres${NC}"
 echo ""
 
 cleanup
+
+# PHASE: image. Pulled explicitly so a cold pull is not folded into the start time.
+# On a fresh CI runner the pull is most of the wall clock; on a warm host it is zero.
+# Those two runs must read differently — the difference IS the measurement.
+if docker image inspect "$IMAGE" >/dev/null 2>&1; then
+    IMG_STATE="cached"
+    echo "  image: cached locally (no pull)"
+else
+    IMG_STATE="pulled"
+    echo "  image: not present locally — pulling ${IMAGE}"
+    _t0=$(now); docker pull -q "$IMAGE" >/dev/null 2>&1; T_PULL=$(( $(now) - _t0 ))
+    echo "  image: pulled in ${T_PULL}s"
+fi
+
+# PHASE: network + start. Kept separate because the remove-then-create window on a
+# fixed network name is a known hazard: `docker rm -f` returns when removal is
+# INITIATED, so the endpoint can still be attached when `network create` runs.
+_t0=$(now)
 docker network create "$NET" >/dev/null
+T_NET=$(( $(now) - _t0 ))
+_t0=$(now)
 docker run -d --name "$PG" --network "$NET" \
     -e POSTGRES_USER="$PLATFORM_ROLE" \
     -e POSTGRES_PASSWORD="$PLATFORM_PASSWORD" \
@@ -159,11 +191,19 @@ echo "  waiting for the throwaway Postgres to accept connections..."
 # a socket-based pg_isready goes green *during* init and then the server
 # disappears underneath the test. Only TCP proves the real server is up.
 pg_ready() { docker exec "$PG" pg_isready -h 127.0.0.1 -U "$PLATFORM_ROLE" >/dev/null 2>&1; }
-for _ in $(seq 1 90); do
+T_START=$(( $(now) - _t0 ))
+# PHASE: ready. Cap UNCHANGED at 90 attempts x 1s. Attempts used is reported so a run
+# that nearly exhausted the budget is visible even when it passes.
+_t0=$(now)
+for _ in $(seq 1 "$READY_CAP_TRIES"); do
+    READY_TRIES=$((READY_TRIES + 1))
     pg_ready && break
-    sleep 1
+    sleep "$READY_CAP_SLEEP"
 done
-pg_ready || fatal "throwaway Postgres never became ready: $(docker logs "$PG" 2>&1 | tail -20)"
+T_READY=$(( $(now) - _t0 ))
+pg_ready || fatal "throwaway Postgres never became ready after ${T_READY}s (${READY_TRIES}/${READY_CAP_TRIES} attempts, cap $((READY_CAP_TRIES * READY_CAP_SLEEP))s): $(docker logs "$PG" 2>&1 | tail -20)"
+echo "  ready: after ${T_READY}s (${READY_TRIES}/${READY_CAP_TRIES} attempts, cap $((READY_CAP_TRIES * READY_CAP_SLEEP))s)"
+_t_assert0=$(now)
 
 # Sanity-check the fixture itself: the platform bootstrap must NOT have created
 # the tenant databases. If it did, this test would be proving the wrong thing.
@@ -409,6 +449,21 @@ expect_check 0 "returns to passing once every probe is reverted" \
     "hill90_akm(hill90_app) hill90_api(hill90_app) hill90_litellm(hill90_app)"
 
 # --------------------------------------------------------------------------
+
+T_ASSERT=$(( $(now) - _t_assert0 ))
+
+echo ""
+echo -e "${BOLD}Phase timing${NC}  (so a slow run says WHICH part was slow)"
+if [ "$IMG_STATE" = "cached" ]; then
+    echo "  image   cached, no pull       (a first run on this host pulls and will differ)"
+else
+    echo "  image   pulled in ${T_PULL}s        (cold; a cached run will report 0s here)"
+fi
+echo "  network ${T_NET}s"
+echo "  start   ${T_START}s"
+echo "  ready   ${T_READY}s  (${READY_TRIES}/${READY_CAP_TRIES} attempts of a $((READY_CAP_TRIES * READY_CAP_SLEEP))s cap)"
+echo "  asserts ${T_ASSERT}s  (${pass_count} assertions; most spawn a throwaway psql container)"
+echo "  total   $(( T_PULL + T_NET + T_START + T_READY + T_ASSERT ))s accounted for"
 
 echo ""
 if [ "$fail_count" -eq 0 ]; then


### PR DESCRIPTION
## The characterisation first, because it is the actual result

**Hill90's suites do not show the signature found in `hill90-app`.** No "different
test each time", no failures at all.

| suite | runs | result |
|---|---|---|
| bats (file order shuffled each run) | 10 | `345 ok` every run, 51–57s |
| pytest (shuffled, then profiled) | 18 | `49 passed` every run, `rc=0` every run |

**4,332 test executions, zero failures, across ten different file orderings.** Neither
runner has a shuffle flag (no `pytest-randomly` installed; bats has none), so I
shuffled the file arguments rather than claim randomisation I did not have.

That is the suite gating the deploy path, the backup script, tenant provisioning and
the preflight guards — so the negative result is the point.

## The one anomaly, which is why this PR exists

**One pytest run took 340s against a 66s median, and passed.** It did not reproduce in
18 further runs, and the distribution is otherwise very tight:

| test | n=8 | min | max | mean |
|---|---|---|---|---|
| `test_the_realm_serves_the_tenant` | | 28.4s | 31.7s | 29.8s |
| `test_tenant_privilege_boundary_holds` | | 21.9s | 24.5s | 23.0s |
| `test_a_tenant_user_can_complete_a_login…` | | 10.5s | 11.4s | 11.0s |
| all 46 others | | — | — | <0.1s |

Nothing in the output said which part was slow. **This does not fix a flake — it fixes
the blindness.** A 5× outlier that passes today is a failure tomorrow, and green CI
would never have surfaced it.

## What the instrumentation does

Per-phase timing in both scripts: image, start (plus network, for the isolation test),
ready, asserts, total.

**The pull is timed separately, deliberately.** Left inside `docker run -d`, a cold
pull is indistinguishable from a slow boot — and on a fresh CI runner the pull is most
of the wall clock. So:

```
warm:  image   cached, no pull       (a first run on this host pulls ~500MB and will differ)
cold:  image   pulled in 47s         (cold; a cached run will report 0s here)
```

**Both branches verified**, not just the one my machine happens to hit: the warm path
against the real image, the cold path against a deliberately absent one (`pulled in
2s`, then `cached` on the second call). The difference between cold and warm is legible
rather than smoothed away, because that difference is the measurement.

**The readiness phase reports attempts used, not just elapsed** — which turns headroom
into a measured number instead of the estimate I declined to give you from the CI logs:

```
ready   18s  (7/60 attempts of a 120s cap)
```

**No cap was raised and no retry was added.** If a cap is genuinely too tight, that
should be learned from this output. Raising a timeout before knowing why something was
slow is how a real slowdown hides for months.

## It earned its keep on the first run

```
isolation test          serves test
  network 0s              image   cached
  start   0s              start   1s
  ready   2s (3/90)       ready   18s (7/60)
  asserts 21s (38)        asserts 12s (21)
  total   23s             total   31s
```

**For the isolation test, 91% of the runtime is the assertion phase** — ~38 throwaway
psql containers — while readiness used 3 of 90 attempts. So the readiness cap was never
that test's risk, and the unbounded per-assertion `docker run --rm` calls are a more
likely home for the 340s outlier than any budget exhaustion. That is a different
conclusion from the one I would have guessed, which is the point of measuring.

## Shared state: still named, still not fixed

The three hazards from the characterisation are unchanged and deliberately untouched —
the remove-then-create window on a fixed network name (`set -e`, aborts loudly), the
same window plus fixed host port `18099` (no `-e`, degrades into a confusing "never
came up"), and the shared local Keycloak with fixed usernames. 28 runs found no failure,
which makes them **latent, not disproven**.

## Verification

`49 passed` pytest, `345` bats, `shellcheck --severity=error scripts/*.sh` clean, and
both modified scripts now clean at **warning** level too (quoted a pre-existing
`ADMIN=admin` that tripped SC2209). No residue: no throwaway containers, no throwaway
networks, no leftover realm users. Local platform 13 containers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)