### PR TITLE
feat(alerting): probe the tenant's API from the edge, and correct what the contract claims about tenant observability

### DIFF
--- a/docs/decisions/app-tenancy-on-the-vps.md
+++ b/docs/decisions/app-tenancy-on-the-vps.md
@@ -452,7 +452,21 @@ deploy workflows, which do not verify `infra`. Worth fixing separately.
 | Container name `minio`, router `minio-console`, host `storage` free | ✗ once PR #556 merges | naming decision, app lane |
 | Tenant deploy tooling | ✗ | build in `hill90-app`; optionally add a preflight here |
 | Tenant secrets store | ✗ (app has none) | app lane |
-| Observability of tenant containers | partial — `cadvisor` scrapes all containers; no app-specific Prometheus job | not a blocker |
+| Observability of tenant containers | **none** — see the correction below | not a blocker; scope decided in [tenant-monitoring-coverage.md](tenant-monitoring-coverage.md) |
+
+> **Correction, `Verified 2026-07-31 10:50 UTC`.** That row used to read *"partial —
+> `cadvisor` scrapes all containers; no app-specific Prometheus job"*. **The stated basis
+> is false.** cAdvisor on this host emits 45 cgroup and systemd series and **zero Docker
+> containers**: `count(container_memory_usage_bytes{name!=""})` is 0, and the only ids
+> mentioning Docker are `docker.service`, `docker.socket` and `containerd.service` — the
+> daemons, not the containers. Prometheus scrapes **no** `app-*` target either. So the
+> partial coverage this table recorded has never existed, and the honest entry is none.
+>
+> What does cover the tenant is outside-in: blackbox probes of `hill90.com` and, since
+> 2026-07-31, `api.hill90.com/health`. Those are edge checks of public hostnames this
+> platform routes, not observation of tenant internals — the boundary argument, and the
+> decision NOT to scrape tenant containers, are in
+> [tenant-monitoring-coverage.md](tenant-monitoring-coverage.md).
 
 Nothing in the "Provided today ✗" column is a Hill90 capability gap except the
 deploy tooling. The rest are naming decisions that belong to the app.

