### PR TITLE
fix(backup): 0600 and --no-role-passwords on dumps, and correct a Grafana claim that was mine to check

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,8 +142,13 @@ revisited deliberately rather than worked around.
 > **That boundary was revisited, and this platform now HOSTS the tenant's
 > databases.** `Verified 2026-07-30 01:35 UTC.` Role `hill90_app` (`NOSUPERUSER`)
 > owns `hill90_akm`, `hill90_api` and `hill90_litellm`; `hill90`, `keycloak`,
-> `postgres` and the templates stay with the platform role. `keycloak`, `grafana`
-> and `postgres` all stayed healthy through the `REVOKE` work. The credential is in
+> `postgres` and the templates stay with the platform role. **That is the complete list
+> of databases on this instance — there is no `grafana` database.** The `keycloak`,
+> `grafana` and `postgres` **containers** all stayed healthy through the `REVOKE` work;
+> naming them straight after a list of databases has already caused `grafana` to be read
+> as one. Grafana keeps its state in SQLite in the `grafana-data` volume, so a Postgres
+> restore does not bring Grafana back — see
+> [disaster-recovery.md](docs/runbooks/disaster-recovery.md). The credential is in
 > SOPS as `HILL90_APP_DB_PASSWORD`. The local check now asserts **tenant
 > isolation** — an application database owned by the platform role still fails, by
 > name — and it was only ever a *local dev* check, never production enforcement.

--- a/docs/decisions/tenant-databases-on-platform-postgres.md
+++ b/docs/decisions/tenant-databases-on-platform-postgres.md
@@ -35,8 +35,16 @@ it was refused on `hill90`, `keycloak`, `postgres` and `template1` with
 rather than an argument: after them, `keycloak` and `postgres-exporter` were still
 connected over the network as `hill90` (`pg_stat_activity` shows `keycloak` from
 `172.19.0.12` and `hill90` from `172.19.0.11`), Keycloak still served realms
-`master, platform`, Grafana returned `200` with `"database": "ok"`, and the
-platform held at 13 containers, 0 unhealthy. The reason it is safe is that every
+`master, platform`, and the platform held at 13 containers, 0 unhealthy.
+
+**Correction, 2026-07-31:** this paragraph also cited Grafana returning `200` with
+`"database": "ok"` as evidence the revokes were safe. It is not evidence, and citing it
+overstated the case. **Grafana does not use this Postgres** — it keeps its state in
+SQLite inside the `grafana-data` volume, verified 2026-07-31 (no `grafana` database
+exists on the instance; `/var/lib/grafana/grafana.db` is ~1.8 MB). Its health endpoint
+was reporting on its own SQLite file and would have said `ok` whatever the ACLs did. The
+remaining evidence — live `keycloak` and `postgres-exporter` connections, served realms,
+and the container baseline — stands on its own. The reason it is safe is that every
 consumer of this Postgres connects as `hill90`, a superuser, and superusers bypass
 ACL checks entirely.
 

--- a/docs/runbooks/disaster-recovery.md
+++ b/docs/runbooks/disaster-recovery.md
@@ -12,6 +12,59 @@ Before starting recovery, ensure you have:
 - [ ] Hostinger API access (for VPS creation)
 - [ ] Tailscale account access (for network re-join)
 
