### PR TITLE
docs: handoff for a cold session, and correct three CLAUDE.md claims that had gone false

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,9 @@ nothing. It is a **platform**: it hosts tenants but is not the application.
 - [`docs/architecture/`](docs/architecture/) — how the pieces fit, plus
   [`certificates.md`](docs/architecture/certificates.md), which is the recovery
   path if ACME goes wrong.
+- [`docs/decisions/2026-07-31-handoff.md`](docs/decisions/2026-07-31-handoff.md) — **start
+  here if you are cold.** Where the estate stands, what is verified versus not checked, the
+  negative results, and the open decisions.
 - [`docs/decisions/`](docs/decisions/) — why things are the way they are.
   [`app-tenancy-on-the-vps.md`](docs/decisions/app-tenancy-on-the-vps.md) defines
   what this platform offers a tenant;
@@ -169,11 +172,13 @@ the migration run — but say "nothing worth preserving", not "empty".
 
 ## Still not done — do not let these read as finished
 
-- **`app-keycloak` and realm `hill90` are still running.** One realm is live on the
-  platform, but nothing has been retired. Accounts now exist in *both* places: `jon`,
-  `hill90admin` and `testuser01` in platform realm `platform`, and the same three in
-  realm `hill90` on the tenant's own Keycloak.
-- **`app-postgres` is still running and still serving.** See above.
+- **Both are now retired — this section previously said they were not.** `app-keycloak`
+  went on 2026-07-30 and `app-postgres` on 2026-07-31. Realm `hill90` is gone from the
+  live directory, which now holds `master, platform` only. Their data was kept: a realm
+  export with users, a per-table-verified dump of all five databases, and the volume
+  `prod_app-postgres-data`. See
+  [2026-07-31-handoff.md](docs/decisions/2026-07-31-handoff.md) for what remains of each
+  and where. `Verified 2026-07-31 06:21 UTC`.
 - **Declaring a client in `platform-realm.json` does NOT put it in a realm that
   already exists.** `start --import-realm` is `IGNORE_EXISTING`, so the file is read
   only on first boot — `keycloak.sh`'s own header says so, and #584 shipped clients
@@ -207,18 +212,27 @@ the migration run — but say "nothing worth preserving", not "empty".
   rebuild** is the case that depends on it, and it must equal the value hill90-app
   holds. `check_env_surface.py` deliberately allows it no default: a fallback would
   import a *known* secret for the client fronting hill90.com and say nothing.
-- **Keycloak event storage is off** — `events_enabled=false` on both `master` and
-  `platform`, `Verified 2026-07-30 02:07 UTC`. That is why "has anyone actually
-  logged in?" cannot be answered from the host: sessions live in Infinispan, not the
-  database, and `event_entity` is empty because nothing writes to it. An empty
-  `event_entity` is **not** evidence that nobody logged in. Turning login events on
-  would make the estate's most-repeated question checkable instead of anecdotal.
+- **Keycloak event storage is now ON** — `events_enabled=true` on both `master` and
+  `platform`, `Verified 2026-07-31 06:21 UTC`, reversing the gap this entry used to
+  record. "Has anyone actually logged in?" is answerable from the database **for logins
+  from here on**. It says nothing about earlier ones: an empty `event_entity` for a past
+  date is still **not** evidence that nobody logged in, because nothing was writing to it
+  then.
 
 ## Genuinely open
 
-**MinIO, and the state is reversed from the other two.** Only `app-minio` exists;
-there is **no platform MinIO**. So the question is whether storage moves *up* into
-the platform, which the governing principle suggests it should. Never addressed.
+**MinIO is settled and shipped — this entry used to say it was never addressed.** A
+platform MinIO runs (`Verified 2026-07-31 06:21 UTC`, healthy) and the tenant was cut over
+to it; storage moved *up*, as the governing principle indicated. `app-minio` was stopped
+2026-07-31 01:40:43 UTC and is **not yet removed**: its retention window expires
+**2026-08-01 01:41 UTC**, and deleting `prod_app-minio-data` is a separate, irreversible
+decision.
+
+**What is genuinely open now is Jon's, not a lane's** — repository visibility for
+hill90-app with the history-rewrite costs, whether the tenant's local stack moves onto the
+platform services, and a reboot to validate the vault auto-unseal path. All of them are
+stated with their evidence in
+[2026-07-31-handoff.md](docs/decisions/2026-07-31-handoff.md).
 
 ## Fast facts
 