--- a/docs/decisions/tenant-monitoring-coverage.md
+++ b/docs/decisions/tenant-monitoring-coverage.md
@@ -1,0 +1,134 @@
+# Tenant monitoring — what the platform covers, and where the boundary is
+
+`Verified 2026-07-31 10:50 UTC`, read-only against production.
+
+All the alerting built today watches the **platform**: its containers, certificates,
+backups and disk. This establishes what any of it says about the **tenant** —
+`hill90.com` and the seven `app-*` containers that serve it — and separates the part
+that is plainly the platform's job from the part that would widen the tenancy contract.
+
+## The short answer
+
+**Prometheus scrapes zero tenant containers.** Fourteen scrape targets, none of them
+`app-*`. What covers the tenant is one thing only: the blackbox probe of
+`https://hill90.com/`, which is an outside-in check of a public hostname.
+
+So `app-ui` failing is caught. **`app-api` failing was not**, and that is the gap this
+change closes.
+
+## The tenant's public surface, and what watches it
+
+Read from the running containers' Traefik labels.
+
+| Hostname | Container | Watched? |
+|---|---|---|
+| `hill90.com`, `www.hill90.com` | `app-ui` | **Yes** — `blackbox-public`, `PublicSiteDown` |
+| `api.hill90.com` | `app-api` | **Now yes** — `blackbox-tenant-api`, `TenantApiDown` (this change) |
+| `litellm.hill90.com` | `app-litellm` | No — see below |
+| `ai.hill90.com/mcp` | `app-mcp` | No — see below |
+| *not routed* | `app-ai`, `app-knowledge`, `app-docker-proxy` | No — internal only, `traefik.enable=false` or unset |
+
+### Why `PublicSiteDown` does not cover the API — measured, not assumed
+
+The obvious assumption is that if the API dies the site breaks, so one probe covers both.
+**It does not**, and the evidence is specific:
+
+```
+https://hill90.com/            -> 200
+https://hill90.com/api/health  -> 200   {"status":"healthy","service":"ui"}
+https://api.hill90.com/health  -> 200   {"status":"healthy","service":"api"}
+```
+
+`hill90.com/api/health` is the **UI's own** health route. It reports `service: "ui"` and
+does not proxy to `app-api`. The homepage renders from `app-ui` alone. So `app-api` can be
+completely dead while `hill90.com` keeps answering 200 and `PublicSiteDown` stays silent.
+
+*Not tested destructively:* `app-api` was never stopped to confirm the site still serves
+200 without it — that would be an outage on production to prove a point. The conclusion
+rests on the two health endpoints reporting different services and the homepage rendering
+independently, which is strong but is inference.
+
+### Why `litellm` and `ai/mcp` were not probed
+
+Both return non-200 in **normal, healthy** operation:
+
+```
+https://litellm.hill90.com/        -> 403      (edge IP allowlist, working as designed)
+https://litellm.hill90.com/health  -> 403
+https://ai.hill90.com/mcp          -> 404
+```
+
+A 200-expecting probe would alert permanently, which is worse than no alert. Probing them
+properly means encoding the expected non-200 code, which is brittle, or reaching past the
+allowlist, which is not an outside-in check. **Left uncovered deliberately**, and recorded
+here rather than silently skipped.
+
+## The tenancy boundary
+
+[`app-tenancy-on-the-vps.md`](app-tenancy-on-the-vps.md) states the contract. Its table
+has a row for this, and **the row's stated basis is false** — corrected in that file by
+this change:
+
+> | Observability of tenant containers | partial — `cadvisor` scrapes all containers; no app-specific Prometheus job | not a blocker |
+
+cAdvisor does **not** scrape all containers on this host. It emits 45 cgroup and systemd
+series and **zero Docker containers** — `count(container_memory_usage_bytes{name!=""})` is
+0, and the only ids mentioning Docker are `docker.service`, `docker.socket` and
+`containerd.service`, which are the daemons. The record claimed partial coverage that has
+never existed; actual coverage of tenant containers is **nil**.
+
+### What this change does — edge scope, not a widening
+
+Probing `https://api.hill90.com/health` from outside is the **same class of check** as the
+already-shipped probe of `hill90.com`:
+
+- It targets a **public hostname this platform's Traefik routes** and holds the
+  certificate for. "Does this hostname serve?" is an edge question, and the edge is the
+  platform's.
+- It uses **no credential** and reaches **no container**. It is HTTP from the outside.
+- It adds **no scrape target inside the tenant** and reads none of its metrics.
+
+The one piece of tenant knowledge it encodes is the path `/health`, because
+`api.hill90.com/` returns 404. That is a real coupling: if the tenant moves that path, this
+alert lies. It is small, and the alternative — probing a root that 404s — is not viable.
+
+### What would be a widening, and is NOT being done
+
+**Scraping the tenant's containers into the platform's Prometheus.** That would mean the
+platform observing tenant internals, alerting on tenant container health, and implicitly
+taking responsibility for them. The contract is deliberately narrow, and this would widen
+it without a decision. **It is Jon's call, not this repository's.**
+
+Two facts for that decision:
+
+1. **It is not currently possible without tenant changes.** No `app-*` container exposes a
+   Prometheus endpoint — checked on the internal network:
+   `app-ui:3000/metrics` 404, `app-litellm:4000/metrics` 404, `app-knowledge:8002/metrics`
+   401, and `app-api`, `app-ai`, `app-mcp` refuse the connection outright. Instrumenting
+   them is **app-lane work** that must happen first regardless.
+2. **The cheap alternative already covers the outcome that matters.** An outside-in probe
+   answers "is this broken for users", which is the question worth waking someone for.
+   Container-level scraping answers "which part broke", which is a debugging convenience
+   once you are already awake.
+
+**Recommendation: do not scrape tenant containers.** Add outside-in probes for public
+hostnames as the platform's edge responsibility, and leave the tenant's internals to the
+tenant. If deeper visibility is wanted later, the right shape is the tenant running its own
+Prometheus, or exporting to this one by agreement — a decision, with the contract updated.
+
+### If you disagree with `TenantApiDown`
+
+It is one job in `prometheus.yml` and one rule in `alerts.yml`, both labelled. Deleting the
+rule and keeping the job leaves the probe collecting data without paging anyone, which is a
+reasonable middle position if the boundary reading is judged too generous.
+
+## What is still not covered, after this change
+
+- **The tenant's internal containers** — `app-ai`, `app-knowledge`, `app-docker-proxy`.
+  Nothing observes them. `app-docker-proxy` is the one worth noting: it fronts the Docker
+  socket for the agent sandbox, so its failure is a security-relevant availability event
+  and it is invisible.
+- **`litellm` and `ai/mcp`**, for the reasons above.
+- **Which tenant component failed.** Both probes say "broken from outside", not why.
+- **Tenant container restart loops.** The same cAdvisor absence that breaks per-container
+  memory alerting on the platform applies here.

