### PR TITLE
fix(scripts): keep the vault token out of argv, where any local user can read it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,12 @@ jobs:
       - name: Assert no destructive volume commands
         run: bash scripts/checks/check_destructive_commands.sh
 
+      # A credential in argv is readable by any local user via `ps` — the shell
+      # analogue of a token in a query string. Greps for the dangerous forms;
+      # genuine throwaways carry an explicit `# argv-ok:` marker.
+      - name: Assert no credentials passed in argv
+        run: bash scripts/checks/check_argv_secrets.sh
+
       # The five admin routers resolve on public DNS and are protected by exactly one
       # middleware. This asserts that middleware still resolves, that its type key
       # matches the pinned Traefik major version (ipWhiteList in v2 became

--- a/.github/workflows/vault-sync-to-sops.yml
+++ b/.github/workflows/vault-sync-to-sops.yml
@@ -108,24 +108,34 @@ jobs:
           echo "hash=$BEFORE_HASH" >> $GITHUB_OUTPUT
 
       - name: Renew sync token
+        env:
+          SYNC_TOKEN: ${{ steps.sync-token.outputs.token }}
         run: |
-          ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
+          # The token goes over STDIN, never into a command line.
+          #
+          # Interpolating it into the ssh command string put it in argv of the
+          # remote shell AND of `docker exec` on the VPS, where `ps -Ao args`
+          # shows it to any local user. It is masked in the Actions log, which is
+          # what made this easy to miss: the leak is on the host, not here.
+          printf '%s' "$SYNC_TOKEN" | ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
             deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
