### PR TITLE
fix(alerting): HostMemoryHigh counted page cache — measure real pressure

### DIFF
--- a/platform/observability/prometheus/alerts.yml
+++ b/platform/observability/prometheus/alerts.yml
@@ -90,23 +90,42 @@ groups:
       # while removing the false claim. Restoring genuine per-container alerting
       # requires fixing cAdvisor first, which is a follow-up in
       # docs/decisions/alerting-audit.md — do not simply rename this back.
+      # ...and MOVED OFF cAdvisor, because the cgroup figure counts page cache.
+      #
+      # container_memory_usage_bytes includes reclaimable page cache. Measured on
+      # this host 2026-07-31: the cgroup ratio read 0.7035 while actual memory
+      # pressure was 0.3095, with 8.6 GB of that gap being cache the kernel frees
+      # on demand. Peak over the full 7-day retention was 0.8122 cgroup against
+      # 0.3815 true — so it has NOT yet fired, but it tracks roughly double the
+      # real number and sits 0.09 below the threshold on a value that file I/O
+      # moves quickly. The nightly backup reads several GB at 03:00.
+      #
+      # node_memory_MemAvailable_bytes is the kernel's own estimate of what can be
+      # allocated without swapping, cache already discounted. It is what "memory
+      # is running out" means, and it does not depend on cAdvisor — which on this
+      # host is the component least able to be trusted (see
+      # docs/decisions/alert-series-verification.md).
+      #
+      # Direction of the old error is worth keeping: usage >= working set always,
+      # so the cgroup form could only ever fire EARLY, never miss real pressure.
       - alert: HostMemoryHigh
-        expr: |
-          (container_memory_usage_bytes{id="/"} / container_spec_memory_limit_bytes{id="/"}) > 0.9
-          and container_spec_memory_limit_bytes{id="/"} > 0
+        expr: (1 - (node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes)) > 0.9
         for: 5m
         labels:
           severity: warning
         annotations:
           summary: "Host memory above 90% on the platform VPS"
           description: >-
-            The host root cgroup is using {{ $value | humanizePercentage }} of total
-            RAM. This is HOST memory, not a single container — cAdvisor exposes no
-            per-container series on this host.
+            {{ $value | humanizePercentage }} of RAM on {{ $labels.instance }} is
+            unavailable — that is real pressure, with page cache already discounted,
+            not merely memory in use. This is HOST memory, not a single container:
+            cAdvisor exposes no per-container series on this host.
           action: >-
-            `docker stats --no-stream` to find the consumer, and `free -h` on the
-            host. Nothing here identifies the container automatically; that needs
-            cAdvisor fixed first.
+            `free -h` on the host to confirm, then `docker stats --no-stream` to find
+            the consumer. Nothing here identifies the container automatically; that
+            needs cAdvisor fixed first. Note `docker stats` will not agree with this
+            alert exactly — it reports usage including cache, which is the thing this
+            rule deliberately stopped measuring.
           runbook: docs/runbooks/observability.md
 
       - alert: DiskSpaceRunningLow


### PR DESCRIPTION
One line of expression changed. The rest of the diff is the reasoning, because the next person will otherwise put it back.

```diff
- (container_memory_usage_bytes{id="/"} / container_spec_memory_limit_bytes{id="/"}) > 0.9
- and container_spec_memory_limit_bytes{id="/"} > 0
+ (1 - (node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes)) > 0.9
```

## The problem

`container_memory_usage_bytes` includes reclaimable page cache. Measured on the live host:

| | value |
|---|---|
| cgroup usage / limit | **0.7035** ← what the rule read |
| cgroup working set / limit | 0.3139 |
| `1 - MemAvailable/MemTotal` | **0.3095** ← actual memory pressure |
| page cache | **8.6 GB** |

The rule tracked roughly double the real number, because 8.6 GB of what it counted is cache the kernel hands back on demand.

## Correcting my own overstatement

I told Jon this was a 3am false page waiting for the nightly backup. **Checked rather than assumed, and it is weaker than that.** Over the full 7-day retention:

| | max | minutes above 0.9 in 7d |
|---|---|---|
| OLD cgroup ratio | 0.8122 | **0** |
| NEW true pressure | 0.3815 | **0** |

**It has not fired and would not have.** What is true: it sits 0.09 below the threshold on a cache-driven value that file I/O moves quickly, and the backup reads several GB at 03:00. A plausible false positive, not a demonstrated one.

## Why now rather than later

Until this morning a rule that fires wrongly was harmless, because nothing delivered anywhere. **Alertmanager is live and proven**, so a wrong alert now reaches a person — and the fastest way to teach someone to ignore a sender is a wrong alert on day one. Behaviour is unchanged today (both forms: 0 minutes above threshold in 7 days), which makes this a safe moment to change it.

## Why this metric

`node_memory_MemAvailable_bytes` is the kernel's own estimate of what can be allocated without swapping, cache already discounted — it is what "memory is running out" means. It also **removes a dependency on cAdvisor**, which on this host reports zero containers ([alert-series-verification.md](https://github.com/jonhill90/Hill90/blob/main/docs/decisions/alert-series-verification.md)).

The direction of the old error is recorded in the comment because it is reassuring: **usage ≥ working set always**, so the cgroup form could only ever fire *early*. It could not have missed real pressure.

## Verified against live Prometheus before shipping

This is exactly where a third never-fires rule would come from, so:

```
node_memory_MemAvailable_bytes         1 series  {instance, job}
node_memory_MemTotal_bytes             1 series  {instance, job}
1 - (MemAvailable / MemTotal)          1 series  {instance, job} = 0.3130
full expression with > 0.9             0 series  (correctly not firing)
```

**Identical label sets on both sides**, so one-to-one vector matching succeeds — the failure that made `PostgresConnectionsHigh` unfireable. `{{ $labels.instance }}` resolves; `instance` and `job` are the labels on the result vector.

`promtool check rules` passes on `prom/prometheus:v3.3.1`, matching production.

## Scope

Deliberately this rule only, so it can land ahead of pane 1's certificate and backup work without touching the same blocks. No deploy. The Loki replacement, `ServiceRestartLoop`, the promtool test suite and the dead-man's-switch record follow separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)