### PR TITLE
chore(secrets): drop the stale AUTH_KEYCLOAK_SECRET, which matched nothing

### DIFF
--- a/infra/secrets/prod.enc.env
+++ b/infra/secrets/prod.enc.env
@@ -37,7 +37,6 @@ KC_ADMIN_PASSWORD=ENC[AES256_GCM,data:gTPam2vQ63XyVFDVEXixgewolvrm3pOfi/mgaGpIb0
 MINIO_ROOT_USER=ENC[AES256_GCM,data:qTq8OQeqLgb5Fgc=,iv:wUnwT3pT2PGkJG62tP8IwPjbUr1fn8FIJ4bnH29Ql8k=,tag:3Zv+NnmsHBn2z36PXmSTzg==,type:str]
 MINIO_ROOT_PASSWORD=ENC[AES256_GCM,data:YcX6FuWPBC3MVqATxwZep/6jDVwmL8nE1rtis8HHuT0Gr6efyRxvha7/7w==,iv:YOYjws6sLREhUOpMyHf+N6Ws26f9NOhjfe3vuiWHFQ4=,tag:+Xg9kqjGcFKp+oyNshONbw==,type:str]
 GRAFANA_ADMIN_PASSWORD=ENC[AES256_GCM,data:+bB9wg2N4C4KmFl7uzlm1kRbXVqfu3YihKZTESIC2Q==,iv:kKpQ61ffSxMiv9diIfZp0xjDwoyewSEEganYmMdhpL4=,tag:U1cbJPJrMfR7JcdNilhgoA==,type:str]
-AUTH_KEYCLOAK_SECRET=ENC[AES256_GCM,data:BSNKHB5Cbms3fbgOkn3qufLLyCkdXGguDt1noZITn6A=,iv:iBmfrnd+O9Rha+a/Tbw6got8G4hpPbpUKV40NCIdD+4=,tag:Tta+kQJ3GOZF2MUcKKYytg==,type:str]
 AUTH_SECRET=ENC[AES256_GCM,data:kWTm91+Hx+/iQSNoLa3Ir1sg7KzQvOGSql4v9CdvJ04OHAtrFtZ13wcRAw==,iv:JR1lZl4DIj6BHNBMsD3SfdkQnD+0M7zLHgD2xqExr/g=,tag:AgXnBIkzEKkFhHGPOOHpiQ==,type:str]
 AUTH_KEYCLOAK_ID=ENC[AES256_GCM,data:2VclmOUO+DwV,iv:cC0cQkrW/l31koPG4IWp0OousGlMMdRNibphl9oabCo=,tag:VRjrSgk2QCf53rBycdDxsA==,type:str]
 SMTP_PASSWORD=ENC[AES256_GCM,data:qJeJbXMFiOW4mPXefLiN5EmMF1IfDl1wuexr54U8,iv:ITdoSKMX15tbtM1Ro30MFL4bG+d3257X/ywgPxIgy8A=,tag:REYAIV98i9V3wywCpwJKyg==,type:str]
@@ -88,7 +87,7 @@ MINIO_TENANT_ACCESS_KEY=ENC[AES256_GCM,data:xKKEYVxyYLv9sBXSKvnC7ru3oiA=,iv:mv1t
 MINIO_TENANT_SECRET_KEY=ENC[AES256_GCM,data:6gho/ycgzhe9hQaG9E0PH8paHdbNBdParlcSJpyW7YstLmTktXTdaQ==,iv:b+6liDHlrtlPY3/vUCZxjXgHTuROH9NaYjie1k6oj18=,tag:WiUPKzDoAVWAYu/eqetKSw==,type:str]
 sops_age__list_0__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBrRy9IcWFNL2pOZWNxdzEr\nYk80dmdiYkVOa2RJYnM2Z29ucURmR05sQkdnCk9ZN2VmYUJpdVZ3WnljQU9XUXdv\nWFYyL2JERGlMd2hCSFAzNlRnUEdlSDQKLS0tIDdncUI5SkxORFE3dnI0aVloaE9z\nSGh3SnNsYnltNmJteFJUeVU3MWpvaDAKfJ6tZctOxb4xPFjesRxQw1Q8FvB8/Gnx\ncFwQpzTlIFc+uXS895d9ydS1VA5lot8PdbPUKk1/wCcuJR4EFR/elQ==\n-----END AGE ENCRYPTED FILE-----\n
 sops_age__list_0__map_recipient=age1p30vk2qpvlkj5pzh72f0wwvlqgmedvr204nldmpskmptgy9ryg8qg9qd5v
-sops_lastmodified=2026-07-31T01:04:13Z
-sops_mac=ENC[AES256_GCM,data:H8HFQnk8DbMOWpqeJwBlXG41KvcC8STeSwuVouY4MvQo3Wr5uxLCg3QMY9B1Qzpj2BkBN8kR5m/Yzsj2dYQcvfwfO0Huvy2te9KVGszkUREYduDsChdQgXfKK6cs2PjD+wkO0/fuXAzkjZIQ0W91J8yCRUOU3e5jf0bMSvtJVIc=,iv:kcdDP39Y3x3twxUavWSvz2inH0r4lywwQgpb7N+G3PQ=,tag:Cazg8wteNdSeeSHJ3k1stg==,type:str]
+sops_lastmodified=2026-07-31T01:54:21Z
+sops_mac=ENC[AES256_GCM,data:Vx+MkoEpW6uCqLW/COZxC7nmEBX2aEMgzL4/GAjPJrXsPAcsZ8m05viYT0RizLtqMHGbn6/zFshOoVDWDUcObrmsFq47XaxnFjP5gZI8qPDaDmWEUA/1jrftviNz9gB2e0hr3LRQNuQocKfNK3CeoVNA+tKn/OV6kIeWXmxIyX4=,iv:yg7jeC3gsJOXgmjEQDOG8gVM2K+yTx/oLQVWMftQ9HU=,tag:J0bkkm6HqAU7r6f4hsPEPw==,type:str]
 sops_unencrypted_suffix=_unencrypted
 sops_version=3.11.0


### PR DESCRIPTION
It was a **trap**, not merely stale. Measured before changing anything, hashes not values:

```
keycloak client hill90-ui   len=64  sha=008156b6a6e3
running app-ui env          len=64  sha=008156b6a6e3   ← agrees with Keycloak
this store                  len=32  sha=ae2a18f2470c   ← agrees with NOTHING
```

The copy here opened nothing, so anyone reading it as authoritative would chase a token exchange that cannot succeed — which already cost a cycle tonight.

## Nothing here consumed it

Established before editing: no compose file, no script, no workflow, and it's absent from `platform/vault/secrets-schema.yaml`, `infra/secrets/prod.enc.env.example` and deploy.sh's required secrets. Remaining references are prose only — `SPEC.md` already lists it under "Remove", `.env.local.example` mentions it as the *tenant's* key. The one grep hit that looked like a consumer was `VAULT_AUTH_SECRET_ID`, a substring collision.

## A third case your framing didn't cover

`docs/decisions/tenant-credential-ownership.md` (decided 2026-07-30) sets the rule: when the platform owns the object, **the platform's store owns the credential** and the tenant holds a replica. Its table names **`HILL90_UI_CLIENT_SECRET`** as *this* repo's authoritative key for client `hill90-ui`, with `AUTH_KEYCLOAK_SECRET` being the **tenant's** key name.

**`HILL90_UI_CLIENT_SECRET` is absent from this store.** So the decided rule is unimplemented, and what sat here instead was a stale value under the *tenant's* key name — an artefact of when the app lived in this repo.

Removing the stale key is right under either reading: it's neither a working replica nor correctly named. But it leaves this repo holding **no** copy of a credential it has decided it owns. Implementing that means writing the live 64-char secret into this store under the right name — a separate change, needing sequencing against the MinIO work, and **not** something to do as a side effect of deleting a trap. Your call when.

The contrast makes the gap visible: **`HILL90_APP_DB_PASSWORD`** — the other row of that same table — *is* here at 64 chars. One half of the rule is implemented, the other isn't.

## Same family, left alone deliberately

`AUTH_KEYCLOAK_ID` (9 chars — the client id, not a secret) and `AUTH_SECRET` (43 chars — Auth.js's session secret, the tenant's concern). SPEC.md lists all three for removal together. Neither is mistakable for a platform credential, and removing extra keys in a PR about one key is how a review stops being able to check anything.

## Method, given what went wrong earlier today

Started from `git show origin/main:infra/secrets/prod.enc.env` — **never** the VPS checkout, which is only reset to main during a deploy. sops 3.8.1 has no `unset`, so the deletion ran as a non-interactive `EDITOR` pass over `sops <file>`, which re-encrypts only what changed.

**The encrypted diff is 5 lines** — the removed key, `sops_lastmodified`, `sops_mac`. Every other value's ciphertext is byte-identical, so this is reviewable line by line.

## Verified by decryption against origin/main

```
key count            main=79  result=78
removed              ['AUTH_KEYCLOAK_SECRET']
added                NONE
changed values       NONE

JON_KC_PASSWORD          len=32  identical_to_main=True
HILL90ADMIN_KC_PASSWORD  len=32  identical_to_main=True
KC_ADMIN_PASSWORD        len=32  identical_to_main=True
DB_PASSWORD              len=32  identical_to_main=True
HILL90_APP_DB_PASSWORD   len=64  identical_to_main=True
```

No VPS state was changed — every measurement above is read-only.