### PR TITLE
fix(vault): give the unseal unit room to wait, and make failure loud

### DIFF
--- a/docs/decisions/object-store.md
+++ b/docs/decisions/object-store.md
@@ -793,6 +793,14 @@ distinguish "no" from "could not ask".
 | `mc ls -r alias/bucket \| wc -l` with a wrong alias | "0 objects" | alias does not exist; the error went to stderr and was not counted |
 | `head -c 40 file \| grep -q 'ENC\['` | "the file is plaintext" | the file was zero bytes. Absence of an encryption marker is not presence of a secret |
 | `grep 'docker compose.*ps' deploy.sh` | "the bug is still there" | it matched the comment explaining the fix |
+| `ls -l platform/edge/dynamic/` | "`.htpasswd` is missing — dashboard auth will break on restart" | `ls -l` does not list dotfiles. The file was there all along. Use `ls -la` |
+| `grep -oE 'VAR:-[0-9]+' \| cut -d- -f3` | "the value is unset" | the name has no hyphen, so `:-120` splits into two fields and `-f3` is empty |
+| `grep -oE 'The "VAR" variable is not set'` | "compose is silent about it" | compose escapes the quotes (`\"VAR\"`); there were 14 warnings |
+
+Two of those are from checks written *while* cataloguing this failure mode, which is the
+point: the reflex to trust a command that returned nothing is very hard to unlearn. The
+rule that actually works is to make the check produce a **positive** result on a known
+input before believing a negative one on an unknown.
 
 The working version of the first one, for the runbook:
 

