### PR TITLE
docs(backup): the tars are crash-consistent, and the age key is the DR single point of failure

### DIFF
--- a/docs/reference/backup-coverage.md
+++ b/docs/reference/backup-coverage.md
@@ -1,0 +1,79 @@
+# Backup coverage — what is in the nightly set, and what a gap costs
+
+What `scripts/backup.sh backup-all` actually covers, volume by volume, and for each
+thing it does not cover, what is lost if the host disappears tonight.
+
+`Verified 2026-07-31 08:12 UTC` — volume list, container list and mount ownership read
+from the VPS read-only (`docker volume ls`, `docker ps`, `docker ps --filter volume=`).
+
+## The schedule
+
+From the `deploy` user's crontab on the VPS, installed by Ansible:
+
+```
+0 3 * * *    cd /opt/hill90/app && SOPS_AGE_KEY_FILE=... bash scripts/backup.sh backup-all
+0 4 * * 0    cd /opt/hill90/app && bash scripts/backup.sh prune 7
+```
+
+Nightly at 03:00 UTC, pruned to 7 days on Sundays at 04:00. Output appends to
+`/opt/hill90/backups/cron.log`. Backups live on the **same host they protect** — there is
+no offsite copy, so this set survives a bad deploy, a dropped table or a corrupted volume,
+and does not survive losing the VPS.
+
+## Covered
+
+Eight named volumes, across six targets.
+
+| Target | Volume | Also has a consistent artifact? |
+|---|---|---|
+| `db` | `prod_postgres-data` | **Yes** — `pg_dumpall`, and the dump is required for the run to pass |
+| `app-db` | `prod_app-postgres-data` | No longer — the container is retired, so the tar is all that is left |
+| `minio` | `prod_minio-data` | No |
+| `vault` | `openbao-data` | No |
+| `infra` | `prod_traefik-certs`, `prod_portainer-data` | No |
+| `observability` | `grafana-data`, `prometheus-data` | No |
+
+Every one of those tars is **crash-consistent at best** — see
+[the caveat in `backup_volume`](../../scripts/backup.sh). `db` is the only target with a
+second artifact that restores cleanly, which makes it the least exposed, not the most.
+
+## Not covered — and what each gap costs
+
+| Volume | Owner | Size | Consequence if the host is lost |
+|---|---|---|---|
+| `loki-data` | `loki` | 59.3 MB | All retained logs. Nothing else holds them; log history is gone for good. Accepted: logs are diagnostic, and a rebuilt estate starts a fresh window. |
+| `tempo-data` | `tempo` | 39.9 MB | All retained traces. Same reasoning as Loki. |
+| `promtail-positions` | `promtail` | small | Read offsets only. Rebuilds itself; losing it re-ships or skips a little log tail. **No real cost.** |
+| `prod_app-akm-data` | `app-knowledge` | 4 KB (one empty `agents/` directory) | The tenant's knowledge store. **Empty today, so the cost today is nil — and that is exactly why this is worth writing down.** The gap is invisible while the volume is empty and becomes a silent data-loss path the moment the tenant starts storing knowledge. |
+| `prod_app-akm-keys` | `app-ai`, `app-knowledge` | 8 KB (`public.pem`, `model-router-public.pem`) | Public keys only, regenerable from their private counterparts. Low cost — but confirm that assumption before the private halves move. |
+| `prod_app-minio-data` | `app-minio` (stopped 2026-07-31 01:40:43 UTC) | — | The retired tenant object store, kept as a safety net until its retention expires **2026-08-01 01:41 UTC**. Nothing backs up the safety net. Whether its contents are fully represented in the platform MinIO has **not** been checked here, so do not assume the gap is harmless — and note that "retained" and "backed up" are being conflated if this is not said out loud. |
+| 9 anonymous container volumes | assorted | — | Docker-generated, no declared state. |
+| `/opt/hill90/secrets/` | host path, not a volume | — | The age key and the OpenBao unseal key. **In no tar, by design** — see below. |
+| `/opt/hill90/agentbox-configs` | host path, not a volume | — | Already recorded in `docs/runbooks/deployment.md`; outside every checkout and every tar. |
+
+A structural note on the last two: `backup_volume` tars **Docker volumes**. Anything that
+lives on a host path is outside the mechanism entirely, so no amount of adding targets
+reaches it.
+
+### The observability asymmetry
+
+`prometheus-data` is backed up nightly (239 MB on 2026-07-31); `loki-data` and
+`tempo-data` are not. That is inconsistent, and it is not obviously wrong — metrics feed
+alert history that has more value than raw logs — but it is not a decision anybody
+recorded. Treat it as unexamined rather than settled.
+
+## The age key is deliberately in no backup
+
+`/opt/hill90/secrets/` holds `openbao-unseal.key` and `keys/keys.txt`, the age private
+key. Neither is in any tar, and neither should be: a backup that contains the key which
+decrypts the rest of the estate is a backup you cannot store anywhere.
+
+The consequence is a hard ordering constraint on recovery, written out in
+[`disaster-recovery.md`](../runbooks/disaster-recovery.md#step-0). The short version: the
+**vault tar is inert without the age key**, and the first step of a rebuild happens in a
+password manager, not on the host.
+
+`OPENBAO_UNSEAL_KEY` is present in `infra/secrets/prod.enc.env`, which is committed —
+confirmed 2026-07-31 by reading the key name from the encrypted file, whose dotenv format
+keeps names in plaintext and values as ciphertext. The value was never decrypted or
+printed. So the unseal key is not a single point of failure; **the age key is.**

--- a/docs/runbooks/deployment.md
+++ b/docs/runbooks/deployment.md
@@ -232,16 +232,38 @@ performed. Verified artifacts from that run:
 A tar of a live `PGDATA` is crash-consistent at best; the `pg_dumpall` is the
 artifact that restores cleanly. Both are taken and the dump is required.
 
+**And that caveat is not about `PGDATA`.** It is true of every tar this script
+takes — `backup_volume` mounts a *running* container's volume `-v vol:/data:ro`
+and tars it, with no stop, no pause and no filesystem freeze. The `:ro` protects
+the data from the tar, not the tar from the data. So `grafana-data` (SQLite),
+`openbao-data` (file storage), `prometheus-data` (TSDB WAL) and `prod_minio-data`
+all carry that risk, and they carry *more* of it than the databases do, because
+the databases are the only targets with a second, consistent artifact behind the
+tar. Restoring one of these is replaying a crashed host: verify the service after
+restarting it rather than assuming the restore was clean.
+
 Not covered by any backup: object storage, agent state, and
 `/opt/hill90/agentbox-configs`, which is a host path outside every checkout.
 
 ### What Gets Backed Up
 
+Eight named volumes across six targets. This table used to list three of them,
+which read as a complete inventory and was not.
+
 | Service | Backup Method | Files |
 |---------|--------------|-------|
+| db | SQL dump **+** volume tar | `database.sql`, `postgres-data.tar.gz` |
+| app-db | Volume tar (dump path retired with `app-postgres`) | `app-postgres-data.tar.gz` |
+| minio | Volume tar | `minio-data.tar.gz` |
 | vault | Volume tar | `openbao-data.tar.gz` |
 | infra | Volume tar | `traefik-certs.tar.gz`, `portainer-data.tar.gz` |
 | observability | Volume tar | `grafana-data.tar.gz`, `prometheus-data.tar.gz` |
+
+For what is **not** in that set, and what each gap actually costs, see
+[`docs/reference/backup-coverage.md`](../reference/backup-coverage.md). The short
+list of uncovered state is `loki-data`, `tempo-data`, the tenant's
+`prod_app-akm-*` volumes, the retained `prod_app-minio-data`, and everything under
+`/opt/hill90/secrets/` — which is a host path, so no backup target can reach it.
 
 ### Restore Procedure
 

--- a/docs/runbooks/disaster-recovery.md
+++ b/docs/runbooks/disaster-recovery.md
@@ -7,10 +7,55 @@ Full platform recovery procedure from total VPS/infrastructure loss.
 Before starting recovery, ensure you have:
 
 - [ ] Local clone of the Hill90 git repository (up to date with `main`)
-- [ ] SOPS encrypted secrets file: `infra/secrets/prod.enc.env`
-- [ ] Age private key: `infra/secrets/keys/age-prod.key`
+- [ ] SOPS encrypted secrets file: `infra/secrets/prod.enc.env` — **this is committed**,
+      so the clone brings it
+- [ ] Age private key: `infra/secrets/keys/age-prod.key` — **this is NOT committed and is
+      in no backup.** See Step 0; get it before anything else
 - [ ] Hostinger API access (for VPS creation)
 - [ ] Tailscale account access (for network re-join)
+
+<a id="step-0"></a>
+## Step 0 — Get the age key. Nothing else works first.
+
+**Do this before touching a host.** Every step below that reads a secret depends on it,
+and it is the one input that no backup, snapshot or tar can give you.
+
+The recovery chain is:
+
+```
+age private key  →  decrypts infra/secrets/prod.enc.env  →  yields OPENBAO_UNSEAL_KEY
+                 →  unseals the restored openbao-data volume  →  vault is usable
+```
+
+Read it right-to-left to see the failure: **the vault tar is inert without the age key.**
+You can restore `openbao-data.tar.gz` perfectly and still have nothing, because the volume
+is ciphertext and the unseal key that opens it is itself inside a SOPS file you cannot
+decrypt.
+
+**Where the key is, and is not.** `Verified 2026-07-31 08:12 UTC.`
+
+| Location | Present? | Survives total VPS loss? |
+|---|---|---|
+| Password manager | The intended durable copy, per [`docs/reference/secrets.md`](../reference/secrets.md). **Inferred from that document, not verified here** — nothing on a host can confirm it, which is the point | **Yes** — the only copy the DR scenario can rely on |
+| Operator workstation, `infra/secrets/keys/age-prod.key` | Yes, gitignored | Only if the workstation is intact. It is not part of the recovery guarantee |
+| VPS, `/opt/hill90/secrets/keys/keys.txt` (`0600 deploy:deploy`) | Yes | **No** — this is the host you just lost |
+| Git | **No**, and must stay that way — only `age-prod.pub` is tracked | n/a |
+| Any backup tar | **No.** `backup_volume` tars Docker volumes; `/opt/hill90/secrets/` is a host path, so no target reaches it | n/a |
+
+That last row is a deliberate design property, not an oversight: a backup containing the
+key that decrypts the estate is a backup that cannot be stored anywhere safely. The cost
+of that choice is this step, and it is why it is written here rather than assumed.
+
+**The unseal key is not the single point of failure — the age key is.** `OPENBAO_UNSEAL_KEY`
+is present in the committed `infra/secrets/prod.enc.env` (confirmed 2026-07-31 by reading
+the key *name* from the encrypted file, whose dotenv format keeps names in plaintext and
+values as ciphertext; the value was not decrypted or printed). So losing the on-host
+`openbao-unseal.key` costs nothing. Losing the age key costs everything downstream of it.
+
+If you reach this runbook at 3am with a dead VPS: **open your password manager first.**
+
+Coverage for every other volume, and what each uncovered one costs, is in
+[`docs/reference/backup-coverage.md`](../reference/backup-coverage.md).
 
 ## Restore verification — last proven 2026-07-31
 
@@ -63,7 +108,45 @@ afterwards, the platform held 13 containers by name plus MinIO with 0 unhealthy,
 possible way to discover that.
 
 **Not verified by this exercise:** that role passwords work after a restore — they are no
-longer in the dump, by design, see step 9 — and Grafana, which is not in this dump at all.
+longer in the dump, by design, see step 9. Grafana is not in this dump at all, and is
+covered by the separate exercise below.
+
+## Volume-tar restore verification — observability, 2026-07-31
+
+The Postgres exercise above proves a **dump** restores. It says nothing about the volume
+tars, which are the only artifact behind five of the six backup targets. So that was
+exercised too.
+
+**The artefact restored was again the SCHEDULED one:**
+
+```
+/opt/hill90/backups/observability/20260731_030038/grafana-data.tar.gz
+13,160,853 bytes   written 2026-07-31 03:00 UTC
+```
+
+**Where:** a throwaway Docker volume, not `grafana-data`. The live volumes were never
+written to. The throwaway was removed afterwards and its absence confirmed by listing.
+
+**Result:** `grafana.db` came back at 1,880,064 bytes. The platform baseline held
+afterwards at 13 containers by name plus `minio`, **0 unhealthy** — re-confirmed
+`Verified 2026-07-31 08:12 UTC`, with the tenant's 7 containers alongside for 21 total.
+
+> **This run got lucky rather than being safe, and the tar itself shows it.**
+> `grafana.db`'s recorded mtime inside the archive is **02:52** — eight minutes before the
+> 03:00 tar — and no `grafana.db-journal` was present. Grafana writes SQLite in
+> rollback-journal mode, so a tar that starts *during* a write transaction can capture a
+> torn database, or a database without the journal that would repair it. Nothing in
+> `backup_volume` prevents that; the container is not stopped, paused or frozen. The clean
+> restore is evidence that the artifact was intact **that night**, not evidence that the
+> mechanism is safe.
+
+**What this exercise does not prove:** that Grafana *starts* against the restored volume
+and renders its dashboards — the restore was verified at the file level, in a throwaway,
+without pointing a Grafana at it. And it says nothing about `openbao-data`,
+`prometheus-data` or `prod_minio-data`, whose exposure to the same problem is larger
+because they are written continuously. OpenBao has a proper fix available — a raft
+snapshot, taken from the running server — costed in
+[`vault-vs-sops.md`](../decisions/vault-vs-sops.md).
 
 ## Recovery Steps
 

--- a/docs/runbooks/vps-rebuild.md
+++ b/docs/runbooks/vps-rebuild.md
@@ -14,7 +14,10 @@ The VPS rebuild is fully automated and requires **zero manual intervention**. Th
 ## Prerequisites
 
 - **Local machine:** Repository cloned, all tools installed
-- **Age key:** `infra/secrets/keys/age-prod.key` in repository
+- **Age key:** `infra/secrets/keys/age-prod.key` — at that path in your **working copy**,
+  not in the repository. It is gitignored and in no backup, so a fresh clone does not
+  bring it and neither does a restore. Get it from your password manager first; see
+  [`disaster-recovery.md`](disaster-recovery.md#step-0)
 - **SSH key:** `~/.ssh/remote.hill90.com` configured
 - **Secrets:** `infra/secrets/prod.enc.env` with VPS credentials
 

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -102,7 +102,41 @@ verify_artifacts() {
 # Volume backup helpers
 # ---------------------------------------------------------------------------
 
-# Backup a named Docker volume to a tar.gz file
+# Backup a named Docker volume to a tar.gz file.
+#
+# EVERY TAR THIS FUNCTION PRODUCES IS CRASH-CONSISTENT AT BEST, NOT CONSISTENT.
+#
+# The container that owns the volume keeps running. There is no stop, no pause,
+# no `fsfreeze`, no application-level quiesce — `:ro` protects the DATA from the
+# tar, not the tar from the data. What comes out is the byte state of a live
+# filesystem sampled over the seconds the tar takes, which is the same thing a
+# restore-from-power-cut has to cope with.
+#
+# This caveat used to be written only against PGDATA, in backup_app_db. That
+# framing was wrong: `db` is the one target with a second, genuinely consistent
+# artifact (the pg_dumpall), so it is the LEAST exposed. The tars with no dump
+# behind them carry the whole risk:
+#
+#   grafana-data     SQLite in rollback-journal mode. A tar taken mid-transaction
+#                    can capture a torn grafana.db, or a db without its journal.
+#   openbao-data     OpenBao file storage under an active writer. There is no
+#                    dump equivalent; see docs/decisions/vault-vs-sops.md for the
+#                    raft-snapshot alternative that would fix this properly.
+#   prometheus-data  TSDB head block and WAL, written continuously.
+#   prod_minio-data  Object data plus xl.meta sidecars, which must agree.
+#   prod_traefik-certs / prod_portainer-data  small and rarely written, so low
+#                    exposure — low, not zero.
+#
+# The 2026-07-31 observability restore is the evidence for stating this rather
+# than assuming it. The scheduled 03:00 tar restored cleanly — and the reason is
+# visible in the tar itself: grafana.db's recorded mtime is 02:52, eight minutes
+# before the tar ran, and no journal file was present. That run got lucky rather
+# than being safe. A tar started during a Grafana write has nothing in this code
+# path to make it come back.
+#
+# Restoring from one of these is a legitimate DR action; treat it as replaying a
+# crashed host, and verify the service after restart rather than assuming the
+# restore was clean. See docs/reference/backup-coverage.md.
 backup_volume() {
     local volume="$1"
     local dest_file="$2"
@@ -229,7 +263,9 @@ Under cron, PATH is /sbin:/bin:/usr/sbin:/usr/bin and sops lives in
 # The user is read from the running container rather than from a secrets store,
 # because the app's store lives in the app's repository and is not present here.
 # A tar of a live PGDATA is crash-consistent at best; pg_dumpall is the artifact
-# that restores cleanly, so both are taken and the dump is required.
+# that restores cleanly, so both are taken and the dump is required. That is a
+# property of every tar this script takes, not of PGDATA — see backup_volume.
+# The database targets are the only ones that also get a consistent artifact.
 # ---------------------------------------------------------------------------
 
 backup_app_db() {


### PR DESCRIPTION
Writes up the backup-restore verification of 2026-07-31. The Postgres half was already
recorded; this is the volume-tar half, plus two things it surfaced that were true of the
whole estate and written down nowhere.

## 1. The crash-consistency caveat was in the wrong place

`backup_volume` tars a **running** container's volume with `-v vol:/data:ro` — no stop, no
pause, no filesystem freeze. The `:ro` protects the data from the tar, not the tar from the
data. The caveat existed, but only on `backup_app_db`, scoped to `PGDATA`.

That framing had it backwards. `db` is the one target with a second, genuinely consistent
artifact behind the tar (the `pg_dumpall`), so it is the **least** exposed. The tars with no
dump behind them carry the whole risk: `grafana-data` (SQLite in rollback-journal mode),
`openbao-data` (file storage under an active writer), `prometheus-data` (TSDB WAL),
`prod_minio-data` (object data plus `xl.meta` sidecars that must agree).

The restore that prompted this **got lucky rather than being safe**, and the artifact itself
shows it: `grafana.db`'s recorded mtime inside the 03:00 tar is **02:52**, eight minutes
before the tar ran, with no journal file present. A tar that starts during a write has
nothing in this code path to save it.

Moved to `backup_volume`, where it governs every caller.

## 2. The age key is a single point of failure, and DR did not say so

`/opt/hill90/secrets/` holds the OpenBao unseal key and the age key. It is **in no tar and
cannot be** — `backup_volume` tars Docker volumes, and that is a host path, so no amount of
adding targets reaches it. That is a deliberate design property: a backup containing the key
that decrypts the estate is a backup you cannot store anywhere.

The consequence is an ordering constraint nobody had written down:

```
age key  →  decrypts prod.enc.env  →  yields OPENBAO_UNSEAL_KEY
         →  unseals the restored openbao-data volume
```

Read right-to-left: **the vault tar is inert without the age key.** You can restore
`openbao-data.tar.gz` perfectly and have nothing.

This is now **Step 0** of `disaster-recovery.md`, with a table of where the key is and is
not, because someone restoring at 3am needs to know the first step happens in a password
manager, not on the host.

Worth being precise about which half is fragile: `OPENBAO_UNSEAL_KEY` **is** present in the
committed `infra/secrets/prod.enc.env`, so losing the on-host copy costs nothing. The age
key is the weak link.

`vps-rebuild.md` described the age key as `` `infra/secrets/keys/age-prod.key` in
repository``. That is false — it is gitignored — and falsely reassuring in exactly the
scenario that runbook covers. Corrected.

## 3. New: `docs/reference/backup-coverage.md`

Every volume on the host, covered or not, with **the consequence of each gap** rather than a
bare list. The uncovered set is `loki-data`, `tempo-data`, `promtail-positions`,
`prod_app-akm-data`, `prod_app-akm-keys`, the retained `prod_app-minio-data`, 9 anonymous
volumes, and the two host paths.

The one worth knowing about is **`prod_app-akm-data`**: the tenant's knowledge store, 4 KB
and empty today, so the cost today is nil — which is precisely why the gap is invisible and
becomes a silent data-loss path the moment the tenant starts storing knowledge.

Also flagged as *unexamined rather than settled*: `prometheus-data` is backed up nightly
while `loki-data` and `tempo-data` are not. Defensible, but not a decision anyone recorded.

`deployment.md`'s "What Gets Backed Up" table listed three of the eight covered volumes and
read as a complete inventory. It now lists all six targets.

## Verification

`Verified 2026-07-31 08:12 UTC`, **read-only against production** — volume and container
inventory, mount ownership per volume, the `deploy` crontab, the 03:00 observability
artefact and the mtime recorded inside it. Baseline held at 13 platform containers by name
plus `minio`, **0 unhealthy**, with the tenant's 7 alongside for 21 total. No live volume
was written to, and no secret value was decrypted or printed — `OPENBAO_UNSEAL_KEY` was
confirmed by reading the key *name* from the encrypted file, whose dotenv format keeps names
in plaintext and values as ciphertext.

CI checks this change touches, run locally:

```
$ python3 scripts/checks/check_md_links.py
Markdown link check passed: no missing local links found.
$ shellcheck --severity=error scripts/*.sh
(clean)
$ bash scripts/checks/check_destructive_commands.sh
No destructive volume commands found.
$ bash scripts/checks/check_argv_secrets.sh
No credentials found in command-line arguments.
```

## What this does NOT prove

- That Grafana **starts** against the restored volume and renders dashboards. The restore
  was verified at file level in a throwaway volume; no Grafana was pointed at it.
- Anything about `openbao-data`, `prometheus-data` or `prod_minio-data` restores, whose
  exposure is larger because they are written continuously. OpenBao has a proper fix
  available — a raft snapshot from the running server — already costed in
  `docs/decisions/vault-vs-sops.md`.
- That `prod_app-minio-data`'s contents are fully represented in the platform MinIO. Not
  checked; do not assume that gap is harmless before its retention expires 2026-08-01 01:41 UTC.

Documentation and one comment block only — no behaviour change. `bash -n` and `backup.sh help`
both still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)