### PR TITLE
fix(minio): wait for MinIO to serve before provisioning policies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,12 @@ jobs:
       - name: Assert no destructive volume commands
         run: bash scripts/checks/check_destructive_commands.sh
 
+      # Guards the 2026-07-31 incident: minio.sh provisioned policies before
+      # MinIO was serving, then blamed the credentials. Stubs docker, so it needs
+      # no running stack.
+      - name: MinIO readiness regression test
+        run: bash scripts/checks/minio-readiness-test.sh
+
       - name: Setup Python
         uses: actions/setup-python@v5
         with:

--- a/docs/decisions/object-store.md
+++ b/docs/decisions/object-store.md
@@ -125,23 +125,84 @@ handover cannot leave storage half cut over with nobody knowing which half.
 |---|---|---|
 | 0 | Platform MinIO up, buckets mirrored, tenant credential minted | **DONE** |
 | 0b | `traefik.enable` parameterised so the dark state survives a deploy | **DONE — this PR** |
-| 1 | Deploy `app-api` so it consumes the platform MinIO, prove a real object | **NOT DONE** |
-| 2 | Stop `app-minio` (container and volume both retained) | **NOT DONE** |
-| 3 | Enable the `minio-console` router on `storage.hill90.com` | **NOT DONE** |
-| 4 | Verify console over Tailscale + whether Keycloak OIDC login works | **NOT DONE** |
+| 1 | Deploy `app-api` so it consumes the platform MinIO, prove a real object | **DONE 2026-07-31 01:40 UTC** |
+| 2 | Stop `app-minio` (container and volume both retained) | **DONE 2026-07-31 01:43 UTC** |
+| 3 | Enable the `minio-console` router on `storage.hill90.com` | **IN EFFECT — but not by step 3; see below** |
+| 4 | Verify console over Tailscale + whether Keycloak OIDC login works | **DONE 2026-07-31 02:05 UTC — console up, OIDC login does NOT work** |
+| 5 | Fix the `minio.sh` readiness race and the exit-1-after-success | **DONE — policies re-applied; fix awaits merge** |
 
 ## Live state right now
 