--- a/docs/runbooks/observability.md
+++ b/docs/runbooks/observability.md
@@ -143,6 +143,7 @@ as "Do this first" and is not optional — add it to any new rule.
 |-------|-----------|----------|-------|
 | **PublicSiteDown** | blackbox probe of `https://hill90.com/` not 200 for 2m | critical | **New.** The only signal for the product being down — the tenant's containers are not scrape targets |
 | **VaultSealedOrUnreachable** | blackbox probe of OpenBao `/v1/sys/health` not 200 for 5m | critical | **New.** 503 means SEALED. Needs no token |
+| **TenantApiDown** | blackbox probe of `api.hill90.com/health` not 200 for 2m | critical | **New.** `PublicSiteDown` does **not** cover this — `hill90.com/api/health` reports `service: ui` and does not proxy to the API, so the site can answer 200 while `app-api` is dead. Scope argument in [tenant-monitoring-coverage.md](../decisions/tenant-monitoring-coverage.md) |
 | ServiceDown | Any scrape target down > 5m | critical | Fired ≥48 h to 2026-07-26 with no receiver |
 | HostMemoryHigh | **Host root cgroup** memory > 90% | warning | **Renamed from HighMemoryUsage** — it never watched containers, see below |
 | DiskSpaceRunningLow | Root filesystem < 15% free | warning | Never fired; `/` is 87.6% free |

--- a/platform/observability/prometheus/alerts.yml
+++ b/platform/observability/prometheus/alerts.yml
@@ -56,6 +56,31 @@ groups:
             same thing happens after the next reboot.
           runbook: docs/runbooks/vault-unseal.md
 
+      # See the job comment in prometheus.yml for why this is edge scope rather
+      # than tenant-internal monitoring, and docs/decisions/tenant-monitoring-coverage.md
+      # for the boundary argument and what deliberately was NOT added.
+      - alert: TenantApiDown
+        expr: probe_success{job="blackbox-tenant-api"} == 0
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "api.hill90.com is not answering from the internet"
+          description: >-
+            The blackbox probe of {{ $labels.instance }} has not received HTTP 200 for
+            over 2 minutes. hill90.com can still return 200 while this is broken — the
+            UI's own /api/health reports service "ui" and does not proxy to the API — so
+            PublicSiteDown will NOT cover this. Signed-in features that call the API are
+            failing for users.
+          action: >-
+            Check the edge first: `docker ps --filter name=traefik`. Then the tenant's
+            container, which is NOT a Prometheus scrape target — `docker ps -a --filter
+            name=app-api` and `docker logs --tail 50 app-api`. Confirm from outside with
+            `curl -s https://api.hill90.com/health`. This is the TENANT's container: the
+            platform can see it is down but cannot fix it, so the tenant's deploy path is
+            where the repair happens.
+          runbook: docs/decisions/tenant-monitoring-coverage.md
+
   - name: service-health
     rules:
       - alert: ServiceDown

