### PR TITLE
feat(storage): make the dark router durable, and record the cutover state

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -218,3 +218,6 @@ CONTAINER_PREFIX=hill90dev-
 NETWORK_PREFIX=hill90dev
 VOLUME_PREFIX=hill90dev
 VOLUME_PREFIX_BARE=hill90dev-
+
+# Hold minio's Traefik router dark across deploys (cutover only). Default true.
+MINIO_TRAEFIK_ENABLE=true

--- a/deploy/compose/prod/docker-compose.minio.yml
+++ b/deploy/compose/prod/docker-compose.minio.yml
@@ -86,7 +86,16 @@ services:
       retries: 3
       start_period: 20s
     labels:
-      - "traefik.enable=true"
+      # PARAMETERISED DELIBERATELY. Merging any change to this file redeploys minio
+      # (deploy.yml triggers on deploy/compose/prod/*.yml — invariant 1), which on
+      # 2026-07-31 silently re-enabled this router while app-minio still claimed
+      # Host(`storage.hill90.com`). Two routers, one rule, and production Traefik sets
+      # no provider constraints: whichever it saw last wins, with no staging state to
+      # catch it. A dark router that depends on nobody merging is not a state.
+      #
+      # Set MINIO_TRAEFIK_ENABLE=false to hold it dark across deploys during a
+      # cutover. Default is true, which is the intended end state.
+      - "traefik.enable=${MINIO_TRAEFIK_ENABLE:-true}"
       # The console. Tailscale-only, like every other admin surface.
       #
       # CERTIFICATE: this host has never issued under the current ACME path —

--- a/docs/decisions/object-store.md
+++ b/docs/decisions/object-store.md
@@ -111,3 +111,75 @@ The first issuance should be watched rather than assumed. Procedure in
 The stale `_acme-challenge.storage` TXT record in the zone is a fossil from when
 MinIO last existed; it survives because `dns-manager`'s `/cleanup` has never
 successfully deleted a record. Retiring it is #538's business, not this change's.
