### PR TITLE
feat(auth): store login events, so "has anyone logged in" has an answer

### DIFF
--- a/docs/runbooks/keycloak-login-events.md
+++ b/docs/runbooks/keycloak-login-events.md
@@ -1,0 +1,162 @@
+# "Did this user log in, and when?"
+
+**Answering it takes one command.** Everything else on this page is why that command
+is shaped the way it is, and what it cannot tell you.
+
+`Verified 2026-07-31 03:30 UTC` — enabled, and proven by completing a login as
+`testuser01` and reading the row back out of the database.
+
+---
+
+## The command
+
+```bash
+ssh vps
+docker exec postgres psql -U hill90 -d keycloak -c "
+SELECT to_timestamp(e.event_time/1000) AT TIME ZONE 'UTC' AS utc_time,
+       e.type, u.username, e.client_id, e.ip_address, r.name AS realm
+FROM event_entity e
+LEFT JOIN user_entity u ON u.id = e.user_id
+LEFT JOIN realm      r ON r.id = e.realm_id
+WHERE u.username = 'THE_USERNAME'
+ORDER BY e.event_time DESC LIMIT 20;"
+```
+
+Real output, from the verification run:
+
+```
+      utc_time       |    type     |    who     | client_id | ip_address  |  realm
+---------------------+-------------+------------+-----------+-------------+----------
+ 2026-07-31 03:30:22 | LOGIN_ERROR | testuser01 | admin-cli | 76.13.26.69 | platform
+ 2026-07-31 03:29:52 | LOGIN       | testuser01 | admin-cli | 76.13.26.69 | platform
+```
+
+Everyone, most recent first — drop the `WHERE` clause. **No rows for a user means no
+recorded login since events were switched on**, which is not the same as never — see
+the next section.
+
+## Read this before you conclude anything from an empty result
+
+**1. Nothing exists before 2026-07-31 ~03:28 UTC.** Event storage was off from the day
+this estate was built until then. Keycloak does not backfill. For any question about an
+earlier date the honest answer is *"not recorded"*, not *"did not happen"*.
+
+**2. Retention is 30 days.** Older rows are deleted by Keycloak's own periodic task. A
+question about two months ago has no answer here either.
+
+**3. An empty `event_entity` is not evidence that nobody logged in.** That sentence is
+the reason this page exists. Sessions live in **Infinispan, not the database**, so a
+logged-in user leaves no database row while their session is alive, and before this
+change nothing wrote to `event_entity` at all. More than one session in July 2026 had to
+say this out loud after reading an empty table.
+
+**4. Only four event types are stored** on `platform`: `LOGIN`, `LOGIN_ERROR`, `LOGOUT`,
+`LOGOUT_ERROR`. A token refresh, a consent grant or a password reset is *not* here.
+
+## Traps in the schema
+
+Each of these will silently give you a wrong answer rather than an error.
+
+| Trap | What happens | What to do |
+|---|---|---|
+| `realm_id` is a **UUID**, not `platform` | `WHERE realm_id = 'platform'` matches nothing and looks like "no logins" | join `realm r ON r.id = e.realm_id` |
+| `event_time` is **epoch milliseconds** | `to_timestamp(event_time)` gives a date in the year 57000-odd | divide by 1000, as above |
+| Timestamps come back in **server local time** unless you ask | off-by-hours answers | keep `AT TIME ZONE 'UTC'`, and compare against UTC |
+| `user_id` is null for a failed login with an **unknown username** | a `LEFT JOIN` shows a blank user | the attempted name is in `details_json` |
+
+## Is the IP trustworthy?
+
+Reasonably. Keycloak runs with `KC_PROXY_HEADERS=xforwarded`, so it records the client
+address from Traefik's `X-Forwarded-For` rather than Traefik's own. In the verification
+run above the client genuinely *was* the VPS — the login was driven from the host — so
+`76.13.26.69` is correct rather than a proxy artefact. Treat the column as good enough to
+distinguish "from the office" from "from somewhere else", not as forensic evidence.
+
+## Admin events: who changed the configuration
+
+Enabled on both realms, and answers a different question — *what was changed by hand,
+outside git*.
+
+```bash
+docker exec postgres psql -U hill90 -d keycloak -c "
+SELECT to_timestamp(admin_event_time/1000) AT TIME ZONE 'UTC' AS utc_time,
+       operation_type, resource_type, resource_path, auth_user_id, ip_address
+FROM admin_event_entity ORDER BY admin_event_time DESC LIMIT 20;"
+```
+
+**`representation` is deliberately empty.** `adminEventsDetailsEnabled` is off, because
+that column stores the full JSON of the changed resource — and a client representation
+carries its `secret`. Switching it on would write client secrets in plaintext into the
+platform Postgres, and from there into every database backup. The audit value is *who
+changed what, when*, which `operation_type` and `resource_path` already give.
+
+If you ever need the representation for one specific investigation, turn it on, capture
+what you need, and turn it straight back off — then treat the database backups taken in
+between as containing secrets.
+
+## Where this lands, and what it costs
+
+- **Database `keycloak` on the platform Postgres** (container `postgres`) — the same
+  database every other platform service depends on, which is why retention is bounded
+  rather than infinite.
+- Tables `event_entity` and `admin_event_entity`.
+- Scale: the whole `keycloak` database was **13 MB** with both tables empty. An event row
+  is a few hundred bytes, so 30 days of this estate's traffic is noise. Check it with:
+
+```bash
+docker exec postgres psql -U hill90 -d keycloak -c "
+SELECT relname, n_live_tup,
+       pg_size_pretty(pg_total_relation_size(relid))
+FROM pg_stat_user_tables WHERE relname LIKE '%event%' ORDER BY relname;"
+```
+
+- Backups: covered by the existing platform Postgres backup. Nothing extra to configure.
+
+## Changing what is recorded
+
+Configuration lives in `scripts/keycloak.sh` (`ensure_event_logging`, called from
+`cmd_apply`) and in `platform/auth/keycloak/platform-realm.json` for a fresh import.
+**Change it there, not in the admin console** — `keycloak.sh apply` reconciles the realm
+and would put a console change back.
+
+Retention and event types are overridable per-run:
+
+```bash
+KC_EVENTS_EXPIRATION=604800 bash scripts/keycloak.sh apply     # 7 days instead of 30
+KC_EVENT_TYPES="LOGIN LOGIN_ERROR REFRESH_TOKEN" bash scripts/keycloak.sh apply
+```
+
+`events/config` updates **replace the whole object**, so any field left out reverts to
+the server default. That is why `ensure_event_logging` names every field explicitly, and
+why a hand-rolled `kcadm update` is a bad idea at 3am.
+
+### Why `master` is configured differently
+
+`master` records `LOGIN` and `LOGIN_ERROR` only — no logout. It holds no application
+users, so "did a user log in" is not a question anyone asks of it. The reason to record
+there is narrower: the master admin credential leaked and was rotated on 2026-07-30, and
+without a login record there was no way to answer whether it had been used in between.
+That question recurs at every rotation. A logout on an admin realm tells you nothing the
+login did not.
+
+## Verifying it still works
+
+If you doubt the pipeline, generate a failed login — it needs no password and touches
+nobody's account:
+
+```bash
+curl -s -o /dev/null -w '%{http_code}\n' \
+  -X POST https://auth.hill90.com/realms/platform/protocol/openid-connect/token \
+  -H 'Content-Type: application/x-www-form-urlencoded' \
+  --data 'grant_type=password&client_id=admin-cli&username=no-such-user&password=x'
+# 401, then a LOGIN_ERROR row should appear within a second or two
+```
+
+A row appearing proves the whole path: Keycloak → JPA event listener → platform
+Postgres. Config that says `eventsEnabled: true` proves only that the config says so.
+
+## See also
+
+- [keycloak-admin-rotation.md](keycloak-admin-rotation.md) — the rotation this exists to
+  make answerable
+- [sso-fallback.md](sso-fallback.md) — when Keycloak itself is the problem

