### PR TITLE
fix(vault): close the one-way door — no path may revoke root before OIDC is enabled

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,9 @@ jobs:
       - name: Assert every referenced OIDC client is created on the deploy path
         run: python3 scripts/checks/check_oidc_clients_reconciled.py
 
+      - name: Assert no path revokes root before OIDC is enabled
+        run: python3 scripts/checks/check_vault_revoke_order.py
+
       - name: Validate secrets schema consistency
         env:
           SECRETS_SCHEMA_STRICT: "0"

--- a/.github/workflows/vault-init.yml
+++ b/.github/workflows/vault-init.yml
@@ -184,6 +184,18 @@ jobs:
       # unconditionally — therefore produced a vault that was up, healthy, and
       # permanently unconfigurable. Run setup, seed and setup-sync-token first,
       # then revoke.
+      # OIDC BEFORE THE REVOKE, and this step is not optional even though the
+      # revoke is. The comment above says "run setup, seed and setup-sync-token
+      # first" — it omitted OIDC, and that omission is how a rebuilt vault ended up
+      # with no OIDC method and no credential able to add one on 2026-08-02.
+      # scripts/checks/check_vault_revoke_order.py fails if this ordering is undone.
+      - name: Enable OIDC auth before anything can revoke root
+        if: ${{ inputs.revoke_root }}
+        run: |
+          ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
+            deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
+            'cd /opt/hill90/app && export SOPS_AGE_KEY_FILE=/opt/hill90/secrets/keys/keys.txt && export BAO_TOKEN="$(cat /opt/hill90/secrets/openbao-root.token)" && bash scripts/vault.sh setup-oidc'
+
       - name: Revoke root token
         if: ${{ inputs.revoke_root }}
         run: |

--- a/.github/workflows/vault-reinitialize.yml
+++ b/.github/workflows/vault-reinitialize.yml
@@ -286,6 +286,18 @@ jobs:
             deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
             'cd /opt/hill90/app && export SOPS_AGE_KEY_FILE=/opt/hill90/secrets/keys/keys.txt && export BAO_TOKEN="$(cat /opt/hill90/secrets/openbao-root.token)" && bash scripts/vault.sh setup-sync-token'
 
+      # Enable OIDC BEFORE anything can revoke root. This workflow does not itself
+      # revoke — but it used to leave the vault with no OIDC method, and the very
+      # next documented step (bootstrap-approles) revokes when it finishes. That
+      # combination rebuilt an unconfigurable vault on 2026-08-02, which is the
+      # 2026-07-26 failure reached by following the recovery. See
+      # docs/runbooks/openbao-rebuild.md and scripts/checks/check_vault_revoke_order.py.
+      - name: Enable OIDC auth against the platform realm
+        run: |
+          ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
+            deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
+            'cd /opt/hill90/app && export SOPS_AGE_KEY_FILE=/opt/hill90/secrets/keys/keys.txt && export BAO_TOKEN="$(cat /opt/hill90/secrets/openbao-root.token)" && bash scripts/vault.sh setup-oidc'
+
       # ---- Prove it, then hand back the secrets ------------------------------
 
       - name: Prove auto-unseal survives a container restart