--- a/docs/decisions/2026-07-31-handoff.md
+++ b/docs/decisions/2026-07-31-handoff.md
@@ -1,0 +1,145 @@
+# Handoff — where this estate stands, 2026-07-31
+
+A statement of current truth, not a changelog. Every perishable claim carries the time it
+was checked. Where something was not checked, it says so rather than hedging.
+
+**All measurements below: `Verified 2026-07-31 06:21 UTC`** unless stated otherwise.
+
+## The shape of the estate right now
+
+The platform runs 13 long-standing containers plus a new MinIO — `cadvisor grafana
+keycloak loki node-exporter openbao portainer postgres postgres-exporter prometheus
+promtail tempo traefik` and `minio` — all present, **0 unhealthy**. The tenant
+(hill90-app) runs **7 containers, all healthy**, alongside them and outside that count.
+
+`hill90.com` 200, `auth.hill90.com/realms/platform` 200, `api.hill90.com/health` 200.
+
+**The platform baseline is now 13 + MinIO.** Anything still asserting a flat 13 as the
+whole platform is describing yesterday.
+
+## Retired, and what remains of each
+
+| What | Retired | What remains |
+|---|---|---|
+| `app-keycloak` | 2026-07-30 | realm export **with users** on the VPS under `/opt/hill90/backups/app-realm-final/`, 0600 in a 0700 directory. `app-auth.hill90.com` returns 404. |
+| realm `hill90` | with app-postgres | **gone from the live directory** — the Keycloak database now holds `master, platform` only. It survives in the export above and inside the retained tenant volume. |
+| `app-postgres` | 2026-07-31 | volume `prod_app-postgres-data` **deliberately kept**, plus dumps of all five databases at `/opt/hill90/backups/app-postgres-final/`, restore-proven per-table before removal. |
+| `app-minio` | stopped 2026-07-31 01:40:43 UTC, **not removed** | volume `prod_app-minio-data` kept. Container still present in `Exited (0)`. |
+
+Identity is the platform's Keycloak, realm `platform`, and authorization is by **client**
+roles on `hill90-ui` — not realm roles. That distinction is load-bearing: realm `platform`
+has a realm role also named `admin`, and holding it does not grant application access.
+
+The tenant's data is on the platform Postgres: `hill90_api`, `hill90_akm`,
+`hill90_litellm`, owned by `hill90_app`, which is **`superuser=false`**.
+
+## Rotated, and how it was proven
+
+Two credentials were rotated on 2026-07-31. Both were proven **in both directions** —
+new value accepted, old value refused — because a rotation tested only positively is half
+a rotation.
+
+- **`DB_PASSWORD`** (platform Postgres superuser). New value 32 chars `[A-Za-z0-9]`.
+  Proven over the **network** from a separate container on `hill90_internal`, not locally:
+  `pg_hba` grants `local ... trust`, so `docker exec … psql` authenticates regardless of
+  the password and proves nothing. Loopback and the Docker bridge were both refused; a
+  tailnet-range source was admitted. Full procedure in
+  [platform-postgres-password-rotation.md](../runbooks/platform-postgres-password-rotation.md).
+- **`KC_ADMIN_PASSWORD`** (Keycloak master admin). Proven live by obtaining a Bearer token
+  from the running Keycloak with the store's value, and by a wrong value being refused
+  `invalid_grant` in the same run.
+
+**Not rotated, and the reasoning is recorded rather than deferred:** the tailnet address
+and the SSH alias in hill90-app's git history — see *Open decisions* below.
+
+## Verified this cycle
+
+- **The terminal WebSocket is hardened and the hardening is proven in production.** One
+  valid `testuser01` token, three requests: allowed Origin → **101**, disallowed Origin →
+  **403**, same token in the query string → **401**. Three consecutive rounds, identical.
+  The Origin check is real, and the query-string path is gone rather than deprecated.
+- **The edge allowlist admits only the Tailscale CGNAT range.** A tailnet address gets 401
+  (admitted, then challenged); IPv4 and IPv6 loopback and the Docker bridge get 403 with no
+  challenge. Corroborated by Traefik's own `ClientHost` field, not inferred from where the
+  command ran. Recorded in [security.md](../architecture/security.md).
+- **`traefik.hill90.com` no longer hands the internet a credential prompt.** Its middleware
+  order was `auth,tailscale-only`; it is now allowlist-first, deployed and verified
+  off-tailnet: **401 → 403, `WWW-Authenticate` gone**. A CI check now fails if an IP
+  allowlist is ever ordered behind an authenticator, if a router references a middleware
+  that does not exist, or if a middleware's type key does not match the pinned Traefik
+  major — the `ipWhiteList` → `ipAllowList` rename in v3 being the case that would
+  otherwise remove the allowlist silently.
+- **Keycloak event storage is ON** — `events_enabled=true` on both `master` and `platform`.
+  This reverses a long-standing gap: "has anyone actually logged in" is now answerable from
+  the database for logins *from here on*. It says nothing about earlier logins, and an
+  empty `event_entity` for a past date is still not evidence that nobody logged in.
+
+## Not checked, and honestly so
+
+- **A sign-in completed before event storage was enabled cannot be confirmed from the
+  host.** A sign-in on 2026-07-30 is recorded on an operator's account, not measured.
+- **A real terminal PTY session.** The handshake is proven to upgrade; no shell traffic has
+  been carried end to end in production. The fixture used for the 101 had no container
+  behind it.
+- **The tenant's cold-start budgets on the VPS.** They were measured on an Apple Silicon
+  laptop on 2026-07-31 (tenant path, volumes destroyed between runs). A VPS rebuild starts
+  from empty volumes by definition, which is exactly the case those budgets exist for, and
+  it has not been measured there.
+- **The vault auto-unseal fix across a reboot.** The `hill90-vault-unseal` unit is
+  `enabled` and OpenBao is currently unsealed, but **host uptime is 1 week 3 days** — there
+  has been no reboot since, so the boot path is untested in practice.
+
+## Negative results, which are half the value
+
+- **Five hypotheses for the api-suite flake are dead, each by measurement or reachability**,
+  and the suite is still unreliable at roughly a third of runs. The positional
+  `mockResolvedValueOnce` queue (a file with **zero** `Once(` calls flakes anyway);
+  misrouted supertest servers (**455 of 470** captured 404s were handler JSON); leaked
+  timers cleared at the test boundary (**6/20** with clearing); unawaited promises (the only
+  two genuine ones are unreachable from the affected paths); and the SSE handler leak —
+  which was **real, was fixed, and did not help**: **7/20** afterwards, with
+  P(≥7 at the pooled 21% baseline) = 0.117. Full record with per-run outcomes in
+  hill90-app's `docs/decisions/api-suite-flakiness.md`. **There is no outstanding
+  hypothesis.**
+- **A green run of hill90-app's api suite is not evidence that a change is safe.**
+  Re-checked by measurement on 2026-07-31, not left standing out of neglect.
+- **The `api.hill90.com` rate-limit asymmetry is an open proposal, not a defect.** The
+  tenant's UI carries the shared rate-limit middleware; its API carries no middleware at
+  all. Proposed: attach the same limit, on the grounds that the identical value is already
+  proven in production on the UI. It is the **tenant's** change — the platform owns the
+  middleware definition, the tenant owns the reference — and it has not been made.
+- **A history rewrite would not conceal the tailnet address**, because public DNS already
+  serves it for six hostnames in the zone. If that address is the concern, the fix is in
+  DNS, not git.
+
+## Open decisions — Jon's, not a lane's
+
+1. **Repository visibility for hill90-app.** The current tree contains neither the tailnet
+   address nor the SSH alias; the exposure is in history only, and the repository is still
+   private, so a rewrite performed *before* first publication is effective while one after
+   is not. Costs are measured, not estimated: **59 commits** contain the address (1 path),
+   **380** contain the SSH alias (4 paths), and the author email is commit **metadata on
+   essentially every commit** — so removing it changes all **619** SHAs. Zero merge commits
+   in the range; all three tags point inside it; 74 squash-merged PRs record SHAs that would
+   cease to exist. By what an attacker gains: **SSH alias > email > tailnet address**, the
+   reverse of the removal cost. Full costing in hill90-app's
+   `docs/decisions/publishing-and-history-rewrite-cost.md`. **No recommendation — risk
+   tolerance is the input.**
+2. **Whether the tenant's local stack moves onto the platform services.** The platform half
+   is done and proven; the tenant's local stack still points at its own `app-keycloak` and
+   its own Postgres, so local proves the realm design and not yet the tenancy. Retiring
+   those compose files would break local development, which is why they were kept with
+   retirement banners rather than deleted.
+3. **A reboot, to validate the vault auto-unseal path.** Cheap, and the only thing that
+   converts "the unit is enabled" into "the unit works". Nothing else is waiting on it.
+4. **`app-minio`'s removal.** Its retention window expires **2026-08-01 01:41 UTC** — a day
+   after it stopped. Removing the container is reversible while `prod_app-minio-data`
+   exists; deleting that volume is the irreversible step and should be a separate decision.
+
+## The rule this cycle kept re-learning
+
+**Decision records preserve, status trackers expire.** A record explaining why something was
+decided stays even where its language has aged; a tracker describing what state things were
+in does not survive its own timestamp. That is why `infra-app-separation.md` still says the
+application is shelved and is correct as such, and why hill90-app's `RESURRECTION.md` was
+removed with its three durable sections relocated rather than deleted.


