### PR TITLE
ops(health): assert the effective host configuration, so drift stops being silent

### DIFF
--- a/scripts/ops.sh
+++ b/scripts/ops.sh
@@ -29,8 +29,17 @@ EOF
 # ---------------------------------------------------------------------------
 
 cmd_health() {
+    # NOT traefik.hill90.com/ping. That check could never pass: `ping` is not
+    # enabled in platform/edge/traefik.yml.tmpl at all — `traefik healthcheck`
+    # replies "please enable `ping` to use health check" — and the dashboard
+    # router carries auth@file, so the URL returned 401 on every run. A health
+    # check that is permanently red is worse than none: it trains people to skim
+    # past the output, and the next real failure goes with it.
+    #
+    # The public apex proves the thing that matters — Traefik is routing and
+    # terminating TLS — and it is unauthenticated, so a 200 means 200.
     local services=(
-        "https://traefik.hill90.com/ping"
+        "https://hill90.com/"
     )
 
     echo "================================"
@@ -173,6 +182,8 @@ cmd_health() {
         fi
     fi
 
+    check_host_invariants || all_healthy=false
+
     echo ""
     if [ "$all_healthy" = true ]; then
         echo "✓ All services healthy!"
@@ -181,6 +192,115 @@ cmd_health() {
         echo "✗ Some services are unhealthy"
         return 1
     fi
+}
+
+# ---------------------------------------------------------------------------
+# Host invariants: things Config VPS applies and nothing ever re-checked
+# ---------------------------------------------------------------------------
+#
+# WHY THIS EXISTS
+#
+# SSH password authentication was enabled on this host for weeks while the
+# repository, the playbook and docs/architecture/security.md all said it was off.
+# Nothing noticed, because nothing looked. The playbook asserts the value during a
+# bootstrap and then never again, and a bootstrap is a rare event.
+#
+# WHAT MAKES A PROPERTY BELONG HERE
+#
+# Three things together: it is documented in this repository, it is applied by
+# Config VPS, and its failure is SILENT. The last one is the filter. Docker being
+# enabled at boot is documented and applied, but if it regresses every service on
+# the host is down and you will hear about it within minutes — it does not need a
+# checker. These three fail quietly and stay failed:
+#
+#   1. sshd's EFFECTIVE hardening
+#   2. SSH not reachable from the public internet
+#   3. the vault auto-unseal unit still enabled at boot
+#
+# ASSERT THE EFFECTIVE CONFIGURATION, NOT THE FILE
+#
+# `sshd -T` is the post-include, composed configuration the daemon is actually
+# running. The whole point of the original finding is that /etc/ssh/sshd_config
+# said `PasswordAuthentication no` while the daemon did the opposite, because a
+# drop-in read earlier won. Grepping the file, or asserting the drop-in exists,
+# would both have reported healthy throughout. Only `sshd -T` tells the truth.
+check_host_invariants() {
+    echo ""
+    echo "Checking host invariants..."
+
+    local ok=true
+
+    # These need root. deploy has NOPASSWD sudo, so -n succeeds non-interactively;
+    # anywhere else, say the check could not run rather than inventing a verdict.
+    # A check that cannot run must never report the thing it checks as healthy —
+    # nor as broken.
+    if ! sudo -n true 2>/dev/null; then
+        echo "  ⚠ Cannot check host invariants — no non-interactive root."
+        echo "    Run on the VPS as deploy, or with sudo."
+        return 0
+    fi
+
+    # --- 1. sshd effective hardening -------------------------------------
+    local effective
+    effective=$(sudo -n /usr/sbin/sshd -T 2>/dev/null)
+    if [ -z "$effective" ]; then
+        echo "  ⚠ sshd -T produced no output — cannot verify SSH hardening"
+    else
+        local pwauth rootlogin dropin=/etc/ssh/sshd_config.d/00-hill90-hardening.conf
+        pwauth=$(printf '%s\n' "$effective" | awk '/^passwordauthentication /{print $2}')
+        rootlogin=$(printf '%s\n' "$effective" | awk '/^permitrootlogin /{print $2}')
+
+        echo -n "  SSH password authentication... "
+        if [ "$pwauth" = "no" ]; then
+            echo "✓ disabled"
+        elif sudo -n test -f "$dropin"; then
+            # The control is installed and something is overriding it. That is a
+            # REGRESSION — the cloud-init-renames-its-drop-in scenario — and it
+            # is the case this check exists to catch.
+            echo "✗ ENABLED despite the hardening drop-in being present"
+            echo "    Something is read before ${dropin}. Find it with:"
+            echo "      sudo grep -rniE '^[[:space:]]*PasswordAuthentication' /etc/ssh/"
+            ok=false
+        else
+            # Known, accepted, not yet applied. WARN rather than FAIL on purpose:
+            # a check that fails every run on a condition someone has already
+            # decided not to fix yet teaches people to ignore the output, and the
+            # next real failure goes with it. This flips to ✗ by itself the moment
+            # the drop-in is installed, so no one has to remember to change it.
+            echo "⚠ enabled — hardening not applied to this host yet"
+            echo "    Known and accepted; see docs/runbooks/ssh-hardening-drop-in.md"
+        fi
+
+        echo -n "  SSH root login... "
+        if [ "$rootlogin" = "no" ]; then
+            echo "✓ disabled"
+        else
+            echo "✗ permitted (effective: ${rootlogin:-unknown})"
+            ok=false
+        fi
+    fi
+
+    # --- 2. SSH not reachable from the public internet -------------------
+    echo -n "  SSH closed on the public zone... "
+    local pub
+    pub=$(sudo -n firewall-cmd --zone=public --query-service=ssh 2>/dev/null)
+    case "$pub" in
+        no)  echo "✓ closed" ;;
+        yes) echo "✗ OPEN — ssh is served to the public interface"; ok=false ;;
+        *)   echo "⚠ could not query firewalld" ;;
+    esac
+
+    # --- 3. vault auto-unseal still enabled at boot ------------------------
+    echo -n "  Vault auto-unseal unit... "
+    local unit
+    unit=$(systemctl is-enabled hill90-vault-unseal 2>/dev/null)
+    case "$unit" in
+        enabled) echo "✓ enabled" ;;
+        "")      echo "⚠ unit not installed on this host" ;;
+        *)       echo "✗ ${unit} — OpenBao will stay sealed after a reboot"; ok=false ;;
+    esac
+
+    [ "$ok" = true ]
 }
 
 # ---------------------------------------------------------------------------

