### PR TITLE
docs(alerting): six rules, two of them proven to fire, and no receiver anywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,8 +189,15 @@ make logs-traefik           # follow a service
 ```
 
 Grafana at https://grafana.hill90.com carries dashboards for Traefik, cAdvisor,
-node-exporter and Loki logs. Prometheus alerts cover service availability, memory
-and disk.
+node-exporter and Loki logs.
+
+**Prometheus alert rules exist but nothing delivers them.** This sentence used to say
+alerts "cover service availability, memory and disk", which overstated it twice: there is
+**no Alertmanager and no receiver of any kind**, so every rule is inert, and the memory
+rule watches the host root cgroup rather than containers. `ServiceDown` has genuinely
+fired in production — for ≥48 hours, ending 2026-07-26 — and reached nobody.
+`Verified 2026-07-31 08:44 UTC`; the full map, the ranked gaps and the cheapest fix are in
+[docs/decisions/alerting-audit.md](docs/decisions/alerting-audit.md).
 
 Runbook: [Observability](docs/runbooks/observability.md).
 

--- a/docs/decisions/alerting-audit.md
+++ b/docs/decisions/alerting-audit.md
@@ -1,0 +1,203 @@
+# Alerting audit — what would actually tell us something broke
+
+`Verified 2026-07-31 08:44 UTC`, read-only against production.
+
+## The answer in one line
+
+**Nothing would tell us. There is no notification path out of this estate at all.**
+
+Six Prometheus alert rules exist and evaluate correctly. Prometheus has **zero
+Alertmanagers configured** — `/api/v1/alertmanagers` returns
+`{"activeAlertmanagers":[],"droppedAlertmanagers":[]}` — and there is no Alertmanager
+container. Grafana has **zero alert rules**. There is no MTA on the host and no `MAILTO`
+in the crontab. `DEPLOY_WEBHOOK_URL`, which two workflows would post to, **is not
+configured** as a repository secret, so that path silently no-ops too.
+
+Every alerting component in this estate is present, plausible and inert.
+
+**This is not hypothetical, and that is the finding.** `ServiceDown` **has fired in
+production** — for `keycloak`, `minio` and `postgres-exporter`, continuously, for **at
+least 48 hours**, ending 2026-07-26 06:42 UTC. Three critical-severity alerts, firing for
+two days, delivered to nobody. The episode is only visible now because it happens to fall
+inside the 7-day retention window; it began at or before the window's start, so its true
+duration cannot be recovered.
+
+## What exists
+
+### Prometheus rules — `platform/observability/prometheus/alerts.yml`
+
+All six load with `health=ok` and no evaluation errors. All are `inactive` right now.
+
+| Rule | Ever fired? | Verdict |
+|---|---|---|
+| `ServiceDown` | **Yes** — ≥48 h, 3 targets, ended 2026-07-26 | Works. Delivered nowhere |
+| `TempoIngestionErrors` | **Yes** — ~1.3 h cumulative | Works. Delivered nowhere |
+| `DiskSpaceRunningLow` | Never | Untested. Signal exists and is healthy (87.6 % free on `/`) |
+| `LokiIngestionErrors` | Never | Untested |
+| `PostgresConnectionsHigh` | Never | Untested. Note its expression was already fixed once for a label-matching bug that made it unfireable |
+| `HighMemoryUsage` | Never | **Broken — see below** |
+
+### `HighMemoryUsage` cannot alert on any container
+
+This is a third instance of the estate's favourite bug, found by checking rather than
+reading.
+
+cAdvisor exposes **45 cgroup series and not one Docker container**. Measured:
+`count(container_memory_usage_bytes)` = 44, `count(container_memory_usage_bytes{name!=""})`
+= **0**. The only ids mentioning Docker are `/system.slice/docker.service`,
+`/system.slice/docker.socket` and `/system.slice/containerd.service` — the *daemons*, not
+the containers. Everything else is `/`, `/init.scope` and systemd units.
+
+`count(container_spec_memory_limit_bytes > 0)` = **1**, and that one series is `id="/"`
+with a limit of 16,761,118,720 bytes — total host RAM.
+
+So the rule evaluates over the host root cgroup and nothing else. It is a **host memory
+alert wearing a container alert's name**, and its annotation
+`"Container {{ $labels.name }} memory > 90%"` would render with an empty name if it ever
+fired. The provisioned cAdvisor dashboard has the same problem for the same reason.
+
+Root-causing cAdvisor's container visibility is a separate job; the audit finding is that
+**no per-container memory, CPU or restart signal exists in Prometheus at all.**
+
+### Grafana alerting — configured to deliver nowhere
+
+Read from `grafana.db` read-only:
+
+- `alert_rule` = **0**, `alert_instance` = **0**. Nothing has ever been defined or fired.
+- `alert_configuration` = 1: the stock default, one receiver `grafana-default-email` of
+  type `email`, and the default route pointing at it.
+- No `GF_SMTP_*` environment variables are set on the container.
+
+So Grafana's default contact point is an email receiver **with no SMTP server**. If
+somebody created a Grafana alert rule today it would fire into a receiver that cannot
+deliver, and the failure would be a line in Grafana's own log.
+
+Grafana also logs, every start:
+`can't read alerting provisioning files from directory path=/etc/grafana/provisioning/alerting`.
+It is asking for the directory that would hold provisioned alert rules and contact points.
+
+### Scrape coverage — 10 jobs, all `up`
+
+`prometheus, traefik, keycloak, postgres-exporter, node-exporter, cadvisor, grafana, loki,
+tempo, minio`.
+
+**OpenBao is not scraped.** No `vault_core_unsealed` or equivalent series exists.
+**The tenant's seven containers are not scraped** — no `app-ui`, `app-api` or the rest.
+There is no blackbox probe, so nothing checks that `hill90.com` answers.
+
+## What is not covered, ranked by how badly it would hurt
+
+Jon's candidates, verified rather than accepted, plus two he did not list.
+
+### 1. The public site could be down and nothing would notice — *not covered, no signal*
+
+`hill90.com` is the tenant's UI and the actual product. None of the tenant's containers is
+a scrape target and there is no HTTP probe anywhere, so `ServiceDown` structurally cannot
+fire for them. Traefik's own metrics would show request rates changing, but no rule reads
+them.
+
+The tenancy contract says a tenant's problems are not automatically this repo's problems —
+but "is the public hostname answering" is an edge question, and the edge is this repo's.
+**Highest impact, no signal today.**
+
+### 2. Vault sealed after a reboot — *not covered, no signal*
+
+OpenBao is not a scrape target, so its seal state is invisible. A sealed vault does not
+break user traffic, which is exactly why it would go unnoticed until the next deploy or —
+worse — until a recovery. The auto-unseal path on boot is *already* listed as untested in
+the 2026-07-31 handoff. Untested and unmonitored is the bad combination.
+
+### 3. The nightly backup failing — *not covered, and this estate has already been bitten*
+
+`backup-all` was deliberately made to exit non-zero on partial failure (#563). That exit
+code goes to `>> /opt/hill90/backups/cron.log`. There is **no MTA on the host and no
+`MAILTO`** in the crontab, so cron's own mail path is dead too. Nothing exports a
+backup-freshness metric: node-exporter runs **without** `--collector.textfile.directory`
+and has no textfile directory mounted, so the standard cheap path for this is not wired.
+
+Three consecutive nightly backups already failed silently once. The fix made the script
+fail loudly into a file nobody reads.
+
+### 4. Certificate renewal failing silently — *signal exists, nothing watches it*
+
+This is the one with the best cost-to-value ratio, because **the metric is already there**:
+`traefik_tls_certs_not_after`, 11 certificates. Margins today:
+
+| Certificate | Days remaining |
+|---|---|
+| `portainer.hill90.com`, `grafana.hill90.com` | **42.8** |
+| `vault.hill90.com` | 84.9 |
+| `auth.hill90.com` | 85.5 |
+| `traefik.hill90.com` | 85.7 |
+| `hill90.com`, `api`, `ai`, `litellm`, `storage`, `app-auth` | 87.8 |
+
+All healthy. CLAUDE.md flags ACME failures as quiet, and the failure mode is a 30-day fuse
+that ends with the public site untrusted for every visitor at once. **A rule over an
+existing metric is all that is missing.**
+
+### 5. A container in a restart loop — *not covered, no signal*
+
+No container-level metrics exist (see `HighMemoryUsage` above), and Docker's own
+`RestartCount` is not scraped. `ServiceDown` catches it only for the ten containers that
+are scrape targets, and only after 5 minutes down — a container that restarts every 60
+seconds may never be caught, because each scrape can land on a running instance.
+
+### 6. Disk filling up — *signal exists, rule exists, delivery does not*
+
+`DiskSpaceRunningLow` is correct and node-exporter reports `/` at **87.6 % free**. This one
+needs nothing except a receiver. Slowest fuse of the six, and the only one where the
+existing rule is genuinely fit for purpose.
+
+## The cheapest meaningful addition
+
+**A receiver is the whole problem.** Six rules, two of them proven to fire, and no
+destination. Nothing else on this list is worth doing before that, because every other
+improvement lands in the same void.
+
+Two options, and they are complementary rather than alternatives.
+
+### Option A — Alertmanager, with an email receiver (recommended first step)
+
+One small container, an `alerting:` block in `prometheus.yml`, and a receiver.
+**`SMTP_PASSWORD` already exists in the encrypted store** and Keycloak already sends through
+`smtp.hostinger.com`, so no new account or credential is needed.
+
+*Why this over Grafana-managed alerting:* the rules already exist in Prometheus and are
+already (mostly) right. Grafana alerting would mean rewriting all six as Grafana rules, and
+Grafana's provisioning directory for them does not exist yet. Alertmanager also brings
+grouping, inhibition and silences, which matter — the 48-hour `ServiceDown` episode was
+three simultaneous alerts that should arrive as one notification, not three.
+
+*The honest caveat:* Alertmanager runs on the host it monitors. It cannot tell you the host
+is gone, and it cannot tell you Prometheus stopped scraping. That is what Option B is for.
+
+*Sequencing note, which the firing history earns:* nothing has fired in the five days since
+2026-07-26, so wiring a receiver today would **not** produce a flood. But fix
+`HighMemoryUsage` before or alongside it — shipping a receiver for a rule that fires with a
+blank container name teaches you to ignore the channel.
+
+### Option B — a dead-man's switch, outside the estate
+
+Have the nightly backup cron ping an external service on success, and have that service
+alert when the ping does not arrive. It is one line at the end of the cron entry.
+
+This is the only mechanism proposed here that survives the estate being down, and it covers
+three of the six gaps at once: **the backup failing, the host dying, and the "who watches
+the watcher" hole in Option A.** For a homelab this may be worth more than Alertmanager,
+and it is smaller.
+
+### What to do first, if only one thing happens
+
+**The certificate-expiry alert, delivered by whichever of the above lands first.** The
+signal already exists, the failure is silent by nature, the blast radius is every visitor,
+and the 30-day fuse means one notification is genuinely enough. Everything else on the
+ranked list either needs a signal built first or has a fuse long enough to wait.
+
+## Not verified
+
+- Why cAdvisor sees no Docker containers. Established that it does not; not root-caused.
+- Whether the 2026-07-24 to 07-26 `ServiceDown` episode was a real outage or three targets
+  that did not exist yet — `minio` was deployed on 2026-07-31, so at least one was
+  legitimately absent. This does not change the finding: the alert fired and reached nobody.
+- Nothing here was changed on the host. No alerting component was deployed, configured or
+  tested end to end, because no delivery path exists to test.

--- a/docs/runbooks/observability.md
+++ b/docs/runbooks/observability.md
@@ -107,7 +107,7 @@ When investigating an issue, follow this signal hierarchy:
 | Dashboard | Source | Covers |
 |-----------|--------|--------|
 | Node Exporter | Provisioned | CPU, memory, disk, network (host) |
-| cAdvisor | Provisioned | Container CPU, memory, network |
+| cAdvisor | Provisioned | **Little — cAdvisor exposes no Docker containers on this host**, only cgroup and systemd slices. `Verified 2026-07-31` |
 | Traefik | Provisioned | Request rates, latencies, errors |
 | Loki Logs | Provisioned | Log search and exploration |
 
@@ -115,15 +115,36 @@ All dashboards are file-provisioned from `platform/observability/grafana/provisi
 
 ## Alert Rules
 
-Baseline alerts in `platform/observability/prometheus/alerts.yml`:
+> ## ⚠ These rules notify nobody. There is no Alertmanager and no receiver.
+>
+> `Verified 2026-07-31 08:44 UTC`: `/api/v1/alertmanagers` returns
+> `{"activeAlertmanagers":[],"droppedAlertmanagers":[]}`, there is no Alertmanager
+> container, Grafana has **0** alert rules, and the host has no MTA and no `MAILTO`.
+> An alert firing here changes a state inside Prometheus and nothing else.
+>
+> This is not theoretical: **`ServiceDown` fired for at least 48 hours** across
+> `keycloak`, `minio` and `postgres-exporter`, ending 2026-07-26 06:42 UTC, and reached
+> nobody. Read [alerting-audit.md](../decisions/alerting-audit.md) before relying on
+> anything in this table.
 
-| Alert | Condition | Severity |
-|-------|-----------|----------|
-| ServiceDown | Any scrape target down > 5m | critical |
-| HighMemoryUsage | Container memory > 90% of limit | warning |
-| DiskSpaceRunningLow | Root filesystem < 15% free | warning |
-| LokiIngestionErrors | Ingestion error rate > 0 | warning |
-| TempoIngestionErrors | Ingestion failure rate > 0 | warning |
+Baseline alerts in `platform/observability/prometheus/alerts.yml`. All six load with
+`health=ok`; the "Ever fired" column is measured over the 7-day retention window.
+
+| Alert | Condition | Severity | Ever fired? |
+|-------|-----------|----------|-------------|
+| ServiceDown | Any scrape target down > 5m | critical | **Yes** — ≥48 h, 3 targets |
+| HighMemoryUsage | **Host root cgroup** memory > 90% — *not containers, see below* | warning | Never |
+| DiskSpaceRunningLow | Root filesystem < 15% free | warning | Never |
+| PostgresConnectionsHigh | Active connections > 80% of max | warning | Never |
+| LokiIngestionErrors | Ingestion error rate > 0 | warning | Never |
+| TempoIngestionErrors | Ingestion failure rate > 0 | warning | **Yes** — ~1.3 h |
+
+> **`HighMemoryUsage` does not watch containers, despite its name and its annotation.**
+> cAdvisor exposes 45 cgroup series and **zero Docker containers** —
+> `count(container_memory_usage_bytes{name!=""})` is 0, and the only series with a memory
+> limit is `id="/"`, whose limit is total host RAM. The rule therefore evaluates over the
+> host root cgroup alone, and `{{ $labels.name }}` would render empty. The same absence is
+> why the cAdvisor dashboard below shows no per-container data.
 
 ## Backup and Retention
 


### PR DESCRIPTION
The week's theme has been things that fail silently. This audits the thing that is supposed
to catch them — and it is itself the purest instance of the pattern.

## Nothing would tell us

There is **no notification path out of this estate at all**. `Verified 2026-07-31 08:44 UTC`:

- Prometheus reports **zero Alertmanagers** — `/api/v1/alertmanagers` returns
  `{"activeAlertmanagers":[],"droppedAlertmanagers":[]}` — and there is no Alertmanager container
- Grafana has **0 alert rules**, **0 alert instances**, and its only contact point is the stock
  `grafana-default-email` with **no `GF_SMTP_*` set** — an email receiver with no mail server
- The host has **no MTA and no `MAILTO`**, so cron's own mail path is dead
- `DEPLOY_WEBHOOK_URL`, which two workflows post to, **is not configured** as a repository secret

Every alerting component here is present, plausible and inert.

## And it has already cost something

Checking whether anything had ever fired is what turned this from a config review into a finding.

**`ServiceDown` fired in production** — `keycloak`, `minio` and `postgres-exporter`, continuously,
for **at least 48 hours**, ending **2026-07-26 06:42 UTC**. Three critical-severity alerts, two
days, delivered to nobody. It began at or before the start of the 7-day retention window, so the
true duration is unrecoverable. `TempoIngestionErrors` has also fired, ~1.3 h cumulative.

The other four rules have **never fired**, which makes them untested.

## `HighMemoryUsage` is broken — a third instance of the same bug

cAdvisor exposes **45 cgroup series and zero Docker containers** on this host:

```
count(container_memory_usage_bytes)            = 44
count(container_memory_usage_bytes{name!=""})  = 0
count(container_spec_memory_limit_bytes > 0)   = 1   → id="/", limit = 16,761,118,720 (all host RAM)
```

The only ids mentioning Docker are `docker.service`, `docker.socket` and `containerd.service` —
the daemons, not the containers. So the rule evaluates over the **host root cgroup alone**, and
its annotation `"Container {{ $labels.name }} memory > 90%"` would render an empty name. The
provisioned cAdvisor dashboard is empty for the same reason. Established, **not root-caused**.

## What is not covered, ranked by how badly it would hurt

Your candidates, verified rather than accepted, plus two you did not list.

| # | Gap | Signal exists? | Why it ranks here |
|---|---|---|---|
| 1 | **`hill90.com` could be down** | **No** | The tenant's 7 containers are not scraped and there is no blackbox probe. `ServiceDown` structurally cannot fire for the product |
| 2 | **Vault sealed after reboot** | **No** | OpenBao is not a scrape target; no seal-state series exists. Auto-unseal-on-boot is *already* listed as untested — untested and unmonitored is the bad pair |
| 3 | **Nightly backup failing** | **No** | Exits non-zero into a log file. No MTA, no `MAILTO`, no freshness metric — node-exporter runs without `--collector.textfile.directory`. This estate has already had three silent backup failures once |
| 4 | **Cert renewal failing** | **YES** | `traefik_tls_certs_not_after`, 11 certs, soonest **42.8 days**. Only a rule and a receiver are missing |
| 5 | **Container restart loop** | **No** | No container metrics exist; a 60-second flap can evade a 5-minute `ServiceDown` even for scraped targets |
| 6 | **Disk filling** | **YES** | Rule is correct, `/` is 87.6 % free. Delivery is the only gap |

## The cheapest meaningful addition — proposed, not built

**A receiver is the whole problem.** Every other improvement lands in the same void without one.

**Option A — Alertmanager with an email receiver (recommended first).** One small container, an
`alerting:` block, a receiver. **`SMTP_PASSWORD` is already in the encrypted store** and Keycloak
already sends via `smtp.hostinger.com`, so no new credential is needed. Preferred over
Grafana-managed alerting because the six rules already exist and are mostly right, and because
Alertmanager's grouping would have turned that 48-hour episode into one notification rather than
three. *Caveat: it runs on the host it monitors, so it cannot report that host's death.*

**Option B — a dead-man's switch outside the estate.** One line appended to the backup cron,
pinging an external service that alerts when the ping stops. It is the only proposal here that
survives the estate being down, and it covers **three gaps at once**: the backup failing, the
host dying, and the watch-the-watcher hole in Option A. For a homelab it may be worth more than
Alertmanager, and it is smaller.

**If only one thing happens: the certificate alert.** The signal already exists, the failure is
silent by nature, the blast radius is every visitor, and a 30-day fuse means one notification is
genuinely enough.

*Sequencing note the firing history earns:* nothing has fired in the five days since 2026-07-26,
so wiring a receiver today would **not** flood. But fix `HighMemoryUsage` alongside it — shipping
a receiver for a rule that fires with a blank container name teaches you to ignore the channel.

## Corrections

Two claims had gone false:

- **README** said alerts "cover service availability, memory and disk" — wrong twice: nothing
  delivers them, and the memory rule watches the host root cgroup
- **observability.md** listed 5 of the 6 rules, described `HighMemoryUsage` as watching
  containers, and credited the cAdvisor dashboard with container CPU and memory

## Verification

Read-only throughout: Prometheus HTTP API for alertmanagers, rules and `ALERTS` history;
`grafana.db` opened via a `mode=ro` URI; container and node-exporter inspection. **No alerting
component was deployed, configured or changed.** Platform held 21 containers, 0 unhealthy.

```
$ python3 scripts/checks/check_md_links.py
Markdown link check passed: no missing local links found.
$ shellcheck --severity=error scripts/*.sh
(clean)
```

## Not verified

Why cAdvisor sees no Docker containers — established, not diagnosed. Whether the 07-24→07-26
`ServiceDown` episode was a real outage or targets that did not exist yet (`minio` was deployed
2026-07-31, so at least one was legitimately absent) — which does not change the finding that it
fired and reached nobody. And nothing here was tested end to end, because there is no delivery
path to test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)