### PR TITLE
chore(checks): guard the OIDC-client rebuild trap — which is not currently open

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,9 @@ jobs:
       - name: Validate local/prod config surface
         run: python3 scripts/checks/check_env_surface.py
 
+      - name: Assert every referenced OIDC client is created on the deploy path
+        run: python3 scripts/checks/check_oidc_clients_reconciled.py
+
       - name: Validate secrets schema consistency
         env:
           SECRETS_SCHEMA_STRICT: "0"

--- a/scripts/checks/check_oidc_clients_reconciled.py
+++ b/scripts/checks/check_oidc_clients_reconciled.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Every OIDC client the repo REFERENCES must be created by something on the deploy path.
+
+WHY THIS EXISTS — AND WHAT IT IS NOT
+====================================
+
+It is NOT a fix for a present break. It was written after a report that a VPS
+rebuild would produce a realm without the `grafana` and `portainer` clients,
+because `platform/auth/keycloak/platform-realm.json` declares only
+`hill90-vault`, `hill90-ui` and `hill90-api`, and `start --import-realm` is
+IGNORE_EXISTING against an existing realm.
+
+That premise was checked and does not hold. `scripts/keycloak.sh apply` already
+reconciles `grafana`, `portainer`, `minio` and `hill90-vault` from SOPS via
+`ensure_client`, and `scripts/deploy.sh` runs `keycloak.sh apply` on the auth
+deploy — which `deploy.sh all` reaches, which is what the disaster-recovery
+runbook runs. The realm JSON being short is therefore survivable: the reconcile,
+not the import, is what puts those clients in an existing realm.
+
+WHAT WOULD MAKE IT TRUE is the regression this guards: someone adds a fifth OIDC
+integration — another `*_CLIENT_ID=` in a compose file, another service wired to
+Keycloak — and does not add a matching `ensure_client` call. Then the realm JSON
+is inert, nothing on the deploy path creates that client, and the integration
+fails on a rebuilt host while looking fine on the running one. Nothing else in
+this repository would catch it: the compose file is valid, the deploy succeeds,
+and SSO for that one service simply never works after a rebuild.
+
+HOW IT DECIDES
+==============
+
+Referenced   parsed from deploy/compose/prod/*.yml and scripts/*.sh — the places
+             that name a client id to authenticate WITH.
+Provisioned  parsed from scripts/keycloak.sh: `ensure_client "<id>"` (the
+             platform path) plus the ids cmd_tenant_clients creates.
+Declared     clientIds in platform-realm.json — enough for a from-nothing realm,
+             and deliberately NOT enough on its own for an existing one.
+
+A referenced client passes if it is provisioned OR declared. It fails if it is
+neither, because then nothing puts it in the realm.
+
+Both sides are PARSED, never hardcoded. A hardcoded expectation would keep
+passing after someone renamed a client, which is the failure this whole file is
+about.
+
+Usage: check_oidc_clients_reconciled.py [keycloak.sh] [platform-realm.json]
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+# Client ids the repo authenticates WITH. Each pattern is anchored on the
+# specific setting rather than on a bare word, so a mention in prose or a
+# comment cannot be mistaken for a dependency.
+REFERENCE_PATTERNS = [
+    # Grafana, MinIO and anything else following the *_CLIENT_ID= convention.
+    re.compile(r"^\s*-?\s*(?:GF_AUTH_GENERIC_OAUTH|MINIO_IDENTITY_OPENID)_CLIENT_ID=([A-Za-z0-9._-]+)", re.M),
+    # Portainer's API payload: "ClientID": "portainer"
+    re.compile(r'"ClientID"\s*:\s*"([A-Za-z0-9._-]+)"'),
+    # vault.sh: oidc_client_id="hill90-vault"
+    re.compile(r'oidc_client_id="([A-Za-z0-9._-]+)"'),
+]
+
+# Interpolated values cannot be resolved statically; a client id that is a
+# variable is out of scope rather than silently treated as a literal.
+INTERPOLATED = re.compile(r"[$\{]")
+
+
+def referenced(root: Path) -> dict[str, list[str]]:
+    found: dict[str, list[str]] = {}
+    files = sorted(root.glob("deploy/compose/prod/*.yml")) + sorted(root.glob("scripts/*.sh"))
+    for f in files:
+        text = f.read_text(encoding="utf-8", errors="replace")
+        for pat in REFERENCE_PATTERNS:
+            for m in pat.finditer(text):
+                cid = m.group(1)
+                if INTERPOLATED.search(cid):
+                    continue
+                found.setdefault(cid, []).append(f.relative_to(root).as_posix())
+    return found
+
+
+def provisioned(keycloak_sh: Path) -> set[str]:
+    text = keycloak_sh.read_text(encoding="utf-8", errors="replace")
+    ids = set(re.findall(r'^\s*ensure_client\s+"([A-Za-z0-9._-]+)"', text, re.M))
+    # cmd_tenant_clients creates these directly rather than through ensure_client.
+    ids |= set(re.findall(r'client_uuid\s+"([A-Za-z0-9._-]+)"', text))
+    return ids
+
+
+def declared(realm_json: Path) -> set[str]:
+    data = json.loads(realm_json.read_text(encoding="utf-8"))
+    return {c.get("clientId") for c in data.get("clients", []) if c.get("clientId")}
+
+
+def main() -> int:
+    keycloak_sh = Path(sys.argv[1]) if len(sys.argv) > 1 else ROOT / "scripts/keycloak.sh"
+    realm_json = Path(sys.argv[2]) if len(sys.argv) > 2 else ROOT / "platform/auth/keycloak/platform-realm.json"
+
+    for p in (keycloak_sh, realm_json):
+        if not p.is_file():
+            print(f"FAIL — missing input: {p}", file=sys.stderr)
+            return 1
+
+    refs = referenced(ROOT)
+    prov = provisioned(keycloak_sh)
+    decl = declared(realm_json)
+
+    if not refs:
+        # A zero-reference result is indistinguishable from every pattern having
+        # rotted, and would pass vacuously. Refuse instead.
+        print("FAIL — no client references found at all. The patterns no longer match "
+              "anything, which is a broken check, not a clean estate.", file=sys.stderr)
+        return 1
+
+    missing = {cid: where for cid, where in refs.items() if cid not in prov and cid not in decl}
+
+    for cid in sorted(refs):
+        how = "ensure_client" if cid in prov else ("realm.json" if cid in decl else "NOTHING")
+        mark = "ok  " if cid not in missing else "FAIL"
+        print(f"  {mark} {cid:<16} referenced by {', '.join(sorted(set(refs[cid])))}  ->  provisioned by {how}")
+
+    print(f"\n{len(refs)} referenced client(s); {len(prov)} provisioned by keycloak.sh; {len(decl)} declared in the realm JSON.")
+
+    if missing:
+        print("\nFAIL — referenced but created by nothing on the deploy path:", file=sys.stderr)
+        for cid, where in sorted(missing.items()):
+            print(f"  {cid}  (referenced by {', '.join(sorted(set(where)))})", file=sys.stderr)
+        print("\nAdd an ensure_client call in scripts/keycloak.sh. Declaring it in\n"
+              "platform-realm.json alone is NOT enough: start --import-realm is\n"
+              "IGNORE_EXISTING, so that file is inert against a realm that already exists.",
+              file=sys.stderr)
+        return 1
+
+    print("PASS — every referenced OIDC client is created on the deploy path.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## The reported defect does not hold

**Reported:** `platform-realm.json` declares only three clients, so because
`start --import-realm` is IGNORE_EXISTING a VPS rebuild yields a realm without `grafana`
and `portainer`, breaking both SSO integrations silently.

**Verified.** Two halves are true; the conclusion is not.

| | |
|---|---|
| ✅ **True** | the realm JSON declares exactly `hill90-vault`, `hill90-ui`, `hill90-api` |
| ✅ **True, and larger than reported** | the live realm also holds `grafana`, `portainer` **and `minio`** — three confidential clients with secrets, not two. Read from Keycloak's own database on the VPS, read-only |
| ❌ **False** | that a rebuild leaves them missing |

**`scripts/keycloak.sh` already has the idempotent reconcile this asked for.** `cmd_apply`
resolves `GRAFANA_`/`PORTAINER_`/`MINIO_`/`VAULT_OIDC_CLIENT_SECRET` from SOPS — refusing
to proceed if any is unresolvable — then calls `ensure_client` for `grafana`, `portainer`,
`hill90-vault` and `minio`. `ensure_client` creates when absent, updates when present, and
**refuses outright to write an empty secret** (`keycloak.sh:301`).

**And it is on the rebuild path.** `scripts/deploy.sh:558` runs `keycloak.sh apply` after
the auth deploy, and `disaster-recovery.md` rebuilds with `deploy.sh all prod`, which
reaches it.

So I have **not** added a second reconcile path, and **not** added the three clients to the
realm JSON — both would be duplicate mechanisms for a closed gap, and putting confidential
clients in that file means either secret placeholders in git or clients created without
secrets.

### One asymmetry that looks like the defect and is not

`ensure_client` **does** write the secret on update, while `cmd_tenant_clients`
deliberately does not. That is correct and documented: the store holds the platform
clients' secrets and the services read the same values, so the write is *convergent*.
Production's `hill90-ui` secret, by contrast, is live while `HILL90_UI_CLIENT_SECRET` has
no production value — writing that one would break login.

## What is genuinely missing — and all this ships

Nothing asserts that the clients the repo **references** match the clients something on the
deploy path **creates**. Add a fifth OIDC integration to a compose file without a matching
`ensure_client`, and the trap becomes real: the compose file is valid, the deploy succeeds,
and SSO for that service fails only on a rebuilt host.

`scripts/checks/check_oidc_clients_reconciled.py` parses **both sides** rather than
hardcoding either — a hardcoded expectation keeps passing after a rename, which is the
failure it exists to catch.

```
  ok   grafana        referenced by docker-compose.observability.yml  ->  ensure_client
  ok   hill90-vault   referenced by scripts/vault.sh                  ->  ensure_client
  ok   minio          referenced by docker-compose.minio.yml          ->  ensure_client
  ok   portainer      referenced by scripts/portainer.sh              ->  ensure_client
PASS — every referenced OIDC client is created on the deploy path.
```

## Positive-controlled three ways

| Control | Result |
|---|---|
| `grafana`'s `ensure_client` removed from the input | **FAIL**, exit 1, names grafana *and* the referencing compose file |
| zero references parsed | **FAIL**, exit 1 — refuses to pass vacuously |
| unmodified repo | **PASS**, 4 referenced, all provisioned |

**My first control was itself an instance of the rule now in `CONTRIBUTING.md`.** I built
the doctored input with `sed` using `\s`, which BSD sed does not support — so the "modified"
file was byte-identical to the original and the check passed. That read as *"the check is
broken"*; it was a blind control. Rebuilt in Python, it went red immediately.

## Verification

Wired into `ci.yml` beside the other checks. `ci.yml` parses; `check_md_links` passes;
the check passes on unmodified `main`. Read-only against production throughout; nothing
deployed.

*(Companion: #633 corrects the CLAUDE.md contradiction, which **was** real.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)