### PR TITLE
docs(secrets): say why AUTH_KEYCLOAK_SECRET is absent, so the gap reads as a decision

### DIFF
--- a/docs/reference/secrets.md
+++ b/docs/reference/secrets.md
@@ -123,6 +123,41 @@ API key for Hostinger VPS management, used by `scripts/vps.sh` and the
 Cloudflare API token used by Traefik/lego for the ACME DNS-01 challenge. Scoped
 to the `hill90.com` zone with Zone/Zone/Read and Zone/DNS/Edit. Not a Global API Key.
 
+### The tenant's OIDC client secret — why `AUTH_KEYCLOAK_SECRET` is not here
+
+**If you are looking for a Keycloak client secret in this store and cannot find
+one, that is the correct outcome. Do not add one.**
+
+Two different names describe the same credential — the secret for client
+`hill90-ui` in realm `platform` — and only one of them belongs in this
+repository:
+
+| Name | Whose | Where it lives |
+|---|---|---|
+| `HILL90_UI_CLIENT_SECRET` | the platform's | this store, declared in `platform/vault/secrets-schema.yaml` |
+| `AUTH_KEYCLOAK_SECRET` | the **tenant's** | hill90-app's store, never this one |
+
+`AUTH_KEYCLOAK_SECRET` is the name hill90-app uses for its copy, because that is
+what NextAuth expects. A value under that name in *this* store opens nothing: the
+platform reads `HILL90_UI_CLIENT_SECRET`, and nothing here consumes the other
+name. One did exist and was removed in #596 — it was 32 characters against a live
+64-character secret, so anyone who found it and used it would have got
+`unauthorized_client` with nothing explaining why.
+
+**`HILL90_UI_CLIENT_SECRET` itself is declared but currently has no production
+value**, which is deliberate rather than an oversight. `scripts/keycloak.sh
+tenant-clients` never rewrites an existing client's secret, so production is
+unaffected — the live client already exists and its secret is correct. The case
+that depends on this key is a **VPS rebuild**, where the realm is imported for the
+first time, and then it must equal the value hill90-app holds.
+`check_env_surface.py` deliberately allows it no default: a fallback would import
+a *known* secret for the client fronting hill90.com and say nothing.
+
+Ownership is argued in
+[tenant-credential-ownership.md](../decisions/tenant-credential-ownership.md):
+the object lives in the platform's realm, so the platform is authoritative and the
+tenant holds the replica — not the other way around.
+
 ## Best Practices
 
 **RECOMMENDED approaches:**


### PR DESCRIPTION
**Nothing was deleted, because there was nothing to delete.** The care was all in the proof, and the proof came back differently than expected.

## `AUTH_KEYCLOAK_SECRET` is not in the store

```
decrypted prod.enc.env       76 key names
AUTH_KEYCLOAK_SECRET         NOT present
matches in the ciphertext    0     (sops leaves dotenv key names readable)
matches in prod.tmp.enc.env  0
```

**It was already removed** — `87b9f890` *"chore(secrets): drop the stale AUTH_KEYCLOAK_SECRET, which matched nothing"* (#596), merged 2026-07-30 21:59, and an ancestor of `main`. Its key-name delta was **exactly one key**:

```
-AUTH_KEYCLOAK_SECRET
-sops_lastmodified          <- metadata any re-encrypt rewrites
-sops_mac
+sops_lastmodified
+sops_mac
```

So the one-key-only diff this brief asked for had already been done, by that PR.

I ran the before/after key-name comparison anyway — **identical at 76 keys both sides** — which is the honest way to state that this branch does not touch the store. **No secret value was read or printed at any point.**

## Unconsumed, confirmed independently

| Checked | Result |
|---|---|
| repo-wide grep (scripts, compose, workflows, docs) | 3 hits, all prose describing the **tenant's** copy |
| `platform/vault/secrets-schema.yaml` | does not declare it |
| `check_secrets_schema.py` | passes |
| `check_env_surface.py` | passes — 41 variables, all documented |

## What was actually missing: the explanation

The absence still read as an omission — which is precisely how a stale value gets helpfully re-added by the next person. This PR adds a short section to `docs/reference/secrets.md` saying why the gap is deliberate.

## One correction to the brief

Writing the note as asked would have contradicted this repo's own decision record. *"The tenant client secret lives in the tenant store and deliberately not here"* is **not** what [`tenant-credential-ownership.md`](docs/decisions/tenant-credential-ownership.md) says: the object is a client in the **platform's** realm, so the platform is authoritative and the tenant holds the replica — not the reverse.

What is true is narrower:

| Name | Whose | Where it belongs |
|---|---|---|
| `HILL90_UI_CLIENT_SECRET` | the platform's | this store |
| `AUTH_KEYCLOAK_SECRET` | the **tenant's** | hill90-app's store, never here |

And separately — `HILL90_UI_CLIENT_SECRET` currently has **no production value**, which is also deliberate: `keycloak.sh tenant-clients` never rewrites an existing client's secret, so the live client is unaffected, and only a **VPS rebuild** (a first realm import) depends on it. `check_env_surface.py` allows it no default on purpose, because a fallback would import a *known* secret for the client fronting hill90.com and say nothing.

## Scope

Documentation only. The encrypted store is byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
