### PR TITLE
docs(alerting): correct two documents that today's own work made false

### DIFF
--- a/docs/decisions/backup-failure-signal.md
+++ b/docs/decisions/backup-failure-signal.md
@@ -1,8 +1,12 @@
 # Making a failed backup visible
 
-**Status: specified, not built.** No signal exists today. This is the design and
-the reasoning behind it; delivery belongs with the Alertmanager work in
-[alerting-audit.md](alerting-audit.md).
+**Status: BUILT and applied, 2026-07-31.** This page is the design and the
+reasoning; it is kept because the reasoning is the valuable part, but it no longer
+describes a future state. `hill90_backup_last_success_timestamp_seconds` is being
+emitted and `BackupNotSucceeding`, `BackupNotSucceedingCritical` and
+`BackupSignalMissing` are live in
+`platform/observability/prometheus/alerts.yml`. Read the sections below as *why it
+is shaped this way*, not as *what remains to do*.
 
 `Established 2026-07-31, read-only against production.`
 

--- a/docs/runbooks/alert-response.md
+++ b/docs/runbooks/alert-response.md
@@ -116,12 +116,16 @@ needed. Free space somewhere else first.
 
 ---
 
-## Site down — `ServiceDown`, or a report from a human
+## Site down — `PublicSiteDown`, `ServiceDown`, or a report from a human
 
-**Read the alert carefully first.** `ServiceDown` means a *scrape target* stopped
-answering Prometheus. That is not the same as the public site being down, and the
-reverse is also true: **nothing currently probes `hill90.com` from outside**, so
-the site can be unreachable to visitors while every alert stays quiet.
+**Read which alert it is first, because they mean different things.**
+
+- **`PublicSiteDown`** is the real one: a blackbox probe of `https://hill90.com/`
+  did not get a 200 for two minutes. Users are seeing it too.
+- **`ServiceDown`** means a *scrape target* stopped answering Prometheus. That is
+  an exporter or an internal endpoint, and the public site may be perfectly fine.
+- **`TenantApiDown`** is `api.hill90.com`. `hill90.com` can return 200 while it is
+  broken, so `PublicSiteDown` will not cover it.
 
 1. **Is it actually down, and for whom?** From outside, then from the host. If the
    host says 200 and the outside says otherwise, it is DNS or the network, not the
@@ -147,21 +151,39 @@ to read.
 
 ---
 
-## What is not wired up yet
+## Alerts do reach you, and this is how fast
+
+`Verified 2026-07-31 11:54 UTC by an end-to-end test, not by reading config.`
+
+Alertmanager is deployed and the whole chain was measured with a deliberate test
+alert: **19.6 seconds** from the condition existing to the mail being accepted by
+the relay — scrape 2.5s, rule evaluation 7.5s, Prometheus to Alertmanager
+immediate, then `group_wait` 10s. For `PublicSiteDown`, add its deliberate
+`for: 2m`, so **expect to hear about the site being down in roughly two and a
+half minutes.**
+
+**The all-clear is much slower, and that is normal.** `group_interval` is 5m and
+governs every notification after the first, so a RESOLVED mail arrives up to five
+minutes after the problem ends — measured at 297s. **An alert that has stopped
+being true but has not sent its resolve yet is not a stuck alert.** Wait for the
+group flush before going looking for a fault in Alertmanager.
+
+## What is still not wired up
 
 Honest, because an index that implies coverage it does not have is worse than
-none:
+none. This list is much shorter than it was this morning:
 
-- **No delivery path exists.** Prometheus evaluates its rules and Alertmanager is
-  not deployed, so nothing above reaches a human automatically yet. Until it does,
-  `bash scripts/ops.sh health` on the VPS is the way these are noticed.
-- **The backup and certificate rules are specified, not applied** — see
-  [../decisions/backup-failure-signal.md](../decisions/backup-failure-signal.md)
-  and [certificate-renewal.md](certificate-renewal.md).
-- **Vault sealed and site down have no signal at all.** The response steps above
-  are still correct; they just have to be triggered by a person or by
-  `ops.sh health` rather than by an alert.
+- **Nothing watches the watcher.** If Prometheus stops evaluating or Alertmanager
+  dies, every alert above goes silent, and silence is what a healthy night looks
+  like. Closing this needs an external dead-man's-switch service, which is a
+  decision rather than a change — see
+  [../decisions/dead-mans-switch.md](../decisions/dead-mans-switch.md).
+- **The tenant's containers are not scraped.** `app-*` are covered only by the
+  edge probes of `hill90.com` and `api.hill90.com`. A tenant container in a crash
+  loop that keeps answering HTTP will not page anyone.
+- **No per-container resource metrics exist at all.** cAdvisor reports zero
+  containers on this host — see
+  [../decisions/alert-series-verification.md](../decisions/alert-series-verification.md).
 
-Every claim in that list was checked against Prometheus rather than inferred —
-including which of the *existing* rules match no series at all — in
-[../decisions/alert-series-verification.md](../decisions/alert-series-verification.md).
+Everything in this file was checked against the running system rather than
+inferred from configuration.


### PR DESCRIPTION
A pass over today's merged changes with the lens we spent the day applying: settings present but inert, checks that cannot fail, claims no longer true, thresholds nobody can defend.

**Most of it held.** Two documents did not — both written this morning and invalidated by this afternoon's work.

## The one that matters

`alert-response.md` is the 3am document. It said:

> **nothing currently probes `hill90.com` from outside**, so the site can be unreachable to visitors while every alert stays quiet

That is now flatly false — `blackbox-public` probes `https://hill90.com/` and `PublicSiteDown` fires after 2m. **The reader most likely to reach that line is someone who has just been paged by that exact probe**, and the runbook would have told them the thing that woke them up does not exist. A stale doc that merely lags is untidy; this one actively contradicts the system and would undermine trust in a real alert.

Its closing section was wrong on all three bullets:

| Claimed | Actually |
|---|---|
| "No delivery path exists, Alertmanager is not deployed" | Deployed, and proven end to end |
| "Backup and certificate rules are specified, not applied" | All applied |
| "Vault sealed and site down have no signal at all" | Both have blackbox probes |

**Rewritten to carry the measured numbers**, because they are what a woken person needs: 19.6s from condition to mail, so ~2½ minutes for `PublicSiteDown` once its deliberate `for: 2m` is added.

And the asymmetry, which is the part that looks like a bug: `group_interval` is 5m and governs everything after the first notification, so the RESOLVED mail lags by up to five minutes (measured: 297s). **An alert that has stopped being true but has not sent its resolve is not stuck** — nobody should go hunting in Alertmanager for it.

The "not wired up" list is now three genuine items: no dead-man's switch, tenant containers unscraped, no per-container metrics.

## Second, cheaper

`backup-failure-signal.md` still opened *"Status: specified, not built. No signal exists today."* The metric is emitting and all three rules are live. A status header is a live claim rather than a snapshot, so it was corrected rather than dated.

## Deliberately not changed

`alert-series-verification.md` carries a row saying the vault alert has no metric and no scrape target, which pane 1 then solved with a blackbox probe. **That document is an explicitly dated audit**, and this repo's own rule is that a dated claim which has aged is honest. Rewriting a point-in-time record to match later events would make it less useful, not more.

## Scope

Documentation only. Read-only against production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
