### PR TITLE
fix(edge): put the IP allowlist before the authenticator, and enforce the contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,14 @@ jobs:
       - name: Assert no destructive volume commands
         run: bash scripts/checks/check_destructive_commands.sh
 
+      # The five admin routers resolve on public DNS and are protected by exactly one
+      # middleware. This asserts that middleware still resolves, that its type key
+      # matches the pinned Traefik major version (ipWhiteList in v2 became
+      # ipAllowList in v3 — a bump without the rename loses the allowlist silently),
+      # and that no IP allowlist sits behind an authenticator.
+      - name: Assert the edge middleware contract
+        run: python3 scripts/checks/check_edge_middlewares.py
+
       # Guards the 2026-07-31 incident: minio.sh provisioned policies before
       # MinIO was serving, then blamed the credentials. Stubs docker, so it needs
       # no running stack.

--- a/deploy/compose/prod/docker-compose.infra.yml
+++ b/deploy/compose/prod/docker-compose.infra.yml
@@ -76,7 +76,15 @@ services:
       - "traefik.http.routers.traefik.entrypoints=${ADMIN_ENTRYPOINT:-websecure}"
       - "traefik.http.routers.traefik.tls.certresolver=${ADMIN_CERT_RESOLVER:-letsencrypt-dns}"
       - "traefik.http.routers.traefik.service=api@internal"
-      - "traefik.http.routers.traefik.middlewares=${TRAEFIK_MIDDLEWARES:-auth@file,tailscale-only@file}"
+      # ORDER IS LOAD-BEARING: the allowlist comes FIRST, the authenticator second.
+      # Chains run left to right. Ordered `auth,tailscale-only` this router answered
+      # 401 with `WWW-Authenticate: Basic realm="traefik"` to the public internet
+      # (observed off-tailnet 2026-07-31) — a credential prompt and a guessing oracle
+      # handed to anyone, before the allowlist refused them. Every other admin router
+      # answered 403. Same protection for a legitimate tailnet user either way;
+      # strictly less disclosed to everyone else. Enforced by
+      # scripts/checks/check_edge_middlewares.py.
+      - "traefik.http.routers.traefik.middlewares=${TRAEFIK_MIDDLEWARES:-tailscale-only@file,auth@file}"
 
   # Portainer Container Management (Tailscale-only access)
   portainer:

--- a/platform/edge/dynamic/middlewares.yml
+++ b/platform/edge/dynamic/middlewares.yml
@@ -47,7 +47,21 @@ http:
     #
     # Do not re-add 172.18.0.1/32 without first re-checking the SNAT rule --
     # if it returns, tailnet traffic breaks and adding the CIDR back reopens v6.
-    # NOTE: ipWhiteList is Traefik v2. If upgrading to v3, use ipAllowList.
+    # ##########################################################################
+    # ipWhiteList IS TRAEFIK v2. IN v3 IT IS ipAllowList. THE RENAME IS NOT
+    # OPTIONAL AND ITS OMISSION IS SILENT.
+    #
+    # This middleware is the ONLY thing protecting traefik, portainer, grafana,
+    # vault and storage.hill90.com — all of which resolve on public DNS. Bump the
+    # image to v3 without renaming this key and v3 does not recognise the
+    # definition: those five routers keep loading and keep serving, with no
+    # allowlist, and nothing logs an error. That is the entire failure mode.
+    #
+    # This is no longer only a comment. scripts/checks/check_edge_middlewares.py
+    # reads the pinned Traefik major version from deploy/compose/prod and FAILS CI
+    # when the type key here does not match it. Do not delete that check to get a
+    # version bump through — rename the key.
+    # ##########################################################################
     #
     # This list must contain ONLY the Tailscale CGNAT range. It previously also
     # carried the Docker bridge gateway, "172.18.0.1/32", added because proxied