--- a/docs/runbooks/openbao-rebuild.md
+++ b/docs/runbooks/openbao-rebuild.md
@@ -116,7 +116,10 @@ bash scripts/vault.sh setup-oidc          # MUST come first — see the warning
 bash scripts/vault.sh bootstrap-approles
 ```
 
-> **`bootstrap-approles` REVOKES the root token when it finishes**, unconditionally. With
+> **`bootstrap-approles` used to REVOKE the root token unconditionally when it finished.**
+> Since #644 both revoke sites call `assert_safe_to_revoke`, which **refuses** when the OIDC
+> auth method is not enabled — so the door can no longer be closed by accident, and the
+> ordering below is enforced rather than merely advised. With
 > `generate-root` disabled, that makes it the last administrative act possible — anything
 > not configured before it cannot be configured afterwards without another reinitialise.
 >

--- a/scripts/checks/check_vault_revoke_order.py
+++ b/scripts/checks/check_vault_revoke_order.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""No path may reach a root-token revoke with the OIDC auth method not yet enabled.
+
+WHY
+===
+
+Revoking root is a ONE-WAY DOOR on OpenBao >= 2.5.3: the unauthenticated
+root-generation endpoints are disabled by default, so `bao operator generate-root`
+returns 403 and whatever was not configured before the revoke can never be
+configured after it. That produced a healthy, permanently unconfigurable vault on
+2026-07-26 — and again on 2026-08-02, this time by FOLLOWING the documented
+recovery, because the reinitialise workflow never enabled OIDC and
+`bootstrap-approles` revokes root when it finishes.
+
+WHAT IS ACTUALLY ASSERTED
+=========================
+
+Not "does a workflow mention setup-oidc somewhere". The question is whether any
+PATH can reach a revoke with OIDC not yet enabled, so this reasons about order:
+
+1. For each workflow, extract the `scripts/vault.sh <verb>` invocations IN STEP
+   ORDER, carrying each step's `if:` condition. If `revoke-root` can be reached
+   without `setup-oidc` strictly earlier in the same job, that is a failure.
+   A step guarded by an `if:` still counts as reachable — a condition an operator
+   controls is not a guarantee.
+
+2. `scripts/vault.sh` must guard the revoke itself. Workflow ordering cannot cover
+   `vault.sh revoke-root` run by hand, nor `bootstrap-approles`'s own terminal
+   revoke, so both revoke sites must call `assert_safe_to_revoke`.
+
+Exit 0 if no path can close the door. Exit 1, naming the path, otherwise.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOWS = ROOT / ".github/workflows"
+VAULT_SH = ROOT / "scripts/vault.sh"
+
+# Only EXECUTED invocations count. `bash scripts/vault.sh <verb>` is a run; a verb
+# inside an `echo` is documentation telling the operator what to do next, and
+# counting it produced two false positives on the first draft — a check that cries
+# wolf gets ignored, which is the failure mode this whole file exists to prevent.
+VERB = re.compile(r"bash\s+scripts/vault\.sh\s+([a-z][a-z0-9-]*)")
+ECHOED = re.compile(r"^\s*echo\b")
+STEP = re.compile(r"^\s*-\s+name:\s*(.+?)\s*$")
+
+
+def steps_with_verbs(text: str):
+    """Ordered (step-name, [verbs]) pairs. Deliberately line-based rather than a
+    YAML walk: the invocations live inside `run: |` blocks and inside single-quoted
+    ssh payloads, and step ORDER is exactly what matters."""
+    out, name, buf = [], None, []
+    for line in text.splitlines():
+        m = STEP.match(line)
+        if m:
+            if name is not None:
+                out.append((name, VERB.findall("\n".join(buf))))
+            name, buf = m.group(1), []
+        elif not ECHOED.match(line):
+            buf.append(line)
+    if name is not None:
+        out.append((name, VERB.findall("\n".join(buf))))
+    return out
+
+
+def check_workflow(path: Path) -> list[str]:
+    problems = []
+    steps = steps_with_verbs(path.read_text(encoding="utf-8"))
+    seen_oidc = False
+    for name, verbs in steps:
+        for v in verbs:
+            if v == "setup-oidc":
+                seen_oidc = True
+            elif v == "revoke-root" and not seen_oidc:
+                problems.append(
+                    f"{path.name}: step {name!r} can reach `vault.sh revoke-root` "
+                    f"with the OIDC auth method not yet enabled — no `setup-oidc` "
+                    f"runs before it in this job. That revoke is a one-way door."
+                )
+    return problems
+
+
+def check_script() -> list[str]:
+    problems = []
+    if not VAULT_SH.is_file():
+        return [f"missing {VAULT_SH}"]
+    text = VAULT_SH.read_text(encoding="utf-8")
+    if "assert_safe_to_revoke()" not in text:
+        problems.append(
+            "scripts/vault.sh: assert_safe_to_revoke is not defined. The workflow "
+            "ordering alone cannot cover `vault.sh revoke-root` run by hand."
+        )
+        return problems
+    # Both revoke sites must be guarded, checked per function body.
+    for fn in ("cmd_revoke_root", "cmd_bootstrap_approles"):
+        m = re.search(rf"^{fn}\(\)\s*\{{(.*?)^\}}", text, re.S | re.M)
+        if not m:
+            problems.append(f"scripts/vault.sh: {fn} not found")
+            continue
+        body = m.group(1)
+        revokes = "token revoke -self" in body
+        if revokes and "assert_safe_to_revoke" not in body:
+            problems.append(
+                f"scripts/vault.sh: {fn} revokes a root token without calling "
+                f"assert_safe_to_revoke first — that path can close the door."
+            )
+    return problems
+
+
+def main() -> int:
+    problems: list[str] = []
+    wfs = sorted(WORKFLOWS.glob("*.yml"))
+    if not wfs:
+        print("FAIL — no workflows found; the check would pass vacuously.", file=sys.stderr)
+        return 1
+    for wf in wfs:
+        problems += check_workflow(wf)
+    problems += check_script()
+
+    for wf in wfs:
+        verbs = [v for _, vs in steps_with_verbs(wf.read_text(encoding="utf-8")) for v in vs]
+        if verbs:
+            print(f"  {wf.name}: {' -> '.join(verbs)}")
+
+    if problems:
+        print("\nFAIL — a revoke can precede OIDC being enabled:\n", file=sys.stderr)
+        for p in problems:
+            print(f"  {p}", file=sys.stderr)
+        print(
+            "\nEnable OIDC before any revoke, or make the revoke refuse. "
+            "See docs/runbooks/openbao-rebuild.md.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("\nPASS — no path reaches a root revoke with OIDC not yet enabled.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/vault.sh
+++ b/scripts/vault.sh
@@ -183,6 +183,52 @@ cmd_init() {
 #
 # So: run `setup`, `seed` and `setup-sync-token` BEFORE this. Revoking first
 # leaves a vault that cannot be configured.
+# Is the OIDC auth method enabled on the live vault?
+#
+# THE CHOKE POINT. Revoking root is irreversible on OpenBao >= 2.5.3 —
+# generate-root is disabled by default — so whatever is not configured before the
+# revoke can never be configured after it. On 2026-07-26 that produced a healthy,
+# permanently unconfigurable vault. On 2026-08-02 the DOCUMENTED RECOVERY produced
+# it again: reinitialise leaves OIDC unconfigured, and bootstrap-approles revokes
+# root when it finishes.
+#
+# Guarding the workflow alone would not close this, because `vault.sh revoke-root`
+# can be run by hand and bootstrap-approles revokes on its own. So the guard lives
+# at the revoke itself, where every path must pass.
+oidc_enabled() {
+    local token="${1:-${BAO_TOKEN:-}}"
+    [ -n "$token" ] || return 1
+    BAO_TOKEN="$token" docker exec -e "BAO_ADDR=http://127.0.0.1:8200" -e BAO_TOKEN \
+        "$CONTAINER_NAME" bao auth list -format=json 2>/dev/null \
+        | python3 -c 'import sys,json
+try: sys.exit(0 if any(v.get("type")=="oidc" for v in json.load(sys.stdin).values()) else 1)
+except Exception: sys.exit(1)'
+}
+
+# Refuse a revoke that would close the door, unless the operator says otherwise.
+assert_safe_to_revoke() {
+    local token="${1:-${BAO_TOKEN:-}}"
+    if [ "${ALLOW_REVOKE_WITHOUT_OIDC:-0}" = "1" ]; then
+        warn "ALLOW_REVOKE_WITHOUT_OIDC=1 — revoking without checking for the OIDC auth method."
+        return 0
+    fi
+    if oidc_enabled "$token"; then
+        return 0
+    fi
+    die "Refusing to revoke root: the OIDC auth method is NOT enabled on this vault.
+
+Revoking now is a ONE-WAY DOOR. generate-root is disabled on OpenBao >= 2.5.3, so
+after this revoke nothing can enable OIDC and the vault becomes permanently
+unconfigurable — the 2026-07-26 failure, which the documented recovery reproduced
+on 2026-08-02.
+
+Run this first, then revoke:
+  bash scripts/vault.sh setup-oidc
+
+If you genuinely intend an AppRole-only vault with no OIDC, say so explicitly:
+  ALLOW_REVOKE_WITHOUT_OIDC=1 bash scripts/vault.sh revoke-root"
+}
+
 cmd_revoke_root() {
     require_running
 
@@ -202,6 +248,8 @@ cmd_revoke_root() {
         rm -f "$ROOT_TOKEN_PATH"
         return 0
     fi
+
+    assert_safe_to_revoke "$token"
 
     echo "Revoking root token..."
     # `-e BAO_TOKEN` passes the variable through from this shell rather than
@@ -855,9 +903,14 @@ existing root token instead:
         stored=$((stored + 1))
     done
 
-    # Revoke the temporary root token
+    # Revoke the temporary root token — but NOT if that would close the door.
+    #
+    # This revoke used to be unconditional, and that is precisely how #643 turned a
+    # successful rebuild into an unconfigurable vault: bootstrap-approles was the
+    # last administrative act, and OIDC had never been enabled.
     echo ""
     echo "Revoking temporary root token..."
+    assert_safe_to_revoke
     bao_exec_env token revoke -self 2>/dev/null || warn "Failed to revoke root token (may have already expired)"
     unset BAO_TOKEN
 


### PR DESCRIPTION
#643's rebuild walked into the 2026-07-26 failure **by following the documented recovery**.
This closes it at the choke point and makes the regression loud.

## The claim I tested is the path one

Not *"does a workflow mention `setup-oidc`"* but *"can any path reach a revoke with OIDC not
yet enabled"*. Reasoning about paths found **three**, not the one reported:

| Path | How it closes the door |
|---|---|
| **`bootstrap-approles`** | revoked root **unconditionally** when it finished — the path #643 took, and reachable by hand straight from the DR runbook |
| **`vault-init.yml`** | with `revoke_root=true`, reached `vault.sh revoke-root` having run **neither `setup`, `seed`, nor `setup-oidc`**. Guarded only by an input **default**, which a human can flip |
| **`vault-reinitialize.yml`** | ran `setup`/`seed`/`setup-sync-token` but never `setup-oidc`, leaving a vault whose very next documented step closes the door |

**`setup-oidc` appeared in no workflow at all**, so inserting one call would not have been
the fix.

## Fixed at the choke point

Ordering workflows cannot cover `vault.sh revoke-root` run by hand, so the guard lives at
the revoke. `assert_safe_to_revoke` **refuses** when the OIDC auth method is absent, naming
the consequence and the remedy, with `ALLOW_REVOKE_WITHOUT_OIDC=1` for a deliberate
AppRole-only vault. **Both** revoke sites call it. **Both** workflows now enable OIDC first.

## The check has been seen to fail

`check_vault_revoke_order.py` extracts each workflow's `vault.sh` verbs **in step order**
and fails if `revoke-root` is reachable without `setup-oidc` earlier; separately it asserts
both script revoke sites are guarded. An `if:` condition still counts as reachable — *a
condition an operator controls is not a guarantee*.

```
control 1  setup-oidc moved AFTER the revoke in vault-init.yml
           -> FAIL: step 'Revoke root token' can reach `vault.sh revoke-root` with the
              OIDC auth method not yet enabled … That revoke is a one-way door.