+
+---
+
+# CUTOVER STATE — read this first if you are picking this up
+
+`Last updated 2026-07-31 ~01:30 UTC.` Written deliberately so a context exhaustion or a
+handover cannot leave storage half cut over with nobody knowing which half.
+
+## Where it actually is
+
+| # | Step | Status |
+|---|---|---|
+| 0 | Platform MinIO up, buckets mirrored, tenant credential minted | **DONE** |
+| 0b | `traefik.enable` parameterised so the dark state survives a deploy | **DONE — this PR** |
+| 1 | Deploy `app-api` so it consumes the platform MinIO, prove a real object | **NOT DONE** |
+| 2 | Stop `app-minio` (container and volume both retained) | **NOT DONE** |
+| 3 | Enable the `minio-console` router on `storage.hill90.com` | **NOT DONE** |
+| 4 | Verify console over Tailscale + whether Keycloak OIDC login works | **NOT DONE** |
+
+## Live state right now
+
+- `minio` running healthy, volume `prod_minio-data`, **`traefik.enable=false`**, three
+  buckets (`agent-avatars`, `chat-attachments`, `user-avatars`), **0 objects**.
+- `app-minio` running, volume `prod_app-minio-data` intact, still the app's live data
+  path, still the only enabled router for `storage.hill90.com`.
+- Platform baseline 13/13 by name, 0 unhealthy, `hill90.com` 200.
+- Tenant credential `tenant-hill90-app` exists on the platform MinIO, scoped to the three
+  buckets. Present in **both** stores: Hill90's (authoritative) and hill90-app's (replica,
+  merged as hill90-app#66).
+- `app-api` on `main` already names the platform MinIO — **but that has not shipped**;
+  the app's deploy is `workflow_dispatch` only.
+
+## The trap that already fired once
+
+Merging any change to `deploy/compose/prod/docker-compose.minio.yml` **redeploys minio**
+(`deploy.yml` triggers on those paths — invariant 1). On 2026-07-31 that silently
+re-enabled the router while `app-minio` still claimed the same Host rule, giving two
+routers one rule with no provider constraints to disambiguate. It was restored by hand.
+
+That is why the label is now `${MINIO_TRAEFIK_ENABLE:-true}`. **During the remaining
+cutover, deploy minio with `MINIO_TRAEFIK_ENABLE=false`** until step 2 is done.
+
+Note both backends are MinIO, so `storage.hill90.com` returns 200 either way — an
+ambiguous route does not announce itself. If it points at the platform store before the
+app has cut over, an operator sees an **empty** bucket list and may conclude data was
+lost. It was not; the data path is still `app-minio`.
+
+## To continue
+
+```bash
+# 1. deploy app-api (pipeline only; dry run first)
+gh workflow run "Manual Deploy App (Prod)" -f service=api -f dry_run=true
+gh workflow run "Manual Deploy App (Prod)" -f service=api
+
+# prove it, do not infer from config: write through the APP's own path, then read the
+# object back from the platform MinIO and compare counts on both sides. They were both
+# 0, so a 0 -> 1 landing in the right bucket is the proof.
+
+# 2. stop app-minio — STOP only. Do not rm, do not touch prod_app-minio-data.
+docker stop app-minio
+
+# 3. only now let the router go live
+bash scripts/deploy.sh minio prod      # MINIO_TRAEFIK_ENABLE unset -> true
+
+# 4. verify over Tailscale, and say plainly whether Keycloak OIDC login WORKS.
+#    The `minio` client in realm platform has never been exercised by a human.
+#    MinIO's AGPL build has no console SSO since May 2025 — the console offers
+#    root-credential form login only, and OIDC gates the S3/STS path. Report what
+#    is actually true rather than "console up".
+```
+
+Baseline by name after every step: 13 present, 0 unhealthy, `hill90.com` 200.

--- a/platform/vault/secrets-schema.yaml
+++ b/platform/vault/secrets-schema.yaml
@@ -49,6 +49,10 @@ excluded_vars:
   - KC_PUBLIC_URL
   - KC_REALM
   - GRAFANA_OIDC_ENABLED
+  # Whether minio's Traefik router is live. Not a secret. Held false during a cutover
+  # so a deploy cannot re-enable the router while another container claims the same
+  # Host rule; defaults to true, the intended end state.
+  - MINIO_TRAEFIK_ENABLE
   # Object store routing and the claim MinIO reads its policy from. Not
   # secrets; all default to the production values.
   - MINIO_HOST

--- a/scripts/checks/check_env_surface.py
+++ b/scripts/checks/check_env_surface.py
@@ -92,6 +92,10 @@ SCRIPT_ONLY = {
     # serve the tenant. No compose ${VAR}: this platform does not run the tenant's
     # UI, it only has to know the URL Keycloak must accept a redirect to.
     "TENANT_UI_PORT",
+    # Whether minio's Traefik router is live. Not a secret and not consumed by any
+    # script — it is read by compose at deploy time to hold the router dark during a
+    # cutover. Defaults to true, the intended end state.
+    "MINIO_TRAEFIK_ENABLE",
     # Portainer stores its OAuth configuration in its own database, applied
     # through its API by scripts/portainer.sh — there is no compose ${VAR} to
     # reference, but the value still has to be documented and kept in SOPS.

--- a/scripts/checks/check_env_surface.py
+++ b/scripts/checks/check_env_surface.py
@@ -92,10 +92,6 @@ SCRIPT_ONLY = {
     # serve the tenant. No compose ${VAR}: this platform does not run the tenant's
     # UI, it only has to know the URL Keycloak must accept a redirect to.
     "TENANT_UI_PORT",
-    # Whether minio's Traefik router is live. Not a secret and not consumed by any
-    # script — it is read by compose at deploy time to hold the router dark during a
-    # cutover. Defaults to true, the intended end state.
-    "MINIO_TRAEFIK_ENABLE",
     # Portainer stores its OAuth configuration in its own database, applied
     # through its API by scripts/portainer.sh — there is no compose ${VAR} to
     # reference, but the value still has to be documented and kept in SOPS.


### PR DESCRIPTION
Two things, both because the cutover is unfinished and my context is nearly exhausted. **The remaining four steps are NOT done** — see the state record.

## The dark router is now a state, not a coincidence

Merging #593 redeployed minio from `main` (`deploy.yml` triggers on `deploy/compose/prod/*.yml` — invariant 1) and **silently re-enabled its Traefik router while `app-minio` still claimed the same Host rule**. Two routers, one rule, no provider constraints: whichever Traefik saw last wins. I restored it by hand, but a dark router that depends on nobody merging a compose change is not a state.

`traefik.enable` is now `${MINIO_TRAEFIK_ENABLE:-true}` — default true (the intended end state), set false to hold it dark across deploys for the rest of the cutover.

**Why that failure was quiet:** both backends are MinIO, so `storage.hill90.com` returns 200 either way. Had it pointed at the platform store before the app cut over, an operator would have seen an **empty** bucket list and reasonably concluded data was lost.

## The cutover state is written down

`docs/decisions/object-store.md` now carries a step-by-step record: what is done (platform MinIO up, buckets mirrored, tenant credential minted, this parameterisation) and what is **not** (deploy `app-api`, prove a real object, stop `app-minio`, enable the console). Plus live state, the trap that already fired, and the exact commands to continue — so a context exhaustion cannot leave storage half cut over with nobody knowing which half.

## One self-inflicted miss, recorded

The first commit went out on a **red suite**: I piped pytest through `| tail -1`, so the exit status came from `tail`. The failure was real — `MINIO_TRAEFIK_ENABLE` needed to be in the schema's `excluded_vars`, not `check_env_surface`'s script-only set (it *is* a compose variable). Fixed in the second commit; `49 passed`, `355` bats, all checks clean.

## State

`13/13` by name, 0 unhealthy, `hill90.com` 200. `minio` healthy and dark; `app-minio` running, container and volume intact, still the live data path and still the only enabled router.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
