### PR TITLE
feat(grafana): repoint role_attribute_path from the zero-holder admin role to platform-admin

### DIFF
--- a/deploy/compose/prod/docker-compose.observability.yml
+++ b/deploy/compose/prod/docker-compose.observability.yml
@@ -199,7 +199,14 @@ services:
       - GF_AUTH_GENERIC_OAUTH_API_URL=${KC_PUBLIC_URL:-https://auth.hill90.com}/realms/${KC_REALM:-platform}/protocol/openid-connect/userinfo
       # Realm role -> Grafana role. Grafana evaluates against the ID token first
       # and falls back to userinfo; keycloak.sh puts realm_access.roles in both.
-      - GF_AUTH_GENERIC_OAUTH_ROLE_ATTRIBUTE_PATH=contains(realm_access.roles[*], 'admin') && 'Admin' || contains(realm_access.roles[*], 'editor') && 'Editor' || 'Viewer'
+      # STAGE 2a (2026-08-01): 'admin' -> 'platform-admin'. The realm role `admin`
+      # has ZERO holders (#635), so this expression fell through to 'Viewer' for
+      # every SSO user — Grafana authenticated them and then authorised nobody.
+      #
+      # The 'editor' term is deliberately UNCHANGED. It names another zero-holder
+      # role, and repointing it is part of removing the old roles, which is a
+      # separate change once every consumer is proven.
+      - GF_AUTH_GENERIC_OAUTH_ROLE_ATTRIBUTE_PATH=contains(realm_access.roles[*], 'platform-admin') && 'Admin' || contains(realm_access.roles[*], 'editor') && 'Editor' || 'Viewer'
       # Realm roles map to Grafana ORGANISATION roles only. Server-admin rights
       # stay with the local `admin` account, so no SSO identity can ever be more
       # powerful than the fallback login. (Users with no mapped role fall through


### PR DESCRIPTION
Stage 2a. One consumer; no other consumer touched.

## The change

`GF_AUTH_GENERIC_OAUTH_ROLE_ATTRIBUTE_PATH` matches **`platform-admin`** instead of
`admin`. The realm role `admin` has **zero holders** (#635), so the expression fell through
to the literal `'Viewer'` for every SSO user — Grafana authenticated them and authorised
nobody. That is why *"Grafana appears to work"* while Jon could see nothing.

The `'editor'` term is **deliberately unchanged** — it names another zero-holder role, and
repointing it belongs with removing the old roles, which is a separate change.

## Evidence I have

Against a **real token for jon**, authorization-code through `hill90-vault`:

```
jon realm_access.roles : [default-roles-platform, offline_access,
                          platform-admin, uma_authorization]

role_attribute_path BEFORE (contains … 'admin')          -> 'Viewer'
role_attribute_path AFTER  (contains … 'platform-admin') -> 'Admin'
```

Grafana's own API corroborates the BEFORE half independently — it reports
`jon@hill90.com  role=Viewer` today.

## ⚠ Evidence I do not have, and will not manufacture

You asked for confirmation **"by actually logging in"**. Grafana reads
`role_attribute_path` from its environment at startup, so that proof requires the change to
be **running**. That requires a deploy; deploys go through the pipeline; the pipeline
deploys `origin/main`; and the PRs are not to be merged.

**Those constraints cannot all hold simultaneously for this stage.** I am not merging, not
deploying from a branch, and not passing a JMESPath evaluation off as a login.

**Stopping here** rather than proceeding to Stage 2b or Stage 3, as instructed.

### To unblock, pick one

1. **Merge this PR, then run the observability deploy** through the pipeline. I complete the
   login proof and check the 16/0 baseline immediately after.
2. **Authorise a one-off pipeline deploy from this branch**, if `deploy.yml` can take a ref
   — proof first, merge after.
3. **Accept the token-level evidence** for Grafana and treat the login as a post-merge
   verification step.

I would take (1): the change is one environment variable, the rollback is reverting one line
and redeploying, and **Grafana's local-admin fallback is verified working** — `POST /login`
→ `200`, and that account is org `Admin`, so Jon cannot be locked out of Grafana by this.

## Stage 2b is separately gated

Independently of the above, **OpenBao should not start until you decide about its
fallback.** `VAULT_SYNC_TOKEN` did not validate, so the only route back in is the unseal key
→ `generate-root`, which I did not exercise because it mints a root credential. Detail in
#636's decision record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)