--- a/platform/observability/prometheus/prometheus.yml
+++ b/platform/observability/prometheus/prometheus.yml
@@ -93,6 +93,37 @@ scrape_configs:
       - target_label: __address__
         replacement: blackbox-exporter:9115
 
+  # Is the tenant's API answering on its public hostname?
+  #
+  # EDGE SCOPE, NOT TENANT INTERNALS. This probes a public hostname that this
+  # platform's Traefik routes and holds the certificate for, from outside, with
+  # no credential — exactly the same class of check as blackbox-public above. It
+  # does not scrape the tenant's containers and does not reach inside them. The
+  # boundary argument is written out in
+  # docs/decisions/tenant-monitoring-coverage.md.
+  #
+  # THE PATH IS NOT INCIDENTAL. api.hill90.com/ returns 404 — there is no root
+  # route — so probing `/` would alert permanently. /health returns
+  # {"status":"healthy","service":"api"} unauthenticated. Verified against the
+  # running blackbox-exporter on 2026-07-31: probe_success 1, status 200.
+  #
+  # It is a SHALLOW liveness endpoint: it says the process is up and routed, not
+  # that its database works. Treat a pass as "app-api is reachable", nothing more.
+  - job_name: blackbox-tenant-api
+    metrics_path: /probe
+    params:
+      module: [http_2xx]
+    static_configs:
+      - targets:
+          - https://api.hill90.com/health
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: __param_target
+      - source_labels: [__param_target]
+        target_label: instance
+      - target_label: __address__
+        replacement: blackbox-exporter:9115
+
   # Is OpenBao sealed? /v1/sys/health answers 503 when sealed and needs no token.
   # Probed over the INTERNAL network on purpose: vault.hill90.com is behind the
   # edge IP allowlist and returns 403 to anything not on the tailnet, which would

--- a/scripts/checks/alert-series-allowlist.txt
+++ b/scripts/checks/alert-series-allowlist.txt
@@ -8,3 +8,5 @@
 # Format:  <metric-name-or-full-selector>    # why it can legitimately be absent
 
 tempo_distributor_ingester_append_failures_total  # Lazily created: Tempo exposes this counter only after the first append failure. Verified 2026-07-31 — after the 09:45 restart /metrics carried tempo_distributor_ingester_appends_total (248 successes) and no failures line at all, while before the restart the series existed with value 30. Absence means "no failures since start", which is the healthy state.
+
+probe_success{job="blackbox-tenant-api"}  # TEMPORARY — the scrape job ships in the same change as the rule, so this selector is absent between merge and the next observability deploy. The target itself is already proven: the running blackbox-exporter returned probe_success 1, status 200 for https://api.hill90.com/health on 2026-07-31. DELETE THIS LINE once observability has been deployed; leaving it would mask a genuinely broken probe.

--- a/tests/prometheus/alerts_test.yml
+++ b/tests/prometheus/alerts_test.yml
@@ -55,6 +55,63 @@ tests:
               action: "Check the edge before the app: `docker ps --filter name=traefik` and `docker logs --tail 50 traefik`. If Traefik is healthy, the tenant's app-ui is the next suspect — it is NOT a Prometheus scrape target, so this probe is the only signal. Confirm from outside with `curl -sI https://hill90.com`."
               runbook: docs/runbooks/troubleshooting.md
 