--- a/tests/scripts/host-invariants.bats
+++ b/tests/scripts/host-invariants.bats
@@ -1,0 +1,131 @@
+#!/usr/bin/env bats
+
+# ops.sh's host-invariant checks.
+#
+# These exist because SSH password authentication was enabled on the running host
+# for weeks while the repo, the playbook and docs/architecture/security.md all
+# said it was off. Nothing noticed because nothing looked.
+#
+# The behaviour under test is the three-state verdict, and specifically that it
+# FLIPS BY ITSELF once the hardening is installed — nobody has to remember to
+# change a threshold:
+#
+#   effective `no`                       -> pass
+#   effective `yes`, drop-in ABSENT      -> warn, exit 0  (known, accepted, not yet applied)
+#   effective `yes`, drop-in PRESENT     -> FAIL, exit 1  (installed and being overridden)
+#
+# Everything is stubbed, so no host is touched and no root is needed.
+
+setup() {
+  REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+  STUB="${BATS_TEST_TMPDIR}/bin"; mkdir -p "$STUB"
+  PATH="${STUB}:$PATH"
+
+  # Defaults: the healthy host. Individual tests override before running.
+  export FIX_PWAUTH=no
+  export FIX_ROOTLOGIN=no
+  export FIX_DROPIN=absent
+  export FIX_PUBSSH=no
+  export FIX_UNIT=enabled
+  export FIX_SUDO=ok
+
+  cat > "${STUB}/sudo" <<'SH'
+#!/usr/bin/env bash
+[ "$1" = "-n" ] && shift
+case "$1" in
+  true)  [ "${FIX_SUDO}" = "ok" ] && exit 0 || exit 1 ;;
+  test)  # `test -f <dropin>`
+         [ "${FIX_DROPIN}" = "present" ] && exit 0 || exit 1 ;;
+  */sshd|sshd)
+         printf 'passwordauthentication %s\n' "${FIX_PWAUTH}"
+         printf 'permitrootlogin %s\n' "${FIX_ROOTLOGIN}"
+         printf 'pubkeyauthentication yes\n'
+         exit 0 ;;
+  firewall-cmd)
+         printf '%s\n' "${FIX_PUBSSH}"; exit 0 ;;
+esac
+exit 0
+SH
+
+  cat > "${STUB}/systemctl" <<'SH'
+#!/usr/bin/env bash
+[ "$1" = "is-enabled" ] && { printf '%s\n' "${FIX_UNIT}"; exit 0; }
+exit 0
+SH
+  chmod +x "${STUB}/sudo" "${STUB}/systemctl"
+}
+
+# Run just the function, without ops.sh's dispatcher.
+run_invariants() {
+  run bash -c "
+    source <(sed -n '/^check_host_invariants()/,/^}/p' '${REPO_ROOT}/scripts/ops.sh')
+    check_host_invariants
+  "
+}
+
+@test "a hardened host passes" {
+  run_invariants
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"✓ disabled"* ]]
+  [[ "$output" == *"✓ closed"* ]]
+  [[ "$output" == *"✓ enabled"* ]]
+}
+
+@test "password auth on with NO drop-in warns, and does not fail the run" {
+  FIX_PWAUTH=yes FIX_DROPIN=absent run_invariants
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"⚠"* ]]
+  [[ "$output" == *"not applied to this host yet"* ]]
+  [[ "$output" == *"ssh-hardening-drop-in.md"* ]]
+}
+
+@test "password auth on WITH the drop-in present is a failure" {
+  # The flip. Once the hardening is installed, the same effective value stops
+  # being an accepted state and becomes a regression — no threshold to remember.
+  FIX_PWAUTH=yes FIX_DROPIN=present run_invariants
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"despite the hardening drop-in being present"* ]]
+}
+
+@test "the assertion reads sshd -T, not a file or sshd_config" {
+  # The original defect was a file that said the right thing while the daemon did
+  # the opposite. A check that greps the file would have reported healthy all
+  # along, so pin that it consults the effective configuration.
+  run bash -c "sed -n '/^check_host_invariants()/,/^}/p' '${REPO_ROOT}/scripts/ops.sh'"
+  [[ "$output" == *"sshd -T"* ]]
+  ! grep -qE "grep .*sshd_config" <<< "$output"
+}
+
+@test "root login permitted is a failure" {
+  FIX_ROOTLOGIN=yes run_invariants
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"permitted"* ]]
+}
+
+@test "ssh open on the public zone is a failure" {
+  FIX_PUBSSH=yes run_invariants
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"OPEN"* ]]
+}
+
+@test "the vault auto-unseal unit being disabled is a failure" {
+  FIX_UNIT=disabled run_invariants
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"sealed after a reboot"* ]]
+}
+
+@test "an absent unit warns rather than failing" {
+  # Not every host runs vault. Absent is not the same as disabled.
+  FIX_UNIT="" run_invariants
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"not installed"* ]]
+}
+
+@test "without non-interactive root it reports that it could not check" {
+  # A check that cannot run must not report the thing it checks as healthy, and
+  # must not report it as broken either.
+  FIX_SUDO=denied run_invariants
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Cannot check host invariants"* ]]
+  [[ "$output" != *"✓ disabled"* ]]
+}


