### PR TITLE
fix(alerting): replace LokiIngestionErrors with two rules that can actually fire

### DIFF
--- a/docs/decisions/alert-series-verification.md
+++ b/docs/decisions/alert-series-verification.md
@@ -282,3 +282,35 @@ docker exec prometheus wget -qO- \
 
 For any rule, query the **selector without its threshold** first. That is the
 whole method, and it is the difference between "not firing" and "cannot fire".
+
+## The checks that lied while doing this work
+
+The rules in this document were not the only things reporting health they did not
+have. Every check below was **mine**, written during this audit, and each was
+caught by running it against a case whose answer was already known rather than by
+trusting a clean result. That habit is the deliverable — more than any individual
+rule — so the failures are recorded rather than quietly fixed.
+
+| Check | What it reported | What was true |
+|---|---|---|
+| `check_alert_series.py`, first draft | `PublicSiteDown` and `DiskSpaceRunningLow` "cannot fire" | It stripped string literals, turning `{job="blackbox-public"}` into `{job= }`, which Prometheus rejects with **HTTP 400**. The rules were fine. |
+| same, same draft | `sum` and `max` are missing metrics | Removing `by (instance)` leaves `sum  (metric)`, and it tested only the *next* character for `(`. Both are PromQL, not metrics. |
+| decay watcher | `connection refused` — read as Prometheus down | It resolved the Prometheus container IP **once at startup**. A deploy moved the container and the cached address went stale. Prometheus was healthy throughout. |
+| a shell `du` over `/var/lib/docker/*/` | the directory is empty | The glob expanded as the unprivileged user against a root-only directory, so it matched nothing. `sudo sh -c` returned 26 GiB. |
+| a `sed` display filter | one broken selector reported **twice** | Overlapping `sed` ranges printed the summary block twice. The checker itself reported one. Cosmetic, and still worth catching before repeating the number. |
+
+Two patterns account for all five, and both are worth naming because they recur:
+
+1. **An empty or error result was treated as an answer.** A 400, an unexpanded
+   glob and a stale address all produce "nothing", and "nothing" reads as a
+   finding. It never is on its own.
+2. **A value was captured once and reused after the world moved.** The cached
+   Prometheus IP is the clean example: correct when taken, wrong two minutes
+   later. `docker exec` avoids it entirely, which is why the commands published in
+   the runbooks use that form rather than an address.
+
+The corollary for anyone extending this work: **before believing a check that
+reports a problem, run it against a case you already know the answer to.**
+`check_alert_series.py` earns its keep by independently rediscovering
+`LokiIngestionErrors` — a defect established by other means first. A check that
+has never been shown to catch anything is not evidence.

--- a/platform/observability/prometheus/alerts.yml
+++ b/platform/observability/prometheus/alerts.yml
@@ -260,19 +260,96 @@ groups:
 
   - name: loki
     rules:
-      - alert: LokiIngestionErrors
-        expr: rate(loki_distributor_lines_received_total{status="error"}[5m]) > 0
+      # REPLACES LokiIngestionErrors, WHICH COULD NEVER FIRE. Do not restore it
+      # from an old example. It was:
+      #
+      #     rate(loki_distributor_lines_received_total{status="error"}[5m]) > 0
+      #
+      # and it was wrong twice over, verified against the live deployment:
+      #
+      #   1. loki_distributor_lines_received_total carries aggregated_metric,
+      #      instance, job and tenant. There is NO `status` label on it at all.
+      #   2. Even if there were, `error` is not a value Loki uses. The `status`
+      #      label exists elsewhere in Loki's metrics — on compaction, retention
+      #      and tsdb operation counters — and every occurrence on this
+      #      deployment reads status="success". Nothing emits status="error".
+      #
+      # It evaluated cleanly, reported health=ok, and matched nothing for months.
+      # That is indistinguishable from health, which is why it was worse than no
+      # rule. See docs/decisions/alert-series-verification.md.
+      #
+      # NOT USED, deliberately: loki_ingester_wal_discarded_samples_total. It is
+      # the only discard counter currently emitting (2037 samples), and its label
+      # is reason="duplicate" — the WAL rejecting a re-sent entry, which is
+      # promtail retrying and Loki de-duplicating correctly. Alerting on it would
+      # page for normal behaviour.
+      #
+      # Also absent: loki_discarded_samples_total does not appear in /metrics at
+      # all on this deployment, and Loki has no
+      # loki_distributor_ingester_append_failures_total.
+
+      # Logs stopped arriving at all. The failure that loses everything, quietly.
+      # The series is present today (11.9 lines/s), and its floor across the full
+      # 7-day retention is 8.96 lines/s — it has never approached zero, so `== 0`
+      # carries no false-positive risk. 15m rate plus `for: 30m` means roughly
+      # three quarters of an hour of silence before this pages, which is right for
+      # "you have lost observability" rather than "the estate is down".
+      #
+      # If Loki itself is down the series goes stale and this does NOT fire —
+      # ServiceDown covers that case. This one catches Loki healthy and receiving
+      # nothing, which is the case nothing else sees.
+      - alert: LokiIngestionStalled
+        expr: rate(loki_distributor_lines_received_total[15m]) == 0
+        for: 30m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Loki has received no log lines for 45 minutes"
+          description: >-
+            Loki on {{ $labels.instance }} is up and accepting connections but has
+            ingested nothing for the last 15 minutes, and has been in that state for
+            30 minutes. Normal on this host is around 9 to 12 lines/sec and has never
+            been lower. Logs from every container are being lost for as long as this
+            continues, and nothing else will tell you.
+          action: >-
+            Check the shipper before Loki: `docker ps --filter name=promtail` and
+            `docker logs --tail 50 promtail`. Promtail is NOT a Prometheus scrape
+            target, so this alert is the only signal that it has stopped. If promtail
+            is healthy, `docker logs --tail 50 loki` and confirm the push endpoint
+            with `docker exec loki wget -qO- http://localhost:3100/ready`.
+          runbook: docs/runbooks/observability.md
+
+      # Logs actively rejected, as opposed to absent. 429 is rate-limiting or a
+      # per-stream limit; 5xx is Loki failing to accept. Either way lines are lost.
+      #
+      # THE SELECTOR MATCHES NOTHING TODAY, AND THAT IS NOT THE OLD BUG.
+      # status_code is a REAL label on this metric, carrying observed values
+      # 200, 204, 503 and "success" across routes — a 503 has genuinely been
+      # recorded on route="ready". The push route has only ever returned 204, so
+      # the non-2xx series has not been created yet; it appears the moment a push
+      # is rejected. Contrast the old rule, whose `status` label does not exist on
+      # its metric under any condition. Declared in
+      # scripts/checks/alert-series-allowlist.txt with that reasoning.
+      - alert: LokiPushRejected
+        expr: |
+          sum by (status_code) (
+            rate(loki_request_duration_seconds_count{route="loki_api_v1_push", status_code!~"2.."}[5m])
+          ) > 0
         for: 5m
         labels:
           severity: warning
         annotations:
-          summary: "Loki ingestion errors detected"
+          summary: "Loki is rejecting log pushes with HTTP {{ $labels.status_code }}"
           description: >-
-            Loki is rejecting log lines at {{ $value }} errors/sec on {{ $labels.instance }}.
-            Logs are being LOST while this fires.
+            Loki is returning {{ $labels.status_code }} to {{ $value }} pushes/sec on
+            the ingest endpoint. Log lines are being LOST while this fires. 429 means
+            a rate or per-stream limit; 5xx means Loki could not accept the write.
           action: >-
-            `docker logs --tail 50 loki`. Rate-limit and per-stream-limit rejections
-            are configuration; disk-full is not — check `df -h /` too.
+            `docker logs --tail 50 loki` for the rejection reason. A 429 is
+            configuration — limits_config in platform/observability/loki/loki.yml —
+            and raising a limit is a deliberate choice, not a reflex. A 5xx is not
+            configuration: check disk with `df -h /`, since a full disk presents this
+            way. Do not restart Loki to clear it; that loses the WAL and the reason.
           runbook: docs/runbooks/observability.md
 
   - name: tempo

--- a/scripts/checks/alert-series-allowlist.txt
+++ b/scripts/checks/alert-series-allowlist.txt
@@ -8,3 +8,5 @@
 # Format:  <metric-name-or-full-selector>    # why it can legitimately be absent
 
 tempo_distributor_ingester_append_failures_total  # Lazily created: Tempo exposes this counter only after the first append failure. Verified 2026-07-31 — after the 09:45 restart /metrics carried tempo_distributor_ingester_appends_total (248 successes) and no failures line at all, while before the restart the series existed with value 30. Absence means "no failures since start", which is the healthy state.