### PR DESCRIPTION
A statement of current truth with its evidence and dates — not a changelog. Everything perishable carries `Verified 2026-07-31 06:21 UTC`; where something wasn't checked it says so rather than hedging.

## Where it went, and why

**A dated file in `docs/decisions/`, not a new top-level document.** This repo already has that convention — `2026-07-26-overnight-summary`, `2026-07-29-morning-brief`, `2026-07-30-credential-exposures` — and `CLAUDE.md` is explicitly a short orientation index that links out rather than carrying evidence tables. A new root file would duplicate `CLAUDE.md`'s job.

**But `CLAUDE.md` needed changing too**, because three of its claims had become *false* rather than merely stale, and it's the first thing a cold session reads:

| It said | Truth |
|---|---|
| "`app-keycloak` and realm `hill90` are still running" · "`app-postgres` is still running and still serving" | both retired (2026-07-30, 2026-07-31); realm `hill90` gone from the live directory |
| "Keycloak event storage is off" | **on** for both realms — while keeping the part that stays true: an empty `event_entity` for a *past* date is still not evidence nobody logged in |
| "MinIO … never addressed" under *Genuinely open* | a platform MinIO runs and the tenant is cut over; replaced with what's genuinely open now |

It also now points a cold reader at the handoff first.

## What the handoff covers

