### PR TITLE
feat(keycloak): grant jon view-events so login events are answerable from the console

### DIFF
--- a/docs/decisions/stage1-platform-roles.md
+++ b/docs/decisions/stage1-platform-roles.md
@@ -65,10 +65,10 @@ So `manage-users` + `view-clients` + `view-realm` lets Jon **administer people**
 users, assign and remove their realm and client roles — which is what granting somebody
 `platform-admin` requires. It does not let him change the shape of the realm.
 
-**The one gap worth flagging:** he cannot view login events. CLAUDE.md records that event
-storage is on and "did this user log in, and when" is answerable from the host — but not by
-Jon in the console, without `view-events`. **Widening is a decision, not an oversight**, so
-it is recorded rather than taken.
+**That gap was closed on 2026-08-02.** This section recorded that Jon could not view login
+events without `view-events`, and flagged widening as a decision rather than taking it. Jon
+took the decision: `view-events` is now granted and codified in `ensure_platform_admins`.
+The `403` recorded below was true when measured and is no longer.
 
 ## Reproducibility on a rebuild — tested, and half of it is a no-op
 

--- a/scripts/keycloak.sh
+++ b/scripts/keycloak.sh
@@ -276,7 +276,11 @@ ensure_platform_admins() {
             && echo "  = ${user}: platform-admin" \
             || warn "  ! ${user}: could not grant platform-admin"
         local rmrole
-        for rmrole in manage-users view-clients view-realm; do
+        # view-events added 2026-08-02. Event storage was deliberately enabled so
+        # that "has anyone logged in, and when" is answerable — and it is not
+        # answerable from the admin console without this role. Measured before
+        # adding it: GET /admin/realms/platform/events returned 403 for jon.
+        for rmrole in manage-users view-clients view-realm view-events; do
             kc add-roles -r "$KC_REALM" --uusername "$user" --cclientid realm-management --rolename "$rmrole" >/dev/null 2>&1 \
                 && echo "  = ${user}: realm-management:${rmrole}" \
                 || warn "  ! ${user}: could not grant realm-management:${rmrole}"


### PR DESCRIPTION
Event storage was deliberately enabled so *"has anyone logged in, and when"* is answerable.
It was not answerable **from the console**, because reading events needs its own
realm-management role. #636 measured that `403` and flagged widening as a decision rather
than taking it. Jon has taken it.

## Proven, not assumed

```
BEFORE  GET /admin/realms/platform/events        -> 403
        granted realm-management:view-events
AFTER   GET /admin/realms/platform/events        -> 200
AFTER   GET /admin/realms/platform/admin-events  -> 200
```

A `200` is not the same claim as being able to read them, so the content was read too:

```
events returned: 5
  type=LOGIN  user=jon  time=1785714186308
  type=LOGIN  user=jon  time=1785714185050
  type=LOGIN  user=jon  time=1785714183649
```

jon's realm-management roles are now `[manage-users, view-clients, view-events, view-realm]`.

## Codified

Added to the `ensure_platform_admins` loop #636 introduced, so it re-applies on a rebuild
rather than existing only because a command was run once — the same reason the other three
are there.

## One correction

#636's decision record stated Jon *"cannot view login events"* and flagged it as an open
gap. **That is now false**, so the record says so and marks the recorded `403` as closed,
rather than leaving a true-when-written claim to be read as current.

Baseline **16 by name, 0 unhealthy**, unchanged. Task B (OpenBao) follows separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)