--- a/docs/runbooks/vault-unseal.md
+++ b/docs/runbooks/vault-unseal.md
@@ -197,6 +197,72 @@ sudo systemctl daemon-reload
 sudo systemctl enable hill90-vault-unseal
 ```
 
+## After a reboot — the checklist
+
+**As of 2026-07-31 the boot path has never actually run.** The unit became active on
+2026-07-26; the host last booted on 2026-07-21, five days earlier. It is enabled and its
+key file is in place, but "enabled" is not "exercised" — the same distinction as
+*reachable is not working*.
+
+So the first reboot is a test. Run this straight after one, in this order:
+
+```bash
+# 1. Platform baseline, BY NAME. A count alone hides which one is missing.
+for n in cadvisor grafana keycloak loki node-exporter openbao portainer postgres \
+         postgres-exporter prometheus promtail tempo traefik; do
+  docker ps --format '{{.Names}}' | grep -qx "$n" || echo "MISSING: $n"
+done
+docker ps --filter health=unhealthy -q | wc -l          # expect 0
+
+# 2. The unit itself. `is-active` is the answer; the journal says why.
+systemctl is-active hill90-vault-unseal                 # expect: active
+journalctl -u hill90-vault-unseal -b --no-pager         # expect a successful unseal
+
+# 3. The end state, not the unit's opinion of it.
+docker exec openbao bao status | grep -E '^(Initialized|Sealed)'   # Sealed: false
+
+# 4. The retirement held. A reboot must not resurrect a retired service.
+docker inspect app-minio --format '{{.State.Status}}'   # expect: exited
+docker ps -a --format '{{.Names}}' | grep -cE '^(app-postgres|app-keycloak)$'   # expect: 0
+
+# 5. Exactly ONE router claims the storage host.
+#    This is the check nobody thinks to include, and the one that catches a
+#    retirement undone by a reboot: app-minio still carries its Traefik labels,
+#    so if it came back there would be two routers on one rule — and because
+#    both backends are MinIO, the host would answer 200 either way.
+for c in $(docker ps -q); do
+  docker inspect "$c" --format '{{.Name}} {{index .Config.Labels "traefik.enable"}}' \
+  | grep -q true && docker inspect "$c" \
+      --format '{{range $k,$v := .Config.Labels}}{{$v}}{{println}}{{end}}' \
+  | grep -q 'storage.hill90.com' && docker inspect "$c" --format '  claimant: {{.Name}}'
+done                                                    # expect exactly one: /minio
+
+curl -s -o /dev/null -w '%{http_code}\n' https://hill90.com/            # expect 200
+curl -s -o /dev/null -w '%{http_code}\n' https://storage.hill90.com/    # expect 200
+```
+
+If step 2 says `failed`, that is the design working — see below — and step 3 will tell
+you whether it is sealed or something stranger.
+
+### What the unit does now when it goes wrong
+
+`Restart=on-failure` with `RestartSec=30`, bounded by `StartLimitBurst=3` inside a
+30-minute window. So:
+
+| Situation | What happens |
+|---|---|
+| Slow boot | Usually succeeds first attempt; otherwise retries after 30s |
+| Missing unseal key | Fails in about a second, three attempts, `failed` within ~90s |
+| Hung dependency | Attempts take the full 300s; `failed` at ~17min. It does not spin |
+
+It ends in `failed` and **stays** there rather than looping quietly. That is deliberate:
+a retry that hides a persistent failure trades a visible outage for an invisible one.
+
+`ExecStartPost=vault.sh assert-unsealed` is what makes that possible. `auto-unseal`
+returns 0 when the container never appears — correct on a fresh VPS, wrong at boot on a
+live host, where it would exit 0 with OpenBao still sealed. The assertion separates
+"not deployed" (0) from "deployed and still sealed" (1).
+
 ## See Also
 
 - [Secrets Architecture](../architecture/secrets-model.md) — vault architecture overview

--- a/infra/systemd/hill90-vault-unseal.service
+++ b/infra/systemd/hill90-vault-unseal.service
@@ -3,13 +3,65 @@ Description=Hill90 OpenBao Auto-Unseal
 After=docker.service
 Requires=docker.service
 
+# The rate limit lives here, not in [Service], and it is what stops a genuinely
+# broken vault from retrying forever. The window is deliberately wider than three
+# full attempts (3 x ~330s = ~17min < 30min), so it is the burst limit that
+# trips, not the window rolling over and resetting the count.
+StartLimitIntervalSec=1800
+StartLimitBurst=3
+
 [Service]
 Type=oneshot
 User=deploy
 Group=deploy
 ExecStart=/opt/hill90/app/scripts/vault.sh auto-unseal
+
+# Assert the END STATE, because ExecStart's exit code does not.
+#
+# `vault.sh auto-unseal` returns 0 when the container never appears — correct on
+# a fresh VPS, where OpenBao is not deployed and a failed unit would be noise. At
+# boot on a live host that is exactly the failure that matters, and it would exit
+# 0 with OpenBao still sealed and nothing marking it. assert-unsealed separates
+# "not deployed" (0) from "deployed and still sealed" (1), so the unit ends in
+# `failed` instead of a quiet success. Restart= below only ever fires because of
+# this line.
+ExecStartPost=/opt/hill90/app/scripts/vault.sh assert-unsealed
+
 Environment=SOPS_AGE_KEY_FILE=/opt/hill90/secrets/keys/keys.txt
-TimeoutStartSec=180
+
+# DELIBERATELY LARGER THAN THE SCRIPT'S OWN BUDGET. Do not "tidy" these to match.
+#
+# vault.sh auto-unseal waits up to VAULT_AUTO_UNSEAL_TIMEOUT (120s) for the
+# container, then up to 60s more for the API: 180s worst case. This was
+# TimeoutStartSec=180 — exactly equal — so a boot where OpenBao was merely slow
+# got the script killed inside its own documented wait, at the moment it was
+# about to succeed, and Type=oneshot with no Restart meant nothing retried.
+#
+# The two numbers must NOT agree. systemd's timeout is a backstop for a script
+# that has hung; it is not the script's deadline. The headroom means the script
+# always reaches its own failure path, which prints a diagnostic naming what it
+# was waiting for, instead of dying by signal with nothing said.
+#
+# If VAULT_AUTO_UNSEAL_TIMEOUT is ever raised, raise this above it too.
+TimeoutStartSec=300
+
+# A slow boot deserves a retry; a misconfigured vault deserves to stop and be
+# seen. Both fall out of these two settings plus StartLimit* above:
+#
+#   slow boot       ExecStart usually wins on attempt 1. If not, 30s is long
+#                   enough for the rest of the stack to settle, and short enough
+#                   that recovery is not itself an outage.
+#   broken config   a missing unseal key fails in about a second, so three
+#                   attempts are spent in ~90s and the unit is `failed` and
+#                   visible almost immediately.
+#   hung dependency attempts take the full 300s; the third ends at ~17min and
+#                   the unit stays `failed`. It does not spin.
+#
+# Restart=on-failure, NOT always: systemd rejects `always` for Type=oneshot, and
+# it would also restart after the success that is meant to be terminal.
+Restart=on-failure
+RestartSec=30
+
 RemainAfterExit=yes
 
 [Install]

--- a/scripts/vault.sh
+++ b/scripts/vault.sh
@@ -42,6 +42,7 @@ Commands:
   backup        Backup OpenBao data volume
   export        Export all KV v2 secrets to stdout (requires BAO_TOKEN)
   auto-unseal         Wait for container + unseal (for systemd/deploy hooks)
+  assert-unsealed     Exit non-zero if OpenBao is deployed but still sealed
   sync-to-sops        Sync vault secrets back to SOPS backup (requires BAO_TOKEN)
   setup-sync-token    Create a read-only sync token and store in SOPS (requires BAO_TOKEN)
   bootstrap-approles  Generate AppRole credentials for all services and store in SOPS
@@ -884,6 +885,38 @@ cmd_auto_unseal() {
     cmd_unseal
 }
 
+# Assert the end state, not the exit code of the attempt.
+#
+# WHY THIS EXISTS: cmd_auto_unseal returns 0 when the container never appears —
+# deliberately, because on a fresh VPS OpenBao is not deployed yet and a failed
+# unit there would be noise. But at BOOT on a live host that is precisely the
+# failure that matters: the unit exits 0, having done nothing, and OpenBao stays
+# sealed with nothing marking it. On a homelab that silence can last days.
+#
+# So the systemd unit runs this afterwards. It separates the two cases the exit
+# code conflates:
+#
+#   container absent    -> 0. Nothing to unseal. Fresh VPS, or vault not deployed.
+#   container + unsealed-> 0. The good path.
+#   container + sealed  -> 1. Loud: the unit goes to `failed` and stays there.
+#
+# `bao status` exits 0 unsealed, 2 sealed, 1 on error — so anything non-zero
+# here is a real problem, and an error is reported as one rather than swallowed.
+cmd_assert_unsealed() {
+    if ! docker container inspect "$CONTAINER_NAME" >/dev/null 2>&1; then
+        echo "OpenBao container '${CONTAINER_NAME}' is not deployed — nothing to assert."
+        return 0
+    fi
+
+    local rc=0
+    bao_exec status >/dev/null 2>&1 || rc=$?
+    case "$rc" in
+        0) success "OpenBao is unsealed." ;;
+        2) die "OpenBao is STILL SEALED after auto-unseal ran. Nothing that depends on Vault will resolve a secret until this is fixed: bash scripts/vault.sh unseal (see docs/runbooks/vault-unseal.md)" ;;
+        *) die "Could not determine OpenBao seal state (bao status exit ${rc}). Treating as failed rather than assuming healthy." ;;
+    esac
+}
+
 # ---------------------------------------------------------------------------
 # Main dispatcher
 # ---------------------------------------------------------------------------
@@ -910,6 +943,7 @@ main() {
         backup)        cmd_backup "$@" ;;
         export)        cmd_export "$@" ;;
         auto-unseal)        cmd_auto_unseal "$@" ;;
+        assert-unsealed)    cmd_assert_unsealed "$@" ;;
         sync-to-sops)       cmd_sync_to_sops "$@" ;;
         setup-sync-token)   cmd_setup_sync_token "$@" ;;
         bootstrap-approles) cmd_bootstrap_approles "$@" ;;

--- a/tests/scripts/vault.bats
+++ b/tests/scripts/vault.bats
@@ -380,6 +380,83 @@
   [ "$status" -eq 0 ]
 }
 
+# ---------------------------------------------------------------------------
+# Boot path: the unit must survive a slow OpenBao, and must be loud when it does
+# not. Guards the state found on 2026-07-31, when TimeoutStartSec was exactly
+# equal to the script's own worst case and nothing retried.
+# ---------------------------------------------------------------------------
+
+@test "systemd TimeoutStartSec exceeds the script's own worst-case wait" {
+  # THE regression this file exists to prevent. vault.sh waits up to
+  # VAULT_AUTO_UNSEAL_TIMEOUT for the container plus 60s for the API. If
+  # systemd's timeout only equals that, a merely-slow boot kills the script
+  # inside its documented wait — which is what used to happen. The two numbers
+  # must not be "tidied" into agreement.
+  local unit="infra/systemd/hill90-vault-unseal.service"
+  local systemd_timeout script_budget api_wait=60
+  systemd_timeout=$(grep -oE '^TimeoutStartSec=[0-9]+' "$unit" | cut -d= -f2)
+  # sed, not `cut -d-`: the variable name has no hyphen, so `:-120` splits into
+  # two fields and -f3 is empty. That mistake made this very test fail closed.
+  script_budget=$(grep -oE 'VAULT_AUTO_UNSEAL_TIMEOUT:-[0-9]+' scripts/vault.sh | head -1 | sed -E 's/.*:-([0-9]+)/\1/')
+
+  [ -n "$systemd_timeout" ]
+  [ -n "$script_budget" ]
+  [ "$systemd_timeout" -gt "$(( script_budget + api_wait ))" ] \
+    || { echo "TimeoutStartSec=${systemd_timeout} does not exceed ${script_budget}+${api_wait}"; return 1; }
+}
+
+@test "systemd retries a failed unseal, but a bounded number of times" {
+  local unit="infra/systemd/hill90-vault-unseal.service"
+  grep -qE '^Restart=on-failure' "$unit" || { echo "no Restart=on-failure"; return 1; }
+  grep -qE '^RestartSec=[0-9]+' "$unit"  || { echo "no RestartSec"; return 1; }
+  # Unbounded retry would trade a visible outage for an invisible loop.
+  grep -qE '^StartLimitBurst=[0-9]+' "$unit" || { echo "no StartLimitBurst — retries are unbounded"; return 1; }
+}
+
+@test "the retry window is wider than the attempts it must contain" {
+  # If StartLimitIntervalSec is shorter than burst x (timeout + RestartSec), the
+  # window rolls over before the burst limit trips and the unit retries forever.
+  local unit="infra/systemd/hill90-vault-unseal.service"
+  local window burst timeout restsec
+  window=$(grep -oE '^StartLimitIntervalSec=[0-9]+' "$unit" | cut -d= -f2)
+  burst=$(grep -oE '^StartLimitBurst=[0-9]+' "$unit" | cut -d= -f2)
+  timeout=$(grep -oE '^TimeoutStartSec=[0-9]+' "$unit" | cut -d= -f2)
+  restsec=$(grep -oE '^RestartSec=[0-9]+' "$unit" | cut -d= -f2)
+  [ "$window" -gt "$(( burst * (timeout + restsec) ))" ] \
+    || { echo "window ${window}s <= ${burst} x (${timeout}+${restsec})s — the burst limit may never trip"; return 1; }
+}
+
+@test "systemd asserts the end state, not just the exit code" {
+  # auto-unseal returns 0 when the container never appears. At boot that is the
+  # failure that matters, so something must check whether OpenBao is ACTUALLY
+  # unsealed afterwards.
+  run grep "ExecStartPost=.*/vault.sh assert-unsealed" infra/systemd/hill90-vault-unseal.service
+  [ "$status" -eq 0 ]
+}
+
+@test "vault.sh exposes assert-unsealed and documents it" {
+  run bash scripts/vault.sh help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"assert-unsealed"* ]]
+  grep -q 'assert-unsealed)' scripts/vault.sh
+}
+
+@test "assert-unsealed exits 0 when the container is absent" {
+  run env VAULT_CONTAINER=definitely-not-a-container-h90 bash scripts/vault.sh assert-unsealed
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"not deployed"* ]]
+}
+
+@test "assert-unsealed fails loudly when seal state cannot be determined" {
+  # A container that exists but has no working `bao` must NOT be read as healthy.
+  if ! docker container inspect "${BATS_PROBE_CONTAINER:-traefik}" >/dev/null 2>&1; then
+    skip "no spare container to probe with"
+  fi
+  run env VAULT_CONTAINER="${BATS_PROBE_CONTAINER:-traefik}" bash scripts/vault.sh assert-unsealed
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Treating as failed rather than assuming healthy"* ]]
+}
+
 @test "auto-unseal exits 0 when no container (graceful skip)" {
   # Set a very short timeout and use a non-existent container name
   # to verify the graceful skip path (exits 0, not an error)


### PR DESCRIPTION
`TimeoutStartSec=180` was **exactly** the script's own worst case — `vault.sh auto-unseal` waits up to `VAULT_AUTO_UNSEAL_TIMEOUT` (120 s) for the container, then 60 s more for the API. A boot where OpenBao was merely slow got the script killed inside its documented wait, at the moment it was about to succeed. `Type=oneshot` with no `Restart=` meant nothing retried, so OpenBao would stay sealed until a human noticed — on a homelab, days.

## The two settings are one design

The unit now says so, in the file, because the next person to read `180` and `120+60` will otherwise tidy them into agreement.

**`TimeoutStartSec=300`, deliberately larger than the script's budget.** systemd's timeout is a backstop for a script that has *hung* — it is not the script's deadline. The headroom means the script always reaches its own failure path, which prints a diagnostic naming what it was waiting for, instead of dying by signal with nothing said.

**`VAULT_AUTO_UNSEAL_TIMEOUT` was not lowered.** Shortening the script's patience to fit the unit is the wrong direction; that budget was chosen for a reason.

**`Restart=on-failure`, `RestartSec=30`, bounded by `StartLimitBurst=3` in a 30-minute window.**

| Situation | What happens |
|---|---|
| Slow boot | Usually first attempt; otherwise retries after 30 s |
| Missing unseal key | Fails in ~1 s → three attempts → `failed` within ~90 s |
| Hung dependency | Full 300 s each; `failed` at ~17 min. Does not spin |

`StartLimitIntervalSec=1800` is wider than three full attempts on purpose — a shorter window rolls over before the burst limit trips, and the retry never stops. There is a test for exactly that arithmetic.

## The loudness hole was worse than the timeout

`cmd_auto_unseal` **returns 0 when the container never appears.** Correct on a fresh VPS. Exactly wrong at boot on a live host: it exits 0 with OpenBao still sealed and nothing marking it — and `Restart=on-failure` cannot fire on an exit code of 0. The retry alone would not have caught the most likely boot failure.

So `ExecStartPost` runs a new `vault.sh assert-unsealed`, which asserts the **end state** and separates what the exit code conflates:

| Case | Exit |
|---|---|
| Container absent (fresh VPS) | 0 — nothing to assert |
| Deployed and unsealed | 0 |
| Deployed and **still sealed** | 1 — loud, unit goes `failed` |
| Seal state indeterminate | 1 — treated as failed, not assumed healthy |

**All four branches were exercised, not reasoned about.** Absent and unsealed against production read-only; indeterminate against a container with no `bao` (`exit 127` → correctly failed); and the **sealed** branch against the *local* OpenBao, which is uninitialised — production was never sealed to test it. The production checkout was restored and verified clean (`0 modified files`).

The unit also passes `systemd-analyze verify` cleanly, which confirms `Restart=on-failure` is legal with `Type=oneshot` rather than my remembering that it is.

## Tests

Six new, and the one that matters asserts the **relationship** rather than either number: `TimeoutStartSec` must exceed the script's budget plus the API wait. Proven by reintroducing the regression —

- setting it back to `180` → `not ok 54 systemd TimeoutStartSec exceeds the script's own worst-case wait`
- deleting `Restart=on-failure` → `not ok 55 systemd retries a failed unseal, but a bounded number of times`