+## Restore verification — last proven 2026-07-31
+
+The Postgres half of this procedure has been exercised, not assumed. Recorded so the next
+person compares against these numbers instead of re-deriving them.
+
+**The artefact restored was the SCHEDULED one**, deliberately — restoring a dump you just
+took proves the tool works, not that the nightly job does:
+
+```
+/opt/hill90/backups/db/20260731_030002/database.sql
+548,439 bytes   mtime 2026-07-31 03:00:12 UTC   sha256 d7be12aa2b73…
+```
+
+`20260731_010528` was ignored on purpose: it was a pre-deploy backup taken by hand hours
+earlier.
+
+**Where it was restored:** a throwaway `pgvector/pgvector:pg16` container **on the VPS**,
+started with `--network none` and a bootstrap superuser named `verifier` so the dump's own
+`hill90` and `hill90_app` roles restore without colliding. Removed afterwards with its
+volume, both confirmed absent by listing.
+
+**Result: `psql` exit 0, zero stderr lines** — not "errors judged benign", none at all. All
+five databases created, and both roles restored with attributes intact, including
+`hill90_app superuser=false`, which is the property tenant isolation depends on.
+
+| Database | Restored (03:00 artefact) | Live at time of check |
+|---|---|---|
+| `hill90_api` | 32 tables / 109 rows | 32 tables / 105 rows |
+| `hill90_akm` | 14 tables / 13 rows | 14 tables / 13 rows |
+| `hill90_litellm` | 47 tables / 77 rows | 47 tables / 77 rows |
+| `keycloak` | 89 tables / 1646 rows | 89 tables / 1660 rows |
+
+Table counts identical throughout. Every row delta was attributed per table rather than
+waved at: `hill90_api`'s four extra rows are a transient test fixture (`agents` 1,
+`chat_threads` 1, `chat_participants` 2) that existed at 03:00 and was removed afterwards —
+the backup faithfully captured short-lived data, which is itself evidence of fidelity. In
+`keycloak`, `event_entity` 0→6 and `admin_event_entity` 0→8 reflect login-event storage
+being enabled after 03:00, and `offline_user_session` 3→0 is expired `admin-cli` sessions.
+
+Semantic checks on the restored Keycloak, since counts alone would not catch a corrupted
+realm: realms `master, platform`; **3** users in `platform`; client `hill90-ui` present with
+a **64-character** secret; client roles `admin, user` both present. `hill90_api` carried 65
+migrations, 15 tools, 9 skills.
+
+**The negative, which matters as much as the positive: the live instance was never written
+to.** All work happened in the throwaway; the live cluster still reported its six databases
+afterwards, the platform held 13 containers by name plus MinIO with 0 unhealthy, and
+`hill90.com` answered 200. A restore test that touched production would be the worst
+possible way to discover that.
+
+**Not verified by this exercise:** that role passwords work after a restore — they are no
+longer in the dump, by design, see step 9 — and Grafana, which is not in this dump at all.
+
 ## Recovery Steps
 
 ### 1. Recreate VPS
@@ -122,6 +175,29 @@ Restore database from backup if available:
 ```bash
 bash scripts/backup.sh restore db /path/to/backup
 ```
+
+> **The dump does not carry role passwords, so a successful restore is not yet a
+> working database.** Since 2026-07-31 the dump is taken with `--no-role-passwords`:
+> roles are recreated, their passwords are not. Without this step the restore reports
+> success and then nothing can authenticate, which reads as a corrupt restore rather
+> than a missing action.
+>
+> Set them from the encrypted store after restoring — `DB_PASSWORD` for `hill90` and
+> `HILL90_APP_DB_PASSWORD` for the tenant role `hill90_app` — via
+> `ALTER ROLE … PASSWORD`, with the value passed on stdin rather than argv. Verify over
+> the **network** from another container, not with `docker exec … psql`, because
+> `pg_hba` grants local connections `trust` and will authenticate regardless of the
+> password. See
+> [platform-postgres-password-rotation.md](platform-postgres-password-rotation.md) for
+> the exact shape of both steps.
+
+> **This restores Postgres only. It does NOT restore Grafana.** Grafana keeps its
+> state in **SQLite** inside the `grafana-data` volume, not in Postgres — verified
+> 2026-07-31: no `grafana` database exists on the platform instance, and
+> `/var/lib/grafana/grafana.db` is ~1.8 MB. Grafana's dashboards, users and
+> preferences come back from the **observability** volume tar:
+> `bash scripts/backup.sh restore observability /path/to/backup`. Sequencing a rebuild
+> around the Postgres dump alone leaves Grafana empty.
 
 ### 10. Deploy All Services
 

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -182,10 +182,30 @@ Under cron, PATH is /sbin:/bin:/usr/sbin:/usr/bin and sops lives in
         # Never leave a truncated dump behind claiming to be a backup: write to
         # a temp file, check the exit status AND that it is non-empty, and only
         # then move it into place.
