### PR TITLE
docs(backup): cost the consistency fixes per volume, and the Grafana one does not pay

### DIFF
--- a/docs/decisions/backup-consistency-options.md
+++ b/docs/decisions/backup-consistency-options.md
@@ -1,0 +1,186 @@
+# Making the volume tars consistent — what it would cost, per volume
+
+`backup_volume` tars a running container's volume with no stop, pause or freeze, so every
+tar is crash-consistent at best (#610). This is the follow-up question: **can that be
+fixed, per service, and is it worth fixing?**
+
+The candidates genuinely differ per service, so this is eight separate decisions rather
+than one mechanism.
+
+`Verified 2026-07-31 08:26 UTC` — everything below was measured against production
+read-only, except one throwaway container described in full at the end.
+
+## The finding that governs every row
+
+**This estate is largely declarative, so the volume tars protect much less than their size
+suggests.**
+
+- Grafana's dashboards and datasources are **provisioned from files in this repository**,
+  bind-mounted at `/etc/grafana/provisioning`.
+- OpenBao is re-initialised and re-seeded **from SOPS** by disaster-recovery steps 4–8.
+  SOPS is the operative store; the vault is a secondary copy.
+- Traefik's certificates **re-issue from ACME**.
+- Prometheus, Loki and Tempo hold time-series and logs that are worthless once the window
+  they cover has passed.
+
+That leaves exactly two categories of genuinely irreplaceable state: **Postgres**, which
+already has a consistent artifact (`pg_dumpall`), and **object storage**, which is 112 KB
+today.
+
+So the honest headline is: **consistency machinery buys very little here, and for most of
+these volumes adding it would be worse than the risk it removes.**
+
+## Per volume
+
+| Volume | Consistent method available? | Cost | Verdict |
+|---|---|---|---|
+| `prod_postgres-data` (103 MB) | **Already have one** — `pg_dumpall`, required for the run to pass | none, already paid | **Solved.** The tar is a bonus artifact next to a consistent one |
+| `prod_app-postgres-data` (102.5 MB) | **Not needed** — no container references this volume at all any more | none | **Consistent by construction.** A tar of a volume with no writer is a clean copy, not a crash-consistent one |
+| `grafana-data` (30.3 MB) | Yes — `sqlite3 .backup` / `VACUUM INTO` | one tool dependency, a few seconds | **Not worth it.** Measured below: what it protects is one OAuth user row |
+| `openbao-data` (180 KB) | **No** — snapshots require Raft; this runs `file` | migrate to Raft, or stop-tar-start | **Do not.** Stop-tar-start swaps a rare torn tar for a routine sealed-vault risk |
+| `prod_minio-data` (112 KB) | Yes — `mc mirror`, or stop-tar-start | credentials plus a mirror target | **Not now — but this is the one to watch.** The only irreplaceable non-Postgres state |
+| `prod_traefik-certs` (148 KB) | Yes — stop-tar-start | stopping Traefik takes the **entire public surface** down | **Do not.** Blast radius is the whole edge; certificates re-issue anyway |
+| `prod_portainer-data` (1 MB) | Yes — stop-tar-start | genuinely free; nothing depends on Portainer | **Cheapest available and still not worth doing** |
+| `prometheus-data` (664.5 MB) | Yes — TSDB snapshot API | requires `--web.enable-admin-api`, which also enables **series deletion** | **Do not. This is the clearest case.** |
+
+### `grafana-data` — the hypothesis was that this was the case that warranted fixing. It is not.
+
+The reasoning was sound: SQLite, small, high-value, cheap to do properly, and the one thing
+a Postgres restore does not cover. `sqlite3 .backup` really is strictly better than tarring
+the file underneath a running process, and the tooling is available offline — `python:3.12-alpine`
+is already on the host and Python's standard library ships SQLite with the backup API, so no
+new image and no `apk add` at 03:00.
+
+**The mechanism is fine. The value is not there.** Measured by starting Grafana 11.6.0 from
+a completely **empty** volume against this repository's provisioning directory, and
+comparing its database to the live one:
+
+| Table | Live | Rebuilt from nothing |
+|---|---|---|
+| `dashboard` | 6 | **6** |
+| `dashboard_provisioning` | 6 | **6** |
+| `data_source` | 3 | **3** |
+| `alert_rule` | 0 | 0 |
+| `annotation` | 0 | 0 |
+| `star` | 0 | 0 |
+| `preferences` | 0 | 0 |
+| `folder`, `playlist`, `team`, `api_key` | 0 | 0 |
+| `user` | 2 | **1** |
+| `user_auth_token` | 2 | 0 |
+
+All six live dashboards carry a `dashboard_provisioning` row — none was created in the UI.
+The entire delta is **one user row**, `jon@hill90.com`, created by OAuth against Keycloak
+(`GF_AUTH_GENERIC_OAUTH_ENABLED`, with the login form disabled), plus two session tokens.
+That user is recreated by the next SSO login; the tokens are worthless.
+
+So a consistent `grafana.db` protects one row that regenerates itself on first sign-in. The
+correct call is to **leave the tar as it is** and stop treating `grafana-data` as the
+high-value volume — a conclusion the *size* of `grafana.db` actively misleads you toward.
+
+> The `admin` user is not at risk either: `GF_SECURITY_ADMIN_USER` and
+> `GF_SECURITY_ADMIN_PASSWORD` come from the environment, sourced from `GRAFANA_ADMIN_PASSWORD`
+> in the encrypted store, so it is recreated on a fresh start.
+
+### `openbao-data` — no snapshot exists for this backend, and the workaround is worse
+
+`bao status` reports `Storage Type file`, and `config.hcl` declares `storage "file"`. The CLI
+is explicit that snapshots belong to a different backend: `bao operator raft snapshot` is
+documented as *"subcommands for operators interacting with the snapshot functionality of the
+**integrated Raft storage backend**"*. There is no snapshot or export operation for `file`.
+`bao operator migrate` exists but moves data **between backends with the server down** — it is
+a migration tool, not a live snapshot.
+
+That leaves two real options:
+
+1. **Migrate to Raft**, which unlocks `raft snapshot save` — a genuine point-in-time backup
+   from the running server. Already costed in
+   [`vault-vs-sops.md`](vault-vs-sops.md), which notes it would be "strictly better" and
+   simultaneously argues the vault should earn its place at all. **Do not do this for backup
+   reasons alone.** It adds a peer port, node identity, autopilot and quorum semantics to a
+   single-node vault holding three infrastructure secrets, and single-node Raft has a failure
+   tolerance of zero.
+2. **Stop-tar-start.** Nothing serves user traffic from OpenBao at 03:00, so the downtime
+   itself is free — but a restarted OpenBao comes back **sealed**. Consistency would then
+   depend on `vault.sh auto-unseal` firing correctly every single night, and its failure mode
+   is a sealed vault that nobody notices until the next deploy. **That trades a rare risk for
+   a routine one**, which is precisely the fragile machinery this exercise is supposed to
+   avoid.
+
+And the tar matters less than it looks: disaster-recovery steps 4–8 **re-initialise and
+re-seed the vault from SOPS**, so `openbao-data.tar.gz` is a convenience, not the recovery
+path. 180 KB, rarely written. **Accept the crash-consistency.**
+
+### `prometheus-data` — the clearest "do not fix"
+
+Prometheus runs with `--web.enable-lifecycle` and **not** `--web.enable-admin-api`, so the
+TSDB snapshot endpoint is unavailable today. Enabling it would work — and would also switch
+on the admin API's **series-deletion** endpoints, adding a destructive surface to a service
+that currently has none, in exchange for protecting metrics.
+
+Retention is `7d` / `20 GB`. In a disaster you are restoring an estate, and the value of the
+seven days of scrape data that preceded it is approximately zero. The 664.5 MB nightly tar is
+already the largest artifact in the backup set by a factor of six.
+
+**Do not add the snapshot API.** The open question worth asking instead is whether
+`prometheus-data` should be in the nightly set at all — it is 664.5 MB a night, retained seven
+days, protecting data that is itself retained seven days.
+
+The same reasoning applies to `loki-data` (59.3 MB) and `tempo-data` (39.9 MB), which are not
+backed up today: **leave them out.**
+
+### `prod_traefik-certs` — right cost, wrong blast radius
+
+Stopping Traefik makes the tar consistent and takes `hill90.com`, `auth.hill90.com`, `api`,
+`ai` and every Tailscale-only route down with it. If the tar then fails and a cleanup `trap`
+does not fire, the edge stays down until somebody notices — at 03:00, that is hours.
+
+Certificates re-issue from ACME on a fresh host, so the tar's real job is avoiding Let's
+Encrypt **rate limits** during a rebuild, not preserving irreplaceable data. Keep taking it;
+do not stop Traefik for it. See
+[`certificates.md`](../architecture/certificates.md), and note `acme-dns.json` holds all four
+DNS-01 certificates in one file.
+
+### `prod_portainer-data` — free, and still not worth it
+
+The one service where a brief stop costs nothing at all: Portainer is a Tailscale-only UI and
+nothing depends on it. If you want the stop-tar-start pattern proven somewhere harmless, this
+is where. But it protects 1 MB of UI state that a redeploy recreates, so the honest verdict is
+that there is nothing here to protect either.
+
+### `prod_minio-data` — the one to watch, with a trigger rather than a change
+
+Object data is the **only** state in the backed-up set that is not reconstructible from git
+plus SOPS plus a login. It is 112 KB today, which is why nothing needs doing now.
+
+`backup_minio`'s existing comment rejects `mc mirror` because it would need working
+credentials and somewhere to mirror to. That reasoning still holds at this size. It stops
+holding when the store holds real objects.
+
+**Trigger: when `prod_minio-data` exceeds roughly 100 MB, or when the tenant stores anything
+a user would miss, revisit this row specifically.** At that point `mc mirror` — which is
+per-object consistent and officially supported — becomes worth its credential handling, and
+the xl.meta sidecar problem (object data and its metadata must agree) becomes a real
+corruption mode rather than a theoretical one.
+
+## What was actually changed
+
+**Nothing mechanical.** No backup path was modified. The evidence said the one candidate
+that looked clearly worth implementing was not, and implementing it anyway to have shipped
+something would have added a dependency to protect a row that regenerates itself.
+
+What did change is a claim this investigation proved wrong — see
+[`disaster-recovery.md`](../runbooks/disaster-recovery.md).
+
+## How the Grafana rebuild was verified
+
+Non-destructive, on the VPS. A `grafana/grafana:11.6.0` container named
+`gf-throwaway-verify`, on a **new empty volume**, with `--network none` and this
+repository's provisioning directory bind-mounted **read-only**. It carried no Traefik
+labels and joined no network, so it could not be published — invariant 3 says any container
+on the socket with `traefik.enable=true` and a `Host` rule is live on the internet the
+moment it starts.
+
+Its database was read with Python's stdlib `sqlite3` over a `mode=ro` URI. The live volume
+was likewise only ever opened read-only. Container and volume were removed afterwards and
+both confirmed absent; the platform held **21 containers, 0 unhealthy** before and after —
+14 platform (13 by name plus `minio`) and the tenant's 7.

--- a/docs/reference/backup-coverage.md
+++ b/docs/reference/backup-coverage.md
@@ -37,6 +37,21 @@ Every one of those tars is **crash-consistent at best** — see
 [the caveat in `backup_volume`](../../scripts/backup.sh). `db` is the only target with a
 second artifact that restores cleanly, which makes it the least exposed, not the most.
 
+**Whether that is worth fixing was worked out per volume, and mostly it is not** —
+[`backup-consistency-options.md`](../decisions/backup-consistency-options.md). Summarised,
+because the sizes above mislead about what is actually at stake:
+
+| Volume | What it protects that git + SOPS cannot rebuild | Fix it? |
+|---|---|---|
+| `prod_postgres-data` | Everything in Postgres | Already fixed — `pg_dumpall` |
+| `prod_app-postgres-data` | The retired tenant database | Not needed — **no container references this volume**, so with no writer the tar is a clean copy, not a crash-consistent one |
+| `prod_minio-data` | **Object data — the only such state here** | Not at 112 KB. Revisit when it grows |
+| `openbao-data` | Nothing — DR re-seeds from SOPS | **No fix exists**: snapshots need Raft, this is `file` storage |
+| `prod_traefik-certs` | Only ACME rate-limit headroom | No — stopping Traefik downs the whole edge |
+| `prod_portainer-data` | 1 MB of UI state | No — free to do, nothing to protect |
+| `grafana-data` | **One OAuth user row** (measured) | No — dashboards and datasources come from provisioning |
+| `prometheus-data` | 7 days of metrics | No — the snapshot API would also enable series deletion |
+
 ## Not covered — and what each gap costs
 
 | Volume | Owner | Size | Consequence if the host is lost |

--- a/docs/runbooks/disaster-recovery.md
+++ b/docs/runbooks/disaster-recovery.md
@@ -142,7 +142,10 @@ afterwards at 13 containers by name plus `minio`, **0 unhealthy** — re-confirm
 
 **What this exercise does not prove:** that Grafana *starts* against the restored volume
 and renders its dashboards — the restore was verified at the file level, in a throwaway,
-without pointing a Grafana at it. And it says nothing about `openbao-data`,
+without pointing a Grafana at it. (A later exercise did start Grafana against an **empty**
+volume, which is a different question and is why the restore matters less than it looks —
+see [`backup-consistency-options.md`](../decisions/backup-consistency-options.md).) And it
+says nothing about `openbao-data`,
 `prometheus-data` or `prod_minio-data`, whose exposure to the same problem is larger
 because they are written continuously. OpenBao has a proper fix available — a raft
 snapshot, taken from the running server — costed in
@@ -274,13 +277,31 @@ bash scripts/backup.sh restore db /path/to/backup
 > [platform-postgres-password-rotation.md](platform-postgres-password-rotation.md) for
 > the exact shape of both steps.
 
-> **This restores Postgres only. It does NOT restore Grafana.** Grafana keeps its
-> state in **SQLite** inside the `grafana-data` volume, not in Postgres — verified
-> 2026-07-31: no `grafana` database exists on the platform instance, and
-> `/var/lib/grafana/grafana.db` is ~1.8 MB. Grafana's dashboards, users and
-> preferences come back from the **observability** volume tar:
-> `bash scripts/backup.sh restore observability /path/to/backup`. Sequencing a rebuild
-> around the Postgres dump alone leaves Grafana empty.
+> **This restores Postgres only, and Grafana is not in it.** Grafana keeps its state in
+> **SQLite** inside the `grafana-data` volume, not in Postgres — verified 2026-07-31: no
+> `grafana` database exists on the platform instance, and `/var/lib/grafana/grafana.db` is
+> ~1.8 MB.
+>
+> **But do not sequence a rebuild around restoring that volume — you almost certainly do
+> not need to.** This entry used to say Grafana's "dashboards, users and preferences come
+> back from the observability volume tar" and that a Postgres-only restore "leaves Grafana
+> empty". Both overstate it, and the second is false. `Verified 2026-07-31 08:26 UTC` by
+> starting Grafana 11.6.0 against an **empty** volume and this repository's provisioning
+> directory: it came up with all **6 dashboards** and all **3 datasources**, because they
+> are provisioned from files in `platform/observability/grafana/provisioning/` — every live
+> dashboard carries a `dashboard_provisioning` row, so none was made in the UI. Alert rules,
+> annotations, stars, preferences, folders, playlists, teams and API keys are **0 in both**.
+>
+> What the volume tar uniquely holds is **one user row** — `jon@hill90.com`, created by
+> OAuth — and two session tokens. The `admin` user is rebuilt from `GF_SECURITY_ADMIN_*`,
+> which comes from `GRAFANA_ADMIN_PASSWORD` in the encrypted store. So the honest
+> instruction is: **deploy observability normally and let it provision.** The OAuth user
+> reappears at the next sign-in.
+>
+> The restore is still available if you want that user row and the session state back
+> without a login — `bash scripts/backup.sh restore observability /path/to/backup` — but it
+> is a convenience, not a step. Full evidence in
+> [`backup-consistency-options.md`](../decisions/backup-consistency-options.md).
 
 ### 10. Deploy All Services
 

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -137,6 +137,28 @@ verify_artifacts() {
 # Restoring from one of these is a legitimate DR action; treat it as replaying a
 # crashed host, and verify the service after restart rather than assuming the
 # restore was clean. See docs/reference/backup-coverage.md.
+#
+# BUT DO NOT READ THAT LIST AS A WORK QUEUE. It ranks CONSISTENCY EXPOSURE, which
+# is not the same as VALUE AT RISK, and the two point in opposite directions here.
+# Whether each one is worth fixing was worked out separately and mostly the answer
+# is no — docs/decisions/backup-consistency-options.md has it per volume:
+#
+#   grafana-data     Heads that list, and protects almost nothing. Measured
+#                    2026-07-31: a Grafana started on an EMPTY volume reproduces all
+#                    6 dashboards and all 3 datasources from provisioning files in
+#                    this repo. The whole delta against live is ONE OAuth user row.
+#   openbao-data     No fix exists — snapshots require Raft and this runs `file`
+#                    storage. Stopping it for the tar returns a SEALED vault every
+#                    night, which is a worse risk than the one being removed. DR
+#                    re-seeds from SOPS anyway, so this tar is a convenience.
+#   prometheus-data  A snapshot API exists but needs --web.enable-admin-api, which
+#                    also turns on series deletion. 7-day retention data. Not worth
+#                    a new destructive surface.
+#   prod_minio-data  The ONLY entry here holding state that git and SOPS cannot
+#                    rebuild. 112 KB today. This is the one to revisit when it grows.
+#
+# So: this caveat exists so a restore is interpreted correctly, not so someone
+# builds quiescing machinery for volumes that rebuild themselves from the repo.
 backup_volume() {
     local volume="$1"
     local dest_file="$2"


### PR DESCRIPTION
Follow-up to #610. That PR established that every `backup_volume` tar is crash-consistent at
best. This one answers whether that can be fixed, per service, and whether it is worth it.

**No backup path was changed.** The one candidate that looked clearly worth implementing
turned out not to be, and the measurement that showed it also falsified a claim in the DR
runbook — which is the real operational finding here.

## The structural reason most of these are not worth fixing

This estate is **largely declarative**, so the tars protect much less than their sizes
suggest:

- Grafana's dashboards and datasources are **provisioned from files in this repo**
- OpenBao is re-initialised and **re-seeded from SOPS** by DR steps 4–8
- Traefik's certificates **re-issue from ACME**
- Prometheus, Loki and Tempo hold data that is worthless once its window passes

That leaves two categories of genuinely irreplaceable state: **Postgres**, which already has
`pg_dumpall`, and **object storage**, which is 112 KB.

## Grafana was the candidate, and it does not pay

The mechanism is fine. `sqlite3 .backup` really is strictly better than tarring a file under
a live writer, and it needs **no new dependency** — `python:3.12-alpine` is already on the
host and ships SQLite with the backup API in its standard library, so no `apk add` at 03:00.

**The value is the problem.** Measured by starting Grafana 11.6.0 on an **empty** volume
against this repo's provisioning directory, and diffing its database against live:

| Table | Live | Rebuilt from nothing |
|---|---|---|
| `dashboard` / `dashboard_provisioning` | 6 / 6 | **6 / 6** |
| `data_source` | 3 | **3** |
| `alert_rule`, `annotation`, `star`, `preferences`, `folder`, `playlist`, `team`, `api_key` | 0 | 0 |
| `user` | 2 | **1** |
| `user_auth_token` | 2 | 0 |

Every live dashboard carries a `dashboard_provisioning` row — none was made in the UI. **The
entire delta is one user row**, `jon@hill90.com`, created by OAuth, plus two session tokens.
That row is recreated by the next sign-in; `admin` is rebuilt from `GF_SECURITY_ADMIN_*` via
`GRAFANA_ADMIN_PASSWORD` in the encrypted store.

Implementing this would add machinery to protect something that regenerates itself.

## The correction it forced

#608 correctly moved Grafana's state from "in the Postgres dump" to "in the `grafana-data`
volume". But it added that Grafana's *"dashboards, users and preferences come back from the
observability volume tar"* and that a Postgres-only restore *"leaves Grafana empty"*.

**The second is false and the first overstates it.** A rebuild should deploy observability
and let it provision. The restore is a convenience for one user row, not a step. Corrected
in `disaster-recovery.md`, where someone would read it at 3am.

## Per-volume verdicts

| Volume | Consistent method? | Verdict |
|---|---|---|
| `prod_postgres-data` | Already has `pg_dumpall` | **Solved** |
| `prod_app-postgres-data` | Not needed — no container references it | **Consistent by construction**; a tar with no writer is a clean copy |
| `grafana-data` | Yes, `sqlite3 .backup` | **No** — protects one OAuth user row |
| `openbao-data` | **None exists** | **No** — see below |
| `prod_minio-data` | Yes, `mc mirror` | **Not yet** — the one to watch |
| `prod_traefik-certs` | Yes, stop-tar-start | **No** — stopping Traefik downs the entire public surface |
| `prod_portainer-data` | Yes, stop-tar-start | **No** — free to do, nothing to protect |
| `prometheus-data` | Yes, TSDB snapshot API | **No** — clearest case |

**OpenBao has no fix available.** `bao status` reports `Storage Type file` and the CLI scopes
snapshots to *"the integrated Raft storage backend"*. Migrating to Raft is already costed in
`vault-vs-sops.md` and should not be done for backup reasons. Stop-tar-start returns a
**sealed vault** every night — trading a rare risk for a routine one whose failure mode is
silent until the next deploy. And DR re-seeds from SOPS anyway, so this 180 KB tar is a
convenience.

**Prometheus is the clearest do-not-fix.** The snapshot API needs `--web.enable-admin-api`,
which also enables **series deletion** — a new destructive surface on a service that has
none — in exchange for protecting 7-day-retention metrics. The 664.5 MB nightly tar is
already six times the next-largest artifact. Same reasoning keeps `loki-data` and
`tempo-data` out.

**`prod_minio-data` is the one to watch.** Object data is the only backed-up state that git
plus SOPS cannot rebuild. Recorded with a **trigger** rather than a change: revisit when it
exceeds ~100 MB or holds anything a user would miss.

Also amends my own `backup_volume` comment from #610 so it is not read as a work queue — it
ranks *consistency exposure*, which here runs in the opposite order from *value at risk*.

## Verification

`Verified 2026-07-31 08:26 UTC`. The throwaway Grafana ran with `--network none`, **no
Traefik labels**, and the provisioning directory mounted read-only, so it could not be
published (invariant 3). Live volumes were only ever opened read-only, via `mode=ro` URIs.
Throwaway container and volume were removed and both confirmed absent. Platform held **21
containers, 0 unhealthy** before and after.

```
$ python3 scripts/checks/check_md_links.py
Markdown link check passed: no missing local links found.
$ shellcheck --severity=error scripts/*.sh
(clean)
$ bash -n scripts/backup.sh && bash scripts/backup.sh help
(parses; help renders)
```

## Not verified

That Grafana starts against a **restored** volume — the #610 exercise checked that tar at
file level, and this one started Grafana from *empty*, which is a different question. Nothing
here tests an `openbao-data`, `prometheus-data` or `prod_minio-data` restore. And whether
`prod_app-minio-data`'s contents are represented in the platform MinIO remains unchecked;
its retention expires 2026-08-01 01:41 UTC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)