### PR TITLE
fix(deploy): finish the secrets-out-of-scope sweep, and write down the rule

### DIFF
--- a/docs/decisions/object-store.md
+++ b/docs/decisions/object-store.md
@@ -713,8 +713,20 @@ same mistake interpolates to empty and says nothing.
 | 1 | Completion banner `docker compose ps` (`cmd_service`) | **Fixed #595** |
 | 2 | `cmd_verify` minio check interpolating `${MINIO_ROOT_USER}` | **Fixed #597** |
 | 3 | `cmd_teardown` `docker compose down` | **Fixed here** |
-| 4 | `${DB_USER:-hill90}` in `cmd_verify` and `cmd_service` | Latent — see below |
-| 5 | `.htpasswd` written with no empty-check (`cmd_infra`) | Latent, different family |
+| 4 | `${DB_USER:-hill90}` in `cmd_verify` and `cmd_service` | **Fixed — sweep** |
+| 5 | `.htpasswd` written with no empty-check (`cmd_infra`) | **Fixed — sweep** |
+| 6 | `cmd_infra`'s completion `docker compose ps` | **Fixed — sweep**; #595 fixed only the `cmd_service` copy |
+| 7 | `validate.sh compose` reporting a valid file as `✗ Invalid` | **Fixed — sweep** |
+
+The sweep was done by property, not memory: enumerate every `docker compose` invocation
+and every credential-shaped interpolation across `scripts/`, then check which run bare.
+That is how 6 and 7 turned up — neither was on anyone's list. The rule now lives in
+[the deployment runbook](../runbooks/deployment.md#secrets-and-the-shells-that-do-not-have-them)
+rather than being re-derived each time.
+
+Two sites were checked and are **not** instances: `local.sh` passes `--env-file`, which
+supplies values by a different and correct mechanism, and the `docker compose` mention in
+`preflight-edge.sh` is inside an error message, not an invocation.
 
 ### 3. `deploy.sh teardown minio` could not run at all
 

--- a/docs/runbooks/deployment.md
+++ b/docs/runbooks/deployment.md
@@ -355,6 +355,67 @@ If a volume name change causes data loss:
      tar xzf /backup/<volume-name>.tar.gz -C /dest
    ```
 
+## Secrets and the shells that do not have them
+
+**The rule: any `deploy.sh` code path that reads a compose file or a secret must run
+inside the secret environment.**
+
+Four bugs in one week were this single mistake in four places. It is worth stating as a
+rule because each instance looked like a different problem, and three of them blamed
+something that was working correctly.
+
+### Why it keeps happening
+
+Service secrets exist only inside a `sops exec-env` child process or a
+`vault_load_secrets` subshell. Anything else sees them as empty:
+
+- a bare `ssh ... deploy.sh verify <svc>` — the workflow invokes verify with no wrapper
+- any line **after** the subshell closes, including the completion banner
+- a function that never loads secrets at all, such as `cmd_teardown`
+- a guard that runs **before** the load, such as the auth pre-deploy database check
+
+Bash does not object to an empty variable. So the failure appears somewhere unrelated,
+and the error message names the wrong cause.
+
+### Compose interpolates for EVERY subcommand
+
+Not just `up`. `ps`, `config` and **`down`** all interpolate the compose file first.
+That is what made `deploy.sh teardown minio` impossible: it fails **after** the
+pre-teardown backup has run and **after** printing `Volumes: KEPT — data survives`,
+which reads like success.
+
+`docker-compose.minio.yml` is currently the only prod compose file using the required
+form `${VAR:?...}`. That is why MinIO is where this keeps surfacing — everywhere else
+the identical mistake interpolates to empty and says nothing at all. **Do not treat the
+other stacks as safe; treat them as not yet noisy.**
+
+### What to do instead
+
+| Need | Do |
+|---|---|
+| Run compose (`up`/`down`/`config`) | Wrap in `sops exec-env`, with `set -e` **inside** the string |
+| Print container status | `docker ps --filter label=com.docker.compose.project=<project>` — no interpolation, no secret |
+| One value, outside a secret scope | `secret_value VAR [env]` from `_common.sh` |
+| A value that cannot be resolved | State the assumption with `warn`, or `die`. **Never** silently substitute a literal |
+| Write a credential to a file | Check it is non-empty first. An empty write is a lockout that looks like a success |
+
+`sops exec-env` runs a **new shell that does not inherit `set -e`, and returns 0
+regardless of what the command did.** Always put `set -e` inside the quoted string, or a
+failed deploy reports success.
+
+### Reporting rule
+
+A check that could not run must never report failure of the thing it was checking.
+`validate.sh compose` reported `docker-compose.minio.yml ✗ Invalid` for a perfectly
+valid file — and suggested a command that failed the same way. It now distinguishes
+validated, validated-with-secrets, and `⚠ needs secrets — NOT validated`.
+
+### Known remaining instances
+
+None in `deploy.sh` as of 2026-07-31. The audit that found them is recorded in
+[object-store.md](../decisions/object-store.md); `scripts/checks/minio-readiness-test.sh`
+asserts the fixed shape so they cannot silently return.
+
 ## Failure Modes
 
 - Missing or invalid secrets: `sops`/runtime env errors at deploy time.

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -95,6 +95,33 @@ load_secrets() {
     rm -f "$temp_file"
 }
 
+# Resolve ONE value: the environment first, then the encrypted store.
+#
+# Deliberately narrower than load_secrets. Several code paths need a single
+# non-sensitive value — a role name, a container user — while running outside
+# any secret environment: `deploy.sh verify db` is invoked as a bare
+# `ssh ... deploy.sh verify db`, and cmd_service's auth precondition runs before
+# secrets are loaded. Pulling the entire store into those processes to read one
+# username would be the wrong trade.
+#
+# Prints nothing and returns 1 when the value cannot be resolved, so callers can
+# decide between dying and stating an assumption out loud. What they must NOT do
+# is silently substitute a literal — see docs/runbooks/deployment.md, "Secrets
+# and the shells that do not have them".
+secret_value() {
+    local var="$1" env="${2:-prod}" value="${!1:-}"
+    if [ -n "$value" ]; then printf '%s' "$value"; return 0; fi
+
+    local file="$PROJECT_ROOT/infra/secrets/${env}.enc.env"
+    [ -f "$file" ] || return 1
+    [ -f "${SOPS_AGE_KEY_FILE:-$PROJECT_ROOT/infra/secrets/keys/age-${env}.key}" ] || return 1
+    export SOPS_AGE_KEY_FILE="${SOPS_AGE_KEY_FILE:-$PROJECT_ROOT/infra/secrets/keys/age-${env}.key}"
+
+    value=$(sops -d "$file" 2>/dev/null | sed -n "s/^${var}=//p" | head -1)
+    [ -n "$value" ] || return 1
+    printf '%s' "$value"
+}
+
 # ---------------------------------------------------------------------------
 # Vault (OpenBao) helpers — vault-first secret loading for deploy
 # ---------------------------------------------------------------------------

--- a/scripts/checks/minio-readiness-test.sh
+++ b/scripts/checks/minio-readiness-test.sh
@@ -275,6 +275,50 @@ else
 fi
 
 echo ""
+echo "7. the rest of the sweep: no secrets-out-of-scope sites left"
+
+deploy_src=$(grep -v '^[[:space:]]*#' "$PROJECT_ROOT/scripts/deploy.sh")
+
+# Completion banners. #595 fixed the cmd_service copy and missed the cmd_infra
+# one, so assert on the property rather than on a remembered line.
+# The subcommand, anchored. An unanchored `.*ps` also matches `--no-deps`, which
+# is a false positive of exactly the kind this file exists to catch.
+if printf '%s' "$deploy_src" | grep -qE 'docker compose .* ps([[:space:]]|$)'; then
+    bad "a 'docker compose ps' survives in deploy.sh — it will interpolate without secrets"
+else
+    ok "no 'docker compose ps' anywhere in deploy.sh"
+fi
+
+# The silent literal. Interpolating ${DB_USER:-hill90} works only while that
+# literal happens to equal the real POSTGRES_USER.
+if printf '%s' "$deploy_src" | grep -q 'DB_USER:-'; then
+    bad "a silent \${DB_USER:-...} fallback survives — resolve it or say so out loud"
+else
+    ok "no silent \${DB_USER:-...} fallback"
+fi
+if printf '%s' "$deploy_src" | grep -q 'secret_value DB_USER'; then
+    ok "DB_USER is resolved from the store"
+else
+    bad "nothing resolves DB_USER from the store"
+fi
+
+# An empty credential written to a file is a lockout that reports success.
+htpasswd_writes=$(printf '%s' "$deploy_src" | grep -c 'htpasswd' || true)
+htpasswd_guards=$(printf '%s' "$deploy_src" | grep -c 'Refusing to write an empty .htpasswd' || true)
+if [ "$htpasswd_guards" -ge 2 ]; then
+    ok "both .htpasswd writes refuse an empty hash (${htpasswd_writes} htpasswd lines, ${htpasswd_guards} guards)"
+else
+    bad "only ${htpasswd_guards} empty-hash guard(s) for the .htpasswd writes"
+fi
+
+# A check that could not run must not report the thing it checked as broken.
+if grep -q 'NOT validated' "$PROJECT_ROOT/scripts/validate.sh"; then
+    ok "validate.sh separates 'could not check' from 'invalid'"
+else
+    bad "validate.sh still reports unvalidatable compose files as Invalid"
+fi
+
+echo ""
 echo "==============================="
 echo "passed: ${pass}  failed: ${fail}"
 [ "$fail" -eq 0 ] || exit 1

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -48,11 +48,31 @@ cmd_verify() {
     local check_cmd
     local diag_container  # primary container name for diagnostics
 
+    # Resolved BEFORE the retry loop, not inside it: the loop runs up to 30
+    # times and this reads the encrypted store.
+    #
+    # It used to be `${DB_USER:-hill90}` interpolated inline. cmd_verify runs as
+    # a bare `ssh ... deploy.sh verify db` with no secret environment, so DB_USER
+    # was always empty and the literal fallback was always what ran. It passes
+    # today only because that literal happens to equal the real POSTGRES_USER —
+    # change DB_USER in the store without editing this file and the check would
+    # query a role that does not exist, while looking like a Postgres fault.
+    local db_user=""
+    if [ "$service" = "db" ] || [ "$service" = "auth" ]; then
+        db_user=$(secret_value DB_USER "$env" 2>/dev/null || true)
+        if [ -z "$db_user" ]; then
+            # Still proceed — a readiness check that refuses to run is worse than
+            # one making a stated assumption — but say the assumption out loud.
+            warn "DB_USER could not be resolved from the store; assuming 'hill90'. If the store disagrees, this check is querying the wrong role."
+            db_user="hill90"
+        fi
+    fi
+
     case "$service" in
         # pg_isready exits 0 regardless of whether the role exists, so it would
         # pass on a Postgres whose credentials are entirely broken and leave
         # Keycloak to crash-loop instead. Run a real query as the real user.
-        db)            check_cmd='docker exec postgres psql -U "${DB_USER:-hill90}" -tAc "SELECT 1"'; diag_container="postgres" ;;
+        db)            check_cmd="docker exec postgres psql -U \"${db_user}\" -tAc 'SELECT 1'"; diag_container="postgres" ;;
         auth)          check_cmd='[ "$(docker inspect --format="{{if .State.Health}}{{.State.Health.Status}}{{end}}" keycloak 2>/dev/null)" = "healthy" ]'; diag_container="keycloak" ;;
         vault)         check_cmd='[ "$(docker inspect --format="{{if .State.Health}}{{.State.Health.Status}}{{end}}" openbao 2>/dev/null)" = "healthy" ]'; diag_container="openbao" ;;
         observability) check_cmd='docker exec prometheus wget -qO- http://localhost:9090/-/healthy'; diag_container="prometheus" ;;
@@ -161,6 +181,14 @@ cmd_infra() {
 
             echo "Generating Traefik basic auth credentials..."
             mkdir -p platform/edge/dynamic
+            # An empty hash writes the line "admin:" over the live dashboard
+            # credential — a lockout that looks like a successful deploy.
+            # keycloak.sh refuses the same shape ("Refusing to write an empty
+            # client secret"); this had no such guard.
+            [ -n "${TRAEFIK_ADMIN_PASSWORD_HASH}" ] || {
+                echo "Refusing to write an empty .htpasswd: TRAEFIK_ADMIN_PASSWORD_HASH resolved empty. Check the key exists in the secrets store." >&2
+                exit 1
+            }
             echo "admin:${TRAEFIK_ADMIN_PASSWORD_HASH}" > platform/edge/dynamic/.htpasswd
             echo "✓ Created .htpasswd for Traefik dashboard authentication"
 
@@ -182,6 +210,10 @@ cmd_infra() {
 
             echo "Generating Traefik basic auth credentials..."
             mkdir -p platform/edge/dynamic
+            # Same guard as the SOPS path: an empty hash locks the dashboard
+            # while the deploy reports success.
+            [ -n "${TRAEFIK_ADMIN_PASSWORD_HASH:-}" ] \
+                || die "Refusing to write an empty .htpasswd: TRAEFIK_ADMIN_PASSWORD_HASH resolved empty from OpenBao. Check the key exists, or force the SOPS path."
             echo "admin:${TRAEFIK_ADMIN_PASSWORD_HASH}" > platform/edge/dynamic/.htpasswd
             echo "✓ Created .htpasswd for Traefik dashboard authentication"
 
@@ -227,7 +259,16 @@ cmd_infra() {
     echo "================================"
     echo "Edge Stack Deployment Complete!"
     echo "================================"
-    docker compose -p "hill90-${env}-edge" -f "$compose_file" ps
+    # By project label, not `docker compose ps` — #595 fixed this exact bug in
+    # cmd_service and missed this second copy. The secrets live only inside the
+    # sops/vault scopes above, both closed by now, and Compose interpolates for
+    # `ps` as much as for `up`. docker-compose.infra.yml uses no `${VAR:?...}`
+    # today so it would only warn, but that is luck, not design: the day this
+    # file gains one required variable, the edge deploy starts exiting 1 after
+    # printing "Complete!".
+    docker ps -a \
+        --filter "label=com.docker.compose.project=hill90-${env}-edge" \
+        --format 'table {{.Names}}\t{{.Status}}\t{{.Ports}}'
 
     echo ""
     echo "Services deployed:"
@@ -322,9 +363,21 @@ cmd_service() {
 
     # Keycloak stores its realms in Postgres, so refuse rather than start into a
     # crash loop if the database is not up.
+    #
+    # This guard runs BEFORE secrets are loaded (that happens further down), so
+    # ${DB_USER} is empty here and the old inline `${DB_USER:-hill90}` fallback
+    # was always what ran. A guard that refuses a deploy must not be built on an
+    # unstated assumption: if the role name were ever changed in the store, this
+    # would block every auth deploy with a message blaming Postgres.
     if [ "$service" = "auth" ]; then
-        if ! docker exec postgres psql -U "${DB_USER:-hill90}" -tAc 'SELECT 1' >/dev/null 2>&1; then
-            die "Cannot deploy auth: cannot query postgres as '${DB_USER:-hill90}'. Deploy it first: bash scripts/deploy.sh db ${env}"
+        local guard_user
+        guard_user=$(secret_value DB_USER "$env" 2>/dev/null || true)
+        if [ -z "$guard_user" ]; then
+            warn "DB_USER could not be resolved from the store; assuming 'hill90' for the pre-deploy database check."
+            guard_user="hill90"
+        fi
+        if ! docker exec postgres psql -U "$guard_user" -tAc 'SELECT 1' >/dev/null 2>&1; then
+            die "Cannot deploy auth: cannot query postgres as '${guard_user}'. Deploy it first: bash scripts/deploy.sh db ${env}"
         fi
     fi
 

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -371,6 +371,7 @@ cmd_secrets() {
 cmd_compose() {
     local env="${1:-prod}"
     local compose_dir="deploy/compose/${env}"
+    local secrets_file="infra/secrets/${env}.enc.env"
 
     echo "================================"
     echo "Docker Compose Validation"
@@ -412,13 +413,33 @@ cmd_compose() {
         local basename
         basename=$(basename "$f")
         echo -n "  $basename... "
-        if docker compose -f "$f" config > /dev/null 2>&1; then
+        # Three outcomes, not two. This validator loads no secrets, and Compose
+        # refuses to interpolate `${VAR:?...}` without a value — so
+        # docker-compose.minio.yml was reported "✗ Invalid" for being perfectly
+        # valid, with a suggested command that fails the same way. Never report
+        # "invalid" for something that could not be checked.
+        local err
+        err=$(mktemp)
+        if docker compose -f "$f" config > /dev/null 2>"$err"; then
             echo "✓"
+        elif grep -q "required variable" "$err"; then
+            # Retry with the store, so this actually validates wherever the age
+            # key is present (the VPS, a maintainer's machine) instead of
+            # permanently skipping the one file most worth checking.
+            if [ -f "$secrets_file" ] && [ -f "${SOPS_AGE_KEY_FILE:-$PROJECT_ROOT/infra/secrets/keys/age-prod.key}" ] \
+               && sops exec-env "$secrets_file" "docker compose -f '$f' config" >/dev/null 2>&1; then
+                echo "✓ (needed secrets)"
+            else
+                echo "⚠ needs secrets — NOT validated"
+                echo "    $(grep -o 'required variable [A-Z_]*' "$err" | head -1) is declared \${VAR:?...}."
+                echo "    Not a fault in the file. To check it: sops exec-env $secrets_file \"docker compose -f $f config\""
+            fi
         else
             echo "✗ Invalid"
             all_valid=false
             echo "    Run: docker compose -f $f config"
         fi
+        rm -f "$err"
     done
 
     if [ "$found_any" = false ]; then


### PR DESCRIPTION
Three fixes in three days were one mistake in three places. Found the rest **by the property, not by memory**: enumerate every `docker compose` invocation and every credential-shaped interpolation across `scripts/`, then check which run outside a secret environment.

## Four more sites — two that nobody had listed

| Site | What it did |
|---|---|
| `cmd_infra` completion `docker compose ps` | **#595 fixed the `cmd_service` copy and missed this one.** `docker-compose.infra.yml` has no `${VAR:?...}` today so it only warns — luck, not design |
| `validate.sh compose` | Reported `docker-compose.minio.yml ✗ Invalid` for a **valid** file, and suggested a command that failed the same way |
| `${DB_USER:-hill90}` (`cmd_verify`, `cmd_service`) | Ran bare, so the literal was always what executed |
| `.htpasswd` writes (`cmd_infra`) | No empty-check — an empty hash writes `admin:` over the live dashboard credential |

**`validate.sh` is the interesting one.** It is not in CI (only `validate.sh traefik` is), so this had never been caught — anyone running the validator by hand was told a correct file was broken. It now retries under `sops` where the store is available, and otherwise reports `⚠ needs secrets — NOT validated`. *A check that could not run must never report the thing it checked as broken.*

**`${DB_USER:-hill90}`** passed only because the literal happens to equal the real `POSTGRES_USER` (both verified). Now resolved through a new `secret_value()` helper, with a loud `warn` if it cannot be — a stated assumption instead of a silent one. `secret_value()` is deliberately narrower than `load_secrets`: several paths need one non-sensitive value while outside any secret scope, and pulling the whole store into a readiness check to read a username would be the wrong trade.

**`.htpasswd`** — both writes are correctly *inside* the secret scope, so not the scope bug, but an empty value is a lockout that reports success. `keycloak.sh` already refuses exactly this shape ("Refusing to write an empty client secret"); `deploy.sh` did not.

## Verified read-only on the host, checkout restored clean

```
validate.sh compose  ->  docker-compose.minio.yml... ✓ (needed secrets)
deploy.sh verify db  ->  ✓ db is healthy
git status           ->  0 modified
```

## The rule, written down

`docs/runbooks/deployment.md` → **"Secrets and the shells that do not have them"**, with the two things that make it bite:

- **Compose interpolates for EVERY subcommand**, `ps`, `config` and `down` included — that is what made `teardown minio` fail *after* the backup ran and *after* printing `Volumes: KEPT`.
- **`sops exec-env` runs a new shell that does not inherit `set -e` and returns 0 regardless** — always put `set -e` inside the string, or a failed deploy reports success.

Plus a table of what to do instead, and the reporting rule.

`docker-compose.minio.yml` is still the only prod compose file using `${VAR:?...}`, which is why MinIO is where this keeps surfacing. **The other stacks are not safe, they are not yet noisy.**

## Checked and NOT instances

`local.sh` passes `--env-file` (different, correct mechanism). The `docker compose` in `preflight-edge.sh` is inside an error message, not an invocation.

## Test

23 assertions; five fail on the pre-sweep branch. One new assertion was wrong first time — an unanchored `.*ps` also matches `--no-deps` — which is the same false-positive shape this suite exists to catch, so it is now anchored and commented.

No VPS state was changed by this PR; the only host commands were read-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)