-        if docker exec postgres pg_dumpall -U "$db_user" > "$backup_dir/.database.sql.partial" 2>/dev/null \
+        #
+        # TWO PROTECTIONS HERE, and they buy different things.
+        #
+        # --no-role-passwords: without it, pg_dumpall writes every role's SCRAM
+        # verifier into the dump as plaintext SQL. That is worse than most credential
+        # exposures because the artefact PERSISTS and gets copied — to a prune-retained
+        # directory, to whatever offsite copy exists, into any tarball of /opt/hill90.
+        # A password leaked into a log ages out; one leaked into a backup set is there
+        # until every copy is destroyed. THE TRADE: a restore no longer recreates role
+        # passwords, so they must be supplied separately from the encrypted store. That
+        # consequence is documented where the restore procedure lives — see
+        # docs/runbooks/disaster-recovery.md. Restoring without it succeeds and then
+        # nothing can authenticate, which reads as a broken restore rather than a
+        # missing step.
+        #
+        # umask 077: the dump was previously written 0644 — readable by every local
+        # user on the host. Same class of mistake as a secret in argv, which is visible
+        # to anyone who can run ps; this one is visible to anyone who can run cat, and
+        # for as long as the file exists.
+        if ( umask 077; docker exec postgres pg_dumpall -U "$db_user" --no-role-passwords > "$backup_dir/.database.sql.partial" 2>/dev/null ) \
            && [ -s "$backup_dir/.database.sql.partial" ]; then
             mv "$backup_dir/.database.sql.partial" "$backup_dir/database.sql"
-            echo "  ✓ SQL dump saved to $backup_dir/database.sql ($(wc -c < "$backup_dir/database.sql") bytes)"
+            chmod 600 "$backup_dir/database.sql"
+            echo "  ✓ SQL dump saved to $backup_dir/database.sql ($(wc -c < "$backup_dir/database.sql") bytes, mode 600)"
         else
             rm -f "$backup_dir/.database.sql.partial"
             die "pg_dumpall failed or produced an empty dump — refusing to report success"