-            "docker exec \
-              -e BAO_ADDR=http://127.0.0.1:8200 \
-              -e BAO_TOKEN='${{ steps.sync-token.outputs.token }}' \
-              openbao bao token renew" || {
+            'read -r BAO_TOKEN; export BAO_TOKEN; \
+             docker exec -e BAO_ADDR=http://127.0.0.1:8200 -e BAO_TOKEN \
+               openbao bao token renew' || {
             echo "::error::Token renewal failed — token may be expired or revoked. Re-run 'vault.sh setup-sync-token'."
             exit 1
           }
 
       - name: Run sync on VPS
+        env:
+          SYNC_TOKEN: ${{ steps.sync-token.outputs.token }}
         run: |
-          ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
+          # Same reasoning as the renew step: stdin, not argv.
+          printf '%s' "$SYNC_TOKEN" | ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
             deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
-            "export SOPS_AGE_KEY_FILE=/opt/hill90/secrets/keys/keys.txt && \
-             export BAO_TOKEN='${{ steps.sync-token.outputs.token }}' && \
-             cd /opt/hill90/app && bash scripts/vault.sh sync-to-sops"
+            'read -r BAO_TOKEN; export BAO_TOKEN; \
+             export SOPS_AGE_KEY_FILE=/opt/hill90/secrets/keys/keys.txt; \
+             cd /opt/hill90/app && bash scripts/vault.sh sync-to-sops'
 
       - name: Hash SOPS after sync
         id: after

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -166,7 +166,11 @@ vault_login() {
 vault_read_kv() {
     local token="$1"
     local path="$2"
-    docker exec -e "BAO_ADDR=http://127.0.0.1:8200" -e "BAO_TOKEN=$token" openbao \
+    # Token via the ENVIRONMENT, not argv — `-e NAME` with no value passes it
+    # through, where `-e NAME=value` would put the token in the docker CLI's
+    # command line for any local user to read with `ps`. Same reasoning as
+    # scripts/keycloak.sh's kc_login and scripts/vault.sh's bao_exec_env.
+    BAO_TOKEN="$token" docker exec -e "BAO_ADDR=http://127.0.0.1:8200" -e BAO_TOKEN openbao \
         bao kv get -format=json "$path" 2>/dev/null | \
         python3 -c "
 import sys, json, shlex

--- a/scripts/checks/check_argv_secrets.sh
+++ b/scripts/checks/check_argv_secrets.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Refuse credentials passed as command-line arguments.
+#
+# WHY
+#
+# A process's argv is world-readable. `ps -Ao args` shows it to every local user
+# on the host, so `docker exec -e "BAO_TOKEN=$token" ...` publishes the vault
+# root token to anyone with a shell. Demonstrated rather than assumed, with a
+# dummy value:
+#
+#   $ ps -Ao args | grep '^docker exec'
+#   docker exec -e PSPROBE=<the value is right here> ... sleep 10
+#
+# The safe form is `-e NAME` with NO value: docker passes the variable through
+# from its own environment, so the value is never an argument. scripts/keycloak.sh
+# used that from the start and said why; scripts/vault.sh and scripts/_common.sh
+# did not, which is what this check now prevents from coming back.
+#
+# This is the shell analogue of a token in a query string: the credential is
+# correct, the transport publishes it.
+#
+# WHY A GREP AND NOT A CENTRAL MECHANISM
+#
+# Shell has no single logger to wrap. What it does have is a small number of
+# shared helpers — bao_exec_env, vault_read_kv, kc_login — through which almost
+# every credential-bearing call already flows. Those are the mechanism; this
+# check is the tripwire for the call that does not use them.
+#
+# ESCAPE HATCH
+#
+# A throwaway credential in a disposable test container is not an exposure. Mark
+# such a line with `# argv-ok: <reason>` on the line itself or the line above.
+# The marker is deliberately ugly so it is noticed in review.
+
+set -uo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/../.." || exit 2
+
+SECRET_NAME='[A-Z_]*(TOKEN|PASSWORD|PASSWD|SECRET|KEY|CREDENTIAL|_PW)'
+FILES=$(git ls-files 'scripts/*.sh' 'scripts/**/*.sh' '.github/workflows/*.yml' 2>/dev/null)
+
+fail=0
+
+report() {
+    local file="$1" line="$2" rule="$3" text="$4"
+    # Print the RULE and the location, and only a shape-safe slice of the line:
+    # everything after the first '=' of the offending assignment is elided, so
+    # this check can never itself print a credential.
+    local safe
+    safe=$(printf '%s' "$text" | sed -E "s/(-e +\"?${SECRET_NAME}=)[^\" ]*/\\1<ELIDED>/g; s/((--new-password|--password|-u) +)[^ ]*/\\1<ELIDED>/g" | cut -c1-140)
+    echo "  ${file}:${line}"
+    echo "     rule: ${rule}"
+    echo "     line: ${safe}"
+    fail=1
+}
+
+has_marker() {
+    # The marker may be on the line itself, or anywhere in the CONTIGUOUS comment
+    # block immediately above it. Walking the block beats a fixed lookback: a
+    # two-line justification defeated a three-line window, and silently ignoring
+    # a correctly written marker is the worst behaviour this check could have.
+    local file="$1" line="$2" i text
+    awk -v n="$line" 'NR==n' "$file" 2>/dev/null | grep -q 'argv-ok:' && return 0
+    i=$(( line - 1 ))
+    while [ "$i" -ge 1 ]; do
+        text=$(awk -v n="$i" 'NR==n' "$file" 2>/dev/null)
+        # Stop at the first line that is neither a comment nor a continuation of
+        # the statement being flagged.
+        case "$text" in
+            *'argv-ok:'*) return 0 ;;
+            '#'*|' '*'#'*|$'	'*'#'*) i=$(( i - 1 )) ;;
+            *'\') i=$(( i - 1 )) ;;
+            *) return 1 ;;
+        esac
+    done
+    return 1
+}
+
+echo "Checking for credentials passed in argv..."
+
+for f in $FILES; do
+    [ -f "$f" ] || continue
+
+    # Rule 1: docker -e NAME=<expansion> where NAME looks like a secret.
+    while IFS=: read -r ln text; do
+        [ -z "${ln:-}" ] && continue
+        has_marker "$f" "$ln" && continue
+        report "$f" "$ln" "secret value in argv: use \`VAR=\$v docker exec -e VAR\` (name only)" "$text"
+    done < <(grep -nE -- "-e +\"?${SECRET_NAME}=[^\"]*(\\\$|\\\$\\{\\{)" "$f" 2>/dev/null | grep -vE '^[0-9]+: *#')
+
+    # Rule 2: a password/user flag taking an expansion.
+    while IFS=: read -r ln text; do
+        [ -z "${ln:-}" ] && continue
+        has_marker "$f" "$ln" && continue
+        report "$f" "$ln" "credential flag in argv: pass it through the environment instead" "$text"
+    # `-u` is deliberately NOT matched generically: `shred -u`, `sort -u` and
+    # friends made it pure noise. curl's form is matched explicitly instead.
+    done < <(grep -nE -- '(--password|--new-password|--bao-token) +"?\$|curl[^|]* -u +"?\$' "$f" 2>/dev/null | grep -vE '^[0-9]+: *#')
+done
+
+echo ""
+if [ "$fail" -eq 0 ]; then
+    echo "No credentials found in command-line arguments."
+else
+    echo "Credentials in argv are readable by any local user via \`ps\`."
+    echo "Fix, or mark a genuine throwaway with '# argv-ok: <reason>'."
+fi
+exit "$fail"

