### PR TITLE
feat(keycloak): codify Stage 1 — platform-admin/platform-viewer and jon's admin-console grants

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -198,6 +198,7 @@ appeared **six times in one day wearing six different coats**:
 | the tenancy contract: *"`cadvisor` scrapes all containers"* | cAdvisor emits **zero Docker container series** here — 45 cgroup and systemd series, `count(container_memory_usage_bytes{name!=""})` = 0. A documented guarantee resting on a blind instrument. |
 | `amtool check-config`: **SUCCESS** | Every notification then failed at *render* time — `default` is not an Alertmanager template function. A **green verdict** from an instrument that could not see the failure. |
 | an exact-match sweep for `blackbox` → *"container missing"* | The container is named `blackbox-exporter`. It was running the whole time. |
+| decoding a token from `admin-cli`: no `sub`, no `realm_access` → *"the user has no roles"* | **`admin-cli` issues a LIGHTWEIGHT access token.** The token is valid — it returned `200` from every admin endpoint — because Keycloak resolves permissions server-side from the session, not from claims. Fine for probing permissions; blind for inspecting claims. Use an authorization-code flow through a real client. |
 
 Three more from the tenant the same week: `ls -l` hiding a dotfile read as *"the file is
 absent"*; a `grep` for a compose warning whose quotes were backslash-escaped read as