@@ -256,10 +276,14 @@ backup_app_db() {
     docker exec "$container" psql -U "$app_user" -tAc 'SELECT 1' >/dev/null 2>&1 \
         || die "Cannot authenticate to ${container} as '${app_user}' — refusing to report a backup with no SQL dump"
 
-    if docker exec "$container" pg_dumpall -U "$app_user" > "$backup_dir/.app-database.sql.partial" 2>/dev/null \
+    # Same two protections as backup_db above, for the same reasons — see the comment
+    # there. This path is currently unreachable (app-postgres is retired), but leaving
+    # it weaker would reintroduce the exposure the moment a tenant database returns.
+    if ( umask 077; docker exec "$container" pg_dumpall -U "$app_user" --no-role-passwords > "$backup_dir/.app-database.sql.partial" 2>/dev/null ) \
        && [ -s "$backup_dir/.app-database.sql.partial" ]; then
         mv "$backup_dir/.app-database.sql.partial" "$backup_dir/app-database.sql"
-        echo "  ✓ SQL dump saved to $backup_dir/app-database.sql ($(wc -c < "$backup_dir/app-database.sql") bytes)"
+        chmod 600 "$backup_dir/app-database.sql"
+        echo "  ✓ SQL dump saved to $backup_dir/app-database.sql ($(wc -c < "$backup_dir/app-database.sql") bytes, mode 600)"
     else
         rm -f "$backup_dir/.app-database.sql.partial"
         die "pg_dumpall against ${container} failed or produced an empty dump — refusing to report success"


### PR DESCRIPTION
Two findings from proving the nightly platform Postgres backup restorable, plus the evidence, plus a correction that came from not trusting an instruction.

## 1. The dump carried role passwords at mode 0644

Both protections now applied to both dump paths, and the comment says what **each** buys, because they're different problems:

- **`--no-role-passwords`** — `pg_dumpall` was writing every role's SCRAM verifier into the dump as plaintext SQL. Worse than most credential exposures because the artefact **persists and gets copied** — into prune-retained directories, any offsite copy, any tarball of `/opt/hill90`. A password leaked into a log ages out; one leaked into a backup set is there until every copy is destroyed.
- **`umask 077` + `chmod 600`** — the dump was world-readable on the host. Same class as a secret in argv, which anyone who can run `ps` sees; this one is seen by anyone who can run `cat`, for as long as the file exists.

**The trade is documented where it bites.** `--no-role-passwords` means a restore recreates roles *without* their passwords, so `disaster-recovery.md` step 9 now says so, names the two store keys to set, says to pass the value on **stdin not argv**, and says to verify over the **network** because `pg_hba` grants local connections `trust` and will authenticate regardless. Without that note a restore succeeds, nothing authenticates, and it reads as a corrupt restore rather than a missing step.

## 2. The Grafana claim — and whose it was

**The instruction for this task listed `grafana` among the databases in that dump. It is not one, and the claim came from the operator briefing me.** Recording that is more useful than quietly fixing it.

Grafana keeps its state in **SQLite** in the `grafana-data` volume — verified 2026-07-31: no `grafana` database exists on the instance, `/var/lib/grafana/grafana.db` is ~1.8 MB. The sequencing consequence is real: **a Postgres-only restore leaves Grafana empty**, and its data comes back from the observability volume tar.

I swept for *every* place implying otherwise, not just the one I noticed:

| Location | Action |
|---|---|
| `docs/runbooks/disaster-recovery.md` | restore step now states it explicitly |
| `CLAUDE.md` | listed the databases, then said "`keycloak`, `grafana` and `postgres` all stayed healthy" — **container** names immediately after a list of **database** names. Not false, but it's the ambiguity that most likely produced the misconception. Disambiguated, with "there is no `grafana` database" stated outright |
| `docs/decisions/tenant-databases-on-platform-postgres.md` | cited Grafana returning `200` with `"database": "ok"` as **evidence** that Postgres ACL revokes were safe. It cannot be — Grafana never touches that Postgres and would have said `ok` whatever the ACLs did. The claim overstated its evidence; corrected, and the rest of the paragraph stands on its own |
| `docs/runbooks/observability.md` | **already correct** — "Grafana \| Persistent \| `grafana-data` volume". Left alone, and said so: the sweep was complete, not abandoned once it found one |

## The evidence, recorded so the next person compares rather than re-derives

**The artefact was the scheduled 03:00 run** — `20260731_030002`, 548,439 bytes, sha256 `d7be12aa2b73…`, mtime 03:00:12 — **not** the `20260731_010528` pre-deploy backup I took by hand hours earlier. Restoring your own dump proves the tool works, not the schedule.

**Where:** a throwaway `pgvector/pgvector:pg16` container **on the VPS**, `--network none`, bootstrap user `verifier` so the dump's own roles restore without colliding. Removed with its volume, both confirmed absent by listing.

**`psql` exit 0, zero stderr lines** — not "errors judged benign". All five databases, both roles with attributes intact including `hill90_app superuser=false`.

| Database | Restored (03:00) | Live at check |
|---|---|---|
| `hill90_api` | 32 tables / 109 rows | 32 / 105 |
| `hill90_akm` | 14 / 13 | 14 / 13 |
| `hill90_litellm` | 47 / 77 | 47 / 77 |
| `keycloak` | 89 / 1646 | 89 / 1660 |

Table counts identical throughout; every row delta attributed per table. Keycloak checked semantically too — realms `master, platform`, 3 users in `platform`, `hill90-ui` with a 64-char secret, client roles `admin, user`.

**And the negative: the live instance was never written to.** Still six databases afterwards, 13 platform containers by name plus MinIO, 0 unhealthy, `hill90.com` 200. A restore test that touched production would be the worst possible way to learn that.

**Not verified by this exercise**, and stated in the runbook: that role passwords work after a restore, and Grafana, which isn't in this dump at all.

`check_md_links.py` passes; `backup.sh` parses.