+
+loki_request_duration_seconds_count{route="loki_api_v1_push", status_code!~"2.."}  # Lazily created per status code. THIS IS NOT THE LokiIngestionErrors BUG: status_code is a real label on this metric, carrying observed values 200, 204, 503 and "success" across routes, and a 503 has genuinely been recorded on route="ready". The ingest route has only ever returned 204 on this deployment, so the non-2xx series has not been created yet; it appears the moment a push is rejected. Contrast the rule this replaced, whose `status` label does not exist on its metric under any condition. Verified 2026-07-31.

--- a/scripts/checks/check_alert_series.py
+++ b/scripts/checks/check_alert_series.py
@@ -177,7 +177,10 @@ def main():
         print("health. Either correct the selector, delete the rule, or add it")
         print(f"to {ALLOWLIST.name} with a reason.")
         return 1
-    print("every selector matches at least one live series")
+    # Deliberately not "every selector matches". Some are declared absent, and a
+    # summary line that hides that is the same kind of small lie this whole check
+    # exists to catch.
+    print("every selector matches a live series, or is declared absent with a reason")
     return 0
 
 

--- a/tests/prometheus/alerts_test.yml
+++ b/tests/prometheus/alerts_test.yml
@@ -16,11 +16,16 @@
 # emits, the test still passes, because the test hands the rule exactly the
 # labels it asked for.
 #
-# That is not hypothetical — see LokiIngestionErrors at the bottom, which has a
-# passing test here and CANNOT FIRE in production. Two rules shipped in this
-# repo had that defect and both looked like coverage for months.
+# That is not hypothetical, and the proof is that a rule used to be tested here.
+# LokiIngestionErrors matched {status="error"} on a metric carrying no `status`
+# label, and it had a PASSING TEST IN THIS FILE while being incapable of firing
+# in production — because the test invented the label the rule asked for. It was
+# removed once the live check caught what this suite structurally could not.
 #
-# The complementary check is scripts/checks/check_alert_series.sh, which asks the
+# Every rule below is subject to the same blind spot. Do not read a green run as
+# evidence that an alert works.
+#
+# The complementary check is scripts/checks/check_alert_series.py, which asks the
 # live Prometheus whether each selector matches anything. Neither test is
 # sufficient alone: this one proves the logic, that one proves the data.
 # ---------------------------------------------------------------------------
@@ -423,37 +428,88 @@ tests:
         exp_alerts: []
 
   # --- loki -----------------------------------------------------------------
+  # --- loki -----------------------------------------------------------------
 
-  - name: LokiIngestionErrors — DEMONSTRATION THAT A GREEN TEST PROVES NOTHING
-    # This test passes. The rule CANNOT FIRE IN PRODUCTION.
-    #
-    # It matches loki_distributor_lines_received_total{status="error"}. On the
-    # live Loki that metric carries aggregated_metric, instance, job and tenant —
-    # there is no `status` label at all. And `status` where it does exist in
-    # Loki's metrics takes discarded|matched|notfound|success, so "error" is not a
-    # value it ever holds either. Verified 2026-07-31, see
-    # docs/decisions/alert-series-verification.md.
-    #
-    # The test passes because the line below INVENTS the label. That is the
-    # limitation of every unit test in this file, stated once, concretely, in the
-    # one place where it is provably true. Do not delete this test without
-    # deleting the rule — it is the honest record of why the suite alone is not
-    # enough.
+  - name: LokiIngestionStalled fires when ingestion goes flat
+    # A counter that stops advancing. rate() over it is 0, which is the whole
+    # signal: Loki is up, answering, and receiving nothing.
     interval: 1m
     input_series:
-      - series: 'loki_distributor_lines_received_total{status="error", instance="loki:3100", job="loki"}'
-        values: '0+5x15'
+      - series: 'loki_distributor_lines_received_total{instance="loki:3100", job="loki", tenant="fake", aggregated_metric="false"}'
+        values: '5000x60'
     alert_rule_test:
-      - eval_time: 12m
-        alertname: LokiIngestionErrors
+      - eval_time: 20m
+        alertname: LokiIngestionStalled
+        exp_alerts: []          # `for: 30m` not yet satisfied
+      - eval_time: 50m
+        alertname: LokiIngestionStalled
         exp_alerts:
           - exp_labels:
               severity: warning
