### PR TITLE
test(checks): make the phase timing visible on a PASSING run

### DIFF
--- a/tests/checks/test_realm_tenant_serves.py
+++ b/tests/checks/test_realm_tenant_serves.py
@@ -31,11 +31,34 @@ def test_script_exists():
     assert SCRIPT.is_file(), f"missing: {SCRIPT}"
 
 
+def echo_phase_timing(stdout: str, capsys) -> None:
+    """Surface the script's phase timing even when the test PASSES.
+
+    pytest captures stdout for passing tests, so without this the timing is visible
+    only when something already failed — which is useless for the case it exists for:
+    a run that is 5x slower than usual and still green. capsys.disabled() writes
+    straight to the terminal, so CI logs it on every run.
+    """
+    lines = stdout.splitlines()
+    for i, line in enumerate(lines):
+        if "Phase timing" in line:
+            with capsys.disabled():
+                print(f"\n    [{SCRIPT.name}]")
+                # Stop at the blank line that closes the block, so the pass/fail
+                # summary underneath it is not dragged in.
+                for out in lines[i + 1 :]:
+                    if not out.strip():
+                        break
+                    print(f"    {out}")
+            return
+
+
 @pytest.mark.skipif(not docker_available, reason="needs a reachable docker daemon")
-def test_the_realm_serves_the_tenant():
+def test_the_realm_serves_the_tenant(capsys):
     result = subprocess.run(
         ["bash", str(SCRIPT)], capture_output=True, text=True, cwd=ROOT, timeout=900
     )
+    echo_phase_timing(result.stdout, capsys)
     assert result.returncode == 0, (
         "the platform realm does not serve the tenant correctly:\n"
         f"{result.stdout}\n{result.stderr}"

--- a/tests/checks/test_tenant_db_isolation.py
+++ b/tests/checks/test_tenant_db_isolation.py
@@ -34,10 +34,32 @@ def test_script_exists():
     assert SCRIPT.is_file(), f"missing: {SCRIPT}"
 
 
+def echo_phase_timing(stdout: str, capsys) -> None:
+    """Surface the script's phase timing even when the test PASSES.
+
+    pytest captures stdout for passing tests, so without this the timing is visible
+    only when something already failed — useless for the case it exists for: a run
+    that is 5x slower than usual and still green. capsys.disabled() writes straight
+    to the terminal, so CI logs it on every run.
+    """
+    lines = stdout.splitlines()
+    for i, line in enumerate(lines):
+        if "Phase timing" in line:
+            with capsys.disabled():
+                print(f"\n    [{SCRIPT.name}]")
+                # Stop at the blank line that closes the block, so the pass/fail
+                # summary underneath it is not dragged in.
+                for out in lines[i + 1 :]:
+                    if not out.strip():
+                        break
+                    print(f"    {out}")
+            return
+
+
 @pytest.mark.skipif(
     not docker_available, reason="needs a reachable docker daemon"
 )
-def test_tenant_privilege_boundary_holds():
+def test_tenant_privilege_boundary_holds(capsys):
     result = subprocess.run(
         ["bash", str(SCRIPT)],
         capture_output=True,
@@ -45,6 +67,7 @@ def test_tenant_privilege_boundary_holds():
         cwd=ROOT,
         timeout=600,
     )
+    echo_phase_timing(result.stdout, capsys)
     assert result.returncode == 0, (
         "tenant isolation assertions failed:\n"
         f"{result.stdout}\n{result.stderr}"


### PR DESCRIPTION
Follow-up to #588, which you merged while I was still working on this — so the fix
needs its own PR rather than a second commit on that branch.

## The instrumentation in #588 was invisible where it mattered

I checked #588's own CI log for the timing lines. **There were none.** pytest captures
stdout for tests that pass, and the case this instrumentation exists for is precisely a
run that is 5× slower than usual and *still green*.

Instrumentation you can only see after something has already failed is not
instrumentation. #588 would have logged the phase timing on a failure — and stayed
silent through exactly the 340s pass that prompted it.

## The fix

Both wrappers echo the phase block through `capsys.disabled()`, which writes straight
to the terminal, so every CI run records where its time went whether it passes or not.
Verified on a plain `pytest -q` with no `-s`:

```
    [realm-tenant-serves-test.sh]
      image   cached, no pull       (a first run on this host pulls ~500MB and will differ)
      start   0s
      ready   19s  (7/60 attempts of a 120s cap)
      asserts 12s  (21 assertions, each one or more docker exec calls)
      total   31s accounted for
```

The extraction stops at the blank line closing the block, so the pass/fail summary
underneath is not dragged in — the first version pulled in an ANSI-coloured "All 21
assertions passed" line.

Still no cap raised and no retry added.

## Verification

`49 passed`. `345` bats unaffected. Cherry-picked cleanly onto the merged `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)