+  - name: TenantApiDown fires 2m after the API probe stops returning 200
+    interval: 1m
+    input_series:
+      - series: 'probe_success{job="blackbox-tenant-api", instance="https://api.hill90.com/health"}'
+        values: '0x10'
+    alert_rule_test:
+      - eval_time: 1m
+        alertname: TenantApiDown
+        exp_alerts: []          # `for: 2m` not yet satisfied
+      - eval_time: 3m
+        alertname: TenantApiDown
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              job: blackbox-tenant-api
+              instance: https://api.hill90.com/health
+            exp_annotations:
+              summary: "api.hill90.com is not answering from the internet"
+              description: "The blackbox probe of https://api.hill90.com/health has not received HTTP 200 for over 2 minutes. hill90.com can still return 200 while this is broken — the UI's own /api/health reports service \"ui\" and does not proxy to the API — so PublicSiteDown will NOT cover this. Signed-in features that call the API are failing for users."
+              action: "Check the edge first: `docker ps --filter name=traefik`. Then the tenant's container, which is NOT a Prometheus scrape target — `docker ps -a --filter name=app-api` and `docker logs --tail 50 app-api`. Confirm from outside with `curl -s https://api.hill90.com/health`. This is the TENANT's container: the platform can see it is down but cannot fix it, so the tenant's deploy path is where the repair happens."
+              runbook: docs/decisions/tenant-monitoring-coverage.md
+
+  - name: TenantApiDown stays silent while the API probe succeeds
+    interval: 1m
+    input_series:
+      - series: 'probe_success{job="blackbox-tenant-api", instance="https://api.hill90.com/health"}'
+        values: '1x10'
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: TenantApiDown
+        exp_alerts: []
+
+  # The two probes are independent: a dead API must not be masked by a healthy site.
+  - name: a healthy public site does not suppress TenantApiDown
+    interval: 1m
+    input_series:
+      - series: 'probe_success{job="blackbox-public", instance="https://hill90.com/"}'
+        values: '1x10'
+      - series: 'probe_success{job="blackbox-tenant-api", instance="https://api.hill90.com/health"}'
+        values: '0x10'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: PublicSiteDown
+        exp_alerts: []
+      - eval_time: 5m
+        alertname: TenantApiDown
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              job: blackbox-tenant-api
+              instance: https://api.hill90.com/health
+            exp_annotations:
+              summary: "api.hill90.com is not answering from the internet"
+              description: "The blackbox probe of https://api.hill90.com/health has not received HTTP 200 for over 2 minutes. hill90.com can still return 200 while this is broken — the UI's own /api/health reports service \"ui\" and does not proxy to the API — so PublicSiteDown will NOT cover this. Signed-in features that call the API are failing for users."
+              action: "Check the edge first: `docker ps --filter name=traefik`. Then the tenant's container, which is NOT a Prometheus scrape target — `docker ps -a --filter name=app-api` and `docker logs --tail 50 app-api`. Confirm from outside with `curl -s https://api.hill90.com/health`. This is the TENANT's container: the platform can see it is down but cannot fix it, so the tenant's deploy path is where the repair happens."
+              runbook: docs/decisions/tenant-monitoring-coverage.md
+
   - name: PublicSiteDown stays silent while the probe succeeds
     interval: 1m
     input_series:


### PR DESCRIPTION
Everything built today watches the **platform**. This establishes what any of it says
about the **tenant**, and closes the one gap that is unambiguously the platform's job.

## The short answer

**Prometheus scrapes zero tenant containers.** Fourteen targets, none of them `app-*`. The
only thing covering the tenant is the outside-in probe of `hill90.com`.

