### PR TITLE
docs(traefik): say that the constraints line needs a restart, and why silence is the hazard

### DIFF
--- a/platform/edge/traefik.local.yml
+++ b/platform/edge/traefik.local.yml
@@ -91,6 +91,23 @@ providers:
     # Every local compose project must be listed. Dropping one silently 404s that
     # stack's hostnames with no error anywhere — which is why the branch that added
     # `hill90-local-storage` left a conflict warning here. Both clauses kept.
+    #
+    # CHANGING THIS LINE REQUIRES A TRAEFIK RESTART, NOT A RELOAD.
+    #
+    # `providers.docker.constraints` is STATIC configuration. Traefik watches the
+    # Docker socket and the file provider for *dynamic* configuration — routers,
+    # services, middlewares — and picks those up live. It does not re-read this file.
+    # So editing this line and reloading leaves the OLD constraint in force, and
+    # that is the failure mode worth naming: **there is no error.** No warning in
+    # `docker logs traefik`, no rejected config, no failed health check. The clause
+    # you just added simply is not there, the stack you added it for still 404s, and
+    # the file on disk says it should work — which sends you looking at labels,
+    # networks and DNS instead of at the process that never read your change.
+    #
+    #   docker restart hill90dev-traefik      # local
+    #
+    # Salvaged from a branch that was closed for unrelated reasons (Hill90 #559);
+    # the note was the only part of it still true.
     constraints: "Label(`com.docker.compose.project`,`hill90-local-edge`) || Label(`com.docker.compose.project`,`hill90-local-observability`) || Label(`com.docker.compose.project`,`hill90-local-identity`) || Label(`com.docker.compose.project`,`hill90-local-platform`) || Label(`com.docker.compose.project`,`hill90-local-db`) || Label(`com.docker.compose.project`,`hill90-local-storage`) || Label(`com.docker.compose.project`,`hill90-local`)"
 
   file:


### PR DESCRIPTION
Four lines of comment, **no behaviour change**. Salvaged from #559, which I closed because its other half — a Prometheus job for a tenant Postgres exporter that no longer exists — was obsolete. This note was the only part still true, and it guards a line that has already caused two merge collisions.

## Why, not just what

`providers.docker.constraints` is **static** configuration. Traefik watches the Docker socket and the file provider for *dynamic* configuration — routers, services, middlewares — and picks those up live. **It does not re-read this file.**

So editing the line and reloading leaves the **old constraint in force**, and the failure mode worth naming is that **there is no error**: nothing in `docker logs traefik`, no rejected config, no failed health check. The clause you just added simply isn't there, the stack you added it for still 404s, and the file on disk says it should work — which sends you looking at labels, networks and DNS instead of at the process that never read your change.

Verified the file still parses as YAML.