### PR DESCRIPTION
SSH password authentication was enabled on this host for weeks while the repo, the playbook and `security.md` all said it was off. **The reason nobody noticed is that nothing looked** — the playbook asserts the value during a bootstrap and never again, and a bootstrap is rare.

## Asserts `sshd -T`, not a file

That distinction *is* the finding. `/etc/ssh/sshd_config` said `PasswordAuthentication no` while the daemon did the opposite, because a drop-in read earlier won. **Grepping the file — or asserting the hardening drop-in exists — would have reported healthy throughout.** Only the effective, post-include configuration tells the truth.

A test pins this, so the check cannot be "simplified" into a grep later.

## WARN today, FAIL once applied — and it flips by itself

| Effective | Drop-in | Verdict |
|---|---|---|
| `no` | — | ✓ pass |
| `yes` | **absent** | ⚠ warn, exit 0 |
| `yes` | **present** | ✗ **fail**, exit 1 |

**Chosen deliberately.** The host is in a known, accepted, not-yet-scheduled state, and a check that fails on every run for a reason someone has already decided to defer teaches people to skim the output — which is how the next real failure gets missed.

Using the drop-in's *presence* as the signal means **nobody has to remember to change a threshold**. The moment Config VPS installs it, the same effective value stops being an accepted state and becomes a regression — which is also exactly the cloud-init-renames-its-drop-in scenario from the runbook.

## Two others of the same shape — not three, not ten

The filter: documented here, applied by Config VPS, and fails **silently**.

- **SSH not reachable from the public internet.** If the firewalld state regressed the host would be exposed and nothing would say so.
- **`hill90-vault-unseal` still enabled at boot.** If disabled, OpenBao stays sealed after a reboot and nobody finds out until a reboot — and that path has never actually run.

**Docker being enabled at boot is documented and applied too, and is deliberately not here:** if it regresses, every service is down within minutes. Loud failures do not need a checker. That is the whole answer to "are there others" — these two, and no more.

## A check that could never pass

`cmd_health` curled `https://traefik.hill90.com/ping`. But **`ping` is not enabled** in `platform/edge/traefik.yml.tmpl` at all — `traefik healthcheck` replies *"please enable `ping` to use health check"* — and the dashboard router carries `auth@file`, so it returned **401 on every run**.

`make health` was permanently red, which would have buried the new warning in noise. It now checks the public apex: unauthenticated, and proves Traefik is routing and terminating TLS.

## Verified against the running host, read-only

```
Checking host invariants...
  SSH password authentication... ⚠ enabled — hardening not applied to this host yet
    Known and accepted; see docs/runbooks/ssh-hardening-drop-in.md
  SSH root login... ✓ disabled
  SSH closed on the public zone... ✓ closed
  Vault auto-unseal unit... ✓ enabled

✓ All services healthy!      (exit 0)
```

The VPS checkout was restored and confirmed clean afterwards. **No host changes.**

## Tests

Nine bats cases covering all three verdicts plus the degraded ones — an absent vault unit **warns** rather than fails (not every host runs vault), and without non-interactive root the check reports that it **could not run** rather than inventing a verdict in either direction. Full suite: **371 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)