### PR TITLE
docs(rebuild): link the cold-start budgets, and stop under-promising the wait

### DIFF
--- a/docs/runbooks/vps-rebuild.md
+++ b/docs/runbooks/vps-rebuild.md
@@ -150,6 +150,17 @@ make deploy-observability   # or: bash scripts/deploy.sh observability prod
 
 ### Step 5: Health Verification
 
+**A container reporting `unhealthy` partway through a rebuild is usually not a
+failure.** A rebuilt host starts every service against empty volumes, and
+several do one-time first-boot work before they can answer a probe at all —
+Keycloak imports the realm and migrates its schema, OpenBao initialises, Tempo
+builds its local blocks. Their healthchecks budget for it (`keycloak`
+`start_period: 90s`, `tempo` `180s`, `openbao` `60s`), so the window in which
+they legitimately look dead is minutes, not seconds.
+
+Intervening during that window is the actual risk. Let `make health` be the
+judge rather than `docker ps` read early.
+
 Verify all services are healthy:
 
 ```bash
@@ -329,6 +340,27 @@ ssh deploy@<vps-ip> "cd /opt/hill90/app && docker compose logs"
 
 **Total rebuild time:** ~8-13 minutes (3-5 min + 3-5 min + 2-3 min)
 
+**What that figure does not include.** It covers the platform steps above and
+nothing else. The **tenant application is a separate repository with a
+manually-dispatched deploy** and is not part of a rebuild; its first deploy onto
+a rebuilt host is the slow one, because every database is empty and services
+migrate before they serve. `litellm` alone has been measured taking minutes in
+that state.
+
+Those measurements live in the tenant repo:
+[hill90-app — Cold start: which healthchecks survive an empty database](https://github.com/jonhill90/hill90-app/blob/main/docs/runbooks/cold-start-budgets.md).
+
+**They are not platform numbers.** They were taken on an Apple Silicon laptop
+against the tenant stack, not on the VPS, and this hardware is different. Read
+them for the *shape* of the problem — first boot is minutes, later boots are
+seconds, and the gap is what makes an optimistic timeout look fine until a
+rebuild — not as an ETA for this host.
+
+**Not measured on the VPS:** cold-start time for any platform service after a
+real rebuild. The figures above are estimates carried from earlier rebuilds; the
+next rebuild is the chance to replace them with observed numbers, and it is
+worth capturing them while it runs.
+
 ---
 
 ## Security Considerations
@@ -351,3 +383,6 @@ ssh deploy@<vps-ip> "cd /opt/hill90/app && docker compose logs"
 - [Bootstrap Runbook](bootstrap.md)
 - [Contributing Guide](../../CONTRIBUTING.md)
 - [Health Check Script](../../scripts/ops.sh)
+- [hill90-app — cold-start budgets](https://github.com/jonhill90/hill90-app/blob/main/docs/runbooks/cold-start-budgets.md)
+  — measured start-up times for the tenant stack, and why an optimistic
+  `start_period` only fails on a rebuild. Tenant measurements, not platform ones.


### PR DESCRIPTION
**The link itself was two lines. Checking the runbook's claims first, as you asked, was not** — it makes two that my measurements bear on.

## The link

Full GitHub URL, matching how this repo already references the tenant (`app-tenancy-on-the-vps.md`, `CONTRIBUTING.md`). Not a relative path: `check_md_links.py` classifies `http(s)` as external and skips it, while a cross-repo relative path would be treated as **local and fail**. Verified both ways —

```
https://github.com/jonhill90/hill90-app/blob/main/docs/...  external=True
bootstrap.md                                                external=False
```

— and the target confirmed present on `hill90-app` main (4917 bytes), so it is not a dead link.

## What contradicted the measurements

**"Total rebuild time: ~8-13 minutes" is left exactly as it was.** I have not measured a real rebuild, and replacing one unmeasured number with another is not an improvement. What it lacked was *scope*, which I have added: it covers the platform steps and nothing else. The tenant application is a separate repository with a manually-dispatched deploy — **not part of a rebuild at all** — and its *first* deploy onto a rebuilt host is the slow one, because every database is empty and services migrate before they serve.

**Step 5 said nothing about what healthy looks like partway through**, which is the exact failure mode: a rebuilt host starts every service against empty volumes, several do one-time first-boot work before they can answer a probe, and their own healthchecks budget minutes for it. Someone reading `docker ps` early sees `unhealthy` and intervenes mid-migration.

The numbers I used there are **this repo's own declared budgets** — `keycloak` `start_period: 90s`, `tempo` `180s`, `openbao` `60s` — not my laptop's.

## On not importing tenant numbers

The linked measurements are labelled, in both places they appear, as tenant-path figures taken on an Apple Silicon laptop — **not platform numbers for this hardware**. The runbook says to read them for the *shape* of the problem (first boot is minutes, later boots are seconds, and that gap is what makes an optimistic timeout look fine until a rebuild), not as an ETA.

It also now records what has **not** been measured: cold-start time for any platform service after a real rebuild. The next rebuild is the chance to replace estimates with observations, and it says so, so the opportunity is not missed again.

## Found but deliberately not fixed

Fixing these means restructuring the Overview, which is a different change and would be inflating this one. Reporting so they are on the record:

- The Overview lists **4 steps**; the body has **5**.
- Overview step 4 is *"Deploy All — Application service deployment"*, but the body's step 4 is **Deploy Observability**, and **no step deploys the tenant app**.
- The Automation Summary claims **"Application deployment"** is fully automated. It is a separate, manually-dispatched workflow in another repository.
- That summary's manual-step list numbers **1, 2, 3, 4, 5, 6, 8**.
- *"~8-13 minutes (3-5 min + 3-5 min + 2-3 min)"* sums **three terms for four listed steps** — the 1-2 minute infra step is missing from the arithmetic.

Docs only. No code, no production, nothing on the host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)