`blackbox-public` **does** target `https://hill90.com/` — the public site is genuinely
covered, not assumed. `app-ui` returning 500s would fire `PublicSiteDown` (the module
requires `200`; a 404 was proven to produce `probe_success 0` in #617).

## The finding: one probe does not cover both

The natural assumption is that if the API dies the site breaks. **It does not:**

```
https://hill90.com/            -> 200
https://hill90.com/api/health  -> 200   {"status":"healthy","service":"ui"}
https://api.hill90.com/health  -> 200   {"status":"healthy","service":"api"}
```

`hill90.com/api/health` is the **UI's own** health route — it reports `service: "ui"` and
does **not** proxy to `app-api`. So `app-api` can be completely dead while `hill90.com`
answers 200 and `PublicSiteDown` stays silent. That is the gap this closes, with
`blackbox-tenant-api` + `TenantApiDown`.

**Not tested destructively:** `app-api` was never stopped to confirm the site still serves
200 without it — that is an outage to prove a point. The conclusion rests on the two health
endpoints naming different services and the homepage rendering independently. Recorded as
inference, not measurement.

## The tenant's public surface

| Hostname | Container | Watched? |
|---|---|---|
| `hill90.com`, `www.hill90.com` | `app-ui` | **Yes** — existing `PublicSiteDown` |
| `api.hill90.com` | `app-api` | **Now yes** — this change |
| `litellm.hill90.com` | `app-litellm` | No — returns **403** normally (edge allowlist) |
| `ai.hill90.com/mcp` | `app-mcp` | No — returns **404** normally |
| *not routed* | `app-ai`, `app-knowledge`, `app-docker-proxy` | No |

`litellm` and `mcp` return non-200 in **healthy** operation, so a 200-expecting probe would
alert permanently — worse than no alert. Left uncovered deliberately and recorded rather
than skipped silently.

## The boundary — I judged this edge scope, and here is the argument

Probing `https://api.hill90.com/health` from outside is the **same class of check** as the
already-shipped `hill90.com` probe:

- it targets a **public hostname this platform's Traefik routes** and holds the certificate
  for — "does this hostname serve?" is an edge question
- it uses **no credential** and reaches **no container**
- it adds **no scrape target inside the tenant**

The one real coupling: it encodes the path `/health`, because `api.hill90.com/` returns
404. If the tenant moves that path, the alert lies. Named rather than hidden.

**If you read the boundary more strictly:** delete the `TenantApiDown` rule and keep the
job. The probe then collects data without paging anyone. One-line change, and the doc says
so.

## What would be a widening, and is NOT done

**Scraping tenant containers into the platform's Prometheus.** That is your call, not this
repository's, and my recommendation is **against**. Two facts for the decision:

1. **It is not currently possible without tenant changes.** No `app-*` container exposes a
   Prometheus endpoint — `app-ui:3000/metrics` 404, `app-litellm:4000/metrics` 404,
   `app-knowledge:8002/metrics` 401, and `app-api`, `app-ai`, `app-mcp` refuse the
   connection. Instrumenting them is app-lane work that must happen first regardless.
2. **The cheap alternative already covers the outcome that matters.** Outside-in answers
   "is this broken for users" — the question worth waking someone for. Container scraping
   answers "which part broke", a debugging convenience once you are already awake.

## A correction: the contract claims coverage that has never existed

`app-tenancy-on-the-vps.md` said:

> | Observability of tenant containers | partial — `cadvisor` scrapes all containers; no app-specific Prometheus job |

**The stated basis is false.** cAdvisor here emits 45 cgroup and systemd series and **zero
Docker containers** — `count(container_memory_usage_bytes{name!=""})` is 0, and the only
Docker-ish ids are `docker.service`, `docker.socket`, `containerd.service`: the daemons.
Corrected to **none**, with the evidence.

## Verification

The target is **already proven against production** — the running blackbox-exporter was
asked to probe it:

```
probe_success 1
probe_http_status_code 200
```

```
promtool check rules      15 rules, valid
promtool test rules       SUCCESS  (incl. a case asserting a healthy site does not mask a dead API)
check_md_links / check_env_surface / check_secrets_schema / shellcheck   pass
```

Read-only against production; **nothing deployed**.

## After merging and deploying

Delete the temporary line from `scripts/checks/alert-series-allowlist.txt` — the selector
is absent only between merge and the observability deploy, and leaving it would mask a
genuinely broken probe. The line says so itself.

## Still not covered

`app-ai`, `app-knowledge`, `app-docker-proxy` — nothing observes them. **`app-docker-proxy`
is worth naming**: it fronts the Docker socket for the agent sandbox, so its failure is a
security-relevant availability event and it is currently invisible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)