### PR TITLE
feat(alerting): Alertmanager, an email receiver proven to deliver, and the first two real alerts

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -221,3 +221,15 @@ VOLUME_PREFIX_BARE=hill90dev-
 
 # Hold minio's Traefik router dark across deploys (cutover only). Default true.
 MINIO_TRAEFIK_ENABLE=true
+
+# Group that may read /opt/hill90/secrets/alertmanager.yml.
+#
+# Alertmanager runs as `nobody` (uid 65534) and the rendered config is 0640
+# deploy:deploy, so the container is started as "65534:${SECRETS_GID}" — uid
+# unchanged so it still owns its data volume, gid set so it can read the config.
+# A 0600 config makes the container exit with "permission denied"; 0644 would
+# put an SMTP password within reach of every local user.
+#
+# Production value: 1000, the `deploy` group on the VPS. Override only on a host
+# where the deploy user's gid differs.
+SECRETS_GID=1000

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -247,7 +247,13 @@ bash scripts/deploy.sh verify <service> prod
 gh workflow run deploy.yml -f service=all
 ```
 
-- Platform baseline is **13 containers, 0 unhealthy**. A tenant's containers sit
+- Platform baseline is **13 containers, 0 unhealthy** — **16 once this PR's
+  observability deploy runs.** `alertmanager` and `blackbox-exporter` are new
+  platform containers; the count before them was 13 by name plus `minio` (14
+  running), so the expected post-deploy figure is **16 platform containers, 0
+  unhealthy**, plus the tenant's 7 for **23 total**. Neither new container has
+  Traefik labels and neither is public. Update this line when they land, not
+  before. A tenant's containers sit
   alongside them and are not part of that count. **Verify the baseline after any
   tenant action — a degraded baseline is the stop-everything signal.** The
   tenancy contract has been tested in both directions: on 2026-07-29 the tenant

--- a/README.md
+++ b/README.md
@@ -191,13 +191,16 @@ make logs-traefik           # follow a service
 Grafana at https://grafana.hill90.com carries dashboards for Traefik, cAdvisor,
 node-exporter and Loki logs.
 
-**Prometheus alert rules exist but nothing delivers them.** This sentence used to say
-alerts "cover service availability, memory and disk", which overstated it twice: there is
-**no Alertmanager and no receiver of any kind**, so every rule is inert, and the memory
-rule watches the host root cgroup rather than containers. `ServiceDown` has genuinely
-fired in production — for ≥48 hours, ending 2026-07-26 — and reached nobody.
-`Verified 2026-07-31 08:44 UTC`; the full map, the ranked gaps and the cheapest fix are in
-[docs/decisions/alerting-audit.md](docs/decisions/alerting-audit.md).
+Alertmanager delivers alerts by **email**, to the address in `ACME_EMAIL`, through the
+SMTP account this estate already had. Eight rules; the two that matter most are
+`PublicSiteDown` (hill90.com not answering) and `VaultSealedOrUnreachable`. Every
+notification names the service, the host, and what to do first.
+
+Delivery was **proven end to end** on 2026-07-31 — a real probe failure, a real email —
+rather than assumed; that exercise found two defects a config check does not catch. Before
+that date there was no receiver at all and every rule was inert, including one that fired
+for 48 hours and reached nobody. The audit, the ranked gaps still open, and the evidence
+are in [docs/decisions/alerting-audit.md](docs/decisions/alerting-audit.md).
 
 Runbook: [Observability](docs/runbooks/observability.md).
 

--- a/deploy/compose/prod/docker-compose.observability.yml
+++ b/deploy/compose/prod/docker-compose.observability.yml
@@ -22,6 +22,11 @@ volumes:
     name: ${VOLUME_PREFIX_BARE:-}grafana-data
   promtail-positions:
     name: ${VOLUME_PREFIX_BARE:-}promtail-positions
+  # Holds silences and notification-dedup state. Losing it re-sends currently
+  # firing alerts once and drops any active silence; it is not in the nightly
+  # backup set and does not need to be — see docs/reference/backup-coverage.md.
+  alertmanager-data:
+    name: ${VOLUME_PREFIX_BARE:-}alertmanager-data
 
 services:
   prometheus:
@@ -44,6 +49,81 @@ services:
       - "--web.enable-lifecycle"
     healthcheck:
       test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:9090/-/healthy"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+  # ---------------------------------------------------------------------------
+  # Alertmanager — the missing half. Prometheus had six rules and no receiver.
+  #
+  # DELIBERATELY NOT PUBLIC. There are no traefik.* labels here, and there must
+  # not be: production Traefik sets no provider `constraints`, so any container
+  # on the socket with traefik.enable=true and a Host rule is live on the public
+  # internet the moment it starts (invariant 3). Alertmanager's UI can silence
+  # alerts with no authentication of its own. Reach it over Tailscale with
+  # `ssh vps -L 9093:localhost:9093` if you need the UI, or add it behind the
+  # same IP-allowlist middleware the other internal services use — deliberately,
+  # not by copying a label block.
+  #
+  # ON `edge` AND NOT ONLY `internal`: hill90_internal is `internal: true`, so a
+  # container attached to it alone has NO EGRESS and cannot resolve or reach
+  # smtp.hostinger.com. An Alertmanager on internal only would start healthy,
+  # accept every alert, and fail every delivery — the exact silent-failure shape
+  # this whole change exists to remove. Verified 2026-07-31 by testing both
+  # networks.
+  alertmanager:
+    image: prom/alertmanager:v0.28.1
+    container_name: ${CONTAINER_PREFIX:-}alertmanager
+    restart: unless-stopped
+    mem_limit: 128m
+    # uid stays 65534 (`nobody`, what the image expects and what owns the
+    # alertmanager-data volume); gid becomes the deploy group so the 0640
+    # rendered config is readable. Dropping either half breaks it — a 0600 config
+    # made the container exit with "permission denied" during verification.
+    user: "65534:${SECRETS_GID:-1000}"
+    networks:
+      - edge
+      - internal
+    volumes:
+      # Rendered OUTSIDE the checkout by scripts/render-alertmanager-config.sh
+      # because it carries the SMTP password. See that script's header.
+      - /opt/hill90/secrets/alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
+      - alertmanager-data:/alertmanager
+    command:
+      - "--config.file=/etc/alertmanager/alertmanager.yml"
+      - "--storage.path=/alertmanager"
+      # Needed for silences and for links in notifications to be meaningful.
+      - "--web.external-url=http://localhost:9093"
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:9093/-/healthy"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+  # ---------------------------------------------------------------------------
+  # Blackbox exporter — the only honest signal for the top two audit gaps.
+  #
+  # The cheaper options were checked and do not exist here:
+  # traefik_service_server_up has zero series, and the tenant's containers are
+  # not scrape targets, so ServiceDown structurally cannot fire for hill90.com.
+  # See platform/observability/blackbox/blackbox.yml.
+  #
+  # Also on `edge`: probing hill90.com goes out to public DNS and back through
+  # the real edge path, which internal-only cannot do.
+  blackbox-exporter:
+    image: prom/blackbox-exporter:v0.26.0
+    container_name: ${CONTAINER_PREFIX:-}blackbox-exporter
+    restart: unless-stopped
+    mem_limit: 64m
+    networks:
+      - edge
+      - internal
+    volumes:
+      - ../../../platform/observability/blackbox/blackbox.yml:/etc/blackbox/blackbox.yml:ro
+    command:
+      - "--config.file=/etc/blackbox/blackbox.yml"
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:9115/-/healthy"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/docs/decisions/alerting-audit.md
+++ b/docs/decisions/alerting-audit.md
@@ -2,9 +2,18 @@
 
 `Verified 2026-07-31 08:44 UTC`, read-only against production.
 
-## The answer in one line
+> ## STATUS: the receiver was built. Read this as the audit that motivated it.
+>
+> Everything below describes the estate **before 2026-07-31 09:17 UTC**. Alertmanager now
+> exists, Prometheus is wired to it, and email delivery is proven end to end. Two of the
+> six ranked gaps — the public site and the sealed vault — are closed with new
+> `PublicSiteDown` and `VaultSealedOrUnreachable` rules. **The remaining four are still
+> open and are listed under "Follow-ups" at the end.** The diagnosis below is preserved
+> deliberately: the reason each gap ranked where it did has not changed.
 
-**Nothing would tell us. There is no notification path out of this estate at all.**
+## The answer in one line (as of the audit)
+
+**Nothing would tell us. There was no notification path out of this estate at all.**
 
 Six Prometheus alert rules exist and evaluate correctly. Prometheus has **zero
 Alertmanagers configured** — `/api/v1/alertmanagers` returns
@@ -201,3 +210,30 @@ ranked list either needs a signal built first or has a fuse long enough to wait.
   legitimately absent. This does not change the finding: the alert fired and reached nobody.
 - Nothing here was changed on the host. No alerting component was deployed, configured or
   tested end to end, because no delivery path exists to test.
+
+
+## Follow-ups — what this audit found and the first alerting change did NOT close
+
+Ranked as before. Two of six are closed; these four are not.
+
+1. **The nightly backup failing** (was #3). Still exits non-zero into a log file nobody
+   reads. No MTA, no `MAILTO`, no freshness metric — node-exporter still runs without
+   `--collector.textfile.directory`. **Cheapest fix:** have the backup cron write a
+   `.prom` file with a completion timestamp and add a staleness rule. That is now worth
+   doing, because a receiver exists to deliver it to.
+2. **Certificate renewal failing silently** (was #4). The signal already exists —
+   `traefik_tls_certs_not_after`, 11 certificates, soonest 42.8 days as of 2026-07-31.
+   **This is now a three-line rule with a working receiver behind it** and is the obvious
+   next change. It was left out of the first one only to keep that change to the two gaps
+   with no signal at all.
+3. **A container in a restart loop** (was #5). Still no signal: cAdvisor exposes no Docker
+   containers on this host, which also makes `HostMemoryHigh` host-wide rather than
+   per-container. Root-causing cAdvisor is the prerequisite.
+4. **Nothing watches the watcher.** Alertmanager runs on the host it monitors, so it cannot
+   report that host's death, and neither can Prometheus. The dead-man's-switch proposal —
+   a ping from the backup cron to an external service that alerts when the ping stops —
+   is unchanged and would close this and item 1 together.
+
+Also unresolved from the audit body: **the tenant's seven containers are still not scrape
+targets.** `PublicSiteDown` probes the public URL, which is the outcome that matters, but
+it cannot say which component failed.

--- a/docs/runbooks/observability.md
+++ b/docs/runbooks/observability.md
@@ -115,31 +115,42 @@ All dashboards are file-provisioned from `platform/observability/grafana/provisi
 
 ## Alert Rules
 
