### PR TITLE
docs(portainer): a symptom-first runbook for the SSO promotion

### DIFF
--- a/docs/runbooks/portainer-sso-admin.md
+++ b/docs/runbooks/portainer-sso-admin.md
@@ -1,0 +1,105 @@
+# Portainer: SSO works, but the user sees nothing
+
+**Symptom.** You sign in to `portainer.hill90.com` with Keycloak, it accepts you,
+and then there are no environments — no local Docker endpoint, nothing to click.
+
+**This is a licensing limitation, not a misconfiguration.** Nothing in Keycloak
+will fix it. Do not spend an evening on realm roles, group mappers or client
+scopes: Portainer Community Edition cannot read them.
+
+`Portainer version verified live 2026-08-01: 2.39.5` — see [Which version this is for](#which-version-this-is-for).
+
+---
+
+## Why
+
+Portainer keeps authentication in its own database and grants authorization from
+its own user records. Two Portainer features would connect an SSO claim to
+permissions, and **both are Business Edition**:
+
+- claim/group → team mapping
+- automatic administrator rights
+
+Recorded at [`scripts/portainer.sh:12`](../../scripts/portainer.sh), and visible in
+the applied settings as `"DefaultTeamID": 0` — no team, so no team-derived access.
+
+So Community Edition does exactly what it supports: it **authenticates** the user
+and auto-creates an account, then grants that account nothing. Login succeeds,
+authorization is empty, and the UI is bare. Confirmed by measurement in
+[sso-claim-measurement-2026-08-01.md](../decisions/sso-claim-measurement-2026-08-01.md):
+`jon`'s token carries `realm_access.roles` populated, and Portainer CE cannot
+consume it.
+
+## The fix: promote once, per person
+
+Sign in as the **local admin** — not through SSO — at
+`https://portainer.hill90.com`, then:
+
+> **Users** → *the user* → set **Role** to **Administrator** → **Update user**
+
+The local login form is deliberately never hidden. `portainer.sh` leaves
+`SSO=false` in Portainer's OAuth settings precisely so Keycloak can never become
+the only way in, which is also what makes this promotion always possible. If you
+need the local admin password, it is `PORTAINER_ADMIN_PASSWORD` in the SOPS store —
+[secrets-workflow.md](secrets-workflow.md).
+
+Equivalently through the API, if you would rather not click:
+
+```
+PUT /api/users/:id     {"Role": 1}      # 1 = administrator, 2 = standard
+```
+
+## What this costs, ongoing
+
+**Every new SSO user needs this done again.** There is no group, no default team
+and no claim that will do it for them — that is the whole point of the
+limitation. Adding a person is therefore two steps, not one:
+
+1. give them the realm role in Keycloak, as for every other service
+2. sign in to Portainer as the local admin and promote them
+
+Step 2 is invisible from Keycloak, so it is the one that gets forgotten. The
+symptom when it is forgotten is exactly the one at the top of this page, which is
+why it reads as a broken login rather than a missing step.
+
+## The first SSO user is not a special case
+
+Portainer makes the **first account on a fresh instance** an administrator. That
+shortcut is not available here, and deliberately so: `portainer.sh init` creates
+the local admin before OAuth is ever configured, so by the time anyone signs in
+with Keycloak an administrator already exists. Every SSO user, including the
+first, arrives as a standard user and needs promoting.
+
+`portainer.sh apply` prints an abbreviated version of this at the end of a run —
+but only someone running the script sees it, which is why it is written down here.
+
+## Which version this is for
+
+The compose file pins `portainer/portainer-ce:latest`
+([`docker-compose.infra.yml:91`](../../deploy/compose/prod/docker-compose.infra.yml)),
+so the running version moves on its own and the UI has changed between releases.
+Check before trusting the click path:
+
+```bash
+docker run --rm --network container:portainer curlimages/curl:latest \
+  -s http://localhost:9000/api/status
+```
+
+Returned `{"Version":"2.39.5", ...}` on 2026-08-01 — the same version the
+promotion path was originally verified against.
+
+**Precisely what is and is not verified**, because a pinned `latest` makes this
+worth stating: the **version** was confirmed live today through that
+unauthenticated endpoint. The **click path** is carried from the earlier
+verification against this same 2.39.5 instance and was not re-walked in the UI
+for this page — doing so needs an authenticated session, and this work was
+read-only by constraint. If the version above no longer matches what
+`/api/status` reports, treat the navigation as unverified and confirm it before
+following it.
+
+## Related
+
+- [sso-fallback.md](sso-fallback.md) — getting in when Keycloak itself is down,
+  and how the other integrations grant access
+- [sso-claim-measurement-2026-08-01.md](../decisions/sso-claim-measurement-2026-08-01.md)
+  — what each integration authorizes on, measured against real tokens

--- a/docs/runbooks/sso-fallback.md
+++ b/docs/runbooks/sso-fallback.md
@@ -99,16 +99,13 @@ more powerful than any SSO identity. Verified against a real token — the realm
 both the ID token and the userinfo response as `realm_access.roles`.
 
 **Portainer Community Edition cannot do this.** Claim-to-team mapping and
-automatic admin rights are Business Edition features. An SSO user is created
-automatically but arrives as a **standard user**, and someone has to promote them
-once, signed in as the local admin:
+automatic admin rights are Business Edition features, so an SSO user authenticates
+and is granted nothing — the login succeeds and the UI is empty. Someone has to
+promote each person once, signed in as the local admin. That is a per-person,
+ongoing step and the main rough edge in this setup.
 
-> Users → *the user* → set Role to Administrator
-
-Equivalently via the API, `PUT /api/users/:id` with `{"Role": 1}` (1 =
-administrator, 2 = standard) — verified against the running 2.39.5 instance.
-
-That is a per-person, one-time step, and it is the main rough edge in this setup.
+Full symptom, cause, click path and version caveat:
+**[portainer-sso-admin.md](portainer-sso-admin.md)**.
 
 **OpenBao** maps the realm `admin` role to the `policy-oidc-admin` policy through
 the `admin-sso` role, configured by `vault.sh setup-oidc`.

--- a/docs/runbooks/troubleshooting.md
+++ b/docs/runbooks/troubleshooting.md
@@ -2,6 +2,14 @@
 
 Common issues and solutions for Hill90 VPS infrastructure.
 
+## Portainer accepts my SSO login but shows no environments
+
+Not a misconfiguration and not fixable in Keycloak — Portainer Community Edition
+cannot map claims to permissions, so it authenticates the user and grants nothing.
+Each person must be promoted once by the local admin.
+
+**[portainer-sso-admin.md](portainer-sso-admin.md)**
+
 ## VPS Access Issues
 
 ### Cannot SSH to VPS

--- a/scripts/portainer.sh
+++ b/scripts/portainer.sh
@@ -11,7 +11,7 @@
 #   * Automatic user provisioning: supported.
 #   * Group/claim -> team mapping and automatic admin rights: BUSINESS ONLY.
 # So an SSO user arrives as a STANDARD user. Granting Portainer admin is a
-# manual, one-time step per person — see docs/runbooks/sso-fallback.md.
+# manual, one-time step per person — see docs/runbooks/portainer-sso-admin.md.
 #
 # THE LOCAL ADMIN LOGIN IS NEVER DISABLED. Portainer's OAuth settings include
 # an "SSO"/hide-internal-auth behaviour; this script leaves internal


### PR DESCRIPTION
Jon's original complaint — SSO login works, no environments visible — now has a page findable **from the symptom** rather than from the service name.

## One correction to the brief, and it changes what this PR is

The brief said there was *"no runbook for it, only a couple of echo lines inside portainer.sh"*. There was more: `docs/runbooks/sso-fallback.md:101-111` already carried the licensing limitation, the exact click path, the API equivalent (`PUT /api/users/:id {"Role": 1}`) and the per-person cost.

Writing a second page from scratch would have duplicated accurate content — which the brief itself warned against. **So this relocates rather than duplicates.**

## Why relocation is the actual fix

The content was accurate and effectively **unfindable**: it lived under a page titled *"Getting in when Keycloak is down"*, and this symptom has nothing to do with Keycloak being down. Someone hitting it searches for Portainer, or for an empty environment list.

That is a discoverability defect, not a content one, so it is fixed by where the words live and what points at them:

| | |
|---|---|
| `docs/runbooks/portainer-sso-admin.md` | **new** — canonical, symptom-titled |
| `docs/runbooks/troubleshooting.md` | symptom entry, in the file people open when something is wrong |
| `scripts/portainer.sh:14` | now points at the canonical page |
| `docs/runbooks/sso-fallback.md` | reduced to a two-line pointer; Grafana and OpenBao content untouched |

## Version checked, not assumed

Compose pins `portainer-ce:latest` and the UI moves between releases, so:

```
$ curl -s http://localhost:9000/api/status
{"Version":"2.39.5","InstanceID":"..."}
```

**2.39.5** — the same version the click path was originally verified against, so the existing path stands.

The page is explicit about what that does and does not cover: the **version** was confirmed live through the unauthenticated endpoint; the **click path** is carried from the earlier verification against this same instance and was **not re-walked in the UI**, which needs an authenticated session and this work was read-only by constraint. Stated rather than implied, with instructions to re-check if `/api/status` ever disagrees.

## The first-user nuance, explained rather than repeated

Portainer makes the first account on a fresh instance an administrator. **That shortcut is unavailable here** because `portainer.sh init` creates the local admin before OAuth is configured — so every SSO user *including the first* arrives standard. The script's line about "the first SSO login" is not describing a special case; it is the general one.

## The ongoing cost, stated plainly

Adding a person is two steps — realm role in Keycloak, then promote in Portainer as local admin — and **the second is invisible from Keycloak**, which is why it gets forgotten and then reads as a broken login.

## Scope

Documentation only. No deploy, no Portainer write, no authenticated session. The only non-doc change is a comment in `portainer.sh` pointing at the new page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