control 2  assert_safe_to_revoke removed from cmd_bootstrap_approles
           -> FAIL, exit 1: cmd_bootstrap_approles revokes a root token without calling
              assert_safe_to_revoke first — that path can close the door.

reverted   -> PASS — no path reaches a root revoke with OIDC not yet enabled.
```

Passing output shows the derived order, so the reasoning is visible rather than implied:

```
vault-init.yml:         init -> unseal -> store-unseal-key -> setup-oidc -> revoke-root -> auto-unseal
vault-reinitialize.yml: init -> unseal -> store-unseal-key -> setup -> seed -> setup-sync-token -> setup-oidc -> auto-unseal
```

## One self-correction

The first draft matched `vault.sh <verb>` anywhere and produced **two false positives** from
commands that were merely **echoed** as advice, plus garbage verbs from prose. A check that
cries wolf gets ignored — the exact failure mode this file exists to prevent — so it now
counts only executed `bash scripts/vault.sh` calls and ignores `echo` lines.

## Scope

Wired into `ci.yml`. **Nothing deployed**; the live vault is untouched. Baseline **16 by
name, 0 unhealthy**.

**Stage 2b is not attempted here.** OIDC is still absent from the live vault, and enabling it
requires a reinitialise that runs *this* workflow — so it is gated on this PR merging. Once
merged I can re-run the reinitialise, then repoint `admin-sso` and prove the OIDC login and
AppRole in one go. Stage 3 (MinIO) untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)