--- a/scripts/checks/realm-tenant-serves-test.sh
+++ b/scripts/checks/realm-tenant-serves-test.sh
@@ -92,6 +92,8 @@ echo "  waiting for Keycloak..."
 # the host returns 403 "HTTPS required" until it is relaxed — scripts/local.sh
 # does exactly that on the running realm. Both of those bit this verification
 # before the realm itself was ever in question.
+# argv-ok: ADMIN_PW is the literal throwaway on line 29, in a container this
+# script creates and destroys. No real credential exists in this process tree.
 ready() { docker exec "$KC" /opt/keycloak/bin/kcadm.sh config credentials \
             --server http://127.0.0.1:8080 --realm master \
             --user "$ADMIN" --password "$ADMIN_PW" >/dev/null 2>&1; }
@@ -126,6 +128,7 @@ else
 fi
 
 kc() { docker exec "$KC" /opt/keycloak/bin/kcadm.sh "$@" 2>&1; }
+# argv-ok: same throwaway credential and throwaway container as above.
 kc config credentials --server http://localhost:8080 --realm master \
    --user "$ADMIN" --password "$ADMIN_PW" >/dev/null 2>&1 \
    || { echo "kcadm login failed"; exit 2; }

--- a/scripts/checks/tenant-login-local-test.sh
+++ b/scripts/checks/tenant-login-local-test.sh
@@ -57,6 +57,8 @@ mkuser() {
   kc create users -r $REALM -s "username=$u" -s enabled=true -s emailVerified=true \
      -s "email=${u}@localtest.me" -s "firstName=${u}" -s "lastName=Probe" >/dev/null 2>&1
   local id; id=$(kc get users -r $REALM -q "username=$u" --fields id --format csv --noquotes 2>/dev/null | tr -d '\r' | head -1)
+  # argv-ok: $PW is a throwaway generated for a throwaway user that this
+  # script deletes; it is never a real account credential.
   kc set-password -r $REALM --userid "$id" --new-password "$PW" >/dev/null 2>&1
   echo "$id"
 }

