### PR TITLE
feat(alerting): alert on containers in a restart loop

### DIFF
--- a/platform/observability/prometheus/alerts.yml
+++ b/platform/observability/prometheus/alerts.yml
@@ -75,6 +75,67 @@ groups:
             the fault, not the service.
           runbook: docs/runbooks/observability.md
 
+      # Complements ServiceDown rather than duplicating it. ServiceDown catches a
+      # container that goes down AND STAYS down for 5m. A container that dies and
+      # is restarted every 30s is never down long enough to trip it, so a crash
+      # loop is invisible to `up == 0`.
+      #
+      # THE SIGNAL IS NOT cADVISOR. The obvious source would be
+      # container_start_time_seconds, and it is a dead end on this host: cAdvisor
+      # exposes 35 series, ZERO of them Docker containers, and no `name` label at
+      # all — {__name__=~"container_.*", name!=""} returns nothing. Verified again
+      # 2026-07-31; the cause is Docker's containerd snapshotter, recorded in
+      # docs/decisions/alert-series-verification.md. Do not "fix" this rule by
+      # pointing it at cAdvisor.
+      #
+      # What does carry it is process_start_time_seconds, exposed by each service's
+      # own /metrics, plus minio_node_process_starttime_seconds for MinIO, which
+      # publishes the same thing under its own name. Both change exactly once per
+      # process start, so changes() over a window counts restarts.
+      #
+      # THRESHOLD, from measurement rather than intuition. Legitimate deploy churn
+      # peaks at THREE changes in a 10m window across the full 7-day retention
+      # (traefik; everything else peaks at 2). `> 4` sits above that with margin,
+      # and evaluating it over the whole retained week returns zero series — it
+      # would not have fired once on real activity. It also matches the working
+      # definition: one restart after an OOM is not an incident, five in ten
+      # minutes is.
+      #
+      # `for: 2m` asks "is it STILL restarting", which is the distinction between a
+      # loop and a bad afternoon.
+      #
+      # COVERAGE IS 12 OF 16 PLATFORM CONTAINERS, and the gap is honest:
+      # openbao, portainer, postgres and promtail expose no metrics endpoint and
+      # are not scrape targets, so no signal exists for them at any threshold.
+      # Note also that postgres-exporter restarting is NOT postgres restarting.
+      #
+      # TENANT CONTAINERS ARE DELIBERATELY NOT COVERED. app-* are scraped by
+      # nothing, so extending this is blocked on a scrape target existing before it
+      # is blocked on the tenancy question — see docs/decisions/alerting-audit.md.
+      - alert: ContainerRestartLoop
+        expr: |
+          (changes(process_start_time_seconds[10m])
+            or changes(minio_node_process_starttime_seconds[10m])) > 4
+        for: 2m
+        labels:
+          severity: warning
+        annotations:
+          summary: "{{ $labels.job }} is in a restart loop"
+          description: >-
+            {{ $labels.job }} ({{ $labels.instance }}) has restarted {{ $value }}
+            times in the last 10 minutes and is still restarting. A single restart
+            after an OOM would not reach this threshold; a crash loop does. Note
+            that `up == 0` will NOT be firing — the container is coming back each
+            time, which is why this rule exists separately.
+          action: >-
+            `docker ps -a --filter name={{ $labels.job }}` and read the exit code
+            first: 137 is OOM-killed, so check `mem_limit` for that service in
+            deploy/compose/prod/. Then `docker logs --tail 100 {{ $labels.job }}`
+            for what it says just before dying — in a loop the useful line is at the
+            END of each cycle, not the start. If it is a dependency it cannot reach,
+            fix that rather than raising the restart limit.
+          runbook: docs/runbooks/observability.md
+
   - name: resource-usage
     rules:
       # RENAMED FROM HighMemoryUsage, because that name was a lie.

--- a/tests/prometheus/alerts_test.yml
+++ b/tests/prometheus/alerts_test.yml
@@ -135,6 +135,82 @@ tests:
         alertname: ServiceDown
         exp_alerts: []
 