**Retired and what remains** — exports, dumps and kept volumes named for each. **Rotated and how proven** — both credentials in *both* directions, and why the Postgres one had to be proven over the **network** (pg_hba grants `local` connections trust auth, so a local `psql` proves nothing).

**Verified kept separate from not-checked.** Measured: the terminal handshake's 101/403/401, and the allowlist admitting only the CGNAT range with `ClientHost` corroboration. **Not checked:** a real PTY session, any sign-in predating event storage, the tenant's cold-start budgets on the VPS, and the vault auto-unseal path across a reboot — host uptime is **1 week 3 days**, which is why that item is real rather than theoretical.

## The negative results, because they're half the value

Five api-suite flake hypotheses dead with the number that killed each — including the SSE leak that was **real, was fixed, and did not help** (7/20; P(≥7 at the pooled 21%) = 0.117). The `api.hill90.com` rate-limit asymmetry still an open **proposal**, and the tenant's change to make since the platform owns the middleware and the tenant owns the reference. Cold-start budgets measured on a laptop, not the VPS — which is the case they exist for. And that a history rewrite **would not conceal the tailnet address**, because public DNS already serves it.

## Four open decisions, all Jon's, each with cost rather than a recommendation

Repository visibility with the measured rewrite scope (**59** commits for the address, **380** for the SSH alias, **619** SHAs if the email in commit metadata goes) · whether the tenant's local stack moves onto the platform services · a reboot to validate auto-unseal · and `app-minio`'s removal once its window expires **2026-08-01 01:41 UTC**, with deleting `prod_app-minio-data` called out as the separate irreversible step.

Closes with the rule this cycle kept re-learning: **decision records preserve, status trackers expire.**

`check_md_links.py` passes.