--- a/platform/auth/keycloak/platform-realm.json
+++ b/platform/auth/keycloak/platform-realm.json
@@ -1,6 +1,16 @@
 {
   "realm": "platform",
   "enabled": true,
+  "eventsEnabled": true,
+  "eventsExpiration": 2592000,
+  "enabledEventTypes": [
+    "LOGIN",
+    "LOGIN_ERROR",
+    "LOGOUT",
+    "LOGOUT_ERROR"
+  ],
+  "adminEventsEnabled": true,
+  "adminEventsDetailsEnabled": false,
   "displayName": "Hill90 Platform",
   "sslRequired": "external",
   "registrationAllowed": false,

--- a/scripts/keycloak.sh
+++ b/scripts/keycloak.sh
@@ -130,6 +130,86 @@ client_uuid() {
 }
 
 # ---------------------------------------------------------------------------
+# Login event storage
+# ---------------------------------------------------------------------------
+
+# How long events are kept, in seconds. 30 days.
+#
+# Chosen, not defaulted. The question this exists to answer — "did this user log
+# in, and when" — is almost always asked about the recent past, and 30 days also
+# covers "was anything used between the leak and the rotation", which is the
+# question this estate actually had to ask twice this week. Longer buys little:
+# beyond a month the answer stops being operational and starts being forensic,
+# and forensics wants the Loki/Grafana pipeline, not a Keycloak table.
+#
+# Storage lands in the PLATFORM Postgres — database `keycloak`, tables
+# `event_entity` and `admin_event_entity` — which every other platform service
+# depends on, so it is bounded on purpose rather than left to grow forever.
+# For scale: the whole `keycloak` database was 13 MB with both tables empty, and
+# an event row is a few hundred bytes. Keycloak expires rows on a periodic task;
+# nothing here needs a cron.
+KC_EVENTS_EXPIRATION="${KC_EVENTS_EXPIRATION:-2592000}"
+
+# The event types worth storing, rather than "all of them".
+#
+# eventsEnabled with an empty enabledEventTypes records EVERY user event,
+# including REFRESH_TOKEN on every token refresh — high volume, and none of it
+# answers the question. This list is the question, written out.
+KC_EVENT_TYPES="${KC_EVENT_TYPES:-LOGIN LOGIN_ERROR LOGOUT LOGOUT_ERROR}"
+
+# Master records logins only. See the comment on cmd_apply's master call.
+KC_MASTER_EVENT_TYPES="${KC_MASTER_EVENT_TYPES:-LOGIN LOGIN_ERROR}"
+
+# Turn on event storage for one realm, idempotently.
+#
+# WHY THIS EXISTS AT ALL: sessions live in Infinispan, not the database, so
+# "who is logged in" and "who has ever logged in" are different questions and
+# only the second one is answerable from the host. With events off, `event_entity`
+# is empty — and an empty `event_entity` is NOT evidence that nobody logged in.
+# More than one session this week has had to say that out loud.
+#
+# admin_events_details is deliberately NOT exposed as an argument. See below.
+ensure_event_logging() {
+    local realm="$1" expiration="$2" admin_events="$3"; shift 3
+    local types="$*"
+
+    # `update events/config` replaces the whole config object, so every field
+    # that should survive has to be named here — omitting one silently reverts
+    # it to the server default rather than leaving it alone.
+    local payload
+    payload=$(python3 -c '
+import json, sys
+realm, expiration, admin_events = sys.argv[1], int(sys.argv[2]), sys.argv[3] == "true"
+print(json.dumps({
+    "eventsEnabled": True,
+    "eventsExpiration": expiration,
+    "enabledEventTypes": sys.argv[4:],
+    "adminEventsEnabled": admin_events,
+    # Details store the full JSON representation of the changed resource in
+    # admin_event_entity.representation (a text column — verified in the live
+    # schema). A client representation carries its `secret`, so switching this
+    # on writes client secrets in plaintext into the platform Postgres, where
+    # they would then be picked up by every database backup. The audit value is
+    # "who changed what and when", which the operation type and resource path
+    # already give. Left off deliberately; do not flip it without a reason that
+    # survives that sentence.
+    "adminEventsDetailsEnabled": False,
+    }))
+' "$realm" "$expiration" "$admin_events" $types)
+
+    # `docker exec -i`, NOT the kc() helper: kc() has no -i, so a payload piped
+    # into `-f -` never reaches kcadm. ensure_client uses the same direct form
+    # for the same reason.
+    echo "$payload" | docker exec -i "$KC_CONTAINER" /opt/keycloak/bin/kcadm.sh \
+        update "events/config" -r "$realm" -f - >/dev/null \
+        || die "Failed to enable event logging on realm '${realm}'"
+
+    local days=$(( expiration / 86400 ))
+    echo "  = ${realm}: login events ON, ${days}d retention, admin events ${admin_events}, details OFF"
+    echo "      types: ${types}"
+}
+
+# ---------------------------------------------------------------------------
 # Realm roles
 # ---------------------------------------------------------------------------
 
@@ -281,6 +361,32 @@ cmd_apply() {
         || die "Cannot resolve MINIO_OIDC_CLIENT_SECRET — refusing to reconfigure any client"
 
     ensure_realm_roles
+
+    echo ""
+    echo "Event logging..."
+    # The tenant realm: user logins. This is the one that answers "has anyone
+    # actually logged in", which nothing on the host could answer before.
+    #
+    # Admin events ON here, because this realm's configuration is supposed to
+    # arrive through this script from git. A change made by hand in the admin
+    # console is exactly the drift nothing else would record, and the resource
+    # path plus operation type is enough to spot it. Details stay off — see
+    # ensure_event_logging.
+    ensure_event_logging "$KC_REALM" "$KC_EVENTS_EXPIRATION" true $KC_EVENT_TYPES
+
+    # MASTER IS A SEPARATE DECISION, not the same one applied twice.
+    #
+    # Master holds no application users, so "did a user log in" is not a question
+    # anyone asks of it. The reason to record here is narrower and concrete: the
+    # master admin credential leaked and was rotated on 2026-07-30, and without a
+    # login record there is no way to answer whether it was used in between. That
+    # question will recur at the next rotation.
+    #
+    # So: logins only, and LOGOUT is dropped — on an admin realm a logout tells
+    # you nothing the login did not. Admin events ON for the same
+    # console-drift reason as above, still without details.
+    ensure_event_logging master "$KC_EVENTS_EXPIRATION" true $KC_MASTER_EVENT_TYPES
+
     echo ""
     echo "Clients..."
 

--- a/tests/checks/test_keycloak_event_logging.py
+++ b/tests/checks/test_keycloak_event_logging.py
@@ -1,0 +1,125 @@
+"""Keycloak event-logging contract tests.
+
+Login event storage exists to answer one question from the host: "did this user
+log in, and when". Before 2026-07-31 nothing could, because `events_enabled` was
+false on both realms and `event_entity` was therefore empty — and an empty
+`event_entity` is not evidence that nobody logged in. See
+docs/runbooks/keycloak-login-events.md.
+
+The assertions that matter here are the ones with a blast radius:
+
+  * admin event DETAILS must stay off. That column stores the full JSON
+    representation of a changed resource, and a client representation carries
+    its `secret`, so turning it on writes client secrets in plaintext into the
+    platform Postgres and from there into every database backup.
+  * retention must be finite. These tables live in the database every other
+    platform service depends on.
+  * the event type list must stay explicit. Keycloak's default is roughly ninety
+    types including a row per token refresh.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+KEYCLOAK_SH = ROOT / "scripts" / "keycloak.sh"
+REALM_JSON = ROOT / "platform" / "auth" / "keycloak" / "platform-realm.json"
+
+THIRTY_DAYS = 30 * 24 * 3600
+
+
+@pytest.fixture(scope="module")
+def realm() -> dict:
+    return json.loads(REALM_JSON.read_text())
+
+
+@pytest.fixture(scope="module")
+def script() -> str:
+    return KEYCLOAK_SH.read_text()
+
+
+# --- the realm import, used when a realm is created from nothing -------------
+
+def test_realm_import_enables_events(realm):
+    assert realm["eventsEnabled"] is True
+
+
+def test_realm_import_sets_finite_retention(realm):
+    assert realm["eventsExpiration"] == THIRTY_DAYS
+
+
+def test_realm_import_lists_event_types_explicitly(realm):
+    types = realm["enabledEventTypes"]
+    assert "LOGIN" in types, "LOGIN is the whole point"
+    assert "LOGIN_ERROR" in types, "a failed attempt is half the question"
+    # Keycloak's default is ~90 types, one row per token refresh included.
+    assert len(types) <= 10, f"event type list has grown to {len(types)}; is it still deliberate?"
+
+
+def test_realm_import_keeps_admin_event_details_off(realm):
+    # admin_event_entity.representation would hold client secrets in plaintext.
+    assert realm["adminEventsDetailsEnabled"] is False
+
+
+# --- keycloak.sh apply, which reconciles an EXISTING realm -------------------
+#
+# The realm import runs on first boot only (IGNORE_EXISTING), so for a realm
+# that already exists the script is the only thing that applies this.
+
+def test_script_has_the_reconciler():
+    assert "ensure_event_logging()" in KEYCLOAK_SH.read_text()
+
+
+def test_script_applies_to_both_realms(script):
+    body = re.search(r"^cmd_apply\(\).*?^}", script, re.S | re.M)
+    assert body, "cmd_apply not found"
+    calls = re.findall(r"ensure_event_logging\s+(\S+)", body.group(0))
+    assert any(c == "master" for c in calls), "master realm is not configured"
+    assert any("KC_REALM" in c for c in calls), "the tenant realm is not configured"
+
+
+def test_script_never_enables_admin_event_details(script):
+    # The only occurrence should be the hardcoded False in the payload.
+    assert not re.search(r'"adminEventsDetailsEnabled"\s*:\s*True', script)
+    assert re.search(r'"adminEventsDetailsEnabled"\s*:\s*False', script)
+
+
+def test_script_default_retention_is_finite(script):
+    m = re.search(r'KC_EVENTS_EXPIRATION="\$\{KC_EVENTS_EXPIRATION:-(\d+)\}"', script)
+    assert m, "KC_EVENTS_EXPIRATION default not found"
+    seconds = int(m.group(1))
+    assert 0 < seconds <= 90 * 24 * 3600, f"retention {seconds}s is not a bounded, sane window"
+
+
+def test_script_feeds_the_payload_over_stdin_with_dash_i(script):
+    """kc() has no -i, so a payload piped into `-f -` would never reach kcadm.
+
+    This is not hypothetical: the first version of ensure_event_logging used
+    kc() and would have silently sent nothing.
+    """
+    body = re.search(r"^ensure_event_logging\(\).*?^}", script, re.S | re.M)
+    assert body, "ensure_event_logging not found"
+    update = [ln for ln in body.group(0).splitlines() if "events/config" in ln and "update" in ln]
+    assert update, "no update call for events/config"
+    assert any("docker exec -i" in ln for ln in body.group(0).splitlines()), \
+        "the events/config update must use `docker exec -i`, not the kc() helper"
+
+
+def test_the_function_survives_naive_extraction(script):
+    """`sed -n '/^ensure_event_logging()/,/^}/p' | bash -n` must parse.
+
+    The repo's own tests extract shell functions with that idiom. A line
+    beginning with `}` in column 0 inside the function — an unindented closing
+    brace in an embedded python heredoc, for instance — truncates the extract
+    and the test fails for a reason that has nothing to do with the code.
+    """
+    body = re.search(r"^ensure_event_logging\(\).*?^}", script, re.S | re.M)
+    assert body
+    inner = body.group(0).splitlines()[1:-1]
+    offenders = [ln for ln in inner if ln.startswith("}")]
+    assert not offenders, f"line(s) starting with '}}' truncate extraction: {offenders}"


### PR DESCRIPTION
`events_enabled` was false on **both** realms, so `event_entity` was empty and the estate's most-repeated question could not be answered from the host at all.

Sessions live in **Infinispan, not the database** — so an empty `event_entity` was never evidence that nobody logged in. It meant nothing was writing.

## Proven, not asserted

`testuser01` completed a login through the public endpoint, then the row was read back out of the database:

```
      utc_time       |    type     |    who     | client_id | ip_address  |  realm
---------------------+-------------+------------+-----------+-------------+----------
 2026-07-31 03:30:22 | LOGIN_ERROR | testuser01 | admin-cli | 76.13.26.69 | platform
 2026-07-31 03:29:52 | LOGIN       | testuser01 | admin-cli | 76.13.26.69 | platform
```

The `LOGIN_ERROR` is a deliberate wrong-password attempt — *"did they try and fail"* is half the question. **jon's account was not touched.**

## The decisions, each with its reason

**Realm `platform`** — `LOGIN`, `LOGIN_ERROR`, `LOGOUT`, `LOGOUT_ERROR`. Not the default: I read a realm's default `enabledEventTypes` and it is ~90 types, including a row per token refresh.

**Realm `master` is a separate decision, not the same one twice.** It holds no application users, so "did a user log in" is not a question anyone asks of it. The reason to record there is narrower and concrete: **the master admin credential leaked and was rotated on 2026-07-30, and without a login record there was no way to answer whether it had been used in between.** That question recurs at every rotation. So logins only — a logout on an admin realm tells you nothing the login did not.

**Retention: 30 days.** It covers "was anything used between the leak and the rotation" — the question actually asked twice this week. Beyond a month the answer stops being operational and starts being forensic, and forensics wants Loki, not a Keycloak table.

**Where it lands:** database `keycloak` on the **platform Postgres** — the one every other platform service depends on, which is why retention is bounded rather than infinite. The whole database was **13 MB** with both event tables empty; a row is a few hundred bytes. Covered by the existing Postgres backup; nothing extra to configure.

## Admin events: ON. Details: OFF — this is the load-bearing one

`admin_event_entity.representation` is a `text` column (verified in the live schema) holding the full JSON of the changed resource. **A client representation carries its `secret`.** Enabling details would write client secrets in plaintext into the platform Postgres, and from there into every database backup.

The audit value wanted here is *who changed what, when* — `operation_type` and `resource_path` already give that. Admin events are **on** because this realm's config is supposed to arrive from git through this script, and a change made by hand in the console is exactly the drift nothing else would record.

## Configured in two places, deliberately

The realm import (`platform-realm.json`) runs on **first boot only** (`IGNORE_EXISTING`), so it covers a realm built from nothing. `ensure_event_logging` in `keycloak.sh` reconciles a realm that **already exists** — which is every realm today. The live realms were updated with the identical payload, so **`keycloak.sh apply` after this merges is a no-op.**

I also ran the committed function against the **local** Keycloak end to end (false → true, 30d, four types, details off) — same result as production, which is what makes the no-op claim checkable rather than hopeful. Note that left event logging enabled on the local `platform` realm too; harmless, and it matches production.

## Two bugs in my own first draft

Both caught before merge, both now asserted by tests:

1. `ensure_event_logging` piped its payload into `kc update ... -f -`, but `kc()` runs `docker exec` **without `-i`** — nothing would have reached kcadm. `ensure_client` uses `docker exec -i` directly for exactly this reason.
2. An unindented `}` inside the embedded python truncated the naive `sed '/^}/'` extraction that this repo's own tests use, so the function could not be tested in isolation.

## The runbook is the deliverable

`docs/runbooks/keycloak-login-events.md` — the setting is only a means to it. One command up top, then the things that will otherwise give a confidently wrong answer at 3am:

- **Nothing exists before 2026-07-31 ~03:28 UTC.** Keycloak does not backfill. For an earlier date the honest answer is *"not recorded"*, not *"did not happen"*.
- `realm_id` is a **UUID**, so `WHERE realm_id = 'platform'` matches nothing and looks like "no logins" — join the `realm` table.
- `event_time` is **epoch milliseconds**; `to_timestamp()` on it lands in the year 57000.
- The IP is trustworthy-ish: `KC_PROXY_HEADERS=xforwarded`, so it is the client address from Traefik rather than Traefik's own.

Plus a self-check that needs no password and touches nobody's account: POST a bad login, watch a `LOGIN_ERROR` row appear.

## Tests

10 pytest assertions in `tests/checks/`, **all 10 failing before this change**. The ones that matter guard blast radius: admin-event details can never be flipped on, retention can never become infinite, and the type list cannot silently grow back to ninety.

Baseline after the change: 13/13 platform containers by name, 0 unhealthy, `keycloak` healthy with **0 restarts**, `hill90.com` 200, `auth.hill90.com/realms/platform` 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)