### PR TITLE
docs: lift the day's most repeated defect out of a decision record and into the guardrails

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -253,6 +253,12 @@ gh workflow run deploy.yml -f service=all
   receiver at all** and every rule was inert — `ServiceDown` fired for ≥48 hours in
   the week to 2026-07-26 and reached nobody. Start at
   [`docs/decisions/alerting-audit.md`](docs/decisions/alerting-audit.md).
+- **Before reporting "none", "empty" or "never", check the instrument first.** An
+  instrument that cannot see the thing looks exactly like the thing being absent —
+  six times on 2026-07-31, including a missing `strings` binary read as an empty
+  log and a green `amtool check-config` on a config that could not deliver. The
+  practice, the six cases and the positive-control defence:
+  [`CONTRIBUTING.md`](CONTRIBUTING.md#verify-the-instrument-before-you-believe-the-verdict).
 - **Two traps that have each cost a session. Do not re-derive them.**
   **cAdvisor emits zero Docker container series on this host** — 45 cgroup and
   systemd series, `count(container_memory_usage_bytes{name!=""})` is 0 — so any

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -181,6 +181,50 @@ workflow, on a weekly schedule or manual trigger.
   unless you actually need one.
 - Skip CI or review feedback.
 
+### Verify the Instrument Before You Believe the Verdict
+
+**An instrument that cannot see the thing is not evidence that the thing is absent.**
+Blindness and absence produce identical output — an empty list, a zero, a silent grep —
+and nothing in that output tells you which one you got.
+
+This is not a maxim. It is the single most common defect found on 2026-07-31, and it
+appeared **six times in one day wearing six different coats**:
+
+| The check said | What was actually true |
+|---|---|
+| `strings` on Alertmanager's log: no matches → *"the log is empty"* | **`strings` was not installed.** The command produced nothing because it did not exist. The file was 123 bytes and non-empty. |
+| `/api/v2/alerts`: `0 alerts` → *"nothing has ever fired"* | That endpoint reports **currently active** alerts, and Alertmanager had restarted minutes earlier. It answers "what is firing now", never "what has fired". |
+| `du` over `/var/lib/docker/*/` → *"the directory is empty"* | The glob expanded **as an unprivileged user** against a root-only directory and matched nothing. `sudo` returned 26 GiB. |
+| the tenancy contract: *"`cadvisor` scrapes all containers"* | cAdvisor emits **zero Docker container series** here — 45 cgroup and systemd series, `count(container_memory_usage_bytes{name!=""})` = 0. A documented guarantee resting on a blind instrument. |
+| `amtool check-config`: **SUCCESS** | Every notification then failed at *render* time — `default` is not an Alertmanager template function. A **green verdict** from an instrument that could not see the failure. |
+| an exact-match sweep for `blackbox` → *"container missing"* | The container is named `blackbox-exporter`. It was running the whole time. |
+
+Three more from the tenant the same week: `ls -l` hiding a dotfile read as *"the file is
+absent"*; a `grep` for a compose warning whose quotes were backslash-escaped read as
+*"compose is silent"*; `wc -l` on a mistyped `mc` alias read as *"zero objects"*.
+
+**The defence is a positive control: run the check against a case whose answer you already
+know, and confirm it produces a result, before believing it when it produces none.**
+
+- `check_alert_series.py` earns its trust by independently rediscovering the two rules
+  already known to be unfireable. If it stops finding those, it has gone blind.
+- Before reporting "no objects in the bucket", put one there and see it.
+- Before reporting a container missing, list all of them and read the names.
+- `promtool test` cannot prove a rule can fire — the test author supplies the labels. Only
+  the live series check can. Neither is sufficient alone.
+
+Two habits that cost nothing:
+
+- **Say "not recorded", never "did not happen"**, when the recording only started recently.
+  Keycloak's event log is the standing example: an empty result for a past date means
+  nothing was writing then.
+- **Check the exit code of the thing you meant**, not of the pipeline. `cmd | tail; echo $?`
+  reports `tail`'s status — which read as "the check passed" for a script that exited 1.
+
+The fuller instance-by-instance record, including the checks that were wrong *about the
+alert rules themselves*, is in
+[`docs/decisions/alert-series-verification.md`](docs/decisions/alert-series-verification.md).
+
 ### Manual Workarounds Are a Merge Blocker
 
 If verifying a PR required an ad-hoc manual workaround — `chmod`/`chown`,


### PR DESCRIPTION
Six times on 2026-07-31, in six disguises, **a check that could not see the thing was read
as the thing being absent.** Blindness and absence produce identical output — an empty
list, a zero, a silent grep — and nothing in that output says which one you got.

## Why `CONTRIBUTING.md` and not `docs/`

You asked me to choose and say why.

| Candidate | Why not |
|---|---|
| `docs/decisions/` | Records *why a decision was made*. The fuller instance table already lives there in `alert-series-verification.md` — **and that is exactly the problem**: it is filed under alerting, so someone about to make this mistake while checking a backup, a volume or a container never reaches it. |
| `docs/runbooks/` | Procedures. This is not one. |
| `docs/reference/` | Flag-level detail behind procedures. This is not detail. |
| **`CONTRIBUTING.md` → `## Guardrails`** | ✅ CLAUDE.md calls it *"conventions and the deploy rules"*; it already holds Guardrails, and already carries a rule of this exact shape in **Manual Workarounds Are a Merge Blocker**. It is read *before* contributing — which is before the mistake. |

Plus a one-line pointer in `CLAUDE.md`, since a cold session reads that first.

## What it adds rather than duplicates

The existing record is pane 2's, and its instances are mostly the audit's own checks
failing. The cases it does **not** have are the ones that generalise furthest:

- **The tenancy contract asserting *"`cadvisor` scrapes all containers"*** — a *documented
  guarantee* resting on a blind instrument. cAdvisor emits **zero** Docker container series
  here. This is the defect promoted to a written claim, which is how it survives longest.
- **`amtool check-config` returning SUCCESS** on a config whose every notification then
  failed at *render* time. A **green verdict** from an instrument that could not see the
  failure — the inverse of the usual shape, and the easiest of all to trust.
- **An exact-match sweep for `blackbox`** reporting a running `blackbox-exporter` missing.
- **The tenant's three**: `ls -l` hiding a dotfile, a `grep` missing a compose warning whose
  quotes were backslash-escaped, and `wc -l` on a mistyped `mc` alias reading as zero
  objects.

## Shape

The value is the examples, so the exhortation is one line and the table is the body — six
rows of *what the check said* against *what was actually true*.

The defence is stated as something to **do**: a positive control — run the check against a
case whose answer you already know, and confirm it produces a result, before believing it
when it produces none. Four concrete instances, including why `promtool test` cannot prove
a rule can fire (the test author supplies the labels) and only the live series check can.

Two habits added because both cost nothing and both bit today:

- **Say "not recorded", never "did not happen"** when the recording started recently —
  Keycloak's event log is the standing example.
- **Check the exit code of the thing you meant**, not of the pipeline. `cmd | tail; echo $?`
  reports `tail`'s status, which read as *"the check passed"* for a script that exited 1.

## Verification

```
check_md_links / check_env_surface / check_secrets_schema   pass
shellcheck --severity=error                                 clean
```

Documentation only — nothing deployed, nothing on the host touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)