### PR TITLE
fix(vault): bind admin-sso to platform-admin, and record why Stage 2b cannot be finished

### DIFF
--- a/docs/decisions/stage2b-oidc-blocked-2026-08-02.md
+++ b/docs/decisions/stage2b-oidc-blocked-2026-08-02.md
@@ -1,0 +1,188 @@
+# Stage 2b is blocked: the vault has no OIDC auth method, and no way to acquire one
+
+`Measured 2026-08-02 against production. Read-only — nothing was deployed, created or
+changed on the host.` Every command below was run over SSH as `deploy` and every one of
+them only reads.
+
+**Stage 2b — repointing OpenBao's `admin-sso` OIDC role from realm role `admin` to
+`platform-admin` — cannot be completed.** Not because the change is wrong; because there
+is no OIDC auth method on the production vault to repoint, and enabling one needs a
+root-or-sudo token that does not exist and cannot be minted.
+
+This is the 2026-07-26 one-way door, standing open again. #645 closed the door on
+*future* revokes; it landed **after** #643 had already walked through it.
+
+## The verdict, and the four facts behind it
+
+| Question | Answer | How |
+|---|---|---|
+| Is the OIDC auth method mounted? | **No** | unauthenticated probe with both controls — below |
+| Is the on-disk root token usable? | **No** — `403 permission denied` | `bao token lookup` with `/opt/hill90/secrets/openbao-root.token` |
+| Can root be regenerated? | **No** — `403 permission denied` | `bao operator generate-root -init` and `-status` |
+| Can any AppRole enable it? | **No** — `deny` on all four | `bao token capabilities sys/auth/oidc` after a real login |
+
+Any one of those would be recoverable. Together they are the closed door.
+
+## Fact 1 — OIDC is not mounted, and the instrument was controlled before it was believed
+
+There is no token, so `bao auth list` is unavailable — which is exactly why this was
+unanswerable until now. The probe instead reads the status of an unauthenticated POST:
+
+```
+positive control  auth/approle/login                -> 500   (mounted; backend rejected the payload)
+negative control  auth/no-such-method-3594870/login -> 403   (absent; no handler)
+target            auth/oidc/oidc/auth_url           -> 403   (matches the ABSENT control)
+```
+
+**403, not 404, is what OpenBao returns for a mount that does not exist**, which is
+counter-intuitive enough that the reading is worthless without the pair of controls. Both
+behaved, so the target's 403 means absent. Shipped as
+`scripts/checks/vault-oidc-enabled-test.sh`, which refuses to report a verdict at all if
+either control misbehaves.
+
+**A second, independent instrument agrees.** The barrier-encrypted auth mount table is a
+single file in the storage backend, and while its contents are unreadable its *mtime* is
+not:
+
+```
+-rw-------  openbao  561  Aug  2 23:48  /openbao/file/core/_auth
+```
+
+`23:48` is the rebuild. Nothing has been added to the auth mount table since — no
+`setup-oidc` ran during #643, and none has run since. (`sys/policy/` is `23:51`, so
+`policy-apply` did run; policies are not auth methods.)
+
+## Fact 2 — the root token file survives, and the token in it is dead
+
+```
+-rw------- 1 deploy deploy 26 Aug  2 23:48 /opt/hill90/secrets/openbao-root.token
+```
+
+The file's existence is misleading and worth stating plainly, because a future session
+will find it and think it has root:
+
+```
+Error looking up token: ... Code: 403. Errors: * permission denied
+```
+
+`bootstrap-approles` revoked the token in-place when it finished — the unconditional
+revoke that #645 later removed — but it revokes with `token revoke -self` and never
+touches the file. Only `vault.sh revoke-root` deletes it, and that was never run. So the
+host holds a 0600 file containing a dead credential. **A root token file on disk is not
+evidence of root access.**
+
+## Fact 3 — `generate-root` is closed, and today's 403 does not by itself prove why
+
+```
+PUT /v1/sys/generate-root-token/attempt -> 403 permission denied
+GET /v1/sys/generate-root-token/attempt -> 403 permission denied
+```
+
+The estate's existing record says this was verified on 2.6.1 "with the flag set at
+listener and at top level" (`docs/runbooks/vault-unseal.md`). **Be precise about what
+today's measurement adds and what it does not.** The live config carries no such flag:
+
+```hcl
+ui = true
+disable_mlock = true
+storage "file" { path = "/openbao/file" }
+listener "tcp" { address = "0.0.0.0:8200"  tls_disable = 1 }
+api_addr = "https://vault.hill90.com"
+```
+
+So today's 403 is the **documented default** for OpenBao ≥ 2.5.3, not a re-proof that
+overriding the default fails. The option is real and top-level — confirmed by name in the
+2.6.1 binary itself, `disable_unauthed_generate_root_endpoints`, alongside its
+`DisableUnauthedGenerateRootEndpointsRaw.hcl` struct tag.
+
+**That leaves exactly one untried lever**, and it is Jon's call, not this session's:
+set `disable_unauthed_generate_root_endpoints = false` in `config.hcl`, deploy through
+the pipeline, restart OpenBao, and mint root with the unseal key — which is present, at
+threshold 1 of 1. If it works, Stage 2b proceeds with no data loss and no reinitialise.
+The prior negative result argues it will not, but that result predates this and its own
+wording ("at listener and at top level") suggests the flag's placement was uncertain at
+the time. **It was not tested here**: it changes production config and restarts the
+platform's vault, which is a deploy and beyond a read-only diagnosis.
+
+## Fact 4 — AppRole is healthy, and is not a way in
+
+All four platform AppRoles authenticate. This is also the Stage 2b post-check the runbook
+asks for, so it is recorded as a result in its own right:
+
+| Service | Login | Policies | `sys/auth/oidc` |
+|---|---|---|---|
+| `infra` | OK | `['default', 'policy-infra']` | **deny** |
+| `db` | OK | `['default', 'policy-db']` | **deny** |
+| `auth` | OK | `['default', 'policy-auth']` | **deny** |
+| `observability` | OK | `['default', 'policy-observability']` | **deny** |
+
+Enabling an auth method is `sys/auth/oidc`, and **no policy in this repo grants it** —
+not even `policy-admin`, the break-glass one, which grants `auth/*` but not `sys/auth/*`.
+`auth/*` and `sys/auth/*` look alike and are not: one operates *within* a mounted method,
+the other *creates* one. Nothing is bound to `policy-admin` in any case.
+
+`VAULT_SYNC_TOKEN` in SOPS is also rejected (`permission denied`) — the pre-rebuild value,
+never regenerated.
+
+## Everything on the Keycloak side is already correct
+
+The blockage is entirely OpenBao's. Measured the same day, read-only:
+
+- `jon` holds realm roles `default-roles-platform` and **`platform-admin`** — Stage 1
+  (#636) is live.
+- Client `hill90-vault` exists, with mapper `realm-roles`,
+  `oidc-usermodel-realm-role-mapper`, **`claim.name=realm_roles`** — the deliberate
+  non-default, unchanged.
+
+So the moment an OIDC method exists, `setup-oidc` writes a role binding
+`{"realm_roles": ["platform-admin"]}` against a claim that is emitted and a role that
+`jon` holds, and the login should work. **"Should" is doing real work in that sentence —
+it has not been tested, and nothing here may be cited as if it had.**
+
+## What this PR changes, and what it deliberately does not
+
+**Changed:** `scripts/vault.sh` now binds `platform-admin` instead of `admin`, matching
+Grafana's repoint in #637. The claim NAME stays `realm_roles` — #635 measured that binding
+as already consistent, and renaming the mapper was the fix that would have changed
+nothing. Two stale comments quoting the old value are corrected, in `scripts/keycloak.sh`
+and `scripts/checks/check_realm_tenant_clients.py`.
+
+The old value was not merely outdated, it was inert: realm role `admin` has **zero
+holders**. Leaving it would mean the next rebuild silently reinstating a binding that can
+authorise nobody.
+
+**Not changed, and not claimed:** nothing was deployed. There is no live `admin-sso` role,
+so there is no OIDC login to prove and none is asserted. This is the value the **next**
+successful `setup-oidc` will write. Stage 2b is **not done**, and a reader finding
+`platform-admin` in `vault.sh` must not conclude otherwise — `vault.sh` carries a comment
+pointing here for that reason.
+
+## What has to happen before Stage 2b can be finished
+
+1. **Jon decides** between the config-flag attempt above and a second reinitialise. The
+   flag is cheap, reversible and might fail; the reinitialise is known to work, destroys
+   the barrier, and mints new AppRole credentials that need their own commit.
+2. Whichever path, run `setup-oidc` **before** `bootstrap-approles`. #645's
+   `assert_safe_to_revoke` now enforces this rather than merely advising it, so a repeat
+   of #643 requires an explicit `ALLOW_REVOKE_WITHOUT_OIDC=1`.
+3. Prove it with a **real authorization-code login** for `jon` yielding
+   `policy-oidc-admin`. Reading `bao read auth/oidc/role/admin-sso` is not proof; it is
+   the config that was already believed correct for the six days the role could authorise
+   nobody.
+4. **Re-confirm AppRole separately afterwards.** OIDC and AppRole are independent auth
+   methods and proving one says nothing about the other — the four rows in Fact 4 are the
+   baseline to re-measure against.
+
+## Baseline
+
+`Verified 2026-08-02` after every step, and unchanged throughout — no step here modified
+anything:
+
+**16 platform containers by name, 0 unhealthy** — `alertmanager blackbox-exporter cadvisor
+grafana keycloak loki minio node-exporter openbao portainer postgres postgres-exporter
+prometheus promtail tempo traefik`. The tenant's 7 (`app-ai app-api app-docker-proxy
+app-knowledge app-litellm app-mcp app-ui`) alongside, for 23 in total.
+
+OpenBao itself is `Initialized true / Sealed false`, version 2.6.1. **It is healthy. It is
+also unadministrable, and health checks cannot tell the difference** — which is the whole
+reason this failure mode keeps going unnoticed.

--- a/docs/runbooks/openbao-rebuild.md
+++ b/docs/runbooks/openbao-rebuild.md
@@ -161,3 +161,18 @@ risk in this design.
 
 Stage 2b — repointing the `admin-sso` OIDC role from `realm_roles: admin` to
 `platform-admin` — follows once AppRole is proven. Stage 3 (MinIO) is out of scope.
+
+> **AppRole was proven, and Stage 2b is still blocked — for a different reason.**
+> `Verified 2026-08-02.` This rebuild ran **before** #645's guard existed, so Step 5 went in
+> the order this page originally gave: `bootstrap-approles` first, `setup-oidc` never. The
+> result is the one-way door again — **no OIDC auth method, a root token file whose token is
+> dead, `generate-root` 403, and `deny` on `sys/auth/oidc` for all four AppRoles.**
+>
+> All four AppRoles do authenticate, so Step 6's first bullet passes. That is not the
+> blocker and never was.
+>
+> Diagnose before assuming a second reinitialise:
+> `bash scripts/checks/vault-oidc-enabled-test.sh` answers "is OIDC mounted" with no token,
+> which is the state a token-based check cannot reach. Full evidence and the one untried
+> non-destructive lever:
+> [`stage2b-oidc-blocked-2026-08-02.md`](../decisions/stage2b-oidc-blocked-2026-08-02.md).

--- a/scripts/checks/check_realm_tenant_clients.py
+++ b/scripts/checks/check_realm_tenant_clients.py
@@ -22,11 +22,12 @@ So three things are asserted here, and each one has a specific way of going wron
 
    `scripts/keycloak.sh` gives every PLATFORM client a realm-roles mapper, and
    `hill90-vault` deliberately uses claim `realm_roles` because
-   `vault.sh setup-oidc` binds `{"realm_roles": ["admin"]}`. That is correct FOR
+   `vault.sh setup-oidc` binds `{"realm_roles": ["platform-admin"]}`. That is correct FOR
    THE PLATFORM'S OWN CLIENTS.
 
    For the tenant it would be a privilege hole. The `platform` realm grants
-   Grafana Admin and OpenBao access off the REALM role `admin`. The app reads
+   Grafana Admin and OpenBao access off a REALM role — `platform-admin` since
+   #637 and Stage 2b, `admin` before that. The app reads
    client roles precisely so that an app admin does not inherit infrastructure
    admin — `services/api/src/middleware/keycloak-config.ts` says there is
    deliberately no fallback to `realm_roles` for that reason. Adding a

--- a/scripts/checks/vault-oidc-enabled-test.sh
+++ b/scripts/checks/vault-oidc-enabled-test.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Is the OIDC auth method mounted on the live OpenBao? Answered WITHOUT a token.
+#
+# WHY THIS EXISTS
+# ===============
+# `vault.sh oidc_enabled` (#645) answers the same question, but it needs a valid
+# token to call `bao auth list`. On a vault whose root has already been revoked
+# there is no such token — which is precisely the state that needs diagnosing.
+# On 2026-08-02 that left "does this vault have OIDC?" unanswerable by any
+# instrument in the repo, on the one vault where the answer decided everything.
+#
+# THE INSTRUMENT, AND ITS CONTROLS
+# ================================
+# An unauthenticated POST to a login endpoint distinguishes mounted from absent:
+#
+#   mounted, bad/empty payload -> 400/500  (the backend ran and rejected it)
+#   not mounted                -> 403      (no handler; OpenBao does not say 404)
+#
+# 403-means-absent is counter-intuitive enough that this script refuses to report
+# anything until BOTH controls behave:
+#
+#   positive control  auth/approle/login   must NOT be 403  (known mounted)
+#   negative control  auth/<random>/login  must BE 403      (known absent)
+#
+# If a control misbehaves the probe has stopped measuring what it claims to, and
+# a wrong answer here is worse than no answer — this is the check that would tell
+# an operator whether a vault is recoverable. It exits 2 (indeterminate) rather
+# than guessing. That is the estate's own rule: verify the instrument before you
+# believe the verdict — CONTRIBUTING.md.
+#
+# Usage:  bash scripts/checks/vault-oidc-enabled-test.sh
+# Exit:   0 OIDC mounted | 1 OIDC absent | 2 indeterminate (controls failed)
+
+set -uo pipefail
+
+CONTAINER="${VAULT_CONTAINER:-openbao}"
+ADDR="http://127.0.0.1:8200"
+
+ok()   { echo "  ✓ $*"; }
+bad()  { echo "  ✗ $*"; }
+
+# Status code for an unauthenticated POST to a v1 path.
+status_for() {
+    docker exec "$CONTAINER" sh -c \
+        "wget -qO- --server-response --post-data='{}' \
+         --header=Content-Type:application/json ${ADDR}/v1/$1 2>&1" \
+        | sed -n 's|.*HTTP/1\.1 \([0-9][0-9][0-9]\).*|\1|p' | head -1
+}
+
+if ! docker inspect "$CONTAINER" >/dev/null 2>&1; then
+    echo "Container ${CONTAINER} is not running — cannot probe." >&2
+    exit 2
+fi
+
+echo "OpenBao OIDC mount probe (unauthenticated)"
+echo "=========================================="
+
+# The negative control must be a mount that cannot plausibly exist.
+ABSENT_PATH="auth/no-such-method-$$/login"
+
+POS=$(status_for "auth/approle/login")
+NEG=$(status_for "$ABSENT_PATH")
+TARGET=$(status_for "auth/oidc/oidc/auth_url")
+
+echo "  positive control  auth/approle/login        -> ${POS:-<none>}"
+echo "  negative control  ${ABSENT_PATH} -> ${NEG:-<none>}"
+echo "  target            auth/oidc/oidc/auth_url   -> ${TARGET:-<none>}"
+echo
+
+if [ -z "$POS" ] || [ -z "$NEG" ] || [ -z "$TARGET" ]; then
+    bad "A probe returned no status code at all — the instrument is not working."
+    exit 2
+fi
+
+if [ "$POS" = "403" ]; then
+    bad "Positive control returned 403: a mount known to exist looks absent."
+    bad "The 403-means-absent inference does not hold here. Not reporting a verdict."
+    exit 2
+fi
+ok "positive control: a mounted method does not return 403"
+
+if [ "$NEG" != "403" ]; then
+    bad "Negative control returned ${NEG}, not 403: an absent mount does not look absent."
+    bad "Not reporting a verdict."
+    exit 2
+fi
+ok "negative control: an absent method returns 403"
+
+echo
+if [ "$TARGET" = "403" ]; then
+    bad "OIDC auth method is NOT mounted (target matches the absent control)."
+    echo
+    echo "  Enabling it needs a root or sudo-capable token:"
+    echo "    BAO_TOKEN=... bash scripts/vault.sh setup-oidc"
+    echo "  If no such token exists, read"
+    echo "    docs/decisions/stage2b-oidc-blocked-2026-08-02.md"
+    echo "  before assuming a reinitialise is the answer."
+    exit 1
+fi
+
+ok "OIDC auth method IS mounted (target does not match the absent control)."
+echo
+echo "  Mounted is not configured. Whether the admin-sso role binds the right"
+echo "  claim is a separate question, and only a real login settles it."
+exit 0

--- a/scripts/keycloak.sh
+++ b/scripts/keycloak.sh
@@ -463,7 +463,7 @@ cmd_apply() {
 
     # hill90-vault is created by the realm import. Its claim is realm_roles, NOT
     # realm_access.roles: vault.sh setup-oidc binds
-    # bound_claims {"realm_roles": ["admin"]}, so defaulting here would create a
+    # bound_claims {"realm_roles": ["platform-admin"]}, so defaulting here would create a
     # mapper OpenBao can never match and SSO would fail for everyone.
     ensure_client "hill90-vault" "$vault_secret" \
         "${VAULT_PUBLIC_URL}/v1/auth/oidc/callback,${VAULT_PUBLIC_URL}/ui/vault/auth/oidc/oidc/callback" \

--- a/scripts/vault.sh
+++ b/scripts/vault.sh
@@ -467,6 +467,19 @@ cmd_setup_oidc() {
     # Create admin-sso role (maps Keycloak admin role to vault policy)
     # Uses JSON via stdin because bound_claims requires a map type that
     # the CLI doesn't parse correctly from positional arguments.
+    # The bound claim is `platform-admin`, NOT `admin` — Stage 2b, matching the
+    # Grafana repoint in #637. The claim NAME stays `realm_roles`: hill90-vault's
+    # mapper is deliberately non-default (`claim.name=realm_roles` rather than
+    # Keycloak's `realm_access.roles`), measured against a real token in #635, and
+    # changing it would break a binding that is already consistent. Only the VALUE
+    # moved, because realm role `admin` has zero holders and `platform-admin` is
+    # the role `jon` actually carries.
+    #
+    # NOT PROVEN BY A LIVE LOGIN. The production vault has no OIDC auth method to
+    # apply this to and no way to acquire one — see
+    # docs/decisions/stage2b-oidc-blocked-2026-08-02.md. This value is what the
+    # NEXT successful `setup-oidc` will write; until then Stage 2b is unfinished,
+    # and this line must not be read as evidence that it works.
     echo "Creating admin-sso OIDC role..."
     # Redirect URIs must match the vault's own public URL. Defaulting to the
     # production URL keeps this byte-identical to what prod got before; local
@@ -481,7 +494,7 @@ print(json.dumps({
     "user_claim": "sub",
     "policies": ["policy-oidc-admin"],
     "oidc_scopes": ["openid", "profile", "email"],
-    "bound_claims": {"realm_roles": ["admin"]},
+    "bound_claims": {"realm_roles": ["platform-admin"]},
     "allowed_redirect_uris": [
         base + "/v1/auth/oidc/callback",
         base + "/ui/vault/auth/oidc/oidc/callback",
@@ -496,7 +509,7 @@ print(json.dumps({
     success "OIDC setup complete!"
     echo "  Login at: ${vault_url}/ui/"
     echo "  Auth method: OIDC"
-    echo "  Keycloak users with 'admin' role can now sign in."
+    echo "  Keycloak users with the 'platform-admin' realm role can now sign in."
     echo ""
 }
 


### PR DESCRIPTION
## Outcome first

**Stage 2b cannot be completed, and this PR does not pretend it was.** The bound claim moves from `admin` to `platform-admin` in `scripts/vault.sh`. The **real OIDC login that was asked for does not exist**, because the production vault has no OIDC auth method to log in against and no way to acquire one.

`Measured 2026-08-02 against production, read-only.` Nothing was deployed, created or changed on the host.

## Why it is blocked — four facts, any one of which would have been recoverable

| Question | Answer | Instrument |
|---|---|---|
| Is the OIDC auth method mounted? | **No** | unauthenticated probe, both controls passing |
| Is the on-disk root token usable? | **No** — `403 permission denied` | `bao token lookup` |
| Can root be regenerated? | **No** — `403 permission denied` | `bao operator generate-root -init` |
| Can any AppRole enable it? | **No** — `deny` ×4 | `bao token capabilities sys/auth/oidc` |

#643 rebuilt the vault **before** #645's guard existed, so Step 5 ran in the order the runbook then gave: `bootstrap-approles` first, `setup-oidc` never. `bootstrap-approles` revoked root on its way out. This is the 2026-07-26 one-way door, standing open again — and #645 closed it for future revokes only.

**The root token file survives and its token is dead.** A future session will find `/opt/hill90/secrets/openbao-root.token` (0600, 26 bytes) and think it has root; `token revoke -self` never touches the file, and only `vault.sh revoke-root` deletes it. Worth stating plainly.

## What is NOT the blocker

- **AppRole is healthy.** All four platform roles authenticate: `infra`, `db`, `auth`, `observability`, each with its own policy. Re-confirmed as its own measurement, since OIDC and AppRole are independent methods.
- **Keycloak is already correct.** `jon` holds realm role `platform-admin` (Stage 1, #636), and `hill90-vault`'s mapper is intact with `claim.name=realm_roles` — the deliberate non-default. The moment an OIDC method exists, the binding should match. *Should* — untested, and cited nowhere as if it were.

## The instrument, and why it has controls

`vault.sh oidc_enabled` (#645) needs a token to call `bao auth list`. A revoked-root vault has none — so on the one vault where the answer decided everything, the question was unanswerable. The new check reads unauthenticated status codes instead:

```
positive control  auth/approle/login                -> 500   (mounted)
negative control  auth/no-such-method-3594870/login -> 403   (absent)
target            auth/oidc/oidc/auth_url           -> 403   -> ABSENT
```

**OpenBao returns 403, not 404, for a mount that does not exist.** That is counter-intuitive enough to be worthless without the pair of controls, so the script exits `2` (indeterminate) rather than guessing if either misbehaves. Verified against the live vault: both controls passed, verdict `absent`, exit 1.

Second independent instrument agreeing: `/openbao/file/core/_auth` — the barrier-encrypted auth mount table — has mtime `Aug 2 23:48`, the rebuild. Nothing has touched it since.

## One untried lever, and it is Jon's call

The live `config.hcl` carries **no** `disable_unauthed_generate_root_endpoints` flag, so today's `generate-root` 403 is the documented **default**, not a re-proof that overriding it fails. The option is real and top-level — confirmed by name in the 2.6.1 binary. Setting it `false`, deploying through the pipeline and restarting would allow minting root from the unseal key, which is present at threshold 1 of 1 — no data loss, no reinitialise.

`vault-unseal.md` records a prior negative result for this, but it predates the rebuild and its own wording ("at listener and at top level") suggests placement was uncertain at the time. **Not tested here** — it changes production config and restarts the platform's vault, which is a deploy.

## Changes

- `scripts/vault.sh` — `bound_claims` -> `platform-admin`, matching Grafana's #637. Claim **name** unchanged; #635 measured that binding as already consistent, and renaming the mapper was the fix that would have changed nothing. Carries a comment marking it unproven and pointing at the decision record.
- `scripts/checks/vault-oidc-enabled-test.sh` — new, token-free, controlled.
- `docs/decisions/stage2b-oidc-blocked-2026-08-02.md` — the evidence.
- `docs/runbooks/openbao-rebuild.md` — its "After" section said Stage 2b follows once AppRole is proven. AppRole *is* proven; the block is elsewhere.
- Two stale comments quoting `["admin"]` corrected.

The old value was not merely outdated but inert — realm role `admin` has **zero holders**. Leaving it would have the next rebuild silently reinstate a binding that can authorise nobody.

## Verification

- Every `scripts/checks/*` CI check run locally: all pass.
- `shellcheck` clean on the new script; `bash -n` clean.
- New check executed against the live vault, controls confirmed.
- **Baseline after every step: 16 platform containers by name, 0 unhealthy**, plus the tenant's 7 = 23. Unchanged throughout, as expected — no step modified anything.
- **No token or secret value was printed at any point.** No root token was generated, so none needed revoking.

**Do not merge yet** — Jon decides the config-flag attempt vs. a second reinitialise first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)