-- `minio` running healthy, volume `prod_minio-data`, **`traefik.enable=false`**, three
-  buckets (`agent-avatars`, `chat-attachments`, `user-avatars`), **0 objects**.
-- `app-minio` running, volume `prod_app-minio-data` intact, still the app's live data
-  path, still the only enabled router for `storage.hill90.com`.
-- Platform baseline 13/13 by name, 0 unhealthy, `hill90.com` 200.
+`Updated 2026-07-31 01:48 UTC.` The four cutover steps are complete. What follows
+replaces the pre-cutover description that stood here.
+
+- `minio` running healthy, volume `prod_minio-data`, **`traefik.enable=true`** — the
+  console router on `storage.hill90.com` is live and is the only claimant.
+  `user-avatars` holds **1** object (the step-1 proof); the other two buckets are empty.
+- `app-minio` **stopped** (`exited 0`), volume `prod_app-minio-data` retained with its
+  168K intact. Nothing was removed. It is no longer the app's data path.
+- `app-api` healthy, reading and writing the platform MinIO with the scoped
+  `tenant-hill90-app` credential.
+- Platform baseline 13/13 by name, 0 unhealthy, `hill90.com` 200,
+  `storage.hill90.com` 200 — checked after every step.
+- MinIO policies: `admin`, `editor`, `viewer` present again, alongside the builtins and
+  `tenant-hill90-app`. Federated S3/STS has its policy names back.
+- **Still open, outside this lane:** `deploy.sh`'s `verify infra` check runs
+  `docker exec traefik wget -qO- http://localhost:8080/api/overview`, and Traefik's API
+  is not on `:8080` — the same wrong endpoint as the runbook command below. That check
+  cannot currently pass. Not touched here; it needs its own change.
 - Tenant credential `tenant-hill90-app` exists on the platform MinIO, scoped to the three
   buckets. Present in **both** stores: Hill90's (authoritative) and hill90-app's (replica,
   merged as hill90-app#66).
 - `app-api` on `main` already names the platform MinIO — **but that has not shipped**;
   the app's deploy is `workflow_dispatch` only.
+
+## Step 1 — what was actually run, and what it proves
+
+`Verified 2026-07-31 01:40 UTC.`
+
+`gh workflow run "Manual Deploy App (Prod)" -f service=api` — dry run first (all guards
+passed, nothing deployed), then the live deploy. Run 30596835839. `app-api` came back
+`running/healthy` at 01:38:08 UTC with `MINIO_ENDPOINT=http://minio:9000`.
+
+The proof was a real object, not a config read. A script was executed **inside
+`app-api`**, importing `app-api`'s own compiled S3 client (`/app/dist/services/s3.js`)
+and using `app-api`'s own deployed environment — so the endpoint, the tenant credential,
+DNS on `hill90_internal` and the MinIO policy were all the deployed ones:
+
+```
+endpoint = http://minio:9000
+PUT ok -> user-avatars/cutover-proof/step1.txt
+GET ok, roundtrip match = true | bytes = 40
+LIST user-avatars count = 1
+NEGATIVE ok: CreateBucket refused -> AccessDenied
+```
+
+Counts on both sides, measured independently with `mc`:
+
+| Bucket | platform `minio` before | after | `app-minio` after |
+|---|---|---|---|
+| `agent-avatars` | 0 | 0 | 0 |
+| `chat-attachments` | 0 | 0 | 0 |
+| `user-avatars` | 0 | **1** | **0** |
+
+The write landed on the platform store and *not* on `app-minio`. The 0 → 1 transition
+also demonstrates the counting check can report non-zero, which a flat row of zeros
+would not have.
+
+The `AccessDenied` on `CreateBucket` is deliberate evidence the tenant credential is the
+scoped one and not root.
+
+**The object `user-avatars/cutover-proof/step1.txt` was left in place on purpose**, as
+evidence a cold session can re-read. It is 40 bytes and safe to delete once this record
+is no longer needed.
+
+**What this does not prove.** `POST /storage/buckets/:name/upload` sits behind
+`requireAuth` + `requireRole('admin')` against realm `platform`, and no human has ever
+completed a sign-in there. The HTTP and authorisation layers above the S3 client were
+therefore **not** exercised. That is an identity gap, not a storage one — everything the
+cutover changed is covered above — but it should not be reported as "the upload endpoint
+works".
 
 ## The trap that already fired once
 
@@ -157,6 +218,239 @@ Note both backends are MinIO, so `storage.hill90.com` returns 200 either way —
 ambiguous route does not announce itself. If it points at the platform store before the
 app has cut over, an operator sees an **empty** bucket list and may conclude data was
 lost. It was not; the data path is still `app-minio`.
+
+## Step 2 — `app-minio` stopped, nothing removed
+
+`Verified 2026-07-31 01:43 UTC.` `docker stop app-minio`.
+
+- Container: `status=exited exit=0` — present, not removed.
+- Volume `prod_app-minio-data`: present, 168K on disk at
+  `/var/lib/docker/volumes/prod_app-minio-data/_data`.
+- Remaining app containers: `app-ai app-api app-docker-proxy app-knowledge app-litellm
+  app-mcp app-ui`, all healthy.
+
+`app-api` is the **only** consumer: `grep -rn MINIO deploy/compose/prod/*.yml` in
+hill90-app matches `docker-compose.api.yml` and nothing else. `knowledge` and `ui` are
+named as consumers in `.env.example`'s comment but are not wired to MinIO in prod
+compose, so stopping `app-minio` could not strand them.
+
+## Step 3 — the trap fired a SECOND time, and #594 is what fired it
+
+**The router was already live before this session started. It was not enabled in the
+safe order.** Recording this plainly because the fix for the trap is what tripped it.
+
+Merging #594 (`2026-07-31 01:32:53 UTC`) fired `Deploy Changed Services (Prod)` on push
+(run `30596624147`, 01:32:56) because `deploy/compose/prod/docker-compose.minio.yml` is
+on its path filter. That run **removed and recreated** `minio` at `01:33:27 UTC` with
+`MINIO_TRAEFIK_ENABLE` unset, so `${MINIO_TRAEFIK_ENABLE:-true}` resolved to **`true`**
+and the console router came up.
+
+`app-minio` was still running at that moment. Both routers therefore claimed
+``Host(`storage.hill90.com`)`` from `01:33:27` until `docker stop app-minio` at
+`~01:43` — about ten minutes.
+
+The lesson is that parameterising the label did **not** make the dark state durable,
+because the default is `true` and the variable is set nowhere. `MINIO_TRAEFIK_ENABLE`
+appears only in `.env.local.example`, `platform/vault/secrets-schema.yaml` and the
+compose file — it is absent from `infra/secrets/prod.enc.env`. A durable dark state
+needs the value actually present in the prod store, or a default of `false`.
+
+Deployed state now, read off the container:
+
+```
+traefik.enable=true
+traefik.http.routers.minio-console.rule=Host(`storage.hill90.com`)
+traefik.http.routers.minio-console.middlewares=tailscale-only@file
+traefik.http.routers.minio-console.service=minio-console
+traefik.http.services.minio-console.loadbalancer.server.port=9001
+```
+
+`minio` was **not** redeployed by this session. The end state matches the intent of
+step 3, so re-running the deploy would be container churn on what is now the live data
+path for no gain.
+
+**A check that was worthless, flagged so it is not reused.** The runbook's
+`docker exec traefik wget -qO- http://localhost:8080/api/http/routers` returns
+*connection refused* — Traefik's API is not on `:8080`; it is `api@internal` behind
+`traefik.hill90.com` with `auth@file` + `tailscale-only@file`. Piped into `grep` it
+prints nothing, which reads exactly like "no router claims this host". It produced that
+false negative here before the container labels were read directly. **Fix the runbook.**
+
+## Step 4 — the console is up over Tailscale. Keycloak OIDC login does NOT work
+
+`Verified 2026-07-31 01:47 UTC` from a tailnet client.
+
+- `https://storage.hill90.com/` → **HTTP 200**, TLS verified (`ssl_verify_result=0`).
+- Certificate: `subject=CN=storage.hill90.com`, issuer Let's Encrypt `YR1`, valid
+  `Jul 29 04:44:53 2026` → `Oct 27 04:44:52 2026`. Not the Traefik default cert. Note
+  this contradicts the "never issued a certificate" section above — issuance happened on
+  2026-07-29, under `app-minio`'s router for the same host.
+- Serving backend is the **platform** `minio`: `app-minio` is stopped, so a route to it
+  would 502; it returns 200.
+
+**Does Keycloak OIDC login to the console work? No.**
+
+```
+$ curl -s https://storage.hill90.com/api/v1/login
+{"animatedLogin":true,"loginStrategy":"form","redirectRules":null}
+```
+
+`loginStrategy: "form"` and `redirectRules: null` — root-credential form login only, no
+Keycloak button. This is measured on the deployed release, and it matches the recorded
+May-2025 console removal rather than any misconfiguration. The `minio` client in realm
+`platform` still has never been exercised by a human, and on this release the console
+gives it no way to be.
+
+Do not report this as "console up". The console is reachable and trusted; SSO to it does
+not exist.
+
+The `tailscale-only@file` middleware is what keeps this off the public internet. That is
+asserted from the container's labels, **not** measured from an off-tailnet client — say
+so rather than claiming the host is confirmed private.
+
+### The identity side is fully wired. The console simply cannot use it
+
+Checked in realm `platform` with `keycloak.sh status`, because "the client has never been
+exercised" is not the same as "the client is missing":
+
+- Client `minio` — **exists, enabled**, redirect URIs `https://storage.hill90.com/oauth_callback`
+  and `https://storage.hill90.com/*`.
+- Realm roles `admin`, `editor`, `viewer` — all present.
+- MinIO policies of the same names — present again after the repair below.
+
+So nothing on the Keycloak side is broken or missing. There is no console login button
+because this MinIO build does not have one, and no amount of realm configuration adds it.
+The remaining federated path is `AssumeRoleWithWebIdentity` (S3/STS), which is not SSO.
+
+### Defect found while verifying: the `admin`/`editor`/`viewer` policies were gone
+
+The same push deploy ran `minio.sh apply` **0.3 s after starting the container**, before
+MinIO was listening:
+
+```
+Provisioning MinIO policies...
+ERROR: Cannot authenticate to MinIO as 'hill90admin' ... dial tcp 127.0.0.1:9000: connect: connection refused
+WARNING: minio.sh apply failed — federated S3 access will be rejected with 'no policy found'.
+```
+
+Confirmed on the running container — only the builtins and the tenant policy survive:
+
+```
+$ mc admin policy ls
+tenant-hill90-app  writeonly  consoleAdmin  diagnostics  readonly  readwrite
+```
+
+So the **S3/STS path is currently broken for federated identities**: OIDC is still wired
+(`MINIO_IDENTITY_OPENID_CONFIG_URL` → realm `platform`, `claim_name=minio_policy`), but
+a token carrying `admin`, `editor` or `viewer` now names a policy that does not exist.
+
+This is a race, not a credential problem. Both bugs are fixed below.
+
+## Step 5 — the two deploy-path bugs, fixed at the cause
+
+`Verified 2026-07-31 02:00 UTC.`
+
+### 5a. `minio.sh` never waited for MinIO to start serving
+
+**Cause, not symptom:** `mc_setup` asked once. `deploy.sh` calls `minio.sh apply`
+immediately after `docker compose up -d`, so that single question landed on a socket
+that was not accepting yet, and the error path reported a connection refusal as
+*"Cannot authenticate ... are MINIO_ROOT_USER/MINIO_ROOT_PASSWORD correct?"* — naming the
+one thing that was not wrong.
+
+It now polls until the server answers: cap `MINIO_READY_TIMEOUT` (default 90s), interval
+3s, each probe bounded by `timeout`. Failing at the cap prints the cap **and** the last
+error verbatim.
+
+**Why not a retry.** A blind retry loses the same race just as often — the container
+starts at the same speed every time — and, worse, a retry loop that cannot tell "not
+listening" from "wrong password" burns the whole cap on a credential error and then
+reports the wrong cause. So the poll classifies:
+
+- **Connectivity failure → retry.** It may become true by waiting.
+- **Authentication failure → die immediately**, with a message that says MinIO answered
+  and rejected the credentials, *so this is not a readiness problem*. A wrong root
+  password never becomes right by waiting.
+- **Anything unrecognised → retry**, and report it verbatim at the cap. Guessing
+  "terminal" on an unfamiliar string is precisely how the original misdiagnosis happened.
+
+### 5b. Exit 1 after a successful deploy — a real gap, not a script artefact
+
+The interpolation error came from `deploy.sh`'s own completion block, not from
+`minio.sh`. Service secrets live only inside the `sops exec-env` child process or the
+`vault_load_secrets` subshell; both have exited by the time the banner prints. The next
+line was `docker compose ... ps`, and **Compose interpolates the compose file for every
+subcommand including `ps`** — and `docker-compose.minio.yml` is the only prod compose
+file using the required form `${MINIO_ROOT_USER:?...}`. Hence a deploy that fully
+succeeded, printed "Complete!", and then exited 1.
+
+That is the most corrosive kind of failure: it teaches everyone that a red MinIO deploy
+is normal, so the next real failure gets waved through.
+
+Fixed by listing status from the **compose project label** instead —
+`docker ps -a --filter label=com.docker.compose.project=...`. No interpolation, no
+secret, and the whole class of bug disappears for any compose file that adopts `:?`
+later. Re-entering the secret environment to decrypt for a cosmetic status line was the
+alternative and is worse.
+
+### The test that fails without the fix
+
+`scripts/checks/minio-readiness-test.sh`, wired into `ci.yml`. It stubs `docker` on
+PATH, so it needs no running stack, and drives the three cases the real thing cannot be
+asked to produce on demand: refuse-then-serve (must succeed, and must actually have
+waited), credentials rejected (must fail fast, and must not blame readiness), and never
+comes up (must stop at the cap, legibly).
+
+Against the **pre-fix** scripts it fails 7 of 12 assertions and reproduces the
+production error string verbatim:
+
+```
+FAIL apply exited 1 — the readiness race is not handled
+     ERROR: Cannot authenticate to MinIO as 'stub-user'. Are MINIO_ROOT_USER/
+     MINIO_ROOT_PASSWORD correct for this data volume? (... connect: connection refused.)
+FAIL returned after only 0s — it cannot have waited for readiness
+FAIL policies were not provisioned
+FAIL the message does not distinguish auth failure from readiness
+FAIL the completion banner still calls 'docker compose ps' — it will exit 1 again
+passed: 5  failed: 7
+```
+
+Against the fixed scripts: `passed: 12  failed: 0`.
+
+### The policies are back
+
+Repaired on the host with the repo's own idempotent command,
+`bash scripts/minio.sh apply` — `+ admin`, `+ editor`, `+ viewer`. Listed afterwards:
+
+```
+$ mc admin policy ls
+consoleAdmin  diagnostics  readwrite  viewer  editor  readonly  tenant-hill90-app  writeonly  admin
+```
+
+All three role-mapped policies present alongside the builtins and the tenant policy, so
+the federated S3/STS path has its policy names again.
+
+**Be precise about what that repair proves.** The VPS checkout is hard-reset to
+`origin/main` by the deploy workflow, so the host ran the **old** script. It succeeded
+only because MinIO had been serving for half an hour — there was no race left to lose.
+The repair fixes the *state*; the regression test is what evidences the *fix*. The fix
+itself is exercised in production on the next deploy.
+
+### Merging this triggers a MinIO deploy — deliberately, but know it before you merge
+
+`scripts/minio.sh` is on `deploy.yml`'s push path filter for the `minio` service. So
+merging this PR **will recreate the `minio` container automatically**, which is the same
+mechanism that fired the router trap twice. Two things make it safe this time, and both
+should be confirmed rather than assumed:
+
+1. `app-minio` is already stopped, so the router going up cannot collide — the enabled
+   state is now the intended one.
+2. That deploy is exactly what exercises the readiness fix on a genuinely cold MinIO.
+   Watch the run: it should print `Waiting up to 90s for MinIO to start serving...`
+   followed by `MinIO answered after Ns.`, then `+ admin / + editor / + viewer`, and
+   should **exit 0**.
+
+If it instead exits 1 with an interpolation error, 5b did not take.
 
 ## To continue
 

--- a/scripts/checks/minio-readiness-test.sh
+++ b/scripts/checks/minio-readiness-test.sh
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+# Regression test: minio.sh must WAIT for MinIO to start serving before it
+# provisions policies, and must still fail fast on bad credentials.
+#
+# WHY THIS EXISTS
+#
+# On 2026-07-31 a push-triggered deploy recreated the minio container and ran
+# `minio.sh apply` 0.3s later. MinIO was not accepting connections yet, so the
+# single-shot readiness check failed with "connection refused" — and reported it
+# as "Cannot authenticate ... are MINIO_ROOT_USER/MINIO_ROOT_PASSWORD correct?".
+# The admin/editor/viewer policies were never created, and every federated
+# AssumeRoleWithWebIdentity stayed broken with "no policy found" until someone
+# ran `mc admin policy ls` by hand.
+#
+# The failure is timing, so the test has to be about timing. It stubs `docker`
+# on PATH and drives three cases the real thing cannot be made to produce on
+# demand:
+#
+#   1. refuse-then-ready  — the actual deploy race. Must SUCCEED after waiting.
+#   2. denied             — MinIO answers and rejects the credentials. Must fail
+#                           FAST, and must not blame readiness.
+#   3. always-refuse      — never comes up. Must fail at the cap, legibly, and
+#                           must not hang.
+#
+# Case 2 is why the fix is a readiness poll and not a blind retry: a retry loop
+# that cannot tell "not listening" from "wrong password" spends the full cap on
+# a credential error and then reports the wrong cause — which is the bug this
+# test is guarding, pointed the other way.
+#
+# It also guards the second half of the same incident: deploy.sh printed its
+# completion banner and THEN exited 1, because `docker compose ps` interpolates
+# the compose file and the secrets had already left the environment.
+#
+# Usage: bash scripts/checks/minio-readiness-test.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+pass=0
+fail=0
+
+ok()   { printf '  \033[0;32mPASS\033[0m %s\n' "$1"; pass=$((pass + 1)); }
+bad()  { printf '  \033[0;31mFAIL\033[0m %s\n' "$1"; fail=$((fail + 1)); }
+
+# ---------------------------------------------------------------------------
+# A stub `docker` that stands in for a MinIO container.
+#
+# STUB_MODE picks the behaviour; STUB_READY_AFTER is how many seconds of
+# wall-clock must pass before `mc admin info` starts succeeding, so the test
+# exercises real elapsed time rather than a call counter. A poll that "retries"
+# without sleeping would fail case 1 exactly as the real deploy did.
+# ---------------------------------------------------------------------------
+mkdir -p "$TMP/bin"
+cat > "$TMP/bin/docker" <<'STUB'
+#!/usr/bin/env bash
+# Only the two verbs minio.sh uses are modelled.
+[ "${1:-}" = "inspect" ] && exit 0
+
+if [ "${1:-}" = "exec" ]; then
+    args="$*"
+    now=$(date +%s)
+    started=$(cat "$STUB_STATE/started" 2>/dev/null || { date +%s > "$STUB_STATE/started"; date +%s; })
+    elapsed=$(( now - started ))
+    echo "$elapsed" > "$STUB_STATE/last_elapsed"
+
+    case "$args" in
+        *"admin info"*)
+            case "$STUB_MODE" in
+                denied)
+                    echo "mc: <ERROR> Unable to get service info. Access Denied." >&2
+                    exit 1 ;;
+                always-refuse)
+                    echo "mc: <ERROR> Unable to get service info. Get \"http://127.0.0.1:9000/minio/admin/v3/info\": dial tcp 127.0.0.1:9000: connect: connection refused." >&2
+                    exit 1 ;;
+                refuse-then-ready)
+                    if [ "$elapsed" -lt "${STUB_READY_AFTER:-5}" ]; then
+                        echo "mc: <ERROR> Unable to get service info. Get \"http://127.0.0.1:9000/minio/admin/v3/info\": dial tcp 127.0.0.1:9000: connect: connection refused." >&2
+                        exit 1
+                    fi
+                    echo "●  127.0.0.1:9000"; exit 0 ;;
+            esac ;;
+        *"policy ls"*)     echo "consoleAdmin"; exit 0 ;;
+        *"policy create"*) exit 0 ;;
+        *)                 exit 0 ;;
+    esac
+fi
+exit 0
+STUB
+chmod +x "$TMP/bin/docker"
+
+run_apply() {
+    # Credentials come from the environment so secret_for short-circuits and the
+    # test never touches SOPS or the age key.
+    local mode="$1" timeout="$2" interval="$3" ready_after="${4:-5}"
+    local state="$TMP/state.$mode.$RANDOM"
+    mkdir -p "$state"
+    PATH="$TMP/bin:$PATH" \
+    STUB_MODE="$mode" STUB_STATE="$state" STUB_READY_AFTER="$ready_after" \
+    MINIO_ROOT_USER="stub-user" MINIO_ROOT_PASSWORD="stub-pass" \
+    MINIO_READY_TIMEOUT="$timeout" MINIO_READY_INTERVAL="$interval" \
+    MINIO_READY_PROBE_TIMEOUT=5 \
+        bash "$PROJECT_ROOT/scripts/minio.sh" apply > "$TMP/out" 2>&1
+}
+
+echo "MinIO readiness regression test"
+echo "==============================="
+echo ""
+echo "1. The deploy race: MinIO refuses for 5s, then serves"
+
+start=$(date +%s)
+rc=0
+run_apply refuse-then-ready 60 2 5 || rc=$?
+elapsed=$(( $(date +%s) - start ))
+
+if [ "$rc" -eq 0 ]; then
+    ok "apply succeeded instead of dying on the cold socket"
+else
+    bad "apply exited ${rc} — the readiness race is not handled"
+    sed 's/^/       /' "$TMP/out"
+fi
+if [ "$elapsed" -ge 4 ]; then
+    ok "it actually waited (${elapsed}s), rather than passing by luck"
+else
+    bad "returned after only ${elapsed}s — it cannot have waited for readiness"
+fi
+if grep -qi "Policies provisioned" "$TMP/out"; then
+    ok "policies were provisioned"
+else
+    bad "policies were not provisioned"
+    sed 's/^/       /' "$TMP/out"
+fi
+
+echo ""
+echo "2. Bad credentials must fail FAST and must not blame readiness"
+
+start=$(date +%s)
+rc=0
+run_apply denied 60 2 || rc=$?
+elapsed=$(( $(date +%s) - start ))
+
+if [ "$rc" -ne 0 ]; then
+    ok "apply failed, as it must"
+else
+    bad "apply SUCCEEDED against credentials MinIO rejected"
+fi
+if [ "$elapsed" -lt 10 ]; then
+    ok "failed fast (${elapsed}s) — no waiting out the cap on an auth error"
+else
+    bad "took ${elapsed}s: an auth failure is being retried like a cold socket"
+fi
+if grep -qi "not a readiness problem" "$TMP/out"; then
+    ok "the message says MinIO answered and rejected the credentials"
+else
+    bad "the message does not distinguish auth failure from readiness"
+    sed 's/^/       /' "$TMP/out"
+fi
+
+echo ""
+echo "3. Never comes up: bounded, legible, and does not hang"
+
+start=$(date +%s)
+rc=0
+run_apply always-refuse 6 2 || rc=$?
+elapsed=$(( $(date +%s) - start ))
+
+if [ "$rc" -ne 0 ]; then
+    ok "apply failed at the cap"
+else
+    bad "apply SUCCEEDED against a MinIO that never answered"
+fi
+if [ "$elapsed" -lt 30 ]; then
+    ok "respected the ${elapsed}s cap instead of retrying forever"
+else
+    bad "ran ${elapsed}s against a 6s cap — the bound is not enforced"
+fi
+if grep -qi "did not answer within" "$TMP/out" && grep -qi "Last error" "$TMP/out"; then
+    ok "failure names the cap and quotes the last error"
+else
+    bad "failure is not legible enough to act on"
+    sed 's/^/       /' "$TMP/out"
+fi
+
+# ---------------------------------------------------------------------------
+# The other half of the same incident.
+# ---------------------------------------------------------------------------
+echo ""
+echo "4. deploy.sh must not run 'docker compose ps' outside the secret env"
+
+COMPOSE="$PROJECT_ROOT/deploy/compose/prod/docker-compose.minio.yml"
+if grep -q 'MINIO_ROOT_USER:?' "$COMPOSE"; then
+    ok "premise holds: the compose file still declares a REQUIRED variable"
+else
+    bad "premise gone: ${COMPOSE} no longer uses \${VAR:?...}; revisit this test"
+fi
+
+# The completion block is the one that ran after the secrets had gone. Comment
+# lines are stripped first: the fix explains itself by NAMING `docker compose ps`
+# in a comment, and a grep that cannot tell code from prose would read that
+# explanation as the bug it describes.
+banner_tail=$(sed -n '/\${banner} Complete!/,/^}/p' "$PROJECT_ROOT/scripts/deploy.sh" \
+    | grep -v '^[[:space:]]*#')
+if printf '%s' "$banner_tail" | grep -q 'docker compose .*ps'; then
+    bad "the completion banner still calls 'docker compose ps' — it will exit 1 again"
+else
+    ok "the completion banner does not call 'docker compose ps'"
+fi
+if printf '%s' "$banner_tail" | grep -q 'label=com.docker.compose.project'; then
+    ok "status is listed by project label, which needs no interpolation"
+else
+    bad "no label-based status listing found in the completion block"
+fi
+
+echo ""
+echo "==============================="
+echo "passed: ${pass}  failed: ${fail}"
+[ "$fail" -eq 0 ] || exit 1

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -469,7 +469,27 @@ cmd_service() {
     echo "================================"
     echo "${banner} Complete!"
     echo "================================"
-    docker compose -p "$project_name" -f "$compose_file" ps
+    # Deliberately `docker ps` by project label, NOT `docker compose ps`.
+    #
+    # The service secrets exist only inside the `sops exec-env` child process or
+    # the vault_load_secrets subshell above — both have exited by the time this
+    # line runs, so MINIO_ROOT_USER is no longer in the environment. Compose
+    # interpolates the compose file for EVERY subcommand including `ps`, and
+    # docker-compose.minio.yml declares ${MINIO_ROOT_USER:?...}, so on
+    # 2026-07-31 this status print failed with "required variable
+    # MINIO_ROOT_USER is missing a value" and, under `set -e`, exited the script
+    # 1 — after the deploy itself had fully succeeded and printed "Complete!".
+    #
+    # That is the worst kind of failure: it teaches everyone that a red minio
+    # deploy is normal, so the next genuine failure gets waved through.
+    #
+    # Re-entering the secret environment just to print container status would be
+    # a decrypt for a cosmetic line. Reading the compose project label needs no
+    # interpolation and no secret at all, so the whole class of bug goes away —
+    # including for any compose file that adopts `:?` later.
+    docker ps -a \
+        --filter "label=com.docker.compose.project=${project_name}" \
+        --format 'table {{.Names}}\t{{.Status}}\t{{.Ports}}'
 
     echo ""
     echo "$summary"

--- a/scripts/minio.sh
+++ b/scripts/minio.sh
@@ -31,6 +31,13 @@ source "$SCRIPT_DIR/_common.sh"
 MINIO_CONTAINER="${MINIO_CONTAINER:-minio}"
 SECRETS_FILE="${MINIO_SECRETS_FILE:-${PROJECT_ROOT}/infra/secrets/prod.enc.env}"
 
+# How long to wait for a freshly started MinIO to begin serving, and how often
+# to ask. The cap is bounded on purpose: this runs inside a deploy holding the
+# deploy-prod concurrency group, so it must fail legibly rather than hang.
+MINIO_READY_TIMEOUT="${MINIO_READY_TIMEOUT:-90}"
+MINIO_READY_INTERVAL="${MINIO_READY_INTERVAL:-3}"
+MINIO_READY_PROBE_TIMEOUT="${MINIO_READY_PROBE_TIMEOUT:-15}"
+
 usage() {
     cat <<EOF
 MinIO CLI — provision policies for Keycloak-federated identities
@@ -83,14 +90,56 @@ mc_setup() {
     #      MinIO. Inside a deploy that means the job blocks until the CI
     #      six-hour default while holding the deploy-prod concurrency group.
     # `timeout` bounds it either way.
-    local out rc=0
-    out=$(MC_HOST_local="$MC_ALIAS_ENV" timeout 30 docker exec -e MC_HOST_local \
-            "$MINIO_CONTAINER" mc admin info local 2>&1) || rc=$?
-    if [ "$rc" -eq 124 ]; then
-        die "MinIO did not answer within 30s — it is running but not serving. Check: docker logs ${MINIO_CONTAINER}"
-    elif [ "$rc" -ne 0 ]; then
-        die "Cannot authenticate to MinIO as '${user}'. Are MINIO_ROOT_USER/MINIO_ROOT_PASSWORD correct for this data volume? (${out})"
-    fi
+    #
+    # WAIT FOR IT, rather than asking once.
+    #
+    # deploy.sh calls `minio.sh apply` immediately after `docker compose up -d`.
+    # On 2026-07-31 the single-shot check below ran 0.3s after the container
+    # started, hit a socket that was not accepting yet, and died with
+    # "Cannot authenticate ... are the credentials correct?" — pointing the
+    # operator at the one thing that was not wrong. The policies were never
+    # created and the federated S3/STS path stayed broken until someone read
+    # `mc admin policy ls` by hand.
+    #
+    # The cause is that nothing waited for readiness. A blind retry is NOT the
+    # fix: the container comes up at the same speed every time, so a fixed
+    # number of immediate retries loses the same race just as reliably. Poll
+    # until the server actually answers, with a bounded cap.
+    #
+    # Connectivity failures are retried. An AUTHENTICATION failure is terminal
+    # and fails immediately, because a wrong root password does not become right
+    # by waiting — that distinction is what makes the error message trustworthy
+    # again. Anything unrecognised is treated as RETRYABLE and reported verbatim
+    # if the cap is hit; guessing "terminal" on an unfamiliar string is exactly
+    # how the original misdiagnosis happened.
+    local out rc=0 waited=0 announced=false
+    while :; do
+        rc=0
+        out=$(MC_HOST_local="$MC_ALIAS_ENV" timeout "$MINIO_READY_PROBE_TIMEOUT" \
+                docker exec -e MC_HOST_local \
+                "$MINIO_CONTAINER" mc admin info local 2>&1) || rc=$?
+        [ "$rc" -eq 0 ] && break
+
+        # Terminal: MinIO answered and rejected these credentials.
+        if printf '%s' "$out" | grep -qiE \
+            'Access Denied|InvalidAccessKeyId|SignatureDoesNotMatch|Access Key Id you provided does not exist|signature we calculated does not match'; then
+            die "Cannot authenticate to MinIO as '${user}'. MinIO answered and rejected the credentials, so this is not a readiness problem — are MINIO_ROOT_USER/MINIO_ROOT_PASSWORD correct for this data volume? (${out})"
+        fi
+
+        if [ "$waited" -ge "$MINIO_READY_TIMEOUT" ]; then
+            die "MinIO did not answer within ${MINIO_READY_TIMEOUT}s of waiting — it is running but not serving. Last error: ${out}. Check: docker logs ${MINIO_CONTAINER}"
+        fi
+
+        if [ "$announced" = false ]; then
+            info "Waiting up to ${MINIO_READY_TIMEOUT}s for MinIO to start serving..."
+            announced=true
+        fi
+        sleep "$MINIO_READY_INTERVAL"
+        waited=$((waited + MINIO_READY_INTERVAL))
+    done
+
+    [ "$announced" = true ] && info "MinIO answered after ${waited}s."
+    return 0
 }
 
 mc() { MC_HOST_local="$MC_ALIAS_ENV" docker exec -e MC_HOST_local -i "$MINIO_CONTAINER" mc "$@"; }


### PR DESCRIPTION
Closes the storage cutover, and fixes the two deploy-path bugs it exposed.

## The bugs

**1. `minio.sh` never waited for MinIO to start serving.** `deploy.sh` calls `minio.sh apply` immediately after `docker compose up -d`. On 2026-07-31 the single-shot readiness check ran 0.3 s after the container started, hit a socket that was not accepting yet, and died with:

```
ERROR: Cannot authenticate to MinIO as 'hill90admin'. Are MINIO_ROOT_USER/
MINIO_ROOT_PASSWORD correct for this data volume? (... connect: connection refused.)
```

It named the one thing that was not wrong. The `admin`/`editor`/`viewer` policies were never created, so every federated `AssumeRoleWithWebIdentity` was rejected with "no policy found" — silently, because the step is non-fatal by design.

**2. Exit 1 after a fully successful deploy.** The same run printed `Object Store Deployment Complete!` and *then* exited 1 on `required variable MINIO_ROOT_USER is missing a value`.

## The fixes, at the cause

**Readiness poll, not a retry.** Poll until MinIO answers, capped by `MINIO_READY_TIMEOUT` (90 s), each probe bounded by `timeout`, failing at the cap with the last error quoted.

A blind retry was rejected deliberately. The container starts at the same speed every time, so a fixed number of immediate retries loses the same race just as reliably — and a loop that cannot distinguish "not listening" from "wrong password" spends the entire cap on a credential error and then reports the wrong cause. So the poll classifies:

| Outcome | Behaviour | Why |
|---|---|---|
| Connectivity failure | retry | may become true by waiting |
| Auth failure | **die immediately**, saying MinIO answered and rejected the credentials | a wrong password never becomes right by waiting |
| Unrecognised | retry, report verbatim at the cap | guessing "terminal" on an unfamiliar string is how the original misdiagnosis happened |

**The exit 1 was a real gap, not a `minio.sh` artefact.** Service secrets live only inside the `sops exec-env` child process or the `vault_load_secrets` subshell — both exited by the time the completion banner prints. The next line was `docker compose ... ps`, and Compose interpolates the compose file for *every* subcommand including `ps`. `docker-compose.minio.yml` is the only prod compose file using the required form `${MINIO_ROOT_USER:?...}`, which is why only MinIO went red.

Fixed by listing status from the compose **project label** — no interpolation, no secret, and the class of bug disappears for any compose file that adopts `:?` later. An exit 1 on a successful deploy is worth fixing properly: it trains everyone to ignore the exit code, and the next genuine failure gets waved through.

## The test

`scripts/checks/minio-readiness-test.sh` stubs `docker` on PATH, so it needs no running stack, and drives the three timing cases the real thing cannot be asked to produce on demand: refuse-then-serve (must succeed, and must actually have waited), credentials rejected (must fail fast, and must not blame readiness), never comes up (must stop at the cap, legibly).

- Pre-fix: **7 of 12 assertions fail**, reproducing the production error string verbatim.
- Post-fix: **12/12 pass.**

Wired into `ci.yml`.

## Production state

Policies repaired on the host with the repo's own idempotent command and listed to prove it:

```
$ mc admin policy ls
consoleAdmin  diagnostics  readwrite  viewer  editor  readonly  tenant-hill90-app  writeonly  admin
```

Note what that does and does not show: the VPS checkout is hard-reset to `origin/main`, so the host ran the **old** script. It succeeded only because MinIO had been serving for half an hour — there was no race left to lose. The repair fixes the state; the test is what evidences the fix.

Platform baseline verified by name after every step: 13/13 present, 0 unhealthy, `hill90.com` 200.

## ⚠️ Merging this triggers a MinIO deploy

`scripts/minio.sh` is on `deploy.yml`'s push path filter, so **merging recreates the `minio` container automatically** — the same mechanism that fired the router trap twice this week.

It is safe now, for reasons worth confirming rather than assuming: `app-minio` is already stopped, so the console router coming up cannot collide with a second claimant on `storage.hill90.com`. And that deploy is what exercises the readiness fix on a genuinely cold MinIO.

Watch the run. Expected: `Waiting up to 90s for MinIO to start serving...` → `MinIO answered after Ns.` → `+ admin / + editor / + viewer` → **exit 0**. An interpolation error means the second fix did not take.

## Also in here

`docs/decisions/object-store.md` records the whole cutover so a cold session can resume: all four steps with their evidence, the 0→1 object proof, and two findings that are **not** fixed here —

- Step 3's router went live via the #594 merge-deploy at 01:33 UTC, ten minutes before `app-minio` was stopped, so two routers claimed `storage.hill90.com` in between. Parameterising the label did not make the dark state durable, because the default is `true` and the variable is set nowhere.
- `deploy.sh`'s `verify infra` check and the object-store runbook both query Traefik's API at `localhost:8080`, which returns connection refused — the API is `api@internal` behind `traefik.hill90.com`. That check cannot pass, and the runbook command produces a false negative that reads exactly like "no router claims this host".

🤖 Generated with [Claude Code](https://claude.com/claude-code)