-              status: error
               instance: loki:3100
               job: loki
+              tenant: fake
+              aggregated_metric: "false"
             exp_annotations:
-              summary: "Loki ingestion errors detected"
-              description: "Loki is rejecting log lines at 0.08333333333333333 errors/sec on loki:3100. Logs are being LOST while this fires."
-              action: "`docker logs --tail 50 loki`. Rate-limit and per-stream-limit rejections are configuration; disk-full is not — check `df -h /` too."
+              summary: "Loki has received no log lines for 45 minutes"
+              description: "Loki on loki:3100 is up and accepting connections but has ingested nothing for the last 15 minutes, and has been in that state for 30 minutes. Normal on this host is around 9 to 12 lines/sec and has never been lower. Logs from every container are being lost for as long as this continues, and nothing else will tell you."
+              action: "Check the shipper before Loki: `docker ps --filter name=promtail` and `docker logs --tail 50 promtail`. Promtail is NOT a Prometheus scrape target, so this alert is the only signal that it has stopped. If promtail is healthy, `docker logs --tail 50 loki` and confirm the push endpoint with `docker exec loki wget -qO- http://localhost:3100/ready`."
               runbook: docs/runbooks/observability.md
+
+  - name: LokiIngestionStalled stays silent at the rate this host actually runs at
+    # ~10 lines/sec, inside the 9-12 range measured on the live deployment. The
+    # 7-day floor was 8.96 lines/sec, so this is the realistic quiet case.
+    interval: 1m
+    input_series:
+      - series: 'loki_distributor_lines_received_total{instance="loki:3100", job="loki", tenant="fake", aggregated_metric="false"}'
+        values: '0+600x60'
+    alert_rule_test:
+      - eval_time: 50m
+        alertname: LokiIngestionStalled
+        exp_alerts: []
+
+  - name: LokiPushRejected fires on 429 and names the status code
+    # Rate-limited pushes. The old rule tried to express this condition and
+    # selected a label that does not exist; this selects status_code, which does.
+    interval: 1m
+    input_series:
+      - series: 'loki_request_duration_seconds_count{instance="loki:3100", job="loki", method="POST", route="loki_api_v1_push", status_code="429", ws="false"}'
+        values: '0+30x15'
+    alert_rule_test:
+      - eval_time: 12m
+        alertname: LokiPushRejected
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              status_code: "429"
+            exp_annotations:
+              summary: "Loki is rejecting log pushes with HTTP 429"
+              description: "Loki is returning 429 to 0.5 pushes/sec on the ingest endpoint. Log lines are being LOST while this fires. 429 means a rate or per-stream limit; 5xx means Loki could not accept the write."
+              action: "`docker logs --tail 50 loki` for the rejection reason. A 429 is configuration — limits_config in platform/observability/loki/loki.yml — and raising a limit is a deliberate choice, not a reflex. A 5xx is not configuration: check disk with `df -h /`, since a full disk presents this way. Do not restart Loki to clear it; that loses the WAL and the reason."
+              runbook: docs/runbooks/observability.md
+
+  - name: LokiPushRejected ignores successful pushes
+    # THE REGRESSION TEST FOR THE STATUS-CODE MATCHER. 204 is what a healthy push
+    # returns and is the ONLY code this endpoint has ever produced here. If the
+    # !~"2.." matcher is broken or dropped, this test starts firing on healthy
+    # traffic — which is the loudest possible failure and the right one.
+    interval: 1m
+    input_series:
+      - series: 'loki_request_duration_seconds_count{instance="loki:3100", job="loki", method="POST", route="loki_api_v1_push", status_code="204", ws="false"}'
+        values: '0+30x15'
+    alert_rule_test:
+      - eval_time: 12m
+        alertname: LokiPushRejected
+        exp_alerts: []
+
+  - name: LokiPushRejected ignores non-ingest routes
+    # A 503 on route="ready" is real and has been observed on this deployment.
+    # It is a readiness blip, not lost logs, and must not page.
+    interval: 1m
+    input_series:
+      - series: 'loki_request_duration_seconds_count{instance="loki:3100", job="loki", method="GET", route="ready", status_code="503", ws="false"}'
+        values: '0+30x15'
+    alert_rule_test:
+      - eval_time: 12m
+        alertname: LokiPushRejected
+        exp_alerts: []