-> ## ⚠ These rules notify nobody. There is no Alertmanager and no receiver.
+> ## Alerts are delivered by email as of 2026-07-31 — this section used to say nobody received them.
 >
-> `Verified 2026-07-31 08:44 UTC`: `/api/v1/alertmanagers` returns
-> `{"activeAlertmanagers":[],"droppedAlertmanagers":[]}`, there is no Alertmanager
-> container, Grafana has **0** alert rules, and the host has no MTA and no `MAILTO`.
-> An alert firing here changes a state inside Prometheus and nothing else.
+> Alertmanager now runs on the platform and Prometheus is wired to it. The receiver is
+> **email to the address in `ACME_EMAIL`**, via `smtp.hostinger.com:587` as
+> `noreply@hill90.com` — the same server Keycloak already uses, with `SMTP_PASSWORD` from
+> the encrypted store. No new account was created.
 >
-> This is not theoretical: **`ServiceDown` fired for at least 48 hours** across
-> `keycloak`, `minio` and `postgres-exporter`, ending 2026-07-26 06:42 UTC, and reached
-> nobody. Read [alerting-audit.md](../decisions/alerting-audit.md) before relying on
-> anything in this table.
+> **Delivery was proven end to end, not assumed**: a real probe failure fired
+> `PublicSiteDown`, Prometheus sent it to Alertmanager, and Alertmanager delivered it via
+> Hostinger — `alertmanager_notifications_total{integration="email"}` 1,
+> `failed_total` 0. Two defects were found only by doing that, and neither was caught by
+> `amtool check-config`: a 0600 config is unreadable by Alertmanager's `nobody` user, and
+> the template function `default` does not exist in Alertmanager (use `or`).
+>
+> Reaching the UI: it is **not public and has no Traefik labels** — production Traefik sets
+> no provider constraints, so a `Host` rule would put a silence-anything UI on the
+> internet. Use `ssh vps -L 9093:localhost:9093`.
+>
+> Full history and the gaps still open: [alerting-audit.md](../decisions/alerting-audit.md).
 