--- a/scripts/checks/check_edge_middlewares.py
+++ b/scripts/checks/check_edge_middlewares.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Validate the edge middleware contract: references resolve, types match the pinned
+Traefik major version, and an IP allowlist is never behind an authenticator.
+
+WHY THIS EXISTS
+
+Five production routers — traefik, portainer, grafana, vault, minio-console — are
+reachable on the public internet by DNS and are protected by exactly one thing: the
+`tailscale-only` middleware, an IP allowlist for the Tailscale CGNAT range. Nothing else
+stands between them and the world. A comment saying "remember to rename this" is not a
+control, so this asserts three properties that a comment cannot.
+
+1. EVERY `@file` MIDDLEWARE A ROUTER REFERENCES ACTUALLY EXISTS.
+   Traefik resolves middleware references at request time, not at load time. A router
+   pointing at a middleware that does not exist does not fail to load — the request
+   errors, and in the meantime the router is present and the protection is not.
+
+2. MIDDLEWARE TYPES MATCH THE PINNED TRAEFIK MAJOR VERSION.
+   This is the hazard worth the most: `ipWhiteList` (v2) was renamed `ipAllowList` in
+   v3. Bumping the image to v3 without renaming leaves a definition Traefik v3 does not
+   recognise, on precisely the routers whose entire protection is that definition. The
+   failure is silent in the way that matters — the routers still load and still serve.
+   This check fails the build instead.
+
+3. AN IP ALLOWLIST IS NEVER ORDERED BEHIND AN AUTHENTICATOR.
+   Middleware chains run left to right. `auth@file,tailscale-only@file` authenticates
+   first, so an off-tailnet request receives a `WWW-Authenticate` prompt and a guessing
+   oracle before the allowlist ever refuses it. Same protection for a legitimate user,
+   strictly more information disclosed to everyone else. Observed in production on
+   2026-07-31: traefik.hill90.com answered 401 from off-tailnet while every other
+   admin router answered 403.
+
+Exit codes:
+    0 — all three properties hold
+    1 — at least one violation
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+COMPOSE_DIR = ROOT / "deploy" / "compose" / "prod"
+MIDDLEWARES = ROOT / "platform" / "edge" / "dynamic" / "middlewares.yml"
+
+# Middleware type keys that exist in only one Traefik major version. The point of the
+# check is the first entry; the rest are included because the same class of rename has
+# bitten other keys and a one-entry table invites "it is only about ipWhiteList".
+VERSIONED_TYPES = {
+    "ipWhiteList": {"v2"},
+    "ipAllowList": {"v3"},
+}
+
+# Middleware types that gate on network location. These must never be preceded by an
+# authenticating middleware in a chain.
+LOCATION_GATES = {"ipWhiteList", "ipAllowList"}
+AUTHENTICATORS = {"basicAuth", "digestAuth", "forwardAuth"}
+
+
+def traefik_major() -> tuple[str, str]:
+    """Return (major, raw_tag) for the pinned Traefik image."""
+    for path in sorted(COMPOSE_DIR.glob("*.yml")):
+        for line in path.read_text().splitlines():
+            m = re.search(r"image:\s*traefik:v(\d+)([\w.\-]*)", line)
+            if m:
+                return f"v{m.group(1)}", f"v{m.group(1)}{m.group(2)}"
+    return "", ""
+
+
+def defined_middlewares() -> dict[str, str]:
+    """Map middleware name -> its type key, parsed from the file provider config.
+
+    Deliberately a line parser rather than yaml.safe_load: this file is mounted into
+    Traefik verbatim and carries long comment blocks that are part of its value. A
+    round-trip through a YAML library would be a reason to rewrite it, and rewriting a
+    file whose comments record why the allowlist contains exactly one CIDR is the last
+    thing this check should encourage.
+    """
+    out: dict[str, str] = {}
+    name = None
+    for line in MIDDLEWARES.read_text().splitlines():
+        if re.match(r"^\s{4}[A-Za-z][\w-]*:\s*$", line):
+            name = line.strip().rstrip(":")
+        elif name and re.match(r"^\s{6}[A-Za-z][\w]*:", line):
+            # Not `:\s*$` — an inline body such as `compress: {}` is a complete
+            # definition and was missed by an anchored version of this pattern, which
+            # would have reported a defined middleware as unresolvable. Found by
+            # counting the parsed names against the file rather than by a failure.
+            out[name] = line.strip().split(":")[0]
+            name = None
+    return out
+
+
+def referenced_chains() -> list[tuple[str, str, list[str]]]:
+    """Return (compose file, router, [middleware names]) for every router chain."""
+    chains = []
+    pat = re.compile(r"traefik\.http\.routers\.([\w-]+)\.middlewares=([^\"']+)")
+    for path in sorted(COMPOSE_DIR.glob("*.yml")):
+        for line in path.read_text().splitlines():
+            m = pat.search(line)
+            if not m:
+                continue
+            raw = m.group(2)
+            # Strip a ${VAR:-default} wrapper and read the default, which is what
+            # production actually uses — the variable is an escape hatch, not the norm.
+            d = re.search(r"\$\{[A-Z_]+:-([^}]*)\}", raw)
+            if d:
+                raw = d.group(1)
+            names = [p.strip().split("@")[0] for p in raw.split(",") if p.strip()]
+            chains.append((path.name, m.group(1), names))
+    return chains
+
+
+def main() -> int:
+    if not MIDDLEWARES.exists():
+        print(f"FAIL: {MIDDLEWARES} not found", file=sys.stderr)
+        return 1
+
+    major, tag = traefik_major()
+    defined = defined_middlewares()
+    chains = referenced_chains()
+    failures: list[str] = []
+
+    print(f"Traefik pinned at {tag or '<unknown>'} (major {major or '?'})")
+    print(f"Middlewares defined: {len(defined)} — {', '.join(sorted(defined))}")
+    print(f"Router chains found: {len(chains)}")
+
+    if not major:
+        failures.append("Could not determine the pinned Traefik major version from "
+                        f"{COMPOSE_DIR}/*.yml — the version check cannot run.")
+    if not defined:
+        failures.append(f"No middleware definitions parsed from {MIDDLEWARES} — the "
+                        "reference check would pass vacuously.")
+    if not chains:
+        failures.append("No router middleware chains found — the ordering check would "
+                        "pass vacuously.")
+
+    # 1. references resolve
+    for fname, router, names in chains:
+        for n in names:
+            if n not in defined:
+                failures.append(
+                    f"{fname}: router '{router}' references middleware '{n}', which is "
+                    f"not defined in {MIDDLEWARES.name}. Traefik resolves references at "
+                    "request time, so the router will load and serve without it.")
+
+    # 2. types valid for the pinned major version
+    for name, typ in sorted(defined.items()):
+        allowed = VERSIONED_TYPES.get(typ)
+        if allowed and major and major not in allowed:
+            failures.append(
+                f"{MIDDLEWARES.name}: middleware '{name}' uses '{typ}', which exists "
+                f"only in Traefik {'/'.join(sorted(allowed))}, but the image is pinned "
+                f"at {tag}. Rename it — this is the silent-loss case: the routers that "
+                "depend on it keep serving with no allowlist.")
+
+    # 3. a location gate is never behind an authenticator
+    for fname, router, names in chains:
+        types = [(n, defined.get(n, "")) for n in names]
+        seen_auth: list[str] = []
+        for n, typ in types:
+            if typ in AUTHENTICATORS:
+                seen_auth.append(n)
+            elif typ in LOCATION_GATES and seen_auth:
+                failures.append(
+                    f"{fname}: router '{router}' orders '{n}' ({typ}) after "
+                    f"{', '.join(seen_auth)}. Chains run left to right, so an "
+                    "off-network request is challenged for credentials before being "
+                    f"refused. Put '{n}' first.")
+
+    print()
+    if failures:
+        print(f"FAIL — {len(failures)} problem(s):", file=sys.stderr)
+        for f in failures:
+            print(f"  - {f}", file=sys.stderr)
+        return 1
+    print("PASS — references resolve, types match the pinned version, and no IP "
+          "allowlist sits behind an authenticator.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/checks/test_edge_middlewares.py
+++ b/tests/checks/test_edge_middlewares.py
@@ -1,0 +1,119 @@
+"""The edge middleware check must catch each failure it exists to catch.
+
+A check that only ever passes is indistinguishable from no check. Each test here
+mutates a COPY of the real tree into one specific broken state and asserts the check
+fails on it, so the check's ability to fail is demonstrated rather than assumed.
+
+The v3 rename case is the one that matters most: it is the failure this whole file
+exists for, and it cannot be tested against the real tree because the real tree is
+correct today.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+CHECK = "scripts/checks/check_edge_middlewares.py"
+MW = "platform/edge/dynamic/middlewares.yml"
+INFRA = "deploy/compose/prod/docker-compose.infra.yml"
+
+
+def run(tree: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(tree / CHECK)],
+        capture_output=True, text=True, cwd=str(tree),
+    )
+
+
+@pytest.fixture
+def tree(tmp_path: Path) -> Path:
+    """A copy of the parts of the repo the check reads."""
+    dst = tmp_path / "repo"
+    for rel in (CHECK, MW, INFRA):
+        (dst / rel).parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(ROOT / rel, dst / rel)
+    # The check globs the compose dir; copy the rest so router chains are complete.
+    for f in (ROOT / "deploy" / "compose" / "prod").glob("*.yml"):
+        shutil.copy2(f, dst / "deploy" / "compose" / "prod" / f.name)
+    return dst
+
+
+def test_the_real_tree_passes(tree: Path) -> None:
+    """Baseline. If this fails, every mutation test below proves nothing."""
+    r = run(tree)
+    assert r.returncode == 0, f"unmutated tree should pass:\n{r.stdout}\n{r.stderr}"
+    assert "PASS" in r.stdout
+
+
+def test_catches_v3_bump_without_rename(tree: Path) -> None:
+    """THE case this file exists for: image bumped to v3, ipWhiteList left behind."""
+    p = tree / INFRA
+    p.write_text(p.read_text().replace("traefik:v2.11", "traefik:v3.1"))
+    r = run(tree)
+    assert r.returncode == 1
+    assert "ipWhiteList" in r.stderr
+    assert "v3" in r.stderr
+    # The message must say what happens, not just that something is wrong.
+    assert "no allowlist" in r.stderr.lower() or "silent" in r.stderr.lower()
+
+
+def test_catches_v2_using_the_v3_name(tree: Path) -> None:
+    """The mirror image: renamed too early, while still pinned at v2."""
+    p = tree / MW
+    p.write_text(p.read_text().replace("ipWhiteList:", "ipAllowList:"))
+    r = run(tree)
+    assert r.returncode == 1
+    assert "ipAllowList" in r.stderr
+
+
+def test_catches_a_reference_to_a_middleware_that_does_not_exist(tree: Path) -> None:
+    """A router pointing at a name with no definition — Traefik loads it anyway."""
+    p = tree / MW
+    p.write_text(p.read_text().replace("    tailscale-only:", "    tailscale-onlyy:"))
+    r = run(tree)
+    assert r.returncode == 1
+    assert "not defined" in r.stderr
+
+
+def test_catches_an_allowlist_ordered_behind_an_authenticator(tree: Path) -> None:
+    """The defect observed in production on 2026-07-31, reintroduced."""
+    p = tree / INFRA
+    p.write_text(p.read_text().replace(
+        "${TRAEFIK_MIDDLEWARES:-tailscale-only@file,auth@file}",
+        "${TRAEFIK_MIDDLEWARES:-auth@file,tailscale-only@file}",
+    ))
+    r = run(tree)
+    assert r.returncode == 1
+    assert "after auth" in r.stderr
+    assert "credentials before being refused" in r.stderr
+
+
+def test_does_not_pass_vacuously_when_definitions_are_missing(tree: Path) -> None:
+    """An empty middlewares file must fail, not pass with nothing to check.
+
+    Every 'is it defined' assertion is a negative, and negatives are satisfied by an
+    empty set. This is the guard against the check quietly measuring nothing.
+    """
+    (tree / MW).write_text("http:\n  middlewares:\n")
+    r = run(tree)
+    assert r.returncode == 1
+    assert "vacuously" in r.stderr or "not defined" in r.stderr
+
+
+def test_inline_bodied_middlewares_are_recognised(tree: Path) -> None:
+    """`compress: {}` is a complete definition and must not read as undefined.
+
+    An earlier version of the parser required the type key to be alone on its line,
+    so it silently dropped `compress`. Nothing referenced it, so nothing failed — the
+    bug was found by counting parsed names against the file. If a router ever
+    references it, a false 'not defined' failure would send someone hunting a
+    non-existent typo.
+    """
+    r = run(tree)
+    assert "compress" in r.stdout, f"compress should be parsed:\n{r.stdout}"


### PR DESCRIPTION
## The fix — one label

`traefik.hill90.com` was ordered `auth@file,tailscale-only@file`. Chains run left to right, so BasicAuth ran **first** and the IP allowlist was evaluated only after authentication. Measured off-tailnet on 2026-07-31 from `173.94.96.65` against the public address:

```
traefik.hill90.com    401   WWW-Authenticate: Basic realm="traefik"
portainer.hill90.com  403
grafana.hill90.com    403
vault.hill90.com      403
storage.hill90.com    403
litellm.hill90.com    403
```

Same protection for a legitimate tailnet user either way — a correct credential from off-tailnet would still have hit the allowlist — but as ordered it handed the public internet a credential prompt and a guessing oracle. Now `tailscale-only@file,auth@file`.

**Checked the other routers in the same pass:** portainer, grafana, vault and minio-console all use `${ADMIN_MIDDLEWARES:-tailscale-only@file}` — a single middleware, no ordering to get wrong. `traefik` was the only two-middleware chain, so it was the only violation. It's now **one rule, enforced**, rather than one fix.

## The v2/v3 hazard: yes, it can be checked

You asked whether a check could assert the middleware each tailnet-only router depends on actually resolves. It can, and more — `scripts/checks/check_edge_middlewares.py` asserts three properties by static parsing, wired into CI:

1. **Every `@file` reference resolves.** Traefik resolves middleware references at *request* time, not load time — a router pointing at a missing middleware loads and serves *without it*.
2. **Type keys match the pinned Traefik major version.** `ipWhiteList` (v2) → `ipAllowList` (v3). Bumping the image without renaming leaves a definition v3 doesn't recognise on exactly the five routers whose entire protection is that definition: they keep loading, keep serving, nothing logs an error. The check reads the image tag from `deploy/compose/prod` and **fails the build**.
3. **No IP allowlist behind an authenticator**, so the defect above can't return.

**Run against the tree before the fix, it failed** — naming the router and the consequence. That's why it's a check and not a comment.

`tests/checks/test_edge_middlewares.py` — 7 tests, each mutating a *copy* of the real tree into one broken state: v3 bump without the rename, the v3 name under v2, a dangling reference, the allowlist reordered behind auth, and an empty middlewares file (which must **fail**, not pass with nothing to check — every "is it defined" assertion is a negative, and negatives are satisfied by an empty set). A baseline test asserts the unmutated tree passes, or the mutation tests would prove nothing.

The comment stays and is now unmissable, pointing at the check that enforces it, with the instruction not to delete the check to get a version bump through.

**A bug in my own parser, found while writing this:** it required the type key alone on its line, so `compress: {}` was silently dropped. Nothing referenced it so nothing failed — I found it by counting parsed names against the file. A router referencing it would have produced a false "not defined" and sent someone hunting a typo that didn't exist. Fixed, with a test.

## Verification

Check passes on the fixed tree; **55 pytest passed / 1 skipped**; `tests/scripts/traefik-config.bats` still passes — including its own "no admin route relies on basic auth alone for network scoping", which checks **presence, not order**, and is why it never caught this.

No production change; read-only until this merges.

## Not in this PR — the api.hill90.com rate limit, and why it can't be

**It belongs in the other repo.** `app-api`'s router labels live in `hill90-app`'s `deploy/compose/prod/docker-compose.api.yml`, not here. Hill90 owns the `rate-limit@file` *definition*; the tenant owns the *reference*. So this is a hill90-app change that consumes a Hill90 middleware.

**Proposal, for Jon:** attach the existing `rate-limit@file` to `app-api` — the same `average: 100/s, burst: 50` the UI already uses.

Reasoning:
- **Symmetry is the argument.** The same limit is already proven in production on `app-ui` without disrupting anything, so it's the lowest-risk number available. Anything else is a new number to justify.
- **The asymmetry looks unintended.** `app-api` has *no* middleware at all while `app-ui` has one, and the API is the more attackable of the two surfaces.
- **It won't disrupt what actually uses `api.hill90.com`.** Browser traffic reaches the API via the UI's server-side proxy on the *internal* network, not through Traefik. The Traefik-facing traffic is WebSocket upgrades and direct API calls. `rateLimit` counts requests, so an established terminal session is one request and then long-lived; SSE endpoints likewise. Internal agent callbacks go to `http://api:3000/internal/...`, never through the edge.
- **One caveat worth stating:** the terminal client retries up to its `maxReconnects` with backoff, so a reconnect storm from a single IP would count against the burst. At 50 burst that's not reachable by one browser, but it is the thing to watch if the limit is ever lowered.

I have not made this change. Say the word and it's a one-label PR in hill90-app.