### PR TITLE
docs(handoff): bring the platform handoff current, and correct three claims that aged today

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ nothing. It is a **platform**: it hosts tenants but is not the application.
 deploy/compose/prod/    the platform stacks — infra, db, auth, vault, observability
 platform/edge/          Traefik static template + dynamic middlewares
 platform/auth/          Keycloak realm and theme
-platform/observability/ Prometheus, Loki, Tempo, Grafana, exporters
+platform/observability/ Prometheus, Alertmanager, blackbox, Loki, Tempo, Grafana, exporters
 infra/secrets/          SOPS-encrypted stores; age private keys are gitignored
 scripts/                deploy.sh, backup.sh, _common.sh, checks/
 ansible/                VPS bootstrap
@@ -247,6 +247,21 @@ bash scripts/deploy.sh verify <service> prod
 gh workflow run deploy.yml -f service=all
 ```
 
+- **Alerts reach a human, as of 2026-07-31.** 16 rules, 8 groups, delivered by
+  Alertmanager over email to `ACME_EMAIL` via the SMTP account the estate already
+  had. Delivery is proven end to end, not assumed. Before that date there was **no
+  receiver at all** and every rule was inert — `ServiceDown` fired for ≥48 hours in
+  the week to 2026-07-26 and reached nobody. Start at
+  [`docs/decisions/alerting-audit.md`](docs/decisions/alerting-audit.md).
+- **Two traps that have each cost a session. Do not re-derive them.**
+  **cAdvisor emits zero Docker container series on this host** — 45 cgroup and
+  systemd series, `count(container_memory_usage_bytes{name!=""})` is 0 — so any
+  plan starting "cAdvisor already scrapes the containers" is starting from a false
+  premise. And **a rule can be `health=ok` and still be unable to fire**, if it
+  matches a label production never emits; two shipped that way. `promtool test` cannot
+  catch it because the test author supplies the labels — run
+  `python3 scripts/checks/check_alert_series.py` **on the VPS**, which asks the live
+  Prometheus.
 - Platform baseline is **16 containers by name, 0 unhealthy** —
   `Verified 2026-07-31 09:58 UTC`, after #617 deployed `alertmanager` and
   `blackbox-exporter`. With the tenant's 7 that is **23 running in total**.

--- a/docs/decisions/2026-07-31-handoff.md
+++ b/docs/decisions/2026-07-31-handoff.md
@@ -3,19 +3,30 @@
 A statement of current truth, not a changelog. Every perishable claim carries the time it
 was checked. Where something was not checked, it says so rather than hedging.
 
-**All measurements below: `Verified 2026-07-31 06:21 UTC`** unless stated otherwise.
+**Most measurements below: `Verified 2026-07-31 06:21 UTC`.** A full day of work landed
+after that, so the sections marked **`Re-verified 2026-07-31 11:20 UTC`** supersede the
+06:21 figures where they disagree. Everything else still carries its original timestamp.
 
 ## The shape of the estate right now
 
-The platform runs 13 long-standing containers plus a new MinIO — `cadvisor grafana
-keycloak loki node-exporter openbao portainer postgres postgres-exporter prometheus
-promtail tempo traefik` and `minio` — all present, **0 unhealthy**. The tenant
-(hill90-app) runs **7 containers, all healthy**, alongside them and outside that count.
+`Re-verified 2026-07-31 11:20 UTC.`
+
+**The platform baseline is 16 containers by name, 0 unhealthy**, plus the tenant's 7 for
+**23 running in total**:
+
+```
+alertmanager blackbox-exporter cadvisor grafana keycloak loki minio node-exporter
+openbao portainer postgres postgres-exporter prometheus promtail tempo traefik
+```
 
 `hill90.com` 200, `auth.hill90.com/realms/platform` 200, `api.hill90.com/health` 200.
 
-**The platform baseline is now 13 + MinIO.** Anything still asserting a flat 13 as the
-whole platform is describing yesterday.
+**Count from that list; do not do arithmetic on an older shorthand.** This entry used to
+say "13 long-standing containers plus a new MinIO". Adding the two new ones to 13 gives 15
+and is wrong, because `minio` was never inside the 13 — it arrived with the storage
+cutover. That mistake was made and corrected today. A second trap: match on
+`blackbox-exporter`, not `blackbox`; an exact-match sweep on the short name reports it
+missing while it is running.
 
 ## Retired, and what remains of each
 
@@ -91,16 +102,26 @@ and the SSH alias in hill90-app's git history — see *Open decisions* below.
 
 ## Negative results, which are half the value
 
-- **Five hypotheses for the api-suite flake are dead, each by measurement or reachability**,
-  and the suite is still unreliable at roughly a third of runs. The positional
+- **Six hypotheses for the api-suite flake are dead, each by measurement or reachability**,
+  and the suite is still unreliable at roughly a third of runs. *(This said "five" when
+  written; the sixth — that the number of supertest servers was the variable — died later
+  the same day.)* The positional
   `mockResolvedValueOnce` queue (a file with **zero** `Once(` calls flakes anyway);
   misrouted supertest servers (**455 of 470** captured 404s were handler JSON); leaked
   timers cleared at the test boundary (**6/20** with clearing); unawaited promises (the only
   two genuine ones are unreachable from the affected paths); and the SSE handler leak —
   which was **real, was fixed, and did not help**: **7/20** afterwards, with
   P(≥7 at the pooled 21% baseline) = 0.117. Full record with per-run outcomes in
-  hill90-app's `docs/decisions/api-suite-flakiness.md`. **There is no outstanding
-  hypothesis.**
+  hill90-app's `docs/decisions/api-suite-flakiness.md`.
+
+  **Correction: "there is no outstanding hypothesis" was true when written and is no longer.**
+  The investigation was localised to half A's 29 files at ~23% with **no necessary member and
+  no reproducing subset**, and it now carries a **standing hypothesis** — explicitly labelled
+  untested reasoning rather than a finding — that the carrier is per-process mutable state,
+  written at an unpredictable moment and read as a branch condition. It also carries a **stop
+  line**: further bisection is expensive and aimed at a minimal pair that probably does not
+  exist. The resume point is the per-configuration table, and the next step is a deterministic
+  environment audit. **Nobody should restart from zero.**
 - **A green run of hill90-app's api suite is not evidence that a change is safe.**
   Re-checked by measurement on 2026-07-31, not left standing out of neglect.
 - **The `api.hill90.com` rate-limit asymmetry is an open proposal, not a defect.** The
@@ -111,6 +132,103 @@ and the SSH alias in hill90-app's git history — see *Open decisions* below.
 - **A history rewrite would not conceal the tailnet address**, because public DNS already
   serves it for six hostnames in the zone. If that address is the concern, the fix is in
   DNS, not git.
+
+## The alerting programme — built, deployed and proven after this was first written
+
+`Re-verified 2026-07-31 11:20 UTC.` None of this existed at 06:21.
+
+**The finding that started it: six rules were firing into nothing.** Prometheus reported
+zero Alertmanagers, Grafana had zero alert rules and a default email contact point with no
+SMTP server, the host had no MTA and no `MAILTO`, and `DEPLOY_WEBHOOK_URL` was unset. Every
+alerting component was present, plausible and inert — and `ServiceDown` had genuinely fired
+for **at least 48 hours** across `keycloak`, `minio` and `postgres-exporter`, ending
+2026-07-26 06:42 UTC, delivered to nobody.
+
+**What runs now:** `alertmanager` and `blackbox-exporter`, **16 rules across 8 groups, all
+`health=ok`, none firing or pending.** Delivery is **email** through
+`smtp.hostinger.com:587` as `noreply@hill90.com`, to the address in `ACME_EMAIL`, using
+credentials the estate already had — no new external account.
+
+**Delivery was proven end to end before shipping and again after deploying**: a real probe
+failure, a real email, and the RESOLVED notification confirmed on the resolve path.
+Two defects were found only by sending a real alert, neither caught by `amtool
+check-config`: a 0600 config is unreadable by Alertmanager's `nobody` user, and `default` is
+not an Alertmanager template function.
+
+| Covers | Rule |
+|---|---|
+| the public site | `PublicSiteDown` — blackbox probe of `hill90.com` |
+| the tenant's API | `TenantApiDown` — probe of `api.hill90.com/health` |
+| a sealed vault | `VaultSealedOrUnreachable` — OpenBao `/v1/sys/health`, 503 when sealed, no token needed |
+| certificates | `CertificateExpiringSoon` (21d), `CertificateExpiringCritical` (10d), `CertificateCountDropped` |
+| backups | `BackupNotSucceeding` (26h), `…Critical` (50h), `BackupSignalMissing` (absent) |
+| restart loops | `ContainerRestartLoop` |
+| the rest | `ServiceDown`, `DiskSpaceRunningLow`, `HostMemoryHigh`, `PostgresConnectionsHigh`, `LokiIngestionErrors`, `TempoIngestionErrors` |
+
+**The backup design is "alert on the absence of success", not the presence of failure** —
+because a job that never runs emits no failure. `backup.sh` writes a textfile that
+node-exporter serves; `BackupSignalMissing` exists underneath because a staleness rule is
+*silent* about a metric that does not exist. That was proven by deleting the file: the
+staleness rule went to 0 series and the absence rule fired.
+
+> **`alertmanager_notifications_total` currently reads 0.** That is the counter resetting
+> when the container was recreated at 10:57, not a broken receiver — delivery was verified
+> both before and after that deploy.
+
+## Capacity, backups and hardening — measured after 06:21
+
+`Re-verified 2026-07-31 11:20 UTC.`
+
+- **Disk: 14% used, 173 GiB free** of 199 GiB. Both large consumers are bounded —
+  Prometheus at `7d` / `20GB`, Loki at `168h` with retention enabled. *(A capacity record
+  written earlier today says 13%; the difference is one manual `backup-all`.)*
+- **Both halves of the backup set are restore-tested.** The nightly Postgres dump restored
+  into a throwaway container with `psql` exit 0 and **zero stderr**, and the scheduled
+  observability volume tar restored a working `grafana.db`. Live volumes were never written
+  to in either exercise.
+- **Dumps are `0600` and taken with `--no-role-passwords`.** The trade is real and is
+  documented where it bites: a restore no longer recreates role passwords, so they must be
+  set from the store afterwards or the restore looks corrupt rather than incomplete.
+- **The vault token is out of `argv`**, where any local user could read it from `ps`.
+- **sshd password authentication is enabled on the host but not in force.** `sshd -T`
+  reports `passwordauthentication yes`; the hardening drop-in exists in this repository but
+  **Config VPS has not been run**, so the effective daemon config still accepts passwords.
+  The firewall admits SSH only from the Tailscale range, which is what keeps this from
+  being an exposure — it is not a substitute for the change. **Jon's to run.**
+
+## Negative results from the second half of the day
+
+These are half the value and are recorded so nobody pays for them twice.
+
+- **No dead man's switch was built, deliberately.** Alertmanager cannot report the death of
+  the host it runs on, so an external heartbeat is the right complement — but nothing
+  available was fit without a new external account, which is Jon's to choose. Recorded as a
+  decision rather than half-built.
+- **cAdvisor emits zero Docker container series on this host.** 45 cgroup and systemd
+  series; `count(container_memory_usage_bytes{name!=""})` is **0**. This closed the obvious
+  route three separate times — per-container memory, restart detection, and tenant
+  container visibility. **Do not start there.**
+- **Two rules could not fire, and looked exactly like coverage.** `HighMemoryUsage` matched
+  a `name` label cAdvisor never emits (renamed `HostMemoryHigh` and rescoped to the host
+  root cgroup); `LokiIngestionErrors` matches `{status="error"}` on a metric carrying no
+  `status` label. A CI-adjacent check now asks the live Prometheus whether every selector
+  resolves, because a unit test cannot catch this — the test author supplies the labels.
+- **Grafana's SQLite is not the high-value volume its size suggests.** A Grafana started on
+  an **empty** volume reproduced all 6 dashboards and all 3 datasources from provisioning
+  files in this repo; the entire delta against live was **one OAuth user row**. A proposal
+  to take consistent `sqlite3 .backup` copies was costed and rejected on that basis, and a
+  runbook claim that a Postgres-only restore "leaves Grafana empty" was corrected.
+- **`app-docker-proxy`'s absence fails CLOSED, and an earlier claim here was retracted.**
+  It was described as a security-relevant availability event; `app-api` holds no raw Docker
+  socket, so losing the proxy leaves it no path to the daemon at all. The absence is
+  operational. What *is* security-relevant is the control's configuration — ACL drift, and
+  the fact that the proxy filters by API path and never by container ownership, so
+  `/containers/json` through it returns all 24 containers including 17 platform ones.
+  **The dangerous failure of a control is being bypassed while still answering, not
+  disappearing.**
+- **The tenancy contract claimed observability it never had.** Its table recorded "partial —
+  `cadvisor` scrapes all containers"; that basis is false and the honest entry is none.
+  Corrected, with the boundary for what the platform may watch written down.
 
 ## Open decisions — Jon's, not a lane's
 
@@ -135,6 +253,21 @@ and the SSH alias in hill90-app's git history — see *Open decisions* below.
 4. **`app-minio`'s removal.** Its retention window expires **2026-08-01 01:41 UTC** — a day
    after it stopped. Removing the container is reversible while `prod_app-minio-data`
    exists; deleting that volume is the irreversible step and should be a separate decision.
+   `Re-verified 2026-07-31 11:20 UTC`: still `Exited (0)`, volume still present.
+5. **Run Config VPS, to put the SSH hardening in force.** The drop-in is in this repository
+   and `sshd -T` still reports `passwordauthentication yes`. Until it runs, the firewall is
+   the only thing standing between the setting and the internet.
+6. **The `api.hill90.com` rate limit, as a specified number.** The UI carries the shared
+   rate-limit middleware and the API carries none. Not an exposure — the API is meant to be
+   public and authenticates its callers — but the asymmetry looks unintended. The proposal
+   is to attach the *same* limit, because that value is already proven in production on the
+   UI. The platform owns the middleware definition; **the tenant owns the reference**, so
+   the change lands in hill90-app.
+7. **Whether to open an external account for a dead man's switch.** Nothing on the host can
+   report that the host is gone. A ping from the nightly backup cron to an outside service
+   would cover the backup failing, the host dying, and the who-watches-the-watcher hole in
+   Alertmanager, all at once. It was deliberately not built because it needs an account that
+   is Jon's to open.
 
 ## The rule this cycle kept re-learning
 


### PR DESCRIPTION
The handoff is what a cold session reads first, and it described the estate as it stood at
**06:21**. A full day landed after that. Everything below was **re-measured at 11:20 UTC**,
not restated.

## Corrected — a stale claim here does the most damage

| Was | Now |
|---|---|
| "13 long-standing containers plus a new MinIO" | **16 by name**, listed in full, with the trap named |
| "**Five** hypotheses for the api-suite flake are dead" | **Six** — the sixth died later the same day |
| "There is **no outstanding hypothesis**" | There is a **standing** one, plus a stop line and a resume point |

The baseline trap is worth stating because it was made and caught today: **13 + 2 new = 15
is natural and wrong**, because `minio` was never inside the 13. And match on
`blackbox-exporter`, not `blackbox` — an exact-match sweep on the short name reports it
missing while it is running.

The flake correction matters most: *"no outstanding hypothesis"* was true when written and
is not any more. The record now carries a standing hypothesis — **explicitly labelled
untested reasoning, not a finding** — and an explicit stop line, so the next person resumes
from the per-configuration table rather than from zero.

## Added

**The alerting programme**, which did not exist at 06:21: 16 rules across 8 groups, all
`health=ok`, delivered by email through credentials the estate already had, **proven end to
end before shipping and again after deploying**. Including the finding that started it —
six rules firing into nothing, while `ServiceDown` had genuinely fired for **≥48 hours** and
reached nobody.

**Capacity and hardening, measured:** disk **14% used, 173 GiB free**, both large consumers
bounded (Prometheus `7d`/`20GB`, Loki `168h`); both halves of the backup set restore-tested;
dumps `0600` with `--no-role-passwords` and the restore consequence documented where it
bites; the vault token out of `argv`; and sshd password auth **enabled but not in force**,
with the firewall named as what keeps that from being an exposure rather than as a
substitute for running Config VPS.

*(A capacity record written earlier today says 13% — the difference is one manual
`backup-all`. Dated rather than silently reconciled.)*

## The negative results are kept, because they are half the value

- **No dead man's switch was built**, deliberately — nothing available was fit without a new
  external account, which is Jon's to open.
- **cAdvisor emits zero Docker container series**, which closed the obvious route **three
  separate times**: per-container memory, restart detection, tenant visibility.
- **Two rules were `health=ok` and could never fire** — `HighMemoryUsage` and
  `LokiIngestionErrors`. `promtool test` cannot catch this; the live-series check can.
- **Grafana's SQLite protects one OAuth user row**, not the dashboards its size implies — a
  consistent-backup proposal was costed and rejected on that evidence.
- **`app-docker-proxy`'s absence fails CLOSED**, retracting an earlier claim here. The
  dangerous failure of a control is **being bypassed while still answering, not
  disappearing**.
- **The tenancy contract claimed observability it never had** — corrected.

## Open decisions now state all of Jon's plainly

The four that were there, plus the three that were implicit: **run Config VPS** for the SSH
hardening, **the `api.hill90.com` rate limit as a specified number** (platform owns the
middleware, tenant owns the reference), and **whether to open the external account** a dead
man's switch needs. `app-minio`'s deadline is re-verified: still `Exited (0)`, volume
present, window closes **2026-08-01 01:41 UTC**.

## CLAUDE.md

Gains the alerting entry it was missing entirely, and the two traps as fast facts — since
that is where a cold session looks before it looks anywhere else. Baseline was already
correct at 16.

Read-only against production; nothing deployed. `check_md_links` passes.

**Companion PR in the tenant repo:** hill90-app `docs/handoff-refresh-2026-07-31`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)