### PR TITLE
feat(alerting): certificate expiry and the backup absence-of-success signal, both proven to fire

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -247,13 +247,17 @@ bash scripts/deploy.sh verify <service> prod
 gh workflow run deploy.yml -f service=all
 ```
 
-- Platform baseline is **13 containers, 0 unhealthy** — **16 once this PR's
-  observability deploy runs.** `alertmanager` and `blackbox-exporter` are new
-  platform containers; the count before them was 13 by name plus `minio` (14
-  running), so the expected post-deploy figure is **16 platform containers, 0
-  unhealthy**, plus the tenant's 7 for **23 total**. Neither new container has
-  Traefik labels and neither is public. Update this line when they land, not
-  before. A tenant's containers sit
+- Platform baseline is **16 containers by name, 0 unhealthy** —
+  `Verified 2026-07-31 09:58 UTC`, after #617 deployed `alertmanager` and
+  `blackbox-exporter`. With the tenant's 7 that is **23 running in total**.
+  The full 16: `alertmanager blackbox-exporter cadvisor grafana keycloak loki
+  minio node-exporter openbao portainer postgres postgres-exporter prometheus
+  promtail tempo traefik`.
+  **Count by that list, not from memory.** The old shorthand was "13 by name plus
+  minio", so 13 + 2 new = 15 is a natural and wrong arithmetic — minio was never
+  inside the 13. And match on `blackbox-exporter`, not `blackbox`: an exact-match
+  sweep for the short name reports it missing when it is running.
+  A tenant's containers sit
   alongside them and are not part of that count. **Verify the baseline after any
   tenant action — a degraded baseline is the stop-everything signal.** The
   tenancy contract has been tested in both directions: on 2026-07-29 the tenant

--- a/deploy/compose/prod/docker-compose.observability.yml
+++ b/deploy/compose/prod/docker-compose.observability.yml
@@ -255,6 +255,18 @@ services:
       - "--path.sysfs=/host/sys"
       - "--path.rootfs=/rootfs"
       - "--collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)"
+      # The emitting half of the backup alert (#616). The textfile COLLECTOR was
+      # already enabled — node_scrape_collector_success{collector="textfile"} is
+      # 1 — but with no directory set it read nothing, so the metric never
+      # existed. This is the one flag that was missing.
+      #
+      # Path is under the EXISTING /rootfs mount, so no new mount is needed:
+      # backup.sh writes /opt/hill90/metrics/textfile_collector on the host,
+      # which appears here as /rootfs/opt/hill90/metrics/textfile_collector.
+      # Changing this flag restarts node-exporter, which serves no traffic and
+      # sits in no request path — the cost is a gap in metrics measured in
+      # seconds.
+      - "--collector.textfile.directory=/rootfs/opt/hill90/metrics/textfile_collector"
     healthcheck:
       test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:9100/metrics"]
       interval: 30s

--- a/docs/decisions/backup-failure-signal.md
+++ b/docs/decisions/backup-failure-signal.md
@@ -59,6 +59,33 @@ Three separate reasons nothing can see it:
 So the estate's most careful failure handling terminates in a log file nobody
 reads. That is why the app-db regression was caught by someone happening to look.
 
+> ## IMPLEMENTED — `2026-07-31 09:57 UTC`
+>
+> `backup.sh` emits the textfile at the end of `backup-all`, node-exporter reads it,
+> and the three rules are live. Thresholds are exactly as specified below.
+>
+> **One deliberate deviation: the directory.** The spec named
+> `/var/lib/node_exporter/textfile_collector`. That path does not exist on this host
+> and `/var/lib` is root-owned, so it would need `sudo` in a script that has never
+> needed root, or an Ansible run before the first backup could emit anything. The
+> implementation uses **`/opt/hill90/metrics/textfile_collector`** — owned by
+> `deploy`, alongside `backups/` and `secrets/`, and equally untouched by
+> `systemd-tmpfiles-clean`, which was the spec's stated reason for rejecting `/tmp`.
+> No new mount was needed either, as intended: node-exporter reaches it through the
+> existing `/rootfs`.
+>
+> **The central claim was proven, not assumed.** With a 30-hour-old textfile,
+> `BackupNotSucceeding` fired and `BackupNotSucceedingCritical` correctly did not.
+> The file was then deleted to simulate a job that never ran at all: the staleness
+> rule went **silent — 0 series**, exactly as this document predicts, and
+> `BackupSignalMissing` fired and delivered. That is the whole design in one
+> observation.
+>
+> One implementation note not in the spec: on a PARTIAL failure the emitter carries
+> the previous `last_success` forward rather than clearing it. Clearing would make
+> the metric absent and the staleness rule silent — manufacturing the very condition
+> `BackupSignalMissing` exists to catch.
+
 ## The signal: a textfile the job writes, node-exporter serves
 
 **The textfile collector is already enabled** — verified rather than assumed:

--- a/docs/runbooks/certificate-renewal.md
+++ b/docs/runbooks/certificate-renewal.md
@@ -132,9 +132,32 @@ below under [Proposed: the alert that would notice](#proposed-the-alert-that-wou
   is good evidence the August renewal will work — not proof, which only Aug 13
   provides.
 
-## Proposed: the alert that would notice
+## The alert that notices — APPLIED
 
-`Specified 2026-07-31. Nothing was enabled — see Scope at the end.`
+> **`Applied 2026-07-31 09:57 UTC`.** These rules are live in
+> `platform/observability/prometheus/alerts.yml`, delivered by the Alertmanager
+> that #617 shipped. The thresholds below are unchanged from the specification —
+> they were argued here and were not re-picked.
+>
+> **Both were proven to fire**, not merely validated: a stub exposing
+> `traefik_tls_certs_not_after` with the real label set
+> (`cn, instance, job, sans, serial`) at 15 and 5 days produced
+> `CertificateExpiringSoon` on both and `CertificateExpiringCritical` on the
+> 5-day one only, and the emails arrived. A third series at 80 days correctly
+> matched neither.
+>
+> Series verified on the live Prometheus first, per #619: 11 series, `cn` present
+> on all of them, and `(value - time())/86400` yielding 42.7–87.8 real days rather
+> than an empty vector.
+>
+> **`CertificateCountDropped` is the exception and is honestly weaker.** Its
+> `offset 1h` comparison cannot be exercised in a short-lived test instance, which
+> has no hour of history. What was verified instead is that both halves evaluate
+> on the live Prometheus — `count(...)` and `count(... offset 1h)` both return 11 —
+> so the rule compares two real numbers rather than silently returning nothing.
+> It has not been observed firing.
+
+`Specified 2026-07-31.`
 
 ### The metric needs nothing turned on
 

--- a/docs/runbooks/observability.md
+++ b/docs/runbooks/observability.md
@@ -149,6 +149,28 @@ as "Do this first" and is not optional — add it to any new rule.
 | PostgresConnectionsHigh | Active connections > 80% of max | warning | Never fired |
 | LokiIngestionErrors | Ingestion error rate > 0 | warning | Never fired |
 | TempoIngestionErrors | Ingestion failure rate > 0 | warning | Fired ~1.3 h with no receiver |
+| **CertificateExpiringSoon** | any cert < 21 days remaining, 1h | warning | **New.** 21 days = nine consecutive failed renewals; thresholds argued in [certificate-renewal.md](certificate-renewal.md) |
+| **CertificateExpiringCritical** | any cert < 10 days remaining, 1h | critical | **New.** ~20 failures; the warning was missed |
+| **CertificateCountDropped** | fewer certs than 1h ago, 2h | warning | **New.** Catches a cert that vanished rather than aged. `for: 2h` so a Traefik restart does not double-report `ServiceDown` |
+| **BackupNotSucceeding** | last success > 26h ago, 15m | warning | **New.** One missed night, fires ~05:00 |
+| **BackupNotSucceedingCritical** | last success > 50h ago, 15m | critical | **New.** Two consecutive nights |
+| **BackupSignalMissing** | metric absent, 6h | warning | **New.** The staleness rules are *silent* when the metric does not exist — this is the rule that notices the alarm was removed |
+
+> **The backup metric comes from a textfile, and it does not exist until one full
+> `backup-all` has run.** `backup.sh` writes
+> `/opt/hill90/metrics/textfile_collector/hill90_backup.prom` at the end of a
+> `backup-all`, and node-exporter serves it via
+> `--collector.textfile.directory` through its existing `/rootfs` mount.
+>
+> **After deploying this, seed it rather than waiting**, or `BackupSignalMissing`
+> fires six hours later and stays firing until 03:00:
+>
+> ```bash
+> cd /opt/hill90/app && SOPS_AGE_KEY_FILE=/opt/hill90/secrets/keys/keys.txt \
+>   bash scripts/backup.sh backup-all
+> ```
+>
+> That is a real backup, not a stub — it takes about a minute.
 
 > **`HostMemoryHigh` was called `HighMemoryUsage` and did not watch containers.**
 > cAdvisor exposes 45 cgroup series and **zero Docker containers** —

--- a/platform/observability/prometheus/alerts.yml
+++ b/platform/observability/prometheus/alerts.yml
@@ -187,3 +187,176 @@ groups:
             week to 2026-07-31 with nobody watching, so treat a first delivery as
             possibly long-standing rather than new.
           runbook: docs/runbooks/observability.md
+
+  # ---------------------------------------------------------------------------
+  # Certificates. Specified in docs/runbooks/certificate-renewal.md (#615); the
+  # thresholds below are that document's, not new numbers.
+  #
+  # SERIES VERIFIED ON THE LIVE PROMETHEUS before these were written, per the
+  # method in docs/decisions/alert-series-verification.md (#619):
+  #   traefik_tls_certs_not_after   11 series
+  #   label set                     cn, instance, job, sans, serial
+  #   cn present on ALL series      yes  (the annotations interpolate it)
+  #   (value - time())/86400        42.7 .. 87.8 days — real numbers, not an
+  #                                 empty vector, so the comparison can match
+  # The metric needs nothing enabled and is already scraped by the traefik job.
+  # ---------------------------------------------------------------------------
+  - name: certificates
+    rules:
+      # Let's Encrypt issues for 90 days; Traefik renews below 30 and retries
+      # every 24h. So every day under 30 is one more FAILED attempt, and the
+      # threshold is really "how many consecutive failures before waking
+      # someone". 21 days = nine failures, with three weeks of runway left.
+      - alert: CertificateExpiringSoon
+        expr: (traefik_tls_certs_not_after - time()) / 86400 < 21
+        # Not about the certificate — the value moves once a day. This guards
+        # against a single failed scrape producing a spurious evaluation.
+        for: 1h
+        labels:
+          severity: warning
+        annotations:
+          summary: "{{ $labels.cn }} expires in {{ $value | printf \"%.0f\" }} days"
+          description: >-
+            Certificate renewal for {{ $labels.cn }} has been failing for roughly nine
+            days. Traefik renews below 30 days remaining and retries every 24 hours, so
+            every day under 30 is another failed attempt — this is a persistent fault,
+            not a slow night.
+          action: >-
+            FIRST check whether it is one certificate or several: `docker exec prometheus
+            wget -qO- 'http://localhost:9090/api/v1/query?query=(traefik_tls_certs_not_after-time())/86400'`.
+            If several DNS-01 hosts are falling together they share one Cloudflare
+            credential and one store — go straight to the token. Then
+            `docker logs traefik --since 48h | grep -iE 'acme|certificate|challenge'`;
+            grep `challenge` too, because a revoked token fails as a DNS challenge error
+            and looks like silence otherwise. Do NOT delete acme-dns.json.
+          runbook: docs/runbooks/certificate-renewal.md
+
+      - alert: CertificateExpiringCritical
+        expr: (traefik_tls_certs_not_after - time()) / 86400 < 10
+        for: 1h
+        labels:
+          severity: critical
+        annotations:
+          summary: "{{ $labels.cn }} expires in {{ $value | printf \"%.0f\" }} days"
+          description: >-
+            Roughly twenty consecutive renewal failures for {{ $labels.cn }}. The warning
+            at 21 days was missed. Still fixable, no longer comfortable — and fixing a
+            revoked DNS token means the Cloudflare dashboard, a SOPS edit and an edge
+            deploy.
+          action: >-
+            Same sequence as CertificateExpiringSoon, but do not wait for the 24h retry
+            cycle after fixing the cause. Restarting Traefik forces an immediate attempt
+            and is a deliberate act — it drops in-flight connections on the component
+            every service sits behind.
+          runbook: docs/runbooks/certificate-renewal.md
+
+      # Covers the failure the expiry rules structurally cannot see: a
+      # certificate that VANISHED rather than aged. Self-adjusting, so adding or
+      # retiring a host needs no edit here.
+      #
+      # for: 2h is load-bearing. A Traefik restart makes every series disappear
+      # briefly, and ServiceDown already reports Traefik being down — this must
+      # not double-report it. Verified that `offset 1h` has data (count 11 both
+      # now and an hour ago), so the comparison evaluates rather than silently
+      # returning an empty vector.
+      - alert: CertificateCountDropped
+        expr: |
+          count(traefik_tls_certs_not_after)
+            < count(traefik_tls_certs_not_after offset 1h)
+        for: 2h
+        labels:
+          severity: warning
+        annotations:
+          summary: "Traefik is serving fewer certificates than it was an hour ago"
+          description: >-
+            The number of certificates Traefik holds has dropped and stayed down for two
+            hours. An expiry alert cannot see this: a certificate that disappears has no
+            series left to be near expiry. Traefik being down is a different alert.
+          action: >-
+            `docker exec traefik wget -qO- http://localhost:8082/metrics | grep -c
+            '^traefik_tls_certs_not_after'` and compare with the router list. A host
+            removed on purpose explains it; otherwise suspect the ACME store. Do NOT
+            delete acme-dns.json — it holds the account key and every DNS-01
+            certificate, and re-issuance runs straight into rate limits.
+          runbook: docs/runbooks/certificate-renewal.md
+
+  # ---------------------------------------------------------------------------
+  # Backups. Specified in docs/decisions/backup-failure-signal.md (#616).
+  #
+  # THE DESIGN IS "ALERT ON THE ABSENCE OF SUCCESS", not the presence of
+  # failure — because a job that never runs at all emits no failure. That is why
+  # the trigger is a staleness comparison against last_success, and why
+  # BackupSignalMissing exists underneath it.
+  #
+  # SERIES NOTE: hill90_backup_last_success_timestamp_seconds does not exist
+  # until backup.sh has completed one full backup-all run. Until then
+  # BackupSignalMissing is the rule that covers the gap — deliberately, and see
+  # the runbook for the post-deploy seeding step.
+  # ---------------------------------------------------------------------------
+  - name: backups
+    rules:
+      # Job runs 03:00 UTC daily and takes about a minute, so a healthy gap is
+      # 24h plus seconds. 26h = one missed night with two hours of slack, and it
+      # fires around 05:00 rather than in the small hours.
+      - alert: BackupNotSucceeding
+        expr: (time() - hill90_backup_last_success_timestamp_seconds) / 3600 > 26
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: "No fully successful backup for {{ $value | printf \"%.0f\" }} hours"
+          description: >-
+            Backups run nightly at 03:00 UTC from the deploy crontab on the VPS and write
+            to /opt/hill90/backups/<target>/<timestamp>/. This means the last run either
+            did not happen or did not fully succeed. Note that backup-all deliberately
+            exits non-zero on a PARTIAL failure, so some targets may still have backed up.
+          action: >-
+            `tail -40 /opt/hill90/backups/cron.log` for the last run, then
+            `hill90_backup_target_success` in Prometheus to see WHICH target failed
+            without reading the whole log. `crontab -l -u deploy | grep hill90` confirms
+            the job is still scheduled at all.
+          runbook: docs/runbooks/deployment.md#scheduled-backups
+
+      - alert: BackupNotSucceedingCritical
+        expr: (time() - hill90_backup_last_success_timestamp_seconds) / 3600 > 50
+        for: 15m
+        labels:
+          severity: critical
+        annotations:
+          summary: "No fully successful backup for {{ $value | printf \"%.0f\" }} hours — two nights"
+          description: >-
+            Two consecutive nights without a complete backup. The warning was missed and
+            the backup set is genuinely ageing. Restores come from these artifacts and
+            nothing else does.
+          action: >-
+            As BackupNotSucceeding, and run one by hand once the cause is fixed:
+            `cd /opt/hill90/app && SOPS_AGE_KEY_FILE=/opt/hill90/secrets/keys/keys.txt
+            bash scripts/backup.sh backup-all`. Do not wait for the next 03:00.
+          runbook: docs/runbooks/deployment.md#scheduled-backups
+
+      # The watcher-watching case. If the textfile is deleted or was never
+      # written, `time() - <absent>` yields NO RESULT and BackupNotSucceeding can
+      # never fire — a staleness alert is silent about a metric that does not
+      # exist. This is the rule that notices the alarm was removed.
+      #
+      # It will overlap with ServiceDown when node-exporter is the cause. That
+      # duplication is accepted deliberately.
+      - alert: BackupSignalMissing
+        expr: absent(hill90_backup_last_success_timestamp_seconds)
+        for: 6h
+        labels:
+          severity: warning
+        annotations:
+          summary: "The backup success metric has disappeared entirely"
+          description: >-
+            hill90_backup_last_success_timestamp_seconds is absent, so the staleness
+            alerts above cannot fire at all. Either the textfile was removed, node-exporter
+            lost its textfile directory, or backup.sh has never completed a full run since
+            the metric was introduced.
+          action: >-
+            Check the file exists and is fresh: `ls -l
+            /opt/hill90/metrics/textfile_collector/hill90_backup.prom`. Then confirm
+            node-exporter is reading that directory — `node_textfile_mtime_seconds` should
+            have a series. If the file is there but the metric is not, the collector
+            directory flag or the /rootfs mount is the fault, not the backup.
+          runbook: docs/runbooks/deployment.md#scheduled-backups

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -389,6 +389,89 @@ backup_vault() {
 }
 
 # ---------------------------------------------------------------------------
+# Prometheus textfile metrics — the emitting half of the backup alert
+#
+# THE DESIGN IS "ALERT ON THE ABSENCE OF SUCCESS", NOT THE PRESENCE OF FAILURE.
+# See docs/decisions/backup-failure-signal.md. The distinction is the whole
+# point: a job that fails can emit a failure, but a job that NEVER RUNS emits
+# nothing at all, and this estate has already had three consecutive nightly
+# backups fail while cron reported success. So the alert watches the age of the
+# last SUCCESS, which goes stale on its own whether the job failed, crashed, or
+# was never scheduled.
+#
+# last_success is the trigger; everything else is annotation so that whoever is
+# woken knows WHICH target broke without reading a 28,000-byte log.
+#
+# DIRECTORY — a deliberate deviation from the spec, which named
+# /var/lib/node_exporter/textfile_collector. That path does not exist on this
+# host and /var/lib is root-owned, so creating it would need sudo in a script
+# that has never needed root, or an Ansible run before the first backup could
+# emit anything. /opt/hill90 is owned by `deploy`, already holds backups/ and
+# secrets/, and — the reason the spec gave for rejecting /tmp — is not touched
+# by systemd-tmpfiles-clean. The compose flag points node-exporter here through
+# its existing /rootfs mount, so no new mount is needed either, as the spec
+# intended.
+# ---------------------------------------------------------------------------
+
+METRICS_DIR="${BACKUP_METRICS_DIR:-/opt/hill90/metrics/textfile_collector}"
+METRICS_FILE="hill90_backup.prom"
+
+write_backup_metrics() {
+    local run_ts="$1"       # epoch seconds when the run started
+    local duration="$2"     # wall-clock seconds
+    local all_ok="$3"       # "true" if every target produced a usable backup
+    shift 3
+    local results=("$@")    # "target:0|1" pairs
+
+    mkdir -p "$METRICS_DIR" 2>/dev/null || {
+        warn "Could not create $METRICS_DIR — backup metrics not written. The backup itself is unaffected."
+        return 0
+    }
+
+    local tmp="${METRICS_DIR}/.${METRICS_FILE}.tmp"
+    local dest="${METRICS_DIR}/${METRICS_FILE}"
+
+    # last_success is CARRIED FORWARD on a failed run rather than cleared. That
+    # is what makes the alert measure staleness: clearing it would make the
+    # metric absent and the staleness rule silent, which is the failure mode
+    # BackupSignalMissing exists to catch and should not be caused by us.
+    local last_success=""
+    if [ "$all_ok" = "true" ]; then
+        last_success="$run_ts"
+    elif [ -f "$dest" ]; then
+        last_success=$(grep '^hill90_backup_last_success_timestamp_seconds ' "$dest" 2>/dev/null | awk '{print $2}' || true)
+    fi
+
+    {
+        echo "# HELP hill90_backup_last_success_timestamp_seconds Unix time of the last fully successful backup-all"
+        echo "# TYPE hill90_backup_last_success_timestamp_seconds gauge"
+        [ -n "$last_success" ] && echo "hill90_backup_last_success_timestamp_seconds ${last_success}"
+        echo "# HELP hill90_backup_last_run_timestamp_seconds Unix time of the last attempt, successful or not"
+        echo "# TYPE hill90_backup_last_run_timestamp_seconds gauge"
+        echo "hill90_backup_last_run_timestamp_seconds ${run_ts}"
+        echo "# HELP hill90_backup_target_success 1 if this target produced a usable backup on the last run"
+        echo "# TYPE hill90_backup_target_success gauge"
+        local pair target ok
+        for pair in "${results[@]}"; do
+            target="${pair%%:*}"
+            ok="${pair##*:}"
+            echo "hill90_backup_target_success{target=\"${target}\"} ${ok}"
+        done
+        echo "# HELP hill90_backup_duration_seconds Wall-clock duration of the last run"
+        echo "# TYPE hill90_backup_duration_seconds gauge"
+        echo "hill90_backup_duration_seconds ${duration}"
+    } > "$tmp"
+
+    # Atomic rename. node-exporter reads this directory on EVERY scrape, and a
+    # half-written file flips node_textfile_scrape_error to 1 — a real alertable
+    # condition that we must not manufacture ourselves.
+    mv -f "$tmp" "$dest"
+    chmod 644 "$dest"
+
+    echo "  ✓ Wrote backup metrics to $dest"
+}
+
+# ---------------------------------------------------------------------------
 # Commands
 # ---------------------------------------------------------------------------
 
@@ -432,20 +515,35 @@ cmd_backup_all() {
     # then skip vault, infra and observability entirely. One missing service must
     # not cost the other four their backups — but it must still turn the run red.
     local failed=()
+    local results=()
+    local run_ts
+    run_ts="$(date +%s)"
     for svc in db app-db minio vault infra observability; do
-        if ! ( cmd_backup "$svc" ); then
+        if ( cmd_backup "$svc" ); then
+            results+=("${svc}:1")
+        else
             failed+=("$svc")
+            results+=("${svc}:0")
             warn "Backup FAILED for: $svc (continuing with the remaining services)"
         fi
         echo ""
     done
 
+    local duration=$(( $(date +%s) - run_ts ))
+
     echo "================================"
     if [ ${#failed[@]} -eq 0 ]; then
+        # Metrics are written BEFORE the success return and before the die()
+        # below, so a partial run still records which targets failed. Emitting
+        # only on success would leave the operator with a stale timestamp and no
+        # indication of what broke.
+        write_backup_metrics "$run_ts" "$duration" "true" "${results[@]}"
         echo "Full Backup Complete!"
         echo "================================"
         return 0
     fi
+
+    write_backup_metrics "$run_ts" "$duration" "false" "${results[@]}"
 
     echo "Full Backup INCOMPLETE"
     echo "================================"


### PR DESCRIPTION
The two designs that were blocked on a receiver existing. **#615's thresholds and #616's
design are used as specified** — neither was re-derived.

## Series verified first, because a third dead rule would be worse than none

#619 found two rules that cannot fire. Everything below was checked on the **live
Prometheus** before any expression was written:

| Check | Result |
|---|---|
| `traefik_tls_certs_not_after` | **11 series**, labels `cn, instance, job, sans, serial` |
| `cn` present on all series | **yes** — the annotations interpolate it |
| `(value - time()) / 86400` | **42.7 – 87.8** — real numbers, not an empty vector |
| `count(...)` and `count(... offset 1h)` | both **11**, so `CertificateCountDropped` compares two real values |
| textfile collector | **enabled** (`success=1`, `scrape_error=0`), directory **unset** — exactly the gap #616 described |

## Certificates

21 days warning / 10 days critical / `for: 1h`, plus `CertificateCountDropped` at
`for: 2h` so a Traefik restart does not double-report `ServiceDown`. The metric needed
nothing enabled.

## Backups — the emitting half is new

`backup.sh` writes `hill90_backup.prom` at the end of `backup-all`; node-exporter gets
`--collector.textfile.directory` pointed through its **existing** `/rootfs` mount. One
flag, no new mount, as designed.

**Directory deviation, deliberate.** The spec named
`/var/lib/node_exporter/textfile_collector`. That path does not exist here and `/var/lib`
is root-owned, so it would need `sudo` in a script that has never needed root, or an
Ansible run before the first emit. `/opt/hill90/metrics/textfile_collector` is
deploy-owned, sits beside `backups/` and `secrets/`, and is equally untouched by
`systemd-tmpfiles-clean` — the spec's actual reason for rejecting `/tmp`.

**Not in the spec:** on a *partial* failure the emitter carries the previous
`last_success` forward rather than clearing it. Clearing would make the metric absent and
the staleness rule silent — manufacturing the very condition `BackupSignalMissing` exists
to catch.

## Both proven to fire — forced, not reasoned about

Expressions matched exactly as intended, including the two that correctly stayed quiet:

```
CertificateExpiringSoon        2 series   [proof-expiring 15.0d, proof-critical 5.0d]
CertificateExpiringCritical    1 series   [proof-critical 5.0d]
BackupNotSucceeding            1 series   [30.0 hours]
BackupNotSucceedingCritical    0 series   <- correct: 30h is under the 50h threshold
BackupSignalMissing            0 series   <- correct: the metric existed
```

An 80-day certificate series matched neither cert rule. Emails arrived:

```
Subject: [Hill90 FIRING] CertificateExpiringCritical on cbproof-certstub:9101
Subject: [Hill90 FIRING] CertificateExpiringSoon on cbproof-certstub:9101
Subject: [Hill90 FIRING] BackupNotSucceeding on cbproof-nodeexporter:9100
```

The backup metric came from the **real emitter**, served by a **real node-exporter with
the real flag** — the whole emit → collect → scrape → alert chain, not just the rule.

### The case the design exists for

The textfile was then **deleted**, simulating a job that never ran at all:

```
BackupNotSucceeding (staleness) ->  0 series   <-- SILENT, as the design predicts
BackupSignalMissing (absent)    ->  1 series   <-- fires
```

…and the email arrived, carrying the file path and the `node_textfile_mtime_seconds`
check as its "Do this first". **That is the whole argument for absence-of-success in one
observation.**

Real Hostinger delivery confirmed for the new rules as well —
`alertmanager_notifications_total{integration="email"} 3`, `failed_total 0`.

**Test honesty:** the proof used the shipped `alerts.yml` with only the `for:` durations
shortened; the diff excluding those lines is byte-identical. **`CertificateCountDropped`
is the one rule not observed firing** — `offset 1h` cannot be exercised in a short-lived
instance with no hour of history — and that limit is stated in the runbook rather than
glossed.

## Baseline — corrected to what the host reports

**16 platform containers by name, not 15**, plus the tenant's 7 for **23 total**.
`Verified 2026-07-31 09:58 UTC`:

```
alertmanager blackbox-exporter cadvisor grafana keycloak loki minio node-exporter
openbao portainer postgres postgres-exporter prometheus promtail tempo traefik
```

The old shorthand was "13 by name plus `minio`", so 13 + 2 new = 15 is a natural and
wrong arithmetic — `minio` was never inside the 13. `CLAUDE.md` now lists all 16 and says
to count from that list, and records the `blackbox-exporter` vs `blackbox` exact-match
trap.

## After merging, seed the backup metric

`BackupSignalMissing` fires 6h after deploy if no `backup-all` has run, and would stay
firing until 03:00. Run one — it is a real backup and takes about a minute:

```bash
cd /opt/hill90/app && SOPS_AGE_KEY_FILE=/opt/hill90/secrets/keys/keys.txt \
  bash scripts/backup.sh backup-all
```

Documented in the observability runbook.

## Verification

```
check_md_links / check_env_surface / check_secrets_schema      pass
check_argv_secrets / check_destructive_commands / volume_names pass
shellcheck --severity=error scripts/*.sh                       clean
promtool check rules                                           14 rules, valid
tests/checks/test_secrets_schema.py                            11 passed
```

Nothing was deployed. Production still runs node-exporter **without** the flag and
`/opt/hill90/metrics` does not exist. The host held 23 containers, 0 unhealthy,
throughout; every proof container and `/tmp/cbproof` were removed and confirmed absent.

## Untouched

`LokiIngestionErrors` is still the broken rule #619 found — `loki_distributor_lines_received_total`
carries no `status` label, re-confirmed here as 0 series. Left for its own change rather
than folded in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)