--- a/scripts/vault.sh
+++ b/scripts/vault.sh
@@ -66,7 +66,18 @@ bao_exec_env() {
     if [ -z "$token" ]; then
         die "BAO_TOKEN is required. Export it before running this command."
     fi
-    docker exec -e "BAO_ADDR=http://127.0.0.1:8200" -e "BAO_TOKEN=${token}" "$CONTAINER_NAME" bao "$@"
+    # The token travels in the ENVIRONMENT, not argv.
+    #
+    # `docker exec -e "BAO_TOKEN=${token}"` puts the value in the docker CLI's
+    # command line, where any local user can read it with `ps`. Demonstrated
+    # rather than assumed: a probe with a dummy value showed
+    # `docker exec -e PSPROBE=<value> ...` in `ps -Ao args`.
+    #
+    # `-e NAME` with no value tells docker to pass the variable through from its
+    # own environment, so the value never becomes an argument. scripts/keycloak.sh
+    # already did this and documented why; this helper did not.
+    BAO_TOKEN="$token" docker exec -e "BAO_ADDR=http://127.0.0.1:8200" -e BAO_TOKEN \
+        "$CONTAINER_NAME" bao "$@"
 }
 
 require_running() {
@@ -193,12 +204,16 @@ cmd_revoke_root() {
     fi
 
     echo "Revoking root token..."
-    docker exec -e "BAO_ADDR=http://127.0.0.1:8200" -e "BAO_TOKEN=${token}" \
+    # `-e BAO_TOKEN` passes the variable through from this shell rather than
+    # putting the value in argv, so it must be SET here — a bare pass-through of
+    # an unset variable sends nothing and the command fails in a way that looks
+    # like a permissions problem.
+    BAO_TOKEN="$token" docker exec -e "BAO_ADDR=http://127.0.0.1:8200" -e BAO_TOKEN \
         "$CONTAINER_NAME" bao token revoke -self >/dev/null 2>&1 || true
 
     # Verify independently. `token revoke -self` prints "Revoked token (if it
     # existed)" and exits 0 regardless, so its exit code proves nothing.
-    if ! docker exec -e "BAO_ADDR=http://127.0.0.1:8200" -e "BAO_TOKEN=${token}" \
+    if ! BAO_TOKEN="$token" docker exec -e "BAO_ADDR=http://127.0.0.1:8200" -e BAO_TOKEN \
             "$CONTAINER_NAME" bao token lookup >/dev/null 2>&1; then
         success "✓ Root token revoked and confirmed dead"
     else
@@ -425,7 +440,8 @@ print(json.dumps({
     ],
 }))' "$vault_url")
     local token="${BAO_TOKEN:-}"
-    echo "$role_json" | docker exec -i -e "BAO_ADDR=http://127.0.0.1:8200" -e "BAO_TOKEN=${token}" "$CONTAINER_NAME" \
+    echo "$role_json" | BAO_TOKEN="$token" docker exec -i \
+        -e "BAO_ADDR=http://127.0.0.1:8200" -e BAO_TOKEN "$CONTAINER_NAME" \
         bao write auth/oidc/role/admin-sso -
 
     echo ""


### PR DESCRIPTION
## Nothing has leaked durably — no rotation task

I scanned the retained GitHub Actions logs of **38 runs** across the 11 workflows that handle secrets, for JWTs, `hv[sb].` vault tokens, `tskey-` auth keys, PEM private-key headers, postgres URIs with a password, long bearer values and `AGE-SECRET-KEY`. **No matches.**

The first version of that scan was broken — `grep -c` collided with an `|| echo 0` fallback and produced a garbage count. It was rebuilt and given a **positive control** that finds a planted shape, because "no matches" from an unverified checker is the one result this estate has learned not to trust.

## The finding: argv is world-readable

A process's command line is visible to every local user. `docker exec -e "BAO_TOKEN=$token"` publishes the **vault root token** to anyone with a shell on the VPS. Demonstrated with a dummy value rather than asserted:

```
$ ps -Ao args | grep '^docker exec'
docker exec -e PSPROBE=<the value is right here> ... sleep 10
```

The safe form is `-e NAME` with **no value** — docker passes the variable through from its own environment. `scripts/keycloak.sh` used that from the start and said why; `vault.sh` and `_common.sh` did not.

Fixed **at the shared helpers**, which is where the mechanism already lives — almost every credential-bearing call flows through `bao_exec_env`, `vault_read_kv` or `kc_login`, so fixing those fixes every caller:

| File | Sites |
|---|---|
| `scripts/vault.sh` | `bao_exec_env`, revoke-root (×2), the OIDC role write |
| `scripts/_common.sh` | `vault_read_kv` |

Each rewritten site now **sets** the variable it passes through. A bare `-e NAME` with the variable unset sends nothing and fails like a permissions problem — the easiest thing to get wrong here.

## One I had missed, found by the check I wrote

`vault-sync-to-sops.yml` had the same shape **twice**: the sync token interpolated into the ssh command string, landing in argv of the remote shell *and* of `docker exec` on the VPS.

It is masked in the Actions log — which is exactly what made it easy to miss. **The leak was on the host, not in the log.** Both steps now pass the token over **stdin**.

## No central mechanism, deliberately

Shell has no single logger to wrap. What it has is those three helpers, plus a tripwire for the call that bypasses them: `scripts/checks/check_argv_secrets.sh`, wired into `ci.yml`.

It greps for `-e SECRET=<expansion>` and for credential flags taking an expansion, skips comments, and **never prints a matched value** — the offending portion is elided before the line is shown, so the check cannot itself become the leak.

Genuine throwaways carry an explicit `# argv-ok: <reason>` marker. Both check scripts use a hardcoded dummy against a container they create and destroy, so they are **marked rather than "fixed"** into something less readable.

**Three bugs in my own check, each caught before shipping:** `-u` matched `shred -u` and `sort -u` and was pure noise; comment lines matched their own explanations; and a fixed three-line lookback **silently ignored a correctly written two-line marker** — the worst behaviour available for a check like this — so `has_marker` now walks the contiguous comment block.

Verified by reintroducing the regression: **exit 1** with the finding named, **exit 0** after restoring.

## Checked and clean

No `set -x` anywhere. No `curl -u`/bearer with an inline credential. `config-vps.yml` and `vault-sync-to-sops.yml` both `::add-mask::` **before** writing to `$GITHUB_OUTPUT` — the correct order. `vault-reinitialize.yml`'s `echo "root token on host: $HAS_TOKEN"` prints `yes`/`no`, not a token. `local.sh`'s `VAR=value command` prefixes put values in the child's environment, not argv.

Suites: **362 bats, 66 pytest**, all green.

## Not changed, recorded

`bao operator generate-root -decode= -otp=` in `vault.sh` passes single-use root-generation material in argv, because those flags have no environment equivalent. Short-lived and single-use — but it is the one remaining instance of this class, and it should not be discovered later as though it were new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)