restored → 86 ok, 0 failures. One of the new tests was itself wrong first time (`cut -d-` on a variable name containing no hyphen, so the field was empty and it failed closed). That is the same shape as the `ls -l` finding, and both are now in the "checks that lie" table along with the escaped-quote one.

## Post-reboot checklist — in the runbook, and here

**The boot path has never run.** The unit became active 2026-07-26; the host last booted 2026-07-21. Enabled is not exercised. The first reboot is the test:

1. **Platform baseline by name** — all 13 present, `docker ps --filter health=unhealthy -q | wc -l` = 0
2. `systemctl is-active hill90-vault-unseal` → `active`, with `journalctl -u ... -b` for the why
3. `docker exec openbao bao status` → `Sealed: false` — the end state, not the unit's opinion of it
4. `app-minio` still `exited`, and `app-postgres`/`app-keycloak` count = **0**
5. **Exactly one router claims `storage.hill90.com`** — the check nobody thinks to include. `app-minio` still carries its Traefik labels, and both backends are MinIO, so a resurrected one would answer **200 and look fine**
6. `hill90.com` and `storage.hill90.com` both 200

## Not applied

The unit is installed by Ansible playbook `11-vault-unseal.yml` via the **Config VPS** workflow. I have not run it, and the only real test is a reboot you schedule. Nothing on the host was changed by this work — the only host commands were read-only, plus one temporary script copy that was restored and verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)