### PR TITLE
fix(backup): app-db must not report FAILED because a retired container is absent

### DIFF
--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -219,10 +219,29 @@ backup_app_db() {
 
     echo "Backing up the hill90-app tenant database..."
 
+    # app-postgres was retired on 2026-07-30 and the tenant's databases moved to the
+    # platform Postgres, so the `db` target's pg_dumpall already contains hill90_akm,
+    # hill90_api and hill90_litellm. Dying here would make `backup all` report FAILED
+    # every night for data that IS backed up — and a backup job that cries wolf is how
+    # a real failure gets ignored.
+    #
+    # This is deliberately not the same as "the tenant is not deployed": that case is
+    # still a failure when the container is expected. The retirement is identified by
+    # the container being absent AND its databases being covered elsewhere, which is
+    # exactly the post-cutover state.
     if ! docker inspect "$container" >/dev/null 2>&1; then
-        die "Container '${container}' not found — the tenant's database cannot be backed up.
-If the tenant is deliberately not deployed, run the other services explicitly
-rather than letting this report success."
+        echo "  • '${container}' is retired (2026-07-30) — its databases moved to the"
+        echo "    platform Postgres and are covered by the 'db' target's pg_dumpall."
+
+        # The retained volume is the only artifact still uniquely app-db's, and only
+        # for as long as it exists. Tar it while it is there; say so when it is not.
+        if docker volume ls --format '{{.Name}}' 2>/dev/null | grep -qx "prod_app-postgres-data"; then
+            echo "    The retained volume prod_app-postgres-data still exists — archiving it."
+            backup_volume "prod_app-postgres-data" "$backup_dir/app-postgres-data.tar.gz" || true
+        else
+            echo "    The retained volume is gone too; nothing left for this target to do."
+        fi
+        return 0
     fi
 
     local app_user="${APP_DB_USER:-}"

--- a/tests/scripts/backup.bats
+++ b/tests/scripts/backup.bats
@@ -263,11 +263,15 @@ EOF
 
 @test "backup-all continues past a failing service and still exits non-zero" {
   setup_stubs
-  # Tenant container absent — the state during any teardown of the app.
+  # The tenant container is PRESENT but its dump fails. This used to induce the
+  # failure by making `inspect app-postgres` exit 1, but app-postgres was retired on
+  # 2026-07-30 and an absent container is now a legitimate no-op — that stub would
+  # test nothing. A present-but-undumpable container is still a real failure, so the
+  # property under test here (keep going, then exit non-zero) is unchanged.
   cat > "$STUB_BIN/docker" <<'EOF'
 #!/usr/bin/env bash
 case "$*" in
-  *inspect\ app-postgres*) exit 1 ;;                 # tenant not deployed
+  *exec\ app-postgres*pg_dumpall*) exit 1 ;;         # tenant dump fails
   *pg_dumpall*|*pg_dump*)  echo "-- dump"; echo "CREATE ROLE hill90;"; exit 0 ;;
   *psql*SELECT\ 1*)        echo "1"; exit 0 ;;
   *)                       exit 0 ;;
@@ -284,4 +288,56 @@ EOF
   dump="$(find "$BATS_TEST_TMPDIR/backups" -name 'database.sql' | head -1)"
   [ -n "$dump" ]
   [ -s "$dump" ]
+}
+
+# ---------------------------------------------------------------------------
+# app-postgres was RETIRED on 2026-07-30. The tenant's databases now live on the
+# platform Postgres, so the `db` target's pg_dumpall already contains hill90_akm,
+# hill90_api and hill90_litellm. What `app-db` must NOT do is die because a
+# container it no longer needs is absent: `backup all` would report FAILED every
+# night for data that is in fact backed up, and a backup job that cries wolf is
+# how a real failure gets ignored.
+#
+# The retained volume is the part that is genuinely app-db's own, and only while
+# it exists. So: absent container plus absent volume is a no-op that says why;
+# absent container plus present volume still tars it.
+# ---------------------------------------------------------------------------
+
+@test "backup app-db does not fail merely because the retired container is gone" {
+  setup_stubs
+  cat > "$STUB_BIN/docker" <<'EOF'
+#!/usr/bin/env bash
+# Quote nothing in these patterns. A `case` pattern is matched literally, so
+# *"inspect app-postgres"* looks for the quote characters themselves, never
+# matches, and the container silently appears PRESENT — which is how the first
+# version of this test passed against a deliberately neutered guard.
+case "$*" in
+  *inspect\ app-postgres*) exit 1 ;;   # retired: container absent
+  *volume\ ls*)            exit 0 ;;   # and its volume already reviewed away
+  *)                       exit 0 ;;
+esac
+EOF
+  chmod +x "$STUB_BIN/docker"
+  run env PATH="$STUB_BIN:/usr/bin:/bin" \
+      BACKUP_DIR="$BATS_TEST_TMPDIR/backups" \
+      bash scripts/backup.sh backup app-db
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"retired"* ]]
+}
+
+@test "backup app-db still fails when the container IS present but undumpable" {
+  setup_stubs
+  cat > "$STUB_BIN/docker" <<'EOF'
+#!/usr/bin/env bash
+case "$*" in
+  *pg_dumpall*|*pg_dump*) exit 1 ;;
+  *psql*SELECT\ 1*)       echo "1"; exit 0 ;;
+  *)                      exit 0 ;;
+esac
+EOF
+  chmod +x "$STUB_BIN/docker"
+  run env PATH="$STUB_BIN:/usr/bin:/bin" \
+      BACKUP_DIR="$BATS_TEST_TMPDIR/backups" APP_DB_USER=hill90 \
+      bash scripts/backup.sh backup app-db
+  [ "$status" -ne 0 ]
 }


### PR DESCRIPTION
## Plan

`app-postgres` was retired on 2026-07-30 (hill90-app #63) and its databases moved to the platform Postgres. `backup_app_db` still `die`s when the container is absent, so tonight's `backup-all` would report FAILED for data that is already covered by the `db` target's `pg_dumpall`.

Absent container + absent volume → no-op that says why. Absent container + retained volume → still tars the volume. Present but undumpable → still fails.

## Risks

A genuinely-not-deployed tenant no longer fails this target. Accepted: the tenant's databases are on the platform Postgres now, so their backup does not depend on that container existing. The volume branch keeps coverage of the one artifact that is still uniquely app-db's.

## Rollback

Revert the commit. No host state is touched by this change.

## Validation Evidence

```
$ bats tests/scripts/backup.bats
ok 31 backup-all continues past a failing service and still exits non-zero
ok 32 backup app-db does not fail merely because the retired container is gone
ok 33 backup app-db still fails when the container IS present but undumpable
```

Mutation-tested — the new test goes red when the guard is removed:

```
$ python3 -c "...replace 'return 0' with 'die neutered' in the retirement guard..."
$ bats tests/scripts/backup.bats -f "retired container is gone"
not ok 1 backup app-db does not fail merely because the retired container is gone
```

That check mattered: the first version of the test used `*"inspect app-postgres"*` as a `case` pattern, which matches the quote characters literally, never fired, and passed against the neutered guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)