+  - name: ContainerRestartLoop fires on five restarts in ten minutes and names the container
+    # Each change of process_start_time_seconds is one process start.
+    interval: 1m
+    input_series:
+      - series: 'process_start_time_seconds{job="loki", instance="loki:3100"}'
+        values: '1000 1001 1002 1003 1004 1005x10'
+    alert_rule_test:
+      - eval_time: 6m
+        alertname: ContainerRestartLoop
+        exp_alerts: []          # condition true from 5m; `for: 2m` not yet met
+      - eval_time: 8m
+        alertname: ContainerRestartLoop
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              job: loki
+              instance: loki:3100
+            exp_annotations:
+              summary: "loki is in a restart loop"
+              description: "loki (loki:3100) has restarted 5 times in the last 10 minutes and is still restarting. A single restart after an OOM would not reach this threshold; a crash loop does. Note that `up == 0` will NOT be firing — the container is coming back each time, which is why this rule exists separately."
+              action: "`docker ps -a --filter name=loki` and read the exit code first: 137 is OOM-killed, so check `mem_limit` for that service in deploy/compose/prod/. Then `docker logs --tail 100 loki` for what it says just before dying — in a loop the useful line is at the END of each cycle, not the start. If it is a dependency it cannot reach, fix that rather than raising the restart limit."
+              runbook: docs/runbooks/observability.md
+
+  - name: ContainerRestartLoop stays silent through ordinary deploy churn
+    # THE THRESHOLD REGRESSION TEST. Three changes in a 10m window is the MAXIMUM
+    # legitimate churn observed across the full 7-day retention (traefik; every
+    # other job peaked at 2). If someone lowers the threshold to > 2, this test
+    # fails — which is the point. A deploy must never page anyone.
+    interval: 1m
+    input_series:
+      - series: 'process_start_time_seconds{job="traefik", instance="traefik:8082"}'
+        values: '1000 1001 1002 1003x12'
+    alert_rule_test:
+      - eval_time: 8m
+        alertname: ContainerRestartLoop
+        exp_alerts: []
+      - eval_time: 14m
+        alertname: ContainerRestartLoop
+        exp_alerts: []
+
+  - name: ContainerRestartLoop stays silent for one restart that then holds
+    # "A container that restarts once after an OOM and stays up is not an
+    # incident." This encodes exactly that.
+    interval: 1m
+    input_series:
+      - series: 'process_start_time_seconds{job="keycloak", instance="keycloak:9000"}'
+        values: '1000 1000 1001x14'
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: ContainerRestartLoop
+        exp_alerts: []
+
+  - name: ContainerRestartLoop covers MinIO through its own start-time metric
+    # MinIO does not expose process_start_time_seconds. It publishes the same
+    # thing as minio_node_process_starttime_seconds, which is why the expression
+    # is an `or` rather than one selector. Without this arm, the one platform
+    # service holding tenant object data would be uncovered.
+    interval: 1m
+    input_series:
+      - series: 'minio_node_process_starttime_seconds{job="minio", instance="minio:9000", server="127.0.0.1:9000"}'
+        values: '1000 1001 1002 1003 1004 1005x10'
+    alert_rule_test:
+      - eval_time: 8m
+        alertname: ContainerRestartLoop
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              job: minio
+              instance: minio:9000
+              server: 127.0.0.1:9000
+            exp_annotations:
+              summary: "minio is in a restart loop"
+              description: "minio (minio:9000) has restarted 5 times in the last 10 minutes and is still restarting. A single restart after an OOM would not reach this threshold; a crash loop does. Note that `up == 0` will NOT be firing — the container is coming back each time, which is why this rule exists separately."
+              action: "`docker ps -a --filter name=minio` and read the exit code first: 137 is OOM-killed, so check `mem_limit` for that service in deploy/compose/prod/. Then `docker logs --tail 100 minio` for what it says just before dying — in a loop the useful line is at the END of each cycle, not the start. If it is a dependency it cannot reach, fix that rather than raising the restart limit."
+              runbook: docs/runbooks/observability.md
+
   # --- resource-usage -------------------------------------------------------
 
   - name: HostMemoryHigh fires on real pressure, measured without page cache


### PR DESCRIPTION
## First, a corrected premise

The brief said cAdvisor exposes container start times, so the signal exists. **It does not on this host.** Re-verified today:

```
container_start_time_seconds                          35 series
  ...of which are Docker containers                    0
{__name__=~"container_.*", name!=""}                   0 series
```

cAdvisor is up, healthy and scraped, and knows only systemd slices — the containerd-snapshotter blindness from #619. **A rule built on it would have joined the two that already could never fire.**

## The signal that does exist

`process_start_time_seconds`, published by each service's own `/metrics`, plus `minio_node_process_starttime_seconds` — MinIO publishes the same thing under its own name, which is why the expression is an `or` rather than one selector. Without that arm, the one platform service holding tenant object data would be uncovered.

Both verified live with the labels the expression assumes: `{instance, job}` on both, plus `{server}` on MinIO's.

## What counts as a loop — measured, not guessed

Legitimate deploy churn peaks at **three** changes in a 10-minute window across the full 7-day retention (traefik; every other job peaks at 2). So `> 4`:

- sits above observed legitimate churn with margin
- evaluated across the entire retained week, returns **zero series** — it would not have fired once on real activity
- matches the working definition: one restart after an OOM does not reach it, five in ten minutes does

`for: 2m` asks whether it is **still** restarting, which is the loop-versus-bad-afternoon line.

## Proven by forcing the condition on live data

cAdvisor restarted **six times at 22s intervals** — above the 15s scrape interval, so each start is sampled. Chosen because **no live rule expression references cAdvisor metrics**, checked before touching it, so nothing depended on it:

```
changes(process_start_time_seconds[10m])        cadvisor = 6
the rule expression,  ( ... ) > 4               1 series:  cadvisor (cadvisor:8080) = 6
```

**Exactly one series crossed. No other job did** — that is the other half of the proof.

Nothing can be left stuck FIRING, because the rule is not deployed (deploys are pipeline-only and this stops before merge). So this forced the **signal**, not the alert. The value decays to 0 as the 10-minute window slides, and that decay was watched to completion.

## It names the container

`job` equals the container name for all 12 covered services — checked against the running set, not assumed.

## Coverage is 12 of 16 platform containers, and the gap is written into the rule

`openbao`, `portainer`, `postgres` and `promtail` expose no metrics endpoint and are not scrape targets, so **no signal exists for them at any threshold**. Also recorded in the rule: **`postgres-exporter` restarting is not `postgres` restarting.**

## Tenant containers: not extended, and the reason is stronger than the policy question

`app-*` are scraped by nothing. Extending this is blocked on **a scrape target existing** before it is blocked on the tenancy boundary. So pane 1's question is real but it is not the first obstacle. Left for you to sequence rather than assumed either way.

## Tests

Force the condition and — more importantly — pin the silences:

| Case | Expected |
|---|---|
| five restarts in ten minutes | **fires**, names the container |
| three restarts (observed legitimate max) | **silent** |
| one restart that then holds | **silent** |
| MinIO via its own metric | **fires**, names `minio` |

Mutation-tested: lowering to `> 2` makes deploy churn page, dropping the MinIO arm loses MinIO, `for: 0s` fires before the loop is confirmed. All three failed correctly; restoring gives SUCCESS across 15 rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)