--- a/docs/decisions/stage1-platform-roles.md
+++ b/docs/decisions/stage1-platform-roles.md
@@ -1,0 +1,203 @@
+# Stage 1 — distinct platform realm roles, and jon's admin-console grants
+
+Option B, per Jon's decision. Evidence base: [`sso-claim-measurement-2026-08-01.md`](sso-claim-measurement-2026-08-01.md) (#635) — not re-derived here.
+
+`Applied to production 2026-08-01. Codified afterwards — see "Ordering" below.`
+
+## Ordering: production changed before the repository did
+
+**This PR does not describe work it is about to do. It describes work already live.**
+
+Stage 1 was executed against production Keycloak and proven with a real token; the session
+then ended on an API error before the change was written back to the repository. Jon
+independently verified the live state read-only from the Keycloak database. So for a period,
+production held realm roles and grants the repository knew nothing about — **the exact drift
+this estate keeps getting bitten by**, and closing it was the first job on resuming.
+
+Recording this rather than presenting the PR as if it came first, because the ordering is
+the thing a future reader needs to know: if this file and the realm disagree, the realm was
+here first.
+
+## What is live, and what now reproduces it
+
+| Object | Live | Reproduced by |
+|---|---|---|
+| realm role `platform-admin` | yes | `REALM_ROLES` in `scripts/keycloak.sh` **and** `platform-realm.json` |
+| realm role `platform-viewer` | yes | same |
+| `jon` → `platform-admin` | yes | `ensure_platform_admins()`, called from `cmd_apply` |
+| `jon` → `realm-management`: `manage-users`, `view-clients`, `view-realm` | yes | same |
+| old roles `admin`, `user`, `editor`, `viewer` | **untouched** | unchanged — deliberately not deleted |
+
+Both halves are additive. Nothing was repointed; every consumer still binds exactly what it
+bound before.
+
+## The narrow set: measured, not assumed
+
+Jon asked for the narrowest set that actually works rather than `realm-admin`. Measured
+against the live admin API on 2026-08-01, as `jon`, with invalid payloads so that nothing
+was created — `403` means denied, `400` means permitted-but-rejected:
+
+**Permitted**
+
+```
+GET  /admin/realms/platform                      200
+GET  /admin/realms/platform/users                200
+GET  /admin/realms/platform/clients              200
+GET  /admin/realms/platform/roles                200
+GET  /admin/realms/platform/groups               200
+GET  .../users/{id}/role-mappings                200
+GET  .../users/{id}/role-mappings/realm/available 200
+POST /admin/realms/platform/users                400   (permitted, payload rejected)
+POST /admin/realms/platform/groups               400   (permitted, payload rejected)
+```
+
+**Denied — say this plainly, because it is what Jon cannot do**
+
+```
+POST /admin/realms/platform/roles                403   cannot create realm roles
+POST /admin/realms/platform/clients              403   cannot create or manage clients
+PUT  /admin/realms/platform                      403   cannot change realm settings
+GET  /admin/realms/platform/identity-provider/instances 403
+GET  /admin/realms/platform/events               403   cannot view login events
+```
+
+So `manage-users` + `view-clients` + `view-realm` lets Jon **administer people**: create
+users, assign and remove their realm and client roles — which is what granting somebody
+`platform-admin` requires. It does not let him change the shape of the realm.
+
+**The one gap worth flagging:** he cannot view login events. CLAUDE.md records that event
+storage is on and "did this user log in, and when" is answerable from the host — but not by
+Jon in the console, without `view-events`. **Widening is a decision, not an oversight**, so
+it is recorded rather than taken.
+
+## Reproducibility on a rebuild — tested, and half of it is a no-op
+
+The concern is the #634 class: a grant that exists only because a command was run once.
+
+**Roles: reproduce.** `platform-realm.json` was imported into a throwaway Keycloak 26.4.0:
+
+```
+Realm 'platform' imported / Import finished successfully
+roles: [admin, default-roles-platform, offline_access, platform-admin,
+        platform-viewer, uma_authorization, user]
+platform-admin present on a from-nothing realm: True
+platform-viewer present on a from-nothing realm: True
+```
+
+**Grants: cannot, and the code says so out loud.** The realm import ships **zero users** by
+design, so on a rebuilt realm there is no `jon` to grant to:
+
+```
+users on a fresh realm: NONE
+```
+
+`ensure_platform_admins()` therefore **warns and continues** rather than failing or
+skipping silently — a silent skip would be the same trap in a new costume. The honest
+statement is: *the roles survive a rebuild; the grants do not, and the rebuild path must
+recreate the accounts and re-run `keycloak.sh apply`.* That is a known gap in the realm
+import, already recorded in CLAUDE.md as "a directory rebuild locks everyone out".
+
+**Idempotency verified against production** — re-running every grant left the role set
+byte-identical:
+
+```
+before: [default-roles-platform, offline_access, platform-admin, uma_authorization]
+after : [default-roles-platform, offline_access, platform-admin, uma_authorization]
+IDEMPOTENT: role set unchanged
+realm-management: [manage-users, view-clients, view-realm]
+```
+
+## Proof that jon carries platform-admin
+
+Real tokens, authorization-code flow, the method #635 used:
+
+```
+hill90-vault  user=jon
+  realm_access.roles : [default-roles-platform, offline_access, platform-admin, uma_authorization]
+  realm_roles        : [default-roles-platform, offline_access, platform-admin, uma_authorization]
+
+minio         user=jon
+  realm_access.roles : [default-roles-platform, offline_access, platform-admin, uma_authorization]
+  minio_policy       : [default-roles-platform, offline_access, platform-admin, uma_authorization]
+```
+
+`platform-admin` is carried in all three claim shapes the consumers read.
+
+## An instrument trap found on the way
+
+**`admin-cli` issues a lightweight access token. It is useless for claim inspection.**
+
+Getting a token for `jon` from `admin-cli` and decoding it produced:
+
+```
+payload keys: [azp, exp, iat, iss, jti, scope, sid, typ]
+preferred_username : None
+realm_access.roles : []
+```
+
+No `sub`, no `preferred_username`, no `realm_access`. **The token is valid** — the same
+token returned `200` from every admin endpoint — because Keycloak resolves permissions
+server-side from the session rather than from claims in the token.
+
+So: `admin-cli` is fine for **probing permissions** and blind for **inspecting claims**.
+Decoding one and finding no roles is *blindness, not absence* — see `CONTRIBUTING.md`,
+*Verify the Instrument Before You Believe the Verdict*. Use an authorization-code flow
+through a real client when the question is "what does this token carry".
+
+## Rollback
+
+### Stage 1 (this change)
+
+Purely additive; nothing is repointed, so **no consumer behaviour changes and there is
+nothing to roll back for correctness**. To reverse anyway:
+
+```bash
+kcadm delete-roles -r platform --uusername jon --rolename platform-admin
+kcadm delete-roles -r platform --uusername jon --cclientid realm-management --rolename manage-users
+kcadm delete-roles -r platform --uusername jon --cclientid realm-management --rolename view-clients
+kcadm delete-roles -r platform --uusername jon --cclientid realm-management --rolename view-realm
+kcadm delete roles/platform-admin  -r platform
+kcadm delete roles/platform-viewer -r platform
+```
+
+Then revert this PR. **Risk: none to access** — Jon's route into Keycloak is the `master`
+realm admin account, which this does not touch.
+
+### Stage 2a — Grafana
+
+Change: `GF_AUTH_GENERIC_OAUTH_ROLE_ATTRIBUTE_PATH`, `admin` → `platform-admin`.
+Rollback: revert the compose line and redeploy observability through the pipeline.
+**Fallback if it goes wrong:** the Grafana local admin login — `GF_AUTH_DISABLE_LOGIN_FORM=false`,
+`GF_AUTH_GENERIC_OAUTH_AUTO_LOGIN=false`, **verified working 2026-08-01** (`POST /login` →
+`200 {"message":"Logged in"}`, and that account is org `Admin`). Worst case is Jon logs in
+locally and sets the role by hand.
+
+### Stage 2b — OpenBao
+
+Change: `bound_claims` `{"realm_roles":["admin"]}` → `{"realm_roles":["platform-admin"]}`,
+written at runtime with `bao write auth/oidc/role/admin-sso`.
+Rollback: write the previous value back — the old role still exists, so the old binding is
+restorable exactly.
+**Fallback: NOT EXERCISED, and this is the weakest link.** `VAULT_SYNC_TOKEN` in the store
+**did not validate**, so there is no confirmed non-OIDC token today. The remaining route is
+the unseal key → `bao operator generate-root`; its inputs are verified present (encrypted
+store **and** `/opt/hill90/secrets/openbao-unseal.key`, `0600`), but exercising it mints a
+root credential, which is a change and a security event, so it was not tested.
+**Do not start Stage 2b without deciding whether that is acceptable.**
+
+### Stage 3 — MinIO
+
+Not designed yet. The claim is populated and wrong rather than absent, so a rename is not
+obviously the fix.
+**Fallback:** MinIO's root credentials (`MINIO_ROOT_USER` / `MINIO_ROOT_PASSWORD`) are in
+the store and are independent of OIDC.
+
+## Out of scope, recorded not answered
+
+- **Portainer** — CE cannot map claims to admin rights at any value (#635). Needs a manual
+  Administrator promotion, written into a runbook, not automated.
+- **LiteLLM** — no client, no OIDC configuration; it is `app-litellm` in hill90-app and
+  authenticates by master key. Whether it should have SSO at all is a tenant question.
+- **The zero-holder roles** `admin`, `user`, `editor`, `viewer` are **deliberately not
+  deleted**. They become safe to remove only once every consumer is repointed and proven,
+  which is a separate PR.

--- a/platform/auth/keycloak/platform-realm.json
+++ b/platform/auth/keycloak/platform-realm.json
@@ -34,6 +34,18 @@
       },
       {
         "name": "admin"
+      },
+      {
+        "name": "platform-admin",
+        "description": "Platform administrator (option B, 2026-08-01)",
+        "composite": false,
+        "clientRole": false
+      },
+      {
+        "name": "platform-viewer",
+        "description": "Platform read-only (option B, 2026-08-01)",
+        "composite": false,
+        "clientRole": false
       }
     ],
     "client": {

--- a/scripts/keycloak.sh
+++ b/scripts/keycloak.sh
@@ -35,7 +35,20 @@ VAULT_PUBLIC_URL="${VAULT_PUBLIC_URL:-https://vault.hill90.com}"
 MINIO_PUBLIC_URL="${MINIO_PUBLIC_URL:-https://storage.hill90.com}"
 
 # Realm roles mapped onto each service's own role model.
-REALM_ROLES="admin editor viewer"
+# platform-admin / platform-viewer are the option-B roles (2026-08-01). They are
+# ADDITIVE: admin, user, editor and viewer stay until every consumer is repointed
+# and proven, which is a separate change. Removing a role a consumer still binds
+# on would break that consumer silently — the binding simply stops matching.
+REALM_ROLES="admin editor viewer platform-admin platform-viewer"
+
+# Humans who administer the platform. Granted platform-admin plus the NARROWEST
+# realm-management set that was measured to work — see ensure_platform_admins.
+#
+# This exists because a role granted by hand is lost the next time the realm is
+# rebuilt from nothing, and nothing would say so. That is the same class as the
+# OIDC-client trap #634 guards: the deploy succeeds, the object is absent, and the
+# failure only appears later.
+PLATFORM_ADMIN_USERS="${PLATFORM_ADMIN_USERS:-jon}"
 
 usage() {
     cat <<EOF
@@ -227,6 +240,51 @@ ensure_realm_roles() {
     done
 }
 
+# Grant the platform administrators their roles, idempotently.
+#
+# THE NARROW SET IS NARROW ON PURPOSE, AND IT WAS MEASURED, NOT ASSUMED.
+# realm-admin would work and grants everything. These three were tested against
+# the live admin API on 2026-08-01 and are what actually lets a human administer
+# users and their role assignments:
+#
+#   manage-users   create/edit users, assign and remove their role mappings
+#   view-clients   see clients, which is required to assign CLIENT roles
+#   view-realm     load the realm in the console at all
+#
+# What they deliberately do NOT permit, measured the same way (403 on each):
+# creating realm roles, creating or managing clients, changing realm settings,
+# viewing identity providers, and viewing login events. Widening is a decision,
+# not an oversight — see docs/decisions/stage1-platform-roles.md.
+#
+# ON A FRESH REALM THIS IS A NO-OP, AND IT SAYS SO LOUDLY. platform-realm.json
+# ships ZERO users by design, so after a rebuild there is no `jon` to grant to.
+# The roles are created by ensure_realm_roles regardless; the GRANT waits for the
+# user to exist. A silent skip here would be exactly the drift this function is
+# meant to close, so it warns.
+ensure_platform_admins() {
+    echo "Platform administrators..."
+    local user uuid missing=0
+    for user in $PLATFORM_ADMIN_USERS; do
+        uuid=$(kc get users -r "$KC_REALM" -q "username=${user}" --fields id --format csv --noquotes 2>/dev/null | tr -d '\r' | head -1)
+        if [ -z "$uuid" ]; then
+            warn "  ! ${user} does not exist in realm '${KC_REALM}' — cannot grant. Create the user, then re-run: bash scripts/keycloak.sh apply"
+            missing=$((missing + 1))
+            continue
+        fi
+        # add-roles is idempotent in kcadm: re-adding an existing mapping is a no-op.
+        kc add-roles -r "$KC_REALM" --uusername "$user" --rolename platform-admin >/dev/null 2>&1 \
+            && echo "  = ${user}: platform-admin" \
+            || warn "  ! ${user}: could not grant platform-admin"
+        local rmrole
+        for rmrole in manage-users view-clients view-realm; do
+            kc add-roles -r "$KC_REALM" --uusername "$user" --cclientid realm-management --rolename "$rmrole" >/dev/null 2>&1 \
+                && echo "  = ${user}: realm-management:${rmrole}" \
+                || warn "  ! ${user}: could not grant realm-management:${rmrole}"
+        done
+    done
+    [ "$missing" -eq 0 ] || warn "  ${missing} administrator(s) not present. On a rebuilt realm this is expected until the accounts are recreated — the realm import ships no users."
+}
+
 # ---------------------------------------------------------------------------
 # Clients
 #
@@ -361,6 +419,7 @@ cmd_apply() {
         || die "Cannot resolve MINIO_OIDC_CLIENT_SECRET — refusing to reconfigure any client"
 
     ensure_realm_roles
+    ensure_platform_admins
 
     echo ""
     echo "Event logging..."
@@ -424,7 +483,7 @@ cmd_apply() {
     echo ""
     echo "  Grant a user access by assigning a realm role:"
     echo "    docker exec ${KC_CONTAINER} /opt/keycloak/bin/kcadm.sh add-roles \\"
-    echo "      -r ${KC_REALM} --uusername <user> --rolename admin"
+    echo "      -r ${KC_REALM} --uusername <user> --rolename platform-admin"
     echo ""
     echo "  Every service keeps its local admin login. If Keycloak is down, see"
     echo "  docs/runbooks/sso-fallback.md."


### PR DESCRIPTION
> ⚠ **This PR is the repository catching up with production, not leading it.**
>
> Stage 1 was executed against production Keycloak and proven with a real token; the session
> then died on an API error before writing it back. Jon verified the live state
> independently, read-only. So production held roles and grants the repository knew nothing
> about — **the drift this estate keeps getting bitten by** — and closing that was the first
> job on resuming. Recorded here rather than presented as though the PR came first.

## What is live, and what now reproduces it

| Object | Live | Reproduced by |
|---|---|---|
| realm role `platform-admin` | ✅ | `REALM_ROLES` **and** `platform-realm.json` |
| realm role `platform-viewer` | ✅ | same |
| `jon` → `platform-admin` | ✅ | `ensure_platform_admins()`, called from `cmd_apply` |
| `jon` → `realm-management`: `manage-users`, `view-clients`, `view-realm` | ✅ | same |
| `admin`, `user`, `editor`, `viewer` | untouched | **deliberately not deleted** |

Purely additive. Nothing repointed; every consumer still binds what it bound before.

## The narrow set — measured, and its limits stated

Against the live admin API **as jon**, with invalid payloads so nothing was created
(`403` = denied, `400` = permitted-but-rejected):

**Permitted:** read realm/users/clients/roles/groups; create and edit users; read and assign
role-mappings (`POST /users` → `400`).

**Denied — what Jon still cannot do:**

```
POST /admin/realms/platform/roles     403   cannot create realm roles
POST /admin/realms/platform/clients   403   cannot create or manage clients
PUT  /admin/realms/platform           403   cannot change realm settings
GET  .../identity-provider/instances  403
GET  /admin/realms/platform/events    403   cannot view login events
```

So the set lets him **administer people** — which is exactly what granting somebody
`platform-admin` requires — and not reshape the realm. **One gap flagged, not closed:** he
cannot view login events without `view-events`. Widening is a decision, so it is recorded.

## Reproducibility — tested, and half of it is honestly a no-op

**Roles reproduce.** `platform-realm.json` imported into a throwaway Keycloak 26.4.0:

```
Realm 'platform' imported / Import finished successfully
platform-admin  present on a from-nothing realm: True
platform-viewer present on a from-nothing realm: True
```

**Grants cannot.** The import ships **zero users**, so there is no `jon` to grant to:

```
users on a fresh realm: NONE
```

`ensure_platform_admins()` therefore **warns loudly and continues** — a silent skip would be
the #634 trap in a new costume. Honest statement: *roles survive a rebuild, grants do not,
and the rebuild path must recreate the accounts and re-run `keycloak.sh apply`.*

**Idempotency verified against production** — re-running every grant left the role set
byte-identical.

## Proof jon carries platform-admin

Real tokens, authorization-code flow, the method #635 used:

```
hill90-vault   realm_access.roles : [..., platform-admin, ...]
               realm_roles        : [..., platform-admin, ...]
minio          minio_policy       : [..., platform-admin, ...]
```

Carried in all three claim shapes the consumers read.

## Rollback + fallbacks (the safety gate)

Full per-stage rollback is in the decision record. Fallback status:

| Service | Local-admin fallback | Status |
|---|---|---|
| Grafana | login form, auto-login off | ✅ **verified** — `POST /login` → `200`, account is org `Admin` |
| Portainer | local admin | ✅ **verified** via `portainer.sh status` |
| OpenBao | unseal key → `generate-root` | ⚠️ **NOT exercised** — `VAULT_SYNC_TOKEN` did not validate; inputs present but exercising mints a root credential |

**Stage 2b (OpenBao) should not start until Jon decides whether that is acceptable.**
Stage 1 itself needs no rollback for correctness — it is additive, and Jon's route into
Keycloak is the `master` realm admin, untouched.

## Instrument trap, recorded durably

**`admin-cli` issues a lightweight access token** — no `sub`, no `preferred_username`, no
`realm_access` — while remaining a valid bearer that returns `200` from every admin
endpoint, because Keycloak resolves permissions server-side. Decoding one and finding no
roles is **blindness, not absence**. Added to `CONTRIBUTING.md`'s instrument table.

*(And once more on the way: I verified that edit with a case-sensitive `grep` for
"lightweight" against text I had written in caps, got `0`, and nearly reported the edit as
missing. Same rule, same day.)*

## Next

Stage 2a (Grafana) follows separately, one consumer at a time. Not merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)