### PR TITLE
test(alerting): unit-test the rules, verify their series live, and record why no dead man's switch was built

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,24 @@ jobs:
       - name: Validate Traefik config
         run: bash scripts/validate.sh traefik
 
+      # Pinned to the deployed Prometheus version, because promtool's rule
+      # semantics are what production will apply — testing against a different
+      # version tests a different engine.
+      - name: Validate and unit-test Prometheus alert rules
+        run: |
+          docker run --rm -v "$PWD:/w" -w /w \
+            --entrypoint promtool prom/prometheus:v3.3.1 \
+            check rules platform/observability/prometheus/alerts.yml
+          docker run --rm -v "$PWD:/w" -w /w \
+            --entrypoint promtool prom/prometheus:v3.3.1 \
+            test rules tests/prometheus/alerts_test.yml
+          echo
+          echo "NOTE: a green run here does NOT prove these rules can fire."
+          echo "The unit tests supply their own input series, so a rule matching"
+          echo "a label production never emits still passes. That is checked"
+          echo "against the live Prometheus by:"
+          echo "  python3 scripts/checks/check_alert_series.py   (run on the VPS)"
+
       - name: Install shellcheck
         run: sudo apt-get install -y shellcheck
 

--- a/docs/decisions/dead-mans-switch.md
+++ b/docs/decisions/dead-mans-switch.md
@@ -1,0 +1,172 @@
+# Who watches Prometheus?
+
+**Status: designed, deliberately NOT built.** No mechanism in this estate is fit
+to be the watcher, and the record of *why* is the deliverable.
+
+`Established 2026-07-31, read-only against production.`
+
+---
+
+## The failure
+
+If Prometheus stops scraping, or Alertmanager dies, or the rules stop being
+loaded, every alert in this estate goes quiet at once. **Silence is what a
+healthy night looks like.** There is no way to tell the two apart from the
+outside, and the person who would notice is the person who stopped being told.
+
+This is not hypothetical here. Until 2026-07-31 `prometheus.yml` had `rule_files`
+and no `alerting` block, so six rules evaluated into nothing. `ServiceDown` fired
+for **at least 48 hours** in the week to 2026-07-26 and reached nobody. Nothing
+looked wrong, because nothing looking wrong is precisely the symptom.
+
+## The standard answer, and its one real requirement
+
+A **dead man's switch**: an alert whose condition is `vector(1)`, so it fires
+permanently, routed to a receiver whose job is to notice when it *stops* arriving.
+Heartbeat present, everything is evaluating and delivering. Heartbeat missing,
+the monitoring itself is down.
+
+The mechanism is trivial. The requirement is not:
+
+> **The thing that notices the absence must not share a failure domain with the
+> thing it watches.**
+
+A watchdog inside the stack dies with the stack and reports nothing, which is
+worse than no watchdog because the empty inbox now looks deliberate.
+
+## What this estate actually has, measured
+
+| Candidate | Outside the failure domain? | Verdict |
+|---|---|---|
+| Cron on the VPS | No — dies with the host, and with Docker | Rejected |
+| A second Prometheus/Alertmanager on the VPS | No — same host, same Docker daemon | Rejected |
+| Alertmanager alerting on its own absence | No — cannot report its own death | Rejected |
+| Tailscale | Coordination is external, but it delivers no notifications | Not applicable |
+| **GitHub Actions scheduled workflow** | **Yes — GitHub's infrastructure, already wired to the tailnet** | **Rejected on evidence, below** |
+| External dead-man SaaS (healthchecks.io, Dead Man's Snitch) | Yes — purpose-built for exactly this | **The only fit; needs an account** |
+
+### Why GitHub Actions was rejected, despite being the obvious answer
+
+It is the only external mechanism this estate already owns, and
+`vault-sync-to-sops.yml` has been exercising it weekly. That workflow is the
+evidence, and it disqualifies the approach:
+
+```
+cron: '0 6 * * 1'   (nominal 06:00 UTC Monday)
+
+2026-07-27  started 07:02:34Z   success
+2026-07-20  started 07:01:50Z   FAILURE
+2026-07-13  started 07:03:54Z   FAILURE
+2026-07-06  started 07:29:40Z   FAILURE
+2026-06-29  started 07:39:01Z   FAILURE
+2026-06-22  started 07:56:36Z   FAILURE
+2026-06-15  started 07:54:46Z   FAILURE
+2026-06-08  started 07:38:38Z   FAILURE
+2026-06-01  started 07:42:45Z   FAILURE
+```
+
+**Eight of the last nine scheduled runs failed**, across two months. Every run
+started **62 to 116 minutes** after its nominal time — GitHub's scheduler is
+best-effort and visibly so here. And the failing step is
+**`Verify SSH connectivity`**: the runner cannot reach the VPS, which is exactly
+the step a watchdog would depend on.
+
+So the candidate is late, it is broken, and it has been broken for two months
+without producing a response. **A watcher with those properties is the thing we
+were told not to build.** Its own silence would need watching.
+
+There is a second, structural objection even if the workflow were repaired:
+GitHub disables scheduled workflows after 60 days of repository inactivity. A
+watchdog that switches itself off during a quiet period fails exactly when
+attention is lowest.
+
+## The conclusion
+
+**Nothing available here can hold this job, so nothing was built.**
+
+The honest position is that this estate currently **cannot detect its own
+monitoring failing**. That gap is real, it is recorded, and it is not closed by
+shipping a watcher that dies with what it watches — which would convert a known
+gap into a false assurance.
+
+Closing it needs one thing that does not exist yet: **an account with an external
+dead-man's-switch service**. That is a decision for Jon, not a change to this
+repo, because it means a third party, an outbound secret, and a monthly
+dependency.
+
+## The design, ready for when that exists
+
+Recorded so this is a short job rather than a rediscovery.
+
+**1. The rule** — `platform/observability/prometheus/alerts.yml`:
+
+```yaml
+  - name: watchdog
+    rules:
+      - alert: Watchdog
+        # Always firing, by construction. Its PRESENCE is the signal; its
+        # absence is what the external receiver alerts on.
+        expr: vector(1)
+        labels:
+          severity: none
+        annotations:
+          summary: "Monitoring heartbeat — this alert always fires"
+          description: >-
+            If this stops arriving at the external receiver, Prometheus or
+            Alertmanager has stopped working. Nothing is wrong with the estate
+            because this IS firing.
+          action: "Nothing. This firing is the healthy state."
+```
+
+**2. The route** — Alertmanager config, and this half is not optional:
+
+```yaml
+route:
+  routes:
+    - matchers: [ 'alertname = "Watchdog"' ]
+      receiver: dead-mans-switch
+      group_wait: 0s
+      group_interval: 1m
+      repeat_interval: 2m      # must be well under the provider's grace period
+      continue: false          # MUST NOT fall through to the email receiver
+
+receivers:
+  - name: dead-mans-switch
+    webhook_configs:
+      - url: <snitch URL from SOPS>
+        send_resolved: false
+```
+
+**3. Grace period** at the provider: roughly 10× `repeat_interval` — 15 to 20
+minutes for a 2m repeat. Short enough to matter, long enough to survive one
+deploy of the observability stack.
+
+### Why shipping the rule alone would be a mistake
+
+An always-firing alert with no matching route falls through to the default
+receiver. The default receiver is the proven email one. **It would email Jon
+every `repeat_interval`, forever, starting immediately** — and the fastest way to
+make someone ignore this sender is to do that. The rule and its route land
+together or not at all. That is the whole reason this is written down rather than
+half-applied.
+
+### What it would and would not prove
+
+- **Would prove:** rules are being evaluated, Alertmanager is alive, and it can
+  deliver through that integration.
+- **Would NOT prove:** that the *email* receiver works — pane 1 proved that
+  separately by delivery — nor that Prometheus is still scraping every target. A
+  Prometheus that has lost all its scrape targets still evaluates `vector(1)`
+  happily. `ServiceDown` and `up == 0` remain the cover for that, and they only
+  work if the heartbeat says the pipeline is alive.
+
+The two checks compose: the watchdog proves the alerting path is alive, and the
+ordinary rules prove the estate is. Neither substitutes for the other.
+
+## Adjacent finding, not chased here
+
+`vault-sync-to-sops.yml` has failed on eight of its last nine scheduled runs
+since 2026-06-01, at the `Verify SSH connectivity` step. It was examined only far
+enough to disqualify GitHub Actions as a watchdog host; whether the vault-to-SOPS
+sync being two months stale matters is a separate question, and it belongs to
+whoever owns the vault fallback path.

--- a/scripts/checks/alert-series-allowlist.txt
+++ b/scripts/checks/alert-series-allowlist.txt
@@ -1,0 +1,10 @@
+# Selectors in platform/observability/prometheus/alerts.yml that are allowed to
+# match zero series on a healthy system, checked by check_alert_series.py.
+#
+# One line per selector, then '#' and the REASON. A selector with no reason is
+# indistinguishable from a rule nobody has verified, which is the failure this
+# whole check exists to catch. Keep this list short and argued.
+#
+# Format:  <metric-name-or-full-selector>    # why it can legitimately be absent
+
+tempo_distributor_ingester_append_failures_total  # Lazily created: Tempo exposes this counter only after the first append failure. Verified 2026-07-31 — after the 09:45 restart /metrics carried tempo_distributor_ingester_appends_total (248 successes) and no failures line at all, while before the restart the series existed with value 30. Absence means "no failures since start", which is the healthy state.

--- a/scripts/checks/check_alert_series.py
+++ b/scripts/checks/check_alert_series.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Ask the LIVE Prometheus whether each alert rule's selectors match anything.
+
+    bash -c 'cd /opt/hill90/app && python3 scripts/checks/check_alert_series.py'
+
+WHY THIS EXISTS SEPARATELY FROM THE UNIT TESTS.
+
+tests/prometheus/alerts_test.yml proves a rule's logic. It cannot prove the
+series exist, because the test author supplies the input series and can invent
+any label the rule asks for. Two rules shipped here with that defect:
+
+  LokiIngestionErrors      matches {status="error"}; the metric has no `status`
+                           label, and `error` is not a value it takes anywhere
+  HighMemoryUsage          annotated {{ $labels.name }}; cAdvisor emits no `name`
+
+Both evaluated cleanly, both reported health=ok, neither could ever fire. From
+the alert list that is indistinguishable from everything being fine.
+
+This check closes that gap by asking the running Prometheus. It must be run
+against production (or a live local stack) — it is deliberately NOT in CI, which
+has no Prometheus to ask. That is the point: the two checks are complementary
+and neither is sufficient alone.
+
+Read-only: instant queries only. Nothing is written, enabled or restarted.
+
+A selector that is legitimately absent — a counter created only when the
+condition first occurs, or a metric whose emitter is not built yet — is declared
+in scripts/checks/alert-series-allowlist.txt, with a reason.
+
+Exit 0 if every selector matches, or is declared absent. Exit 1 otherwise.
+"""
+import json
+import re
+import subprocess
+import sys
+import urllib.parse
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:
+    sys.exit("PyYAML required: pip install pyyaml")
+
+RULES = Path(__file__).resolve().parents[2] / \
+    "platform/observability/prometheus/alerts.yml"
+ALLOWLIST = Path(__file__).resolve().parent / "alert-series-allowlist.txt"
+
+# Identifiers that are PromQL, not metrics. Functions are detected by the '('
+# that follows them, so this only needs the keywords and bare words.
+KEYWORDS = {
+    "by", "without", "on", "ignoring", "group_left", "group_right", "offset",
+    "bool", "and", "or", "unless", "if", "default", "start", "end", "atan2",
+    "inf", "nan",
+}
+
+# Applied in order. Each removes a construct whose contents would otherwise be
+# mistaken for metric names.
+#
+# String literals are deliberately NOT stripped. An earlier version removed them
+# and turned {job="blackbox-public"} into {job= }, which Prometheus rejects with
+# HTTP 400 — and the script reported that as "cannot fire". The label matcher is
+# the most important part of the selector to keep: a rule can name a real metric
+# and still match nothing because of one wrong label, which is the entire defect
+# this check exists to find.
+STRIP = [
+    re.compile(r"\[[^\]]*\]"),                       # range/subquery selectors
+    re.compile(r"\b(?:by|without|on|ignoring|group_left|group_right)\s*\([^)]*\)"),
+]
+
+SELECTOR = re.compile(r"(?<![\w:.])([a-zA-Z_:][\w:]*)\s*(\{[^}]*\})?")
+
+
+def prometheus_query(expr):
+    """Instant query via the container, so no published port is needed and no
+    hardcoded IP goes stale when Prometheus is redeployed."""
+    url = ("http://localhost:9090/api/v1/query?"
+           + urllib.parse.urlencode({"query": expr}))
+    p = subprocess.run(
+        ["docker", "exec", "prometheus", "wget", "-qO-", url],
+        capture_output=True, text=True, timeout=30)
+    if p.returncode != 0:
+        return None, (p.stderr.strip() or "docker exec failed")
+    try:
+        d = json.loads(p.stdout)
+    except json.JSONDecodeError as e:
+        return None, f"unparseable response: {e}"
+    if d.get("status") != "success":
+        return None, d.get("error", "query rejected")
+    return d["data"]["result"], None
+
+
+def selectors_in(expr):
+    """Every metric selector in a PromQL expression, label matchers included.
+
+    The label matchers are the reason this keeps the braces: a rule can name a
+    real metric and still match nothing because of one wrong label.
+    """
+    text = expr
+    for pattern in STRIP:
+        text = pattern.sub(" ", text)
+
+    found = []
+    for m in SELECTOR.finditer(text):
+        name, labels = m.group(1), m.group(2) or ""
+        # A '(' after the identifier makes it a function call. Skip whitespace
+        # first: stripping "by (instance)" out of "sum by (instance) (metric)"
+        # leaves "sum  (metric)", and an earlier version checked only the very
+        # next character, so it reported `sum` and `max` as missing metrics.
+        if text[m.end(1):].lstrip(" \t\n")[:1] == "(":
+            continue
+        if name in KEYWORDS or name.isdigit():
+            continue
+        sel = name + labels
+        if sel not in found:
+            found.append(sel)
+    return found
+
+
+def main():
+    raw = RULES.read_text()
+    doc = yaml.safe_load(raw)
+
+    allowed = {}
+    if ALLOWLIST.exists():
+        for line in ALLOWLIST.read_text().splitlines():
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            sel, _, reason = line.partition("#")
+            allowed[sel.strip()] = reason.strip() or "(no reason given)"
+
+    print(f"Alert rule series check — {RULES}")
+    if allowed:
+        print(f"declared absent ({ALLOWLIST.name}): {len(allowed)} selector(s)")
+    print()
+
+    probe, err = prometheus_query("up")
+    if err:
+        print(f"CANNOT REACH PROMETHEUS: {err}")
+        print("A check that cannot run must not report success. Exiting 1.")
+        return 1
+
+    missing, checked = [], 0
+    for group in doc.get("groups", []):
+        for rule in group.get("rules", []):
+            name = rule.get("alert")
+            if not name:
+                continue
+            print(f"{name}")
+            for sel in selectors_in(rule["expr"]):
+                base = sel.split("{")[0]
+                res, err = prometheus_query(sel)
+                checked += 1
+                if err:
+                    print(f"    ?  {sel}   (query error: {err})")
+                    missing.append((name, sel, "query error"))
+                elif res:
+                    labels = sorted({k for s in res for k in s["metric"]
+                                     if k != "__name__"})
+                    print(f"    ok {sel}   {len(res)} series   "
+                          f"[{', '.join(labels)}]")
+                elif base in allowed or sel in allowed:
+                    why = allowed.get(sel) or allowed.get(base)
+                    print(f"    -  {sel}   0 series — declared absent: {why}")
+                else:
+                    print(f"    NO {sel}   0 SERIES — this rule cannot fire")
+                    missing.append((name, sel, "no series"))
+            print()
+
+    print("-" * 70)
+    print(f"{checked} selectors checked")
+    if missing:
+        print(f"\n{len(missing)} SELECTOR(S) MATCH NOTHING:\n")
+        for rule, sel, why in missing:
+            print(f"  {rule}: {sel}  ({why})")
+        print("\nA rule matching no series never fires and looks exactly like")
+        print("health. Either correct the selector, delete the rule, or add it")
+        print(f"to {ALLOWLIST.name} with a reason.")
+        return 1
+    print("every selector matches at least one live series")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/prometheus/alerts_test.yml
+++ b/tests/prometheus/alerts_test.yml
@@ -1,0 +1,326 @@
+# Unit tests for platform/observability/prometheus/alerts.yml.
+#
+# Run:  promtool test rules tests/prometheus/alerts_test.yml
+# CI:   .github/workflows/ci.yml, job `prometheus-rules`
+#
+# ---------------------------------------------------------------------------
+# WHAT THIS SUITE CAN AND CANNOT PROVE. Read before trusting a green run.
+#
+# It CAN prove: the expression computes what you meant, the threshold is on the
+# right side, `for:` holds firing off for the right duration, aggregation
+# produces a matchable vector, and the annotation templates render to real text
+# rather than to blanks.
+#
+# It CANNOT prove the series exist in production. Every input_series below is
+# INVENTED BY THE TEST AUTHOR. If a rule matches on a label production never
+# emits, the test still passes, because the test hands the rule exactly the
+# labels it asked for.
+#
+# That is not hypothetical — see LokiIngestionErrors at the bottom, which has a
+# passing test here and CANNOT FIRE in production. Two rules shipped in this
+# repo had that defect and both looked like coverage for months.
+#
+# The complementary check is scripts/checks/check_alert_series.sh, which asks the
+# live Prometheus whether each selector matches anything. Neither test is
+# sufficient alone: this one proves the logic, that one proves the data.
+# ---------------------------------------------------------------------------
+
+rule_files:
+  - ../../platform/observability/prometheus/alerts.yml
+
+evaluation_interval: 1m
+
+tests:
+  # --- availability ---------------------------------------------------------
+
+  - name: PublicSiteDown fires 2m after the public probe stops returning 200
+    interval: 1m
+    input_series:
+      - series: 'probe_success{job="blackbox-public", instance="https://hill90.com/"}'
+        values: '0x10'
+    alert_rule_test:
+      - eval_time: 1m
+        alertname: PublicSiteDown
+        exp_alerts: []          # `for: 2m` not yet satisfied
+      - eval_time: 3m
+        alertname: PublicSiteDown
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              job: blackbox-public
+              instance: https://hill90.com/
+            exp_annotations:
+              summary: "hill90.com is not answering from the internet"
+              description: "The blackbox probe of https://hill90.com/ has not received HTTP 200 for over 2 minutes. This is the tenant's UI — the public product — so users are seeing this too."
+              action: "Check the edge before the app: `docker ps --filter name=traefik` and `docker logs --tail 50 traefik`. If Traefik is healthy, the tenant's app-ui is the next suspect — it is NOT a Prometheus scrape target, so this probe is the only signal. Confirm from outside with `curl -sI https://hill90.com`."
+              runbook: docs/runbooks/troubleshooting.md
+
+  - name: PublicSiteDown stays silent while the probe succeeds
+    interval: 1m
+    input_series:
+      - series: 'probe_success{job="blackbox-public", instance="https://hill90.com/"}'
+        values: '1x10'
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: PublicSiteDown
+        exp_alerts: []
+
+  - name: PublicSiteDown does not fire on a blip shorter than `for`
+    # A deploy replacing app-ui takes seconds. One failed probe must not page.
+    interval: 1m
+    input_series:
+      - series: 'probe_success{job="blackbox-public", instance="https://hill90.com/"}'
+        values: '1 1 0 1 1 1 1 1'
+    alert_rule_test:
+      - eval_time: 7m
+        alertname: PublicSiteDown
+        exp_alerts: []
+
+  - name: VaultSealedOrUnreachable fires 5m after the health probe stops
+    interval: 1m
+    input_series:
+      - series: 'probe_success{job="blackbox-vault", instance="http://openbao:8200/v1/sys/health"}'
+        values: '0x10'
+    alert_rule_test:
+      - eval_time: 4m
+        alertname: VaultSealedOrUnreachable
+        exp_alerts: []
+      - eval_time: 6m
+        alertname: VaultSealedOrUnreachable
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              job: blackbox-vault
+              instance: http://openbao:8200/v1/sys/health
+            exp_annotations:
+              summary: "OpenBao is sealed, uninitialised or unreachable"
+              description: "The unauthenticated health probe of http://openbao:8200/v1/sys/health has not returned HTTP 200 for over 5 minutes. 503 means SEALED, 501 means uninitialised. A sealed vault breaks nothing user-facing, which is exactly why this would otherwise go unnoticed until the next deploy — or until a recovery."
+              action: "Run `docker exec openbao bao status`. If it reports `Sealed true`, unseal with `bash scripts/vault.sh unseal`. If this followed a reboot, the systemd unit hill90-vault-unseal did not do its job — check `systemctl status hill90-vault-unseal` before unsealing by hand, or the same thing happens after the next reboot."
+              runbook: docs/runbooks/vault-unseal.md
+
+  # --- service-health -------------------------------------------------------
+
+  - name: ServiceDown fires after 5m and names the job in its annotations
+    # The annotation assertions are the point as much as the firing: the rule
+    # this replaced annotated {{ $labels.name }}, a label cAdvisor never emits,
+    # so it rendered "Container " and told the reader nothing.
+    interval: 1m
+    input_series:
+      - series: 'up{job="loki", instance="loki:3100"}'
+        values: '0x10'
+    alert_rule_test:
+      - eval_time: 4m
+        alertname: ServiceDown
+        exp_alerts: []
+      - eval_time: 6m
+        alertname: ServiceDown
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              job: loki
+              instance: loki:3100
+            exp_annotations:
+              summary: "Scrape target loki is down"
+              description: "Scrape target loki:3100 (job loki) has been down for more than 5 minutes on the platform host."
+              action: "`docker ps -a --filter name=loki` then `docker logs --tail 50 loki`. If the container is healthy but the target is down, the metrics endpoint or the internal network is the fault, not the service."
+              runbook: docs/runbooks/observability.md
+
+  - name: ServiceDown stays silent while the target is up
+    interval: 1m
+    input_series:
+      - series: 'up{job="loki", instance="loki:3100"}'
+        values: '1x10'
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: ServiceDown
+        exp_alerts: []
+
+  # --- resource-usage -------------------------------------------------------
+
+  - name: HostMemoryHigh fires on real pressure, measured without page cache
+    # 5 GiB available of 50 GiB total => 90% unavailable, just over threshold.
+    interval: 1m
+    input_series:
+      - series: 'node_memory_MemAvailable_bytes{instance="node-exporter:9100", job="node-exporter"}'
+        values: '4000000000x10'
+      - series: 'node_memory_MemTotal_bytes{instance="node-exporter:9100", job="node-exporter"}'
+        values: '50000000000x10'
+    alert_rule_test:
+      - eval_time: 6m
+        alertname: HostMemoryHigh
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              instance: node-exporter:9100
+              job: node-exporter
+            exp_annotations:
+              summary: "Host memory above 90% on the platform VPS"
+              description: "92% of RAM on node-exporter:9100 is unavailable — that is real pressure, with page cache already discounted, not merely memory in use. This is HOST memory, not a single container: cAdvisor exposes no per-container series on this host."
+              action: "`free -h` on the host to confirm, then `docker stats --no-stream` to find the consumer. Nothing here identifies the container automatically; that needs cAdvisor fixed first. Note `docker stats` will not agree with this alert exactly — it reports usage including cache, which is the thing this rule deliberately stopped measuring."
+              runbook: docs/runbooks/observability.md
+
+  - name: HostMemoryHigh is silent at the pressure this host actually runs at
+    # The regression this rule was changed for. These are the real 2026-07-31
+    # figures: 11.5 GiB available of 16.76 GiB => 31% unavailable. The previous
+    # cgroup-based expression read 0.70 on the very same host, because it counted
+    # 8.6 GiB of reclaimable page cache. Anything that makes this test fire again
+    # has reintroduced that bug.
+    interval: 1m
+    input_series:
+      - series: 'node_memory_MemAvailable_bytes{instance="node-exporter:9100", job="node-exporter"}'
+        values: '11514765312x10'
+      - series: 'node_memory_MemTotal_bytes{instance="node-exporter:9100", job="node-exporter"}'
+        values: '16761118720x10'
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: HostMemoryHigh
+        exp_alerts: []
+
+  - name: DiskSpaceRunningLow fires below 15% free
+    interval: 1m
+    input_series:
+      - series: 'node_filesystem_avail_bytes{mountpoint="/", instance="node-exporter:9100", job="node-exporter", device="/dev/sda4", fstype="xfs"}'
+        values: '10x15'
+      - series: 'node_filesystem_size_bytes{mountpoint="/", instance="node-exporter:9100", job="node-exporter", device="/dev/sda4", fstype="xfs"}'
+        values: '100x15'
+    alert_rule_test:
+      - eval_time: 12m
+        alertname: DiskSpaceRunningLow
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              mountpoint: /
+              instance: node-exporter:9100
+              job: node-exporter
+              device: /dev/sda4
+              fstype: xfs
+            exp_annotations:
+              summary: "Disk space below 15% on node-exporter:9100"
+              description: "Root filesystem on node-exporter:9100 has 10% free space remaining."
+              action: "`df -h /` on the host. The usual consumers are /opt/hill90/backups (prune with `bash scripts/backup.sh prune 7`) and Docker images (`docker image prune`). prometheus-data is capped at 20GB and is not usually the cause."
+              runbook: docs/runbooks/troubleshooting.md
+
+  - name: DiskSpaceRunningLow is silent with headroom
+    interval: 1m
+    input_series:
+      - series: 'node_filesystem_avail_bytes{mountpoint="/", instance="node-exporter:9100", job="node-exporter"}'
+        values: '50x15'
+      - series: 'node_filesystem_size_bytes{mountpoint="/", instance="node-exporter:9100", job="node-exporter"}'
+        values: '100x15'
+    alert_rule_test:
+      - eval_time: 12m
+        alertname: DiskSpaceRunningLow
+        exp_alerts: []
+
+  # --- postgres -------------------------------------------------------------
+
+  - name: PostgresConnectionsHigh aggregates across mismatched label sets
+    # THE REGRESSION TEST FOR A RULE THAT COULD NEVER FIRE.
+    #
+    # pg_stat_activity_count carries datname and state; pg_settings_max_connections
+    # carries neither. Dividing them directly yields an empty vector, because
+    # one-to-one matching needs identical label sets. The `sum by (instance)` /
+    # `max by (instance)` form is what makes this fire at all.
+    #
+    # The input below deliberately keeps those label sets DIFFERENT. Simplify it
+    # to matching labels and the test passes against a broken rule.
+    interval: 1m
+    input_series:
+      - series: 'pg_stat_activity_count{instance="postgres-exporter:9187", job="postgres-exporter", server="postgres:5432", datname="hill90", state="active"}'
+        values: '50x10'
+      - series: 'pg_stat_activity_count{instance="postgres-exporter:9187", job="postgres-exporter", server="postgres:5432", datname="keycloak", state="idle"}'
+        values: '35x10'
+      - series: 'pg_settings_max_connections{instance="postgres-exporter:9187", job="postgres-exporter", server="postgres:5432"}'
+        values: '100x10'
+    alert_rule_test:
+      - eval_time: 6m
+        alertname: PostgresConnectionsHigh
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              instance: postgres-exporter:9187
+            exp_annotations:
+              summary: "PostgreSQL connections above 80% capacity"
+              description: "Active connections are 85% of max_connections on postgres-exporter:9187."
+              action: "`docker exec postgres psql -U hill90 -c \"SELECT datname, state, count(*) FROM pg_stat_activity GROUP BY 1,2 ORDER BY 3 DESC;\"` to find which database and which state is holding them. Idle-in-transaction is the usual culprit, not genuine load."
+              runbook: docs/runbooks/troubleshooting.md
+
+  - name: PostgresConnectionsHigh is silent at normal connection counts
+    interval: 1m
+    input_series:
+      - series: 'pg_stat_activity_count{instance="postgres-exporter:9187", job="postgres-exporter", datname="hill90", state="idle"}'
+        values: '6x10'
+      - series: 'pg_settings_max_connections{instance="postgres-exporter:9187", job="postgres-exporter"}'
+        values: '100x10'
+    alert_rule_test:
+      - eval_time: 6m
+        alertname: PostgresConnectionsHigh
+        exp_alerts: []
+
+  # --- tempo ----------------------------------------------------------------
+
+  - name: TempoIngestionErrors fires on a rising append-failure counter
+    interval: 1m
+    input_series:
+      - series: 'tempo_distributor_ingester_append_failures_total{instance="tempo:3200", job="tempo", ingester="127.0.0.1:9095"}'
+        values: '0+2x15'
+    alert_rule_test:
+      - eval_time: 12m
+        alertname: TempoIngestionErrors
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              instance: tempo:3200
+              job: tempo
+              ingester: 127.0.0.1:9095
+            exp_annotations:
+              summary: "Tempo ingestion errors detected"
+              description: "Tempo is failing to append traces at 0.03333333333333333/sec on tempo:3200. Traces are being LOST while this fires."
+              action: "`docker logs --tail 50 tempo`. This fired for ~1.3 cumulative hours in the week to 2026-07-31 with nobody watching, so treat a first delivery as possibly long-standing rather than new."
+              runbook: docs/runbooks/observability.md
+
+  - name: TempoIngestionErrors is silent on a flat counter
+    interval: 1m
+    input_series:
+      - series: 'tempo_distributor_ingester_append_failures_total{instance="tempo:3200", job="tempo", ingester="127.0.0.1:9095"}'
+        values: '30x15'
+    alert_rule_test:
+      - eval_time: 12m
+        alertname: TempoIngestionErrors
+        exp_alerts: []
+
+  # --- loki -----------------------------------------------------------------
+
+  - name: LokiIngestionErrors — DEMONSTRATION THAT A GREEN TEST PROVES NOTHING
+    # This test passes. The rule CANNOT FIRE IN PRODUCTION.
+    #
+    # It matches loki_distributor_lines_received_total{status="error"}. On the
+    # live Loki that metric carries aggregated_metric, instance, job and tenant —
+    # there is no `status` label at all. And `status` where it does exist in
+    # Loki's metrics takes discarded|matched|notfound|success, so "error" is not a
+    # value it ever holds either. Verified 2026-07-31, see
+    # docs/decisions/alert-series-verification.md.
+    #
+    # The test passes because the line below INVENTS the label. That is the
+    # limitation of every unit test in this file, stated once, concretely, in the
+    # one place where it is provably true. Do not delete this test without
+    # deleting the rule — it is the honest record of why the suite alone is not
+    # enough.
+    interval: 1m
+    input_series:
+      - series: 'loki_distributor_lines_received_total{status="error", instance="loki:3100", job="loki"}'
+        values: '0+5x15'
+    alert_rule_test:
+      - eval_time: 12m
+        alertname: LokiIngestionErrors
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              status: error
+              instance: loki:3100
+              job: loki
+            exp_annotations:
+              summary: "Loki ingestion errors detected"
+              description: "Loki is rejecting log lines at 0.08333333333333333 errors/sec on loki:3100. Logs are being LOST while this fires."
+              action: "`docker logs --tail 50 loki`. Rate-limit and per-stream-limit rejections are configuration; disk-full is not — check `df -h /` too."
+              runbook: docs/runbooks/observability.md


### PR DESCRIPTION
Rebased onto main now that #620 is merged. Touches no rule pane 1 is working on — the held Loki replacement and `ServiceRestartLoop` are not in here.

Three things, all downstream of one lesson: **a rule matching no series never fires and looks exactly like health.**

## 1. Unit tests — `tests/prometheus/alerts_test.yml`

Every rule gets a firing case and a silent case, with `for:` boundaries checked either side. Annotations are asserted **in full**, deliberately: the rule this replaced annotated `{{ $labels.name }}`, a label cAdvisor never emits, so it rendered `"Container "`. Asserting rendered text catches that class.

**It passed first try, so I mutation-tested it rather than trusting it:**

| Mutation | Result |
|---|---|
| loosen `HostMemoryHigh` 0.9 → 0.2 | **FAILED** ✓ |
| revert `HostMemoryHigh` to the cgroup form | **FAILED** ✓ |
| break Postgres back to a direct division | **FAILED** ✓ |
| restore | SUCCESS |

The Postgres case is the regression test for a rule that could never fire, and its inputs keep the label sets **deliberately mismatched**. Simplify them to matching labels and the test passes against a broken rule.

## 2. The limit of that suite — and the check that covers it

**Unit tests cannot prove the series exist.** Every `input_series` is invented by the test author, so a rule matching a label production never emits still passes.

`LokiIngestionErrors` is therefore left in the suite **with a passing test and a comment saying exactly that** — the one place the limitation is provably true rather than merely asserted.

`scripts/checks/check_alert_series.py` asks the live Prometheus instead. Run on the VPS; deliberately **not** in CI, which has no Prometheus to ask.

**I got it wrong twice before it worked**, which is why running it mattered:
- stripping string literals turned `{job="blackbox-public"}` into `{job= }` → HTTP 400 → reported as "cannot fire". The label matcher is the most important part of the selector to keep.
- `sum by (instance) (metric)` leaves `sum  (metric)` after stripping, and checking only the *next* character reported `sum` and `max` as missing metrics.

Corrected, it **independently rediscovers `LokiIngestionErrors`** — that is its acceptance test. It exits 1 today for that one reason, correctly; the fix is held pending pane 1.

**It also found something real.** `tempo_distributor_ingester_append_failures_total` is **lazily created**: after the 09:45 restart `/metrics` carries `appends_total` (248 successes) and *no failures line at all*, though the series existed with value 30 beforehand. Absence means "no failures since start" — the healthy state — so it is declared in `alert-series-allowlist.txt` with that reasoning. Exemptions require a reason; one without is indistinguishable from a rule nobody checked.

## 3. No dead man's switch was built — `docs/decisions/dead-mans-switch.md`

The noticer must not share a failure domain with the watched. Measured against that, everything here fails: VPS cron dies with the host, a second Alertmanager dies with Docker, Alertmanager cannot report its own death.

**GitHub Actions was the obvious answer** — the only external mechanism the estate owns — and `vault-sync-to-sops.yml` disqualifies it on evidence:

- **Eight of its last nine scheduled runs failed**, 2026-06-01 to 2026-07-20
- every run started **62–116 minutes** after its nominal 06:00
- the failing step is **`Verify SSH connectivity`** — precisely what a watchdog would depend on

Late, broken, and broken unnoticed for two months. Plus GitHub disables schedules after 60 days of inactivity, so it would switch itself off when attention is lowest.

So the honest position is recorded instead: **this estate cannot currently detect its own monitoring failing.** Closing that needs an external dead-man's-switch account — your decision, not a repo change.

The full design is written down (Watchdog rule, route, grace period) with **why shipping the rule alone would be a mistake**: with no matching route it falls through to the proven email receiver and mails you every `repeat_interval` forever — the fastest possible way to teach someone to ignore the sender.

## CI

`promtool check` + `test` pinned to `v3.3.1`, matching production, and the step prints that a green run does **not** prove the rules can fire.

## Adjacent, not chased

The vault-to-SOPS sync has been failing for two months. Examined only far enough to disqualify Actions as a watchdog host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)