### PR DESCRIPTION
Removes the rule established as incapable of firing, and replaces it with two that were verified against the live deployment first.

## What Loki actually exposes — read from its own `/metrics`, not assumed

```
loki_ingester_wal_discarded_samples_total{reason="duplicate"}                   2037
loki_request_duration_seconds_count{route="loki_api_v1_push",status_code="204"}  945
loki_distributor_lines_received_total{tenant="fake",...}                       12855
```

And decisively for the old rule: **the `status` label appears only on compaction, retention and tsdb operation counters, every one reading `status="success"`.** Nothing on this deployment emits `status="error"` on any metric.

So `rate(loki_distributor_lines_received_total{status="error"}[5m]) > 0` was wrong twice over — no `status` label on that metric, and no such value anywhere even if there were. **Both facts are now in the rule comment so nobody restores it from an old example.**

### Rejected, deliberately — and recorded in the comment

- **`loki_ingester_wal_discarded_samples_total`** — the only discard counter actually emitting, and its reason is `"duplicate"`: promtail retrying and Loki de-duplicating correctly. **Alerting on it would page for normal behaviour.**
- `loki_discarded_samples_total` — not present in `/metrics` at all here.
- A Tempo-style append-failure counter — Loki has none.

## What landed

**`LokiIngestionStalled`** — `rate(loki_distributor_lines_received_total[15m]) == 0`

Logs stopped arriving at all: the failure that loses everything, quietly. The series exists today at **11.9 lines/s**, and its floor across the full 7-day retention is **8.96** — it has never approached zero, so `== 0` carries no false-positive risk. If Loki is *down* the series goes stale and this does **not** fire; `ServiceDown` covers that. This catches Loki healthy and receiving nothing, which nothing else sees. Worth noting: **promtail is not a scrape target**, so this is the only signal that it has stopped.

**`LokiPushRejected`** — non-2xx on the ingest route

Lines actively rejected rather than absent. 429 is a rate or per-stream limit, 5xx is Loki failing to accept; either way logs are lost.

**Its selector matches nothing today, and that is not the old bug.** `status_code` is a real label on this metric with observed values `200`, `204`, `503` and `success` across routes — a 503 has genuinely been recorded on `route="ready"`. The ingest route has only ever returned 204, so the non-2xx series appears the moment a push is rejected. Contrast `status`, which does not exist on its metric under any condition. Declared in `alert-series-allowlist.txt` with that distinction spelled out, because **the allowlist is exactly where a future mistake could hide.**

## Verified, not delegated to the check

Every expression was evaluated against live Prometheus before being written — base series, label sets, the rate, and the full expression. `check_alert_series.py` then passes independently: **21 selectors, exit 0.**

Unit tests fire both rules and pin the silences that matter:

| Case | Expected |
|---|---|
| ingestion flat for 45m | **fires** |
| traffic at this host's real rate | silent |
| 429 on the ingest route | **fires**, names the code |
| healthy 204s | silent |
| 503 on `route="ready"` | silent |

Mutation-tested: dropping the `status_code` matcher, dropping the `route` matcher, and turning `== 0` into `>= 0` each failed **exactly the intended test**. Restoring gives SUCCESS across 17 rules.

## Two smaller corrections

- The checker printed *"every selector matches at least one live series"* while one was allowlisted. **Corrected** — a summary that hides an exemption is the same small lie this check exists to catch.
- The test file's header used `LokiIngestionErrors` as its worked example of what a green run cannot prove. That rule is gone, so the lesson is rewritten to say it *was* tested here and passed while being incapable of firing.

## The record you asked for

`docs/decisions/alert-series-verification.md` now carries **the checks that lied during this work — all five mine**, including the two from the last task: a first-draft checker that mangled `{job="blackbox-public"}` into `{job= }` and read the resulting HTTP 400 as "cannot fire", and a decay watcher that cached the Prometheus IP and reported `connection refused` when a deploy moved the container.

Two patterns cover all five: **an empty or error result treated as an answer**, and **a value captured once then reused after the world moved**. With the corollary — before believing a check that reports a problem, run it against a case whose answer you already know.

## Scope

No deploy. Instant queries and one read of Loki's `/metrics`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)