-Baseline alerts in `platform/observability/prometheus/alerts.yml`. All six load with
-`health=ok`; the "Ever fired" column is measured over the 7-day retention window.
+Alerts live in `platform/observability/prometheus/alerts.yml`. Every rule carries
+`summary`, `description` and **`action`** annotations; `action` is rendered into the email
+as "Do this first" and is not optional — add it to any new rule.
 
-| Alert | Condition | Severity | Ever fired? |
-|-------|-----------|----------|-------------|
-| ServiceDown | Any scrape target down > 5m | critical | **Yes** — ≥48 h, 3 targets |
-| HighMemoryUsage | **Host root cgroup** memory > 90% — *not containers, see below* | warning | Never |
-| DiskSpaceRunningLow | Root filesystem < 15% free | warning | Never |
-| PostgresConnectionsHigh | Active connections > 80% of max | warning | Never |
-| LokiIngestionErrors | Ingestion error rate > 0 | warning | Never |
-| TempoIngestionErrors | Ingestion failure rate > 0 | warning | **Yes** — ~1.3 h |
+| Alert | Condition | Severity | Notes |
+|-------|-----------|----------|-------|
+| **PublicSiteDown** | blackbox probe of `https://hill90.com/` not 200 for 2m | critical | **New.** The only signal for the product being down — the tenant's containers are not scrape targets |
+| **VaultSealedOrUnreachable** | blackbox probe of OpenBao `/v1/sys/health` not 200 for 5m | critical | **New.** 503 means SEALED. Needs no token |
+| ServiceDown | Any scrape target down > 5m | critical | Fired ≥48 h to 2026-07-26 with no receiver |
+| HostMemoryHigh | **Host root cgroup** memory > 90% | warning | **Renamed from HighMemoryUsage** — it never watched containers, see below |
+| DiskSpaceRunningLow | Root filesystem < 15% free | warning | Never fired; `/` is 87.6% free |
+| PostgresConnectionsHigh | Active connections > 80% of max | warning | Never fired |
+| LokiIngestionErrors | Ingestion error rate > 0 | warning | Never fired |
+| TempoIngestionErrors | Ingestion failure rate > 0 | warning | Fired ~1.3 h with no receiver |
 
-> **`HighMemoryUsage` does not watch containers, despite its name and its annotation.**
+> **`HostMemoryHigh` was called `HighMemoryUsage` and did not watch containers.**
 > cAdvisor exposes 45 cgroup series and **zero Docker containers** —
 > `count(container_memory_usage_bytes{name!=""})` is 0, and the only series with a memory
 > limit is `id="/"`, whose limit is total host RAM. The rule therefore evaluates over the

--- a/platform/observability/alertmanager/alertmanager.yml.tmpl
+++ b/platform/observability/alertmanager/alertmanager.yml.tmpl
@@ -1,0 +1,96 @@
+# Alertmanager configuration TEMPLATE.
+#
+# Rendered by scripts/render-alertmanager-config.sh to a 0600 file OUTSIDE this
+# checkout — see that script for why the rendered copy must not live here.
+#
+# __SMTP_PASSWORD__ and __ALERT_EMAIL_TO__ are substituted at deploy time from the
+# encrypted store. Never commit a rendered copy.
+
+global:
+  # Hostinger, port 587, STARTTLS — the same server and the same noreply@hill90.com
+  # account Keycloak already sends through. Verified 2026-07-31: AUTH accepted.
+  smtp_smarthost: 'smtp.hostinger.com:587'
+  smtp_from: 'noreply@hill90.com'
+  smtp_auth_username: 'noreply@hill90.com'
+  smtp_auth_password: '__SMTP_PASSWORD__'
+  smtp_require_tls: true
+  # Alertmanager's default is 5m. A resolved notification arriving 5 minutes late
+  # is fine; a firing one is not, and group_wait below governs that.
+  resolve_timeout: 5m
+
+route:
+  # Group everything from one host into one email. The 2026-07-26 episode was
+  # three simultaneous ServiceDown alerts; that should arrive as one message, not
+  # three — see docs/decisions/alerting-audit.md.
+  group_by: ['alertname', 'job']
+  group_wait: 30s
+  group_interval: 5m
+  # Deliberately long. This is a homelab with one recipient and no on-call
+  # rotation: a re-notification every 4 hours is a reminder, every 15 minutes is
+  # training to filter the sender.
+  repeat_interval: 4h
+  receiver: 'email'
+
+  routes:
+    # Critical alerts skip the grouping delay and repeat sooner. Both of the
+    # first two rules (PublicSiteDown, VaultSealedOrUnreachable) land here.
+    - matchers:
+        - severity = "critical"
+      receiver: 'email'
+      group_wait: 10s
+      repeat_interval: 1h
+
+receivers:
+  - name: 'email'
+    email_configs:
+      - to: '__ALERT_EMAIL_TO__'
+        send_resolved: true
+        headers:
+          # `or`, NOT `default`. Alertmanager's template engine is Go text/template
+          # plus its own small function set — it has no Sprig, so `default` is
+          # undefined. `amtool check-config` accepts a template using it and every
+          # notification then fails at RENDER time with "function \"default\" not
+          # defined", which Alertmanager treats as unrecoverable and does not retry.
+          # Found by sending a real alert; a config check does not catch it.
+          Subject: '[Hill90 {{ .Status | toUpper }}] {{ .CommonLabels.alertname }} on {{ or .CommonLabels.instance "platform" }}'
+        # The body exists so that a human woken by this knows what broke, where,
+        # and what to do FIRST — without opening a laptop to find out. An alert
+        # that says FIRING and nothing else trains people to ignore it.
+        html: |
+          <h2>{{ .Status | toUpper }} — {{ .Alerts | len }} alert(s)</h2>
+          {{ range .Alerts }}
+          <hr>
+          <p><b>{{ .Labels.alertname }}</b> ({{ .Labels.severity }})</p>
+          <p>{{ .Annotations.summary }}</p>
+          <table cellpadding="4">
+            <tr><td><b>Service</b></td><td>{{ or .Labels.job .Labels.service "—" }}</td></tr>
+            <tr><td><b>Instance / host</b></td><td>{{ or .Labels.instance "—" }}</td></tr>
+            <tr><td><b>Started</b></td><td>{{ .StartsAt }}</td></tr>
+          </table>
+          <p><b>What happened:</b> {{ .Annotations.description }}</p>
+          <p><b>Do this first:</b> {{ .Annotations.action }}</p>
+          {{ if .Annotations.runbook }}<p><b>Runbook:</b> {{ .Annotations.runbook }}</p>{{ end }}
+          {{ end }}
+        text: |
+          {{ .Status | toUpper }} — {{ .Alerts | len }} alert(s)
+          {{ range .Alerts }}
+          ----------------------------------------------------------------
+          {{ .Labels.alertname }} ({{ .Labels.severity }})
+          {{ .Annotations.summary }}
+
+          Service        : {{ or .Labels.job .Labels.service "—" }}
+          Instance/host  : {{ or .Labels.instance "—" }}
+          Started        : {{ .StartsAt }}
+
+          What happened  : {{ .Annotations.description }}
+          Do this first  : {{ .Annotations.action }}
+          {{ if .Annotations.runbook }}Runbook        : {{ .Annotations.runbook }}{{ end }}
+          {{ end }}
+
+inhibit_rules:
+  # If the whole site is down, do not also mail about the vault being unreachable.
+  - source_matchers:
+      - alertname = "PublicSiteDown"
+    target_matchers:
+      - severity = "warning"
+    equal: ['instance']

--- a/platform/observability/blackbox/blackbox.yml
+++ b/platform/observability/blackbox/blackbox.yml
@@ -1,0 +1,44 @@
+# Blackbox exporter modules.
+#
+# WHY THIS EXISTS AT ALL — the cheaper options were checked first and do not work:
+#
+#   - Traefik does not export backend health here. `traefik_service_server_up` has
+#     ZERO series (verified 2026-07-31); Traefik only emits it for services with a
+#     configured health check, and the tenant's routers define none.
+#   - The tenant's seven containers are not Prometheus scrape targets, so
+#     `ServiceDown` structurally cannot fire for hill90.com — the actual product.
+#   - Request-rate metrics exist but "no requests recently" is not an availability
+#     signal on a low-traffic homelab site.
+#
+# So an HTTP probe is the only honest way to answer "is the site answering".
+
+modules:
+  # Public site. Follows redirects, requires a 2xx.
+  http_2xx:
+    prober: http
+    timeout: 10s
+    http:
+      valid_http_versions: ["HTTP/1.1", "HTTP/2.0"]
+      valid_status_codes: [200]
+      follow_redirects: true
+      preferred_ip_protocol: ip4
+      # ip4 is not cosmetic: the probe runs from a container on hill90_edge and
+      # reaches hill90.com by public DNS, so it exercises the real edge path.
+
+  # OpenBao seal state, WITHOUT a token.
+  #
+  # /v1/sys/health encodes the state in the STATUS CODE: 200 initialized+unsealed
+  # and active, 503 sealed, 501 not initialized. So a plain 200-or-nothing probe
+  # answers "is the vault usable" without any credential, and without enabling
+  # unauthenticated metrics on the listener — which would have meant editing
+  # config.hcl and restarting OpenBao, and a restarted OpenBao comes back SEALED.
+  # Using the health endpoint avoids taking that risk to build a sealed-vault
+  # detector.
+  vault_health:
+    prober: http
+    timeout: 10s
+    http:
+      valid_http_versions: ["HTTP/1.1", "HTTP/2.0"]
+      valid_status_codes: [200]
+      follow_redirects: false
+      preferred_ip_protocol: ip4

--- a/platform/observability/prometheus/alerts.yml
+++ b/platform/observability/prometheus/alerts.yml
@@ -1,4 +1,61 @@
+# Every rule here MUST carry summary, description and action annotations.
+# `action` is not decoration: it is rendered into the notification body as
+# "Do this first". An alert that says FIRING and nothing else trains the one
+# person who receives it to ignore the sender — see
+# docs/decisions/alerting-audit.md.
+
 groups:
+  # ---------------------------------------------------------------------------
+  # The two gaps ranked highest in the alerting audit. Both are failures that
+  # would otherwise go unnoticed for days, and neither had ANY signal before.
+  # ---------------------------------------------------------------------------
+  - name: availability
+    rules:
+      - alert: PublicSiteDown
+        # probe_success is 0 when the HTTP probe did not get a 200. 2m rather
+        # than 5m: this is the product being unreachable from the internet, and
+        # a deploy that replaces app-ui takes seconds, not minutes.
+        expr: probe_success{job="blackbox-public"} == 0
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "hill90.com is not answering from the internet"
+          description: >-
+            The blackbox probe of {{ $labels.instance }} has not received HTTP 200
+            for over 2 minutes. This is the tenant's UI — the public product — so
+            users are seeing this too.
+          action: >-
+            Check the edge before the app: `docker ps --filter name=traefik` and
+            `docker logs --tail 50 traefik`. If Traefik is healthy, the tenant's
+            app-ui is the next suspect — it is NOT a Prometheus scrape target, so
+            this probe is the only signal. Confirm from outside with
+            `curl -sI https://hill90.com`.
+          runbook: docs/runbooks/troubleshooting.md
+
+      - alert: VaultSealedOrUnreachable
+        # /v1/sys/health returns 503 when sealed and 501 when uninitialised, so a
+        # 200-or-nothing probe covers sealed, down and uninitialised alike without
+        # depending on which code came back.
+        expr: probe_success{job="blackbox-vault"} == 0
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "OpenBao is sealed, uninitialised or unreachable"
+          description: >-
+            The unauthenticated health probe of {{ $labels.instance }} has not returned
+            HTTP 200 for over 5 minutes. 503 means SEALED, 501 means uninitialised.
+            A sealed vault breaks nothing user-facing, which is exactly why this
+            would otherwise go unnoticed until the next deploy — or until a recovery.
+          action: >-
+            Run `docker exec openbao bao status`. If it reports `Sealed true`, unseal
+            with `bash scripts/vault.sh unseal`. If this followed a reboot, the
+            systemd unit hill90-vault-unseal did not do its job — check
+            `systemctl status hill90-vault-unseal` before unsealing by hand, or the
+            same thing happens after the next reboot.
+          runbook: docs/runbooks/vault-unseal.md
+
   - name: service-health
     rules:
       - alert: ServiceDown
@@ -7,21 +64,50 @@ groups:
         labels:
           severity: critical
         annotations:
-          summary: "{{ $labels.job }} is down"
-          description: "Scrape target {{ $labels.instance }} (job {{ $labels.job }}) has been down for more than 5 minutes."
+          summary: "Scrape target {{ $labels.job }} is down"
+          description: >-
+            Scrape target {{ $labels.instance }} (job {{ $labels.job }}) has been
+            down for more than 5 minutes on the platform host.
+          action: >-
+            `docker ps -a --filter name={{ $labels.job }}` then
+            `docker logs --tail 50 {{ $labels.job }}`. If the container is healthy
+            but the target is down, the metrics endpoint or the internal network is
+            the fault, not the service.
+          runbook: docs/runbooks/observability.md
 
   - name: resource-usage
     rules:
-      - alert: HighMemoryUsage
+      # RENAMED FROM HighMemoryUsage, because that name was a lie.
+      #
+      # It claimed to watch containers and annotated "Container {{ $labels.name }}".
+      # cAdvisor on this host exposes 45 cgroup series and ZERO Docker containers:
+      # count(container_memory_usage_bytes{name!=""}) is 0, and the only series
+      # carrying a memory limit is id="/", whose limit is total host RAM. So the
+      # rule only ever evaluated the host root cgroup, and $labels.name rendered
+      # empty. Verified 2026-07-31.
+      #
+      # Renaming rather than deleting keeps the (real, useful) host-memory signal
+      # while removing the false claim. Restoring genuine per-container alerting
+      # requires fixing cAdvisor first, which is a follow-up in
+      # docs/decisions/alerting-audit.md — do not simply rename this back.
+      - alert: HostMemoryHigh
         expr: |
-          (container_memory_usage_bytes / container_spec_memory_limit_bytes) > 0.9
-          and container_spec_memory_limit_bytes > 0
+          (container_memory_usage_bytes{id="/"} / container_spec_memory_limit_bytes{id="/"}) > 0.9
+          and container_spec_memory_limit_bytes{id="/"} > 0
         for: 5m
         labels:
           severity: warning
         annotations:
-          summary: "Container {{ $labels.name }} memory > 90%"
-          description: "Container {{ $labels.name }} is using {{ $value | humanizePercentage }} of its memory limit."
+          summary: "Host memory above 90% on the platform VPS"
+          description: >-
+            The host root cgroup is using {{ $value | humanizePercentage }} of total
+            RAM. This is HOST memory, not a single container — cAdvisor exposes no
+            per-container series on this host.
+          action: >-
+            `docker stats --no-stream` to find the consumer, and `free -h` on the
+            host. Nothing here identifies the container automatically; that needs
+            cAdvisor fixed first.
+          runbook: docs/runbooks/observability.md
 
       - alert: DiskSpaceRunningLow
         expr: |
@@ -31,7 +117,15 @@ groups:
           severity: warning
         annotations:
           summary: "Disk space below 15% on {{ $labels.instance }}"
-          description: "Root filesystem on {{ $labels.instance }} has {{ $value | humanizePercentage }} free space remaining."
+          description: >-
+            Root filesystem on {{ $labels.instance }} has {{ $value | humanizePercentage }}
+            free space remaining.
+          action: >-
+            `df -h /` on the host. The usual consumers are
+            /opt/hill90/backups (prune with `bash scripts/backup.sh prune 7`) and
+            Docker images (`docker image prune`). prometheus-data is capped at 20GB
+            and is not usually the cause.
+          runbook: docs/runbooks/troubleshooting.md
 
   - name: postgres
     rules:
@@ -49,7 +143,15 @@ groups:
           severity: warning
         annotations:
           summary: "PostgreSQL connections above 80% capacity"
-          description: "Active connections ({{ $value | humanizePercentage }} of max) on {{ $labels.instance }}."
+          description: >-
+            Active connections are {{ $value | humanizePercentage }} of max_connections
+            on {{ $labels.instance }}.
+          action: >-
+            `docker exec postgres psql -U hill90 -c "SELECT datname, state, count(*)
+            FROM pg_stat_activity GROUP BY 1,2 ORDER BY 3 DESC;"` to find which
+            database and which state is holding them. Idle-in-transaction is the
+            usual culprit, not genuine load.
+          runbook: docs/runbooks/troubleshooting.md
 
   - name: loki
     rules:
@@ -60,7 +162,13 @@ groups:
           severity: warning
         annotations:
           summary: "Loki ingestion errors detected"
-          description: "Loki is reporting ingestion errors at {{ $value }} errors/sec on {{ $labels.instance }}."
+          description: >-
+            Loki is rejecting log lines at {{ $value }} errors/sec on {{ $labels.instance }}.
+            Logs are being LOST while this fires.
+          action: >-
+            `docker logs --tail 50 loki`. Rate-limit and per-stream-limit rejections
+            are configuration; disk-full is not — check `df -h /` too.
+          runbook: docs/runbooks/observability.md
 
   - name: tempo
     rules:
@@ -71,4 +179,11 @@ groups:
           severity: warning
         annotations:
           summary: "Tempo ingestion errors detected"
-          description: "Tempo is reporting ingestion failures at {{ $value }}/sec on {{ $labels.instance }}."
+          description: >-
+            Tempo is failing to append traces at {{ $value }}/sec on {{ $labels.instance }}.
+            Traces are being LOST while this fires.
+          action: >-
+            `docker logs --tail 50 tempo`. This fired for ~1.3 cumulative hours in the
+            week to 2026-07-31 with nobody watching, so treat a first delivery as
+            possibly long-standing rather than new.
+          runbook: docs/runbooks/observability.md

--- a/platform/observability/prometheus/prometheus.yml
+++ b/platform/observability/prometheus/prometheus.yml
@@ -5,6 +5,18 @@ global:
 rule_files:
   - /etc/prometheus/alerts.yml
 
+# WITHOUT THIS BLOCK EVERY RULE ABOVE IS INERT.
+#
+# Until 2026-07-31 this file had rule_files and no alerting section, so
+# /api/v1/alertmanagers returned empty lists and six rules evaluated into
+# nothing. ServiceDown fired for at least 48 hours in the week to 2026-07-26 and
+# reached nobody. Do not remove this block; if Alertmanager is ever retired,
+# remove the rules too rather than leaving them looking like coverage.
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets: ["alertmanager:9093"]
+
 scrape_configs:
   - job_name: prometheus
     static_configs:
@@ -50,3 +62,52 @@ scrape_configs:
     metrics_path: /minio/v2/metrics/cluster
     static_configs:
       - targets: ['minio:9000']
+
+  - job_name: alertmanager
+    static_configs:
+      - targets: ["alertmanager:9093"]
+
+  - job_name: blackbox-exporter
+    static_configs:
+      - targets: ["blackbox-exporter:9115"]
+
+  # ---------------------------------------------------------------------------
+  # Blackbox probes. The `instance` label ends up being the probed URL, which is
+  # what the alert annotations report — so it must stay readable.
+  # ---------------------------------------------------------------------------
+
+  # Is the public product answering from the internet? The tenant's containers
+  # are not scrape targets, so this is the ONLY signal for hill90.com being down.
+  - job_name: blackbox-public
+    metrics_path: /probe
+    params:
+      module: [http_2xx]
+    static_configs:
+      - targets:
+          - https://hill90.com/
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: __param_target
+      - source_labels: [__param_target]
+        target_label: instance
+      - target_label: __address__
+        replacement: blackbox-exporter:9115
+
+  # Is OpenBao sealed? /v1/sys/health answers 503 when sealed and needs no token.
+  # Probed over the INTERNAL network on purpose: vault.hill90.com is behind the
+  # edge IP allowlist and returns 403 to anything not on the tailnet, which would
+  # make a public probe alert permanently. Verified 2026-07-31.
+  - job_name: blackbox-vault
+    metrics_path: /probe
+    params:
+      module: [vault_health]
+    static_configs:
+      - targets:
+          - http://openbao:8200/v1/sys/health
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: __param_target
+      - source_labels: [__param_target]
+        target_label: instance
+      - target_label: __address__
+        replacement: blackbox-exporter:9115

--- a/platform/vault/secrets-schema.yaml
+++ b/platform/vault/secrets-schema.yaml
@@ -34,6 +34,11 @@ excluded_vars:
   - VOLUME_PREFIX_BARE
   - HTTP_PORT
   - HTTPS_PORT
+  # Numeric gid, not a secret. Alertmanager runs as `nobody` (uid 65534) and its
+  # rendered config is 0640 deploy:deploy, so the service starts as
+  # "65534:${SECRETS_GID}" to gain read access without making the file
+  # world-readable. Defaults to 1000, the deploy group on the VPS.
+  - SECRETS_GID
   # Storage backend selection for the vault, used by
   # .github/workflows/vault-reinitialize.yml. Both default to the file-backend
   # values so an unset environment resolves to what production has always run.

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -285,7 +285,8 @@ cmd_service() {
     local service="$1"
     local env="${2:-prod}"
 
-    local compose_file banner containers summary stack stateful
+    local compose_file banner containers summary stack stateful pre_up_hook
+    pre_up_hook=""
     case "$service" in
         db)
             compose_file="deploy/compose/${env}/docker-compose.db.yml"
@@ -331,10 +332,15 @@ cmd_service() {
             ;;
         observability)
             compose_file="deploy/compose/${env}/docker-compose.observability.yml"
-            containers="prometheus loki tempo grafana promtail node-exporter cadvisor"
+            containers="prometheus loki tempo grafana promtail node-exporter cadvisor alertmanager blackbox-exporter"
             banner="Observability Stack Deployment"
             stack="observability"
             stateful=true
+            # Renders /opt/hill90/secrets/alertmanager.yml from the encrypted
+            # store. MUST run before compose up: the file is bind-mounted, so
+            # without it Docker creates a DIRECTORY at that path and Alertmanager
+            # fails to start with a confusing config error.
+            pre_up_hook="render-alertmanager-config.sh"
             summary="Services deployed:
   - grafana (dashboards at grafana.hill90.com, Tailscale-only)
   - prometheus (metrics at :9090)
@@ -342,7 +348,9 @@ cmd_service() {
   - tempo (traces at :3200)
   - promtail (log collector)
   - node-exporter (host metrics)
-  - cadvisor (container metrics)"
+  - cadvisor (container metrics)
+  - alertmanager (:9093, NOT public — no Traefik labels by design)
+  - blackbox-exporter (:9115, probes hill90.com and OpenBao health)"
             ;;
     esac
 
@@ -421,6 +429,16 @@ cmd_service() {
         local mode="$1"  # "stateful" or "stateless"
         if [ "$mode" = "stateful" ]; then
             sops exec-env "$secrets_file" '
+                set -e
+                if [ -n "'"$pre_up_hook"'" ]; then
+                    # ALERT_EMAIL_TO falls back to ACME_EMAIL: both are addresses
+                    # already configured in the store, and ACME_EMAIL is already
+                    # where certificate-expiry notices go. The fallback is to
+                    # another explicit value, never to a hardcoded guess — the
+                    # render script still refuses if both are empty.
+                    export ALERT_EMAIL_TO="${ALERT_EMAIL_TO:-$ACME_EMAIL}"
+                    bash "'"$SCRIPT_DIR"'/'"$pre_up_hook"'"
+                fi
                 echo "Stopping existing '"$service"' containers..."
                 docker compose -p "'"$project_name"'" -f '"$compose_file"' down || true
                 for container in '"$containers"'; do
@@ -451,6 +469,11 @@ cmd_service() {
         # transiently, fall through to SOPS.
         (
             vault_load_secrets "$service" "$secrets_file"
+
+            if [ -n "$pre_up_hook" ]; then
+                export ALERT_EMAIL_TO="${ALERT_EMAIL_TO:-${ACME_EMAIL:-}}"
+                bash "$SCRIPT_DIR/$pre_up_hook"
+            fi
 
             if [ "$deploy_mode" = "stateful" ]; then
                 echo "Stopping existing $service containers..."

--- a/scripts/render-alertmanager-config.sh
+++ b/scripts/render-alertmanager-config.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Render the Alertmanager configuration from its template.
+#
+# Reads SMTP_PASSWORD and ALERT_EMAIL_TO from the environment and writes
+# platform/observability/alertmanager/alertmanager.yml.tmpl
+#   -> /opt/hill90/secrets/alertmanager.yml   (0640 deploy:deploy — see the
+#      mode note further down; 0600 does not work and the reason matters)
+#
+# WHY THE OUTPUT IS NOT IN THE CHECKOUT
+#
+# This is the difference from render-traefik-config.sh, which writes its output
+# next to its template. That one substitutes ACME_CA_SERVER — a URL, not a
+# secret. This one substitutes an SMTP password, and three things follow:
+#
+#   1. A plaintext credential must not sit in the repository working tree. This
+#      estate has already fixed a 0644 pg_dumpall and a secret in argv; a
+#      world-readable rendered config in /opt/hill90/app would be the same bug
+#      a third time.
+#   2. Every deploy path runs `git reset --hard origin/main` on the VPS
+#      checkout, and scripts/preflight-checkout.sh refuses on a dirty tree. A
+#      generated file inside the checkout is either destroyed or blocks the
+#      deploy, depending on whether it is gitignored.
+#   3. /opt/hill90/secrets already holds exactly this class of file — the
+#      OpenBao unseal key, at 0600. Putting it there keeps one
+#      convention rather than inventing a second.
+#
+# NOTE FOR DISASTER RECOVERY: that directory is in no backup, by design. This
+# file is fully derivable from the encrypted store by re-running this script, so
+# it adds no new single point of failure — see
+# docs/reference/backup-coverage.md and disaster-recovery.md Step 0.
+#
+# Separate script rather than a function in deploy.sh for the same reason as
+# render-traefik-config.sh: the SOPS path runs inside `sops exec-env '<command>'`,
+# a new shell where a function defined in deploy.sh would not exist.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/_common.sh"
+
+TEMPLATE="${ALERTMANAGER_CONFIG_TEMPLATE:-${PROJECT_ROOT}/platform/observability/alertmanager/alertmanager.yml.tmpl}"
+OUTPUT="${ALERTMANAGER_CONFIG_OUTPUT:-/opt/hill90/secrets/alertmanager.yml}"
+
+[ -f "$TEMPLATE" ] || die "Alertmanager config template missing: $TEMPLATE"
+
+# No defaults, for the same reason ACME_CA_SERVER has none: a deploy that stops
+# is better than one that silently produces an Alertmanager which accepts alerts
+# and cannot deliver them. That failure mode is the entire subject of
+# docs/decisions/alerting-audit.md — do not reintroduce it with a fallback.
+if [ -z "${SMTP_PASSWORD:-}" ]; then
+    die "SMTP_PASSWORD is not set. Refusing to render the Alertmanager config.
+
+  Without it Alertmanager starts, accepts alerts, and fails every delivery with
+  an authentication error in its own log — which is precisely the silent-failure
+  shape this alerting work exists to remove.
+
+  Run the deploy through the secrets path so the store is loaded:
+    bash scripts/deploy.sh observability prod"
+fi
+
+if [ -z "${ALERT_EMAIL_TO:-}" ]; then
+    die "ALERT_EMAIL_TO is not set. Refusing to render the Alertmanager config.
+
+  An Alertmanager with no recipient is the default-contact-point bug in a new
+  costume: it reports success and reaches nobody."
+fi
+
+mkdir -p "$(dirname "$OUTPUT")"
+
+# MODE 0640, NOT 0600, AND THE REASON IS NOT LAZINESS.
+#
+# Alertmanager's image runs as `nobody` (uid 65534). A 0600 file owned by deploy
+# is unreadable by it, and the container exits with
+# "open /etc/alertmanager/alertmanager.yml: permission denied" — found by running
+# it, not by reading it. The fix is group read for the deploy group plus
+# `user: "65534:${SECRETS_GID}"` on the service, so the container keeps uid 65534
+# (which owns its data volume) and gains the group that can read this file.
+#
+# 0644 would also "work" and is the bug this estate has already fixed twice — a
+# world-readable credential on a multi-user host. Only the deploy group can read
+# this; nothing else can.
+#
+# umask BEFORE the file exists, not chmod after: a chmod leaves a window in which
+# the credential is world-readable, and this file is rewritten on every deploy.
+(
+    umask 027
+    sed -e "s|__SMTP_PASSWORD__|${SMTP_PASSWORD}|g" \
+        -e "s|__ALERT_EMAIL_TO__|${ALERT_EMAIL_TO}|g" \
+        "$TEMPLATE" > "$OUTPUT"
+)
+chmod 640 "$OUTPUT"
+
+# Prove the substitution happened rather than trusting sed. A template that
+# reached Alertmanager with the literal placeholder still parses as valid YAML
+# and still fails every send.
+if grep -q '__SMTP_PASSWORD__\|__ALERT_EMAIL_TO__' "$OUTPUT"; then
+    rm -f "$OUTPUT"
+    die "Placeholder substitution failed — refusing to leave an undeliverable config in place."
+fi
+
+echo "✓ Rendered Alertmanager config -> $OUTPUT (mode 640, group-readable by deploy only)"
+echo "  Recipient: ${ALERT_EMAIL_TO}"
+echo "  SMTP: smtp.hostinger.com:587 as noreply@hill90.com (password not shown)"


### PR DESCRIPTION
#614 found six rules, two of them proven to fire, and no receiver anywhere. This builds the
missing half, deliberately small: **one delivery path, two new alerts, nothing else.**

> ⚠ **`platform/observability/**` and this compose file are `deploy.yml` path filters, so
> merging this deploys it.** The proof below ran in a fully isolated throwaway stack.
> Production was not modified — the live Prometheus still reports zero alertmanagers.

## Delivery mechanism, chosen on evidence

**Email**, because the estate already had a working SMTP path and **no new external account
is needed**. Checked before building anything:

- Keycloak already sends via `smtp.hostinger.com:587` (STARTTLS, `noreply@hill90.com`)
- `SMTP_PASSWORD` is already in the encrypted store
- **AUTH tested first** — `smtp.hostinger.com` accepted the credentials

Recipient is `ACME_EMAIL` — already Jon's address, already where certificate notices go.
`ALERT_EMAIL_TO` falls back to it, i.e. to another explicitly configured value, never a
hardcoded guess. If either is empty the render script **refuses**, because an Alertmanager
with no recipient is the default-contact-point bug in a new costume.

## Delivery proven end to end — and proving it found two defects

Both pass `amtool check-config`. Neither is visible by reading.

1. **A 0600 config is unreadable by Alertmanager's `nobody` user** — the container exits
   with `permission denied`. Fixed as **0640 + `user: "65534:${SECRETS_GID}"`**: uid
   unchanged so it still owns its data volume, gid added so it can read the config. `0644`
   would also "work" and is the world-readable-credential bug this estate has fixed twice.
2. **`default` is not an Alertmanager template function.** There is no Sprig. Every
   notification failed at *render* time with an unrecoverable error, *after* the config
   validated. Replaced with `or`.

**The proof:** a genuine probe failure fired `PublicSiteDown` → Prometheus → Alertmanager →
Hostinger.

```
alertmanager_notifications_total{integration="email"}         1
alertmanager_notifications_failed_total{...,reason="other"}   0
```

The real `https://hill90.com/` probe stayed **green** throughout, so this is not a rule that
fires on anything. The message was then captured verbatim against a local SMTP sink:

```
Subject: [Hill90 FIRING] PublicSiteDown on https://hill90.com/__alerting-proof-should-404__
To: <ACME_EMAIL>

PublicSiteDown (critical)
hill90.com is not answering from the internet

Service        : blackbox-public
Instance/host  : https://hill90.com/__alerting-proof-should-404__
Started        : 2026-07-31 09:09:34.112 +0000 UTC

What happened  : The blackbox probe ... has not received HTTP 200 for over 2 minutes.
                 This is the tenant's UI — the public product — so users are seeing this too.
Do this first  : Check the edge before the app: `docker ps --filter name=traefik` and
                 `docker logs --tail 50 traefik`. If Traefik is healthy, the tenant's
                 app-ui is the next suspect — it is NOT a Prometheus scrape target, so
                 this probe is the only signal. Confirm with `curl -sI https://hill90.com`.
Runbook        : docs/runbooks/troubleshooting.md
```

Service, host, and what to do first. Every rule now carries an `action` annotation.

**The last mile is yours to confirm:** Hostinger accepted the message, but I cannot read
your inbox. Please check that the `[Hill90 FIRING] PublicSiteDown` mail from ~09:09 UTC
arrived — if it did not, the fault is between Hostinger and live.com, not in this config.

## The two new alerts — the top gaps from the audit, both of which had no signal at all

| Alert | Signal | Why this way |
|---|---|---|
| **PublicSiteDown** | blackbox probe of `https://hill90.com/`, 2m | The tenant's containers are not scrape targets and `traefik_service_server_up` has **zero series** here, so a probe is the only honest signal |
| **VaultSealedOrUnreachable** | blackbox probe of OpenBao `/v1/sys/health`, 5m | Returns **503 when sealed**, needs no token. Probed over the **internal** network on purpose — `vault.hill90.com` 403s off the tailnet and would alert permanently. Also avoids enabling unauthenticated metrics, which would mean restarting OpenBao, and a restarted OpenBao comes back **sealed** |

`HighMemoryUsage` → **`HostMemoryHigh`**, scoped to `id="/"`. It never watched containers;
the audit measured why (cAdvisor exposes 45 cgroup series and zero Docker containers).
Renamed rather than deleted, so the real host-memory signal survives without the false claim.

## Two facts that would otherwise have failed silently

- **`hill90_internal` is `internal: true`.** An Alertmanager attached to it alone has **no
  egress** — it would start healthy, accept every alert and deliver none. Both new
  containers are on `edge` **and** `internal`.
- **Neither container has Traefik labels.** Production Traefik sets no provider
  constraints, and Alertmanager's UI can silence alerts with no authentication of its own.
  Reach it with `ssh vps -L 9093:localhost:9093`.

## Baseline

`alertmanager` and `blackbox-exporter` are new platform containers.

**Expected after deploy: 16 platform containers, 0 unhealthy** (from 13 by name plus
`minio` = 14), plus the tenant's 7 → **23 total**. `CLAUDE.md` updated.

## Secret handling

The SMTP password is rendered by `scripts/render-alertmanager-config.sh` to
`/opt/hill90/secrets/alertmanager.yml`, **outside the checkout** — because every deploy runs
`git reset --hard`, `preflight-checkout.sh` refuses a dirty tree, and a plaintext credential
must not sit in the working tree. Same directory and convention as the OpenBao unseal key.
It is fully re-derivable from the store, so it adds no new single point of failure.

## Still open — recorded, not half-built

Four of six audit gaps: **backup failure**, **certificate expiry** (now a three-line rule,
since a receiver exists — the obvious next change), **restart loops** (needs cAdvisor fixed
first), and **the dead-man's switch** for the watcher itself, since Alertmanager cannot
report the death of the host it runs on.

## Verification

```
check_md_links / check_env_surface / check_secrets_schema      pass
check_argv_secrets / check_destructive_commands / volume_names pass
shellcheck --severity=error scripts/*.sh                       clean
bats tests/scripts/                                            371 passed
promtool check rules + check config                            8 rules, valid
amtool check-config                                            SUCCESS
```

Throwaway stack removed and confirmed absent; `/tmp/amproof` deleted. Host held **21
containers, 0 unhealthy** before and after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)