### PR TITLE
feat(vault): Stage 2b complete — OIDC enabled, and a real login for jon proves it

### DIFF
--- a/.github/workflows/vault-init.yml
+++ b/.github/workflows/vault-init.yml
@@ -172,13 +172,19 @@ jobs:
             deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
             'cd /opt/hill90/app && git checkout -- infra/secrets/prod.enc.env && rm -f infra/secrets/prod.enc.env.backup.*' || true
 
-      # ONE-WAY DOOR — off by default, and this is why.
+      # EXPENSIVE DOOR — off by default, and this is why.
       #
       # On OpenBao >= 2.5.3 the unauthenticated root-generation endpoints are
-      # disabled by default, so `bao operator generate-root` returns 403
-      # (verified against 2.6.1). With no other sudo-capable token, revoking
-      # root means the vault can never be configured again without
-      # reinitializing it.
+      # disabled by default. With no other sudo-capable token, revoking root
+      # means the vault cannot be configured again until it is redeployed on
+      # platform/vault/config.recovery.hcl and root is minted from the unseal
+      # key — `gh workflow run vault-regain-root.yml`, proven end to end
+      # 2026-08-03.
+      #
+      # This comment said "can never be configured again without reinitializing"
+      # and cited `bao operator generate-root` returning 403. That CLI targets a
+      # legacy path which 403s under every configuration; the live endpoint is
+      # sys/generate-root/*. See docs/decisions/stage2b-oidc-blocked-2026-08-02.md.
       #
       # Revoking immediately after init — which this workflow used to do
       # unconditionally — therefore produced a vault that was up, healthy, and

--- a/.github/workflows/vault-reinitialize.yml
+++ b/.github/workflows/vault-reinitialize.yml
@@ -13,9 +13,11 @@ name: Vault Reinitialize (Prod)
 #   backup -> wipe -> redeploy (on raft) -> init -> unseal -> store key
 #          -> setup -> seed -> setup-sync-token -> PR the new secrets
 #
-# Root is NOT revoked. That is the one-way door, it is the mistake this
+# Root is NOT revoked. Revoking before anything is configured is the mistake this
 # workflow exists to avoid repeating, and it is left as a separate deliberate
-# command printed at the end.
+# command printed at the end. (It was called a ONE-WAY door here until
+# 2026-08-03; it is not — see vault-regain-root.yml — but it is expensive enough
+# that the ordering still matters.)
 #
 # DESTRUCTIVE: it deletes the openbao-data volume. Three things stand in the
 # way of that happening by accident:

--- a/docs/architecture/secrets-model.md
+++ b/docs/architecture/secrets-model.md
@@ -26,8 +26,11 @@
 > Filling it is a deliberate next step, not an oversight — it depends on the
 > open question in [Vault vs SOPS](../decisions/vault-vs-sops.md), which is
 > still Jon's call. Running `setup` and `seed` also needs a root token, and the
-> one minted at init was revoked immediately by design; a new one comes from
-> `bao operator generate-root` using the unseal key.
+> one minted at init was revoked immediately by design; a new one comes from the
+> unseal key via `bash scripts/vault.sh regain-root`, which needs the vault
+> redeployed on `config.recovery.hcl` first — `gh workflow run
+> vault-regain-root.yml` does both. **Not** `bao operator generate-root`: that CLI
+> targets a legacy path and returns 403 whatever the configuration.
 
 ## Intended model
 

--- a/docs/architecture/security.md
+++ b/docs/architecture/security.md
@@ -45,11 +45,17 @@ restricting administration to a private network.
 
 **Vault admin access is token-based. There is no single sign-on.**
 
-OIDC through Keycloak was removed along with the Keycloak stack — the
-`hill90-vault` client was its only remaining consumer, and carrying a full
-identity provider for one operator was not worth the surface. Obtain a token
-from `vault.sh init` output or `bao operator generate-root`, and revoke
-generated root tokens immediately after use.
+**OIDC through Keycloak is ENABLED, and this paragraph said it had been removed.**
+`Verified 2026-08-03` by a completed authorization-code login: `jon` authenticates
+against realm `platform` through client `hill90-vault` and receives
+`policy-oidc-admin`, bound on the realm role `platform-admin`. The claim is
+`realm_roles`, deliberately not Keycloak's `realm_access.roles` default.
+`scripts/checks/vault-oidc-login-test.sh` re-proves it.
+
+For a root token: `vault.sh init` output, or the unseal key via
+`bash scripts/vault.sh regain-root` (see `vault-regain-root.yml`). **Not**
+`bao operator generate-root` — that CLI targets a legacy path and returns 403
+whatever the configuration. Revoke generated root tokens immediately after use.
 
 The Traefik dashboard and Portainer are protected by Traefik basic auth plus the
 Tailscale IP allowlist. The dashboard password hash is generated at deploy time

--- a/docs/decisions/stage2b-oidc-blocked-2026-08-02.md
+++ b/docs/decisions/stage2b-oidc-blocked-2026-08-02.md
@@ -1,4 +1,17 @@
-# Stage 2b: the vault has no OIDC method — and the door back is not one-way after all
+# Stage 2b: the vault had no OIDC method — and the door back was not one-way after all
+
+> ## RESOLVED 2026-08-03. Stage 2b is complete.
+>
+> OIDC is enabled on the production vault, and **a real authorization-code login for `jon`
+> yields `policy-oidc-admin`** against the `platform-admin` bound claim. The recovery ran
+> through `vault-regain-root.yml`; the unauthenticated root-generation window was opened and
+> closed inside that one run, and the root token minted for it has been **revoked and
+> removed**. Everything below the line is the investigation that got here and is kept as the
+> record; the outcome is in "How it actually ended" at the bottom.
+>
+> *The filename still says `blocked`. Links to it exist in seven files and in merged commit
+> messages, so it stays — the banner is the correction, not a rename.*
+
 
 `Measured 2026-08-02.` Production was inspected **read-only**; nothing was deployed or
 changed there. The recovery was proven on **throwaway OpenBao 2.6.1 instances**, isolated,
@@ -159,20 +172,101 @@ grafana keycloak loki minio node-exporter openbao portainer postgres postgres-ex
 prometheus promtail tempo traefik` — with the tenant's 7 alongside, 23 in total. OpenBao
 `Initialized true / Sealed false`, 2.6.1.
 
-## What remains, in order
+## How it actually ended — `Verified 2026-08-03`
 
-1. **Merge, then `gh workflow run vault-regain-root.yml -f confirm=REGAIN`.** Deploys come
-   from `origin/main`, so this cannot run from a branch.
-2. **Prove a real authorization-code login for `jon` yields `policy-oidc-admin`** at
-   `https://vault.hill90.com/ui/`. Reading `auth/oidc/role/admin-sso` is not proof — config
-   that reads correctly is what this estate had for six days while it authorised nobody.
-3. **Re-prove AppRole separately** — `scripts/checks/vault-approle-login-test.sh`. The
-   workflow runs it, and it is independent of OIDC by construction.
-4. **Decide the root token's end state.** `revoke_root_at_end` defaults to `false`, leaving a
-   live token on the host; `assert_safe_to_revoke` will now permit the revoke because OIDC
-   exists. Leaving it live is the standing largest risk in this design; revoking it means the
-   next configuration change needs another recovery run. That trade is Jon's.
+### The recovery ran, and the window shut
 
-**If step 1 or 2 fails, the reinitialise remains available and is unaffected by any of
-this** — `vault-reinitialize.yml`, with #643's non-negotiables: fresh backup, restore proven
-into a throwaway volume, and every stored KV path confirmed to have a SOPS source.
+`vault-regain-root.yml` (run 30783449270) completed with every step green: baseline → deploy
+`config.recovery.hcl` → assert auto-unseal → mint → `setup-oidc` → deploy `config.hcl` →
+assert the endpoint is shut → confirm OIDC → re-prove AppRole → baseline.
+
+```
+Regain root from the unseal key    ✓ Root regained ... policies: root
+ASSERT ... shut again              POST sys/generate-root/attempt -> 405  (405 = closed)
+Confirm OIDC survived              positive 500 / negative 403 / target 400  -> MOUNTED
+```
+
+**The guard was checked for teeth, not just for green.** Running the workflow's assert logic
+verbatim against a throwaway vault that *is* on the recovery config returns 200 and exits 1
+with the `::error::`. A passing assertion therefore means something.
+
+Independently confirmed on the host afterwards: the live container mounts
+`platform/vault/config.hcl`, that file contains **0** occurrences of the flag, and
+`sys/generate-root/attempt` answers **405** while the absent-path control answers 403.
+
+### The login — proven, and proven to gate
+
+```
+✓ OpenBao issued an authorize URL for role admin-sso
+✓ it points at https://auth.hill90.com, realm platform
+✓ Keycloak served a login form
+✓ Keycloak issued an authorization code
+✓ OpenBao issued a token (value not printed)
+✓ policies: default,policy-oidc-admin
+```
+
+A positive result alone would not show the binding *gates* anything. Negative control: the
+same user, same flow, a throwaway role bound to `a-role-nobody-holds` —
+
+```
+{"errors":["OpenBao login failed. error validating claims: claim \"realm_roles\" does not
+match any associated bound claim values"]}
+```
+
+— refused, explicitly on the claim. The throwaway role was deleted; `bao list auth/oidc/role`
+returns `['admin-sso']`.
+
+Shipped as `scripts/checks/vault-oidc-login-test.sh`, re-runnable.
+
+### The defect that made a working system look broken
+
+The first login attempts failed with `{"errors":["permission denied"]}` and **nothing in the
+OpenBao log**, which reads exactly like a rejected claim. It was not.
+
+**The API callback is `/v1/auth/oidc/oidc/callback`** — the method is mounted at `oidc` and
+the plugin's own route is `oidc/callback`. `setup-oidc` registered
+`/v1/auth/oidc/callback`, which is not a route at all, so the request never reached the OIDC
+backend and OpenBao denied it generically.
+
+The UI redirect URI was always correct, so **browser logins were never affected** — which is
+why this survived undetected. Corrected in `scripts/vault.sh`, `scripts/keycloak.sh`,
+`scripts/local.sh` and `platform/auth/keycloak/platform-realm.json`.
+
+Diagnostic worth keeping: `permission denied` **with no OIDC log line** means the path is
+wrong; a bound-claim failure names the claim and appears in the response.
+
+### AppRole, independently
+
+Re-proved after all OIDC work and again after the root revoke: `db`, `auth`, `infra`,
+`observability` all authenticate with their own policies. This whole episode began with one
+auth method silently failing while the other looked fine, so it is measured separately every
+time, never inferred.
+
+### Root token: revoked, and the file removed
+
+`vault.sh revoke-root` reported `✓ Root token revoked and confirmed dead` — it verifies by
+looking the token up again, because `token revoke -self` exits 0 even for a token that never
+existed — then `✓ Removed /opt/hill90/secrets/openbao-root.token`.
+
+**The file is absent, and that is the intended end state.** Confirmed by `ls`. It holds no
+value, live or dead, so there is nothing for a future session to mistake for root.
+`openbao-unseal.key` is untouched: it is the input to any future recovery.
+
+Proof the estate still works with no root token anywhere: a fresh OIDC login still returns
+`policy-oidc-admin`, and all four AppRoles still authenticate.
+
+### Baseline
+
+**16 platform containers by name, 0 unhealthy**, before and after every deploy and after the
+revoke, with the tenant's 7 alongside.
+
+## Loose ends, stated rather than left
+
+- **`TEST_USER_PASSWORD` does not authenticate `testuser01`.** Found while looking for a
+  negative-control user; the login form returns 200 with no redirect. Store-versus-realm
+  drift, the same shape as the `GRAFANA_OIDC_CLIENT_SECRET` finding in #635. Not
+  investigated — it blocks nothing and is outside this change.
+- **The host checkout was five commits behind with a dirty `prod.enc.env`.** The file was
+  byte-identical to `origin/main`, so `git reset --hard` was safe and AppRole was re-proved
+  immediately afterwards. `preflight-checkout.sh` would have halted the deploy first, which
+  is the guard working.

--- a/docs/decisions/vault-vs-sops.md
+++ b/docs/decisions/vault-vs-sops.md
@@ -202,8 +202,10 @@ with the new secrets.
 anyway. Doing it separately means a second outage and an `operator migrate` for
 no benefit.
 
-**Root is not revoked.** That is the one-way door, and revoking it before
-anything was configured is precisely what produced the current inert vault. The
+**Root is not revoked.** Revoking it before anything was configured is precisely
+what produced the current inert vault. *(Called a one-way door here until
+2026-08-03; it is recoverable via `vault.sh regain-root` at the cost of a config change, two restarts and a credential-free window — see
+[`stage2b-oidc-blocked-2026-08-02.md`](stage2b-oidc-blocked-2026-08-02.md).)* The
 run summary prints the single command to do it once you are satisfied.
 
 It cannot fire by accident. The confirmation input must be exactly

--- a/docs/runbooks/local-development.md
+++ b/docs/runbooks/local-development.md
@@ -182,8 +182,9 @@ change both.**
 ## Rehearsing the vault lifecycle
 
 The vault is the one part of the stack with irreversible steps — initialization
-mints a key that cannot be recovered, and revoking root is a one-way door on
-OpenBao ≥ 2.5.3. Locally all of it is free and the volume is disposable, so the
+mints a key that cannot be recovered, and revoking root on OpenBao ≥ 2.5.3 costs
+a full recovery run to undo (`vault.sh regain-root`) — it was described here as a
+one-way door until 2026-08-03, which was wrong. Locally all of it is free and the volume is disposable, so the
 sequence can be practised before it is run against the VPS:
 
 ```bash

--- a/docs/runbooks/openbao-rebuild.md
+++ b/docs/runbooks/openbao-rebuild.md
@@ -129,13 +129,16 @@ bash scripts/vault.sh bootstrap-approles
 > Since #644 both revoke sites call `assert_safe_to_revoke`, which **refuses** when the OIDC
 > auth method is not enabled — so the door can no longer be closed by accident, and the
 > ordering below is enforced rather than merely advised. With
-> `generate-root` disabled, that makes it the last administrative act possible — anything
-> not configured before it cannot be configured afterwards without another reinitialise.
+> `generate-root` disabled, that makes it the last administrative act possible on the
+> production config — anything not configured before it needs a recovery run
+> (`vault-regain-root.yml`) afterwards. This sentence said "without another reinitialise",
+> which overstated it.
 >
 > **This was learned the hard way on 2026-08-02.** The reinitialise workflow does not run
 > `setup-oidc` at all, and this runbook originally listed `bootstrap-approles` first. The
 > result was a rebuilt vault with working AppRoles, no OIDC auth method, and no way to add
-> one — the same one-way door as 2026-07-26, recreated by the repair itself.
+> one — the same trap as 2026-07-26, recreated by the repair itself. It was reopened on
+> 2026-08-03 by minting root from the unseal key, without destroying anything.
 
 `bootstrap-approles` writes the new role/secret IDs back into SOPS — **that change must be
 committed**, or the next deploy syncs the host checkout to `main` and reverts them.
@@ -174,8 +177,10 @@ Stage 2b — repointing the `admin-sso` OIDC role from `realm_roles: admin` to
 > **AppRole was proven, and Stage 2b is still blocked — for a different reason.**
 > `Verified 2026-08-02.` This rebuild ran **before** #645's guard existed, so Step 5 went in
 > the order this page originally gave: `bootstrap-approles` first, `setup-oidc` never. The
-> result is the one-way door again — **no OIDC auth method, a root token file whose token is
+> result was that trap again — **no OIDC auth method, a root token file whose token is
 > dead, `generate-root` 403, and `deny` on `sys/auth/oidc` for all four AppRoles.**
+> **RESOLVED 2026-08-03** by `vault-regain-root.yml`: OIDC is enabled and a real login for
+> `jon` yields `policy-oidc-admin`.
 >
 > All four AppRoles do authenticate, so Step 6's first bullet passes. That is not the
 > blocker and never was.

--- a/platform/auth/keycloak/platform-realm.json
+++ b/platform/auth/keycloak/platform-realm.json
@@ -84,7 +84,7 @@
       "directAccessGrantsEnabled": false,
       "serviceAccountsEnabled": false,
       "redirectUris": [
-        "https://vault.hill90.com/v1/auth/oidc/callback",
+        "https://vault.hill90.com/v1/auth/oidc/oidc/callback",
         "https://vault.hill90.com/ui/vault/auth/oidc/oidc/callback"
       ],
       "webOrigins": [

--- a/scripts/checks/check_vault_revoke_order.py
+++ b/scripts/checks/check_vault_revoke_order.py
@@ -85,7 +85,8 @@ def check_workflow(path: Path) -> list[str]:
                 problems.append(
                     f"{path.name}: step {name!r} can reach `vault.sh revoke-root` "
                     f"with the OIDC auth method not yet enabled — no `setup-oidc` "
-                    f"runs before it in this job. That revoke is a one-way door."
+                    f"runs before it in this job. Undoing that needs a full "
+                    f"root-recovery run (vault-regain-root.yml)."
                 )
     return problems
 

--- a/scripts/checks/vault-oidc-login-test.sh
+++ b/scripts/checks/vault-oidc-login-test.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+# Drive a REAL OpenBao OIDC login for jon and assert the policy it yields.
+#
+# WHY A LOGIN AND NOT A CONFIG READ
+# =================================
+# `bao read auth/oidc/role/admin-sso` tells you what the role says. This estate
+# has already been burned by exactly that gap: the role bound realm role `admin`,
+# the config read fine, and the role had ZERO holders — so it authorised nobody
+# for six days while looking correct. Only a completed flow proves the chain
+# Keycloak mapper -> claim -> bound_claims -> policy actually joins up.
+#
+# WHAT IT DOES
+# ============
+# The full authorization-code flow, headless:
+#   1. ask OpenBao for the authorize URL   (auth/oidc/oidc/auth_url)
+#   2. GET it at Keycloak, keep the session cookie, find the login form
+#   3. POST jon's credentials, capture `code` and `state` from the 302
+#   4. hand them back to OpenBao's callback and read the token it issues
+#
+# OpenBao is addressed on its PUBLIC URL, through Traefik, because that is the
+# path a human uses and because busybox wget inside the container discards error
+# bodies — and the error body is the whole diagnosis here. A bound-claim mismatch
+# and a broken flow both look like "no token" without it.
+#
+# SIDE EFFECT, stated because it is real: this creates a genuine user session and
+# a LOGIN event for jon in realm `platform`. That is the cost of proving it.
+#
+# The password is read from SOPS into a variable and never printed, never placed
+# in argv, and never written to disk. The token is never printed either — only
+# the policies it carries.
+#
+# Usage: bash scripts/checks/vault-oidc-login-test.sh
+# Exit:  0 login succeeded with the expected policy | 1 otherwise
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+CONTAINER="${VAULT_CONTAINER:-openbao}"
+SECRETS_FILE="${VAULT_SECRETS_FILE:-${PROJECT_ROOT}/infra/secrets/prod.enc.env}"
+VAULT_PUBLIC_URL="${VAULT_PUBLIC_URL:-https://vault.hill90.com}"
+KC_URL="${KC_PUBLIC_URL:-https://auth.hill90.com}"
+KC_REALM="${KC_REALM:-platform}"
+ROLE="${VAULT_OIDC_ROLE:-admin-sso}"
+USERNAME="${OIDC_TEST_USERNAME:-jon}"
+PASSWORD_KEY="${OIDC_TEST_PASSWORD_KEY:-JON_KC_PASSWORD}"
+EXPECT_POLICY="${VAULT_OIDC_EXPECT_POLICY:-policy-oidc-admin}"
+
+ok()  { echo "  ✓ $*"; }
+bad() { echo "  ✗ $*"; }
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+echo "OpenBao OIDC login — real authorization-code flow"
+echo "================================================="
+echo "  user: ${USERNAME}   role: ${ROLE}   realm: ${KC_REALM}"
+echo
+
+command -v sops >/dev/null 2>&1 || { bad "sops is required"; exit 1; }
+docker inspect "$CONTAINER" >/dev/null 2>&1 || { bad "Container $CONTAINER is not running"; exit 1; }
+
+PASSWORD="$(sops -d --extract "[\"${PASSWORD_KEY}\"]" "$SECRETS_FILE" 2>/dev/null)"
+[ -n "$PASSWORD" ] || { bad "${PASSWORD_KEY} not found in ${SECRETS_FILE}"; exit 1; }
+
+# THE REDIRECT URI AND THE CALLBACK PATH ARE NOT THE SAME STRING, and conflating
+# them is what made this look like a bound-claim failure. The plugin is mounted at
+# `oidc` and its own route is `oidc/callback`, so the real endpoint is
+#     /v1/auth/oidc/oidc/callback        <- note the doubled segment
+# while `vault.sh setup-oidc` registered `/v1/auth/oidc/callback` until 2026-08-03.
+# That path is not a route at all: it answers `permission denied` with nothing in
+# the OpenBao log, which reads exactly like a rejected claim.
+#
+# The default here is deliberately the UI redirect — it was correct even while the
+# API one was wrong, so this check works against a vault configured either way.
+# The code is redeemed at the API callback regardless: OpenBao exchanges with the
+# redirect_uri it stored alongside the state, so the two need not match.
+REDIRECT="${VAULT_REDIRECT_URI:-${VAULT_PUBLIC_URL}/ui/vault/auth/oidc/oidc/callback}"
+CALLBACK="${VAULT_PUBLIC_URL}/v1/auth/oidc/oidc/callback"
+
+# --- 1. Ask OpenBao where to send the user ---------------------------------
+BODY="$(python3 -c 'import json,sys; print(json.dumps({"role": sys.argv[1], "redirect_uri": sys.argv[2]}))' "$ROLE" "$REDIRECT")"
+AUTH_JSON="$(curl -sS -X POST -H 'Content-Type: application/json' \
+    --data "$BODY" "${VAULT_PUBLIC_URL}/v1/auth/oidc/oidc/auth_url")"
+
+AUTH_URL="$(printf '%s' "$AUTH_JSON" | python3 -c 'import sys,json
+try: print(json.load(sys.stdin)["data"]["auth_url"])
+except Exception: print("")' 2>/dev/null)"
+
+if [ -z "$AUTH_URL" ]; then
+    bad "OpenBao did not return an auth_url."
+    printf '%s\n' "$AUTH_JSON" | head -3 | sed 's/^/     /'
+    echo "     (an empty auth_url usually means role ${ROLE} does not exist, or the"
+    echo "      redirect_uri is not in its allowed_redirect_uris)"
+    exit 1
+fi
+ok "OpenBao issued an authorize URL for role ${ROLE}"
+
+# Sanity: it must point at the realm we think it does.
+case "$AUTH_URL" in
+    "${KC_URL}/realms/${KC_REALM}/protocol/openid-connect/auth"*) ok "it points at ${KC_URL}, realm ${KC_REALM}" ;;
+    *) bad "unexpected authorize URL host/realm"; echo "     ${AUTH_URL%%\?*}"; exit 1 ;;
+esac
+
+# --- 2. Fetch the login form -----------------------------------------------
+FORM="$(curl -sS -c "$TMP/cookies" "$AUTH_URL")" || { bad "could not reach Keycloak"; exit 1; }
+
+ACTION="$(printf '%s' "$FORM" | python3 -c '
+import sys, re, html
+m = re.search(r"<form[^>]*id=\"kc-form-login\"[^>]*action=\"([^\"]+)\"", sys.stdin.read())
+print(html.unescape(m.group(1)) if m else "")')"
+
+if [ -z "$ACTION" ]; then
+    bad "no Keycloak login form in the response."
+    # A user with a pending required action lands somewhere else entirely, and
+    # that looks exactly like rejected credentials if you do not check.
+    printf '%s' "$FORM" | grep -o "required-action[^\"]*" | head -2 | sed 's/^/     /'
+    exit 1
+fi
+ok "Keycloak served a login form"
+
+# --- 3. Log in, capture the code -------------------------------------------
+# --data-urlencode keeps the password out of argv-visible URL assembly and
+# handles any character it may contain.
+HEADERS="$(curl -sS -b "$TMP/cookies" -c "$TMP/cookies" -D - -o /dev/null \
+    --data-urlencode "username=${USERNAME}" \
+    --data-urlencode "password=${PASSWORD}" \
+    --data-urlencode "credentialId=" \
+    "$ACTION")"
+unset PASSWORD
+
+LOCATION="$(printf '%s' "$HEADERS" | grep -i '^location:' | tail -1 | sed 's/^[Ll]ocation:[[:space:]]*//' | tr -d '\r')"
+
+if [ -z "$LOCATION" ]; then
+    bad "no redirect after the credential POST — the login did not complete."
+    printf '%s' "$HEADERS" | head -1 | sed 's/^/     /'
+    exit 1
+fi
+
+case "$LOCATION" in
+    *code=*) ok "Keycloak issued an authorization code" ;;
+    *error=*) bad "Keycloak refused: ${LOCATION#*error=}"; exit 1 ;;
+    *required-action*|*login-actions*)
+        bad "diverted to a required action — this is NOT rejected credentials."
+        echo "     ${LOCATION%%\?*}"
+        exit 1 ;;
+    *) bad "unexpected redirect: ${LOCATION%%\?*}"; exit 1 ;;
+esac
+
+CODE="$(printf '%s' "$LOCATION" | sed -n 's/.*[?&]code=\([^&]*\).*/\1/p')"
+STATE="$(printf '%s' "$LOCATION" | sed -n 's/.*[?&]state=\([^&]*\).*/\1/p')"
+[ -n "$CODE" ] && [ -n "$STATE" ] || { bad "could not extract code/state"; exit 1; }
+
+# --- 4. Redeem it at OpenBao's callback ------------------------------------
+CB="$(curl -sS -G "${CALLBACK}" \
+    --data-urlencode "code=${CODE}" --data-urlencode "state=${STATE}")"
+
+POLICIES="$(printf '%s' "$CB" | python3 -c 'import sys,json
+try: print(",".join(json.load(sys.stdin)["auth"]["policies"]))
+except Exception: print("")' 2>/dev/null)"
+HAS_TOKEN="$(printf '%s' "$CB" | python3 -c 'import sys,json
+try: print("yes" if json.load(sys.stdin)["auth"]["client_token"] else "no")
+except Exception: print("no")' 2>/dev/null)"
+
+if [ "$HAS_TOKEN" != "yes" ]; then
+    bad "OpenBao did not issue a token."
+    printf '%s\n' "$CB" | head -5 | sed 's/^/     /'
+    echo "     A 400 mentioning bound claims means the flow WORKED and the claim did"
+    echo "     not match — check the realm role, not the plumbing."
+    exit 1
+fi
+ok "OpenBao issued a token (value not printed)"
+ok "policies: ${POLICIES}"
+
+echo
+case ",${POLICIES}," in
+    *",${EXPECT_POLICY},"*)
+        echo "LOGIN PROVEN — ${USERNAME} authenticated by OIDC and received ${EXPECT_POLICY}."
+        exit 0 ;;
+    *)
+        bad "expected ${EXPECT_POLICY} in the policy list, got: ${POLICIES}"
+        exit 1 ;;
+esac

--- a/scripts/keycloak.sh
+++ b/scripts/keycloak.sh
@@ -465,8 +465,13 @@ cmd_apply() {
     # realm_access.roles: vault.sh setup-oidc binds
     # bound_claims {"realm_roles": ["platform-admin"]}, so defaulting here would create a
     # mapper OpenBao can never match and SSO would fail for everyone.
+    # The API callback is /v1/auth/oidc/OIDC/callback — the mount path and the
+    # plugin's own route are both `oidc`. This list read /v1/auth/oidc/callback,
+    # which is not a route: it answers `permission denied` with nothing logged,
+    # indistinguishable from a rejected claim. Corrected 2026-08-03; the UI entry
+    # was always right, so browser logins never saw it.
     ensure_client "hill90-vault" "$vault_secret" \
-        "${VAULT_PUBLIC_URL}/v1/auth/oidc/callback,${VAULT_PUBLIC_URL}/ui/vault/auth/oidc/oidc/callback" \
+        "${VAULT_PUBLIC_URL}/v1/auth/oidc/oidc/callback,${VAULT_PUBLIC_URL}/ui/vault/auth/oidc/oidc/callback" \
         "${VAULT_PUBLIC_URL}" \
         "realm_roles"
 

--- a/scripts/local.sh
+++ b/scripts/local.sh
@@ -340,10 +340,13 @@ cmd_up() {
 import json, sys
 base = sys.argv[1].rstrip("/")
 print(json.dumps([
+    # The API callback is /v1/auth/oidc/OIDC/callback — mount path plus the
+    # plugin route, both `oidc`. These read /v1/auth/oidc/callback until
+    # 2026-08-03; that is not a route and answers permission denied silently.
     "https://vault.hill90.com/ui/vault/auth/oidc/oidc/callback",
-    "https://vault.hill90.com/v1/auth/oidc/callback",
+    "https://vault.hill90.com/v1/auth/oidc/oidc/callback",
     base + "/ui/vault/auth/oidc/oidc/callback",
-    base + "/v1/auth/oidc/callback",
+    base + "/v1/auth/oidc/oidc/callback",
 ]))' "$vault_local")
     local vault_cid
     vault_cid=$(docker exec "${cpfx}keycloak" /opt/keycloak/bin/kcadm.sh get clients \

--- a/scripts/vault.sh
+++ b/scripts/vault.sh
@@ -630,6 +630,17 @@ cmd_setup_oidc() {
     # production URL keeps this byte-identical to what prod got before; local
     # rehearsal sets VAULT_PUBLIC_URL instead of forking the command.
     local vault_url="${VAULT_PUBLIC_URL:-https://vault.hill90.com}"
+    # THE API CALLBACK HAS A DOUBLED SEGMENT, and allowed_redirect_uris had it
+    # wrong below. The method is mounted at `oidc` and the plugin route is also
+    # `oidc/callback`, so the real endpoint is /v1/auth/oidc/oidc/callback. This
+    # list used to carry /v1/auth/oidc/callback — not a route at all, which
+    # answers `permission denied` with NOTHING in the OpenBao log and therefore
+    # reads exactly like a rejected bound claim. It cost an hour on 2026-08-03.
+    # The UI entry was always right, which is why browser logins were unaffected.
+    #
+    # Keep prose OUT of the python block below: it is inside a single-quoted
+    # shell string, so one apostrophe in a comment terminates the quote and
+    # breaks the command. That happened while writing this fix.
     local role_json
     role_json=$(python3 -c '
 import json, sys
@@ -641,7 +652,7 @@ print(json.dumps({
     "oidc_scopes": ["openid", "profile", "email"],
     "bound_claims": {"realm_roles": ["platform-admin"]},
     "allowed_redirect_uris": [
-        base + "/v1/auth/oidc/callback",
+        base + "/v1/auth/oidc/oidc/callback",
         base + "/ui/vault/auth/oidc/oidc/callback",
     ],
 }))' "$vault_url")
@@ -994,8 +1005,11 @@ cmd_bootstrap_approles() {
     root_token=$(bao_exec operator generate-root -decode="$encoded" -otp="$otp" 2>/dev/null)
 
     if [ -z "$root_token" ]; then
-        die "Failed to generate root token. On OpenBao >= 2.5.3 the unauthenticated
-root-generation endpoints are disabled by default, so this cannot mint one. Supply an
+        die "Failed to generate root token. This code path uses \`bao operator
+generate-root\`, which targets a LEGACY endpoint and returns 403 on 2.6.1 whatever the
+configuration — it cannot mint one here. The working route is
+\`gh workflow run vault-regain-root.yml\` (redeploys on config.recovery.hcl, then
+scripts/vault.sh regain-root). Supply an
 existing root token instead:
 
   export BAO_TOKEN=\"\$(sudo cat /opt/hill90/secrets/openbao-root.token)\"


### PR DESCRIPTION
## Outcome

**Stage 2b is done.** OIDC is enabled on the production vault and a real authorization-code login for `jon` yields `policy-oidc-admin` against the `platform-admin` bound claim. The root token minted to get there has been revoked and its file removed.

## The two things you asked to be stated plainly

### 1. Are the documents corrected?

**#648 corrected five. A full sweep found seven more still asserting it, and this PR corrects those.** Your concern was well placed — a corrected system with uncorrected documents is exactly what was left.

| Site | Was | Now |
|---|---|---|
| `.github/workflows/vault-init.yml` | "ONE-WAY DOOR … can never be configured again without reinitializing" | names the recovery run |
| `.github/workflows/vault-reinitialize.yml` | "That is the one-way door" | corrected, with the retraction dated |
| `scripts/checks/check_vault_revoke_order.py` | **runtime message** "That revoke is a one-way door." | "Undoing that needs a full root-recovery run" |
| `docs/architecture/security.md` | **"OIDC through Keycloak was removed"** | false since today — replaced with the verified state |
| `docs/architecture/secrets-model.md` | "a new one comes from `bao operator generate-root`" | the command that works |
| `docs/runbooks/local-development.md` | "revoking root is a one-way door" | corrected |
| `docs/decisions/vault-vs-sops.md` (3rd site) | "That is the one-way door" | corrected |
| `docs/runbooks/openbao-rebuild.md` (3 sites) | "the one-way door again", "without another reinitialise" | corrected + marked RESOLVED |

`security.md` is the one I'd flag: it asserted OIDC had been **removed** and that `hill90-vault` was its only consumer. Anyone reading it would have concluded this work was pointless.

**Deliberately not rewritten:** `docs/decisions/2026-07-26-overnight-summary.md` and `stage1-platform-roles.md`. Those are dated records of what was believed then; rewriting them would destroy the history rather than correct it. The current-state documents all point at the corrected record.

### 2. Is the flag left enabled anywhere?

**No. Verified, not assumed.**

- The flag appears in exactly three files: `config.recovery.hcl` (by design), `vault.sh` (the `regain-root` guard and comments), `vault-regain-root.yml` (the one step that sets it).
- `platform/vault/config.hcl` — the default — contains **0** occurrences.
- Compose default is `${VAULT_CONFIG_FILE:-config.hcl}`. The workflow's **restore** step sets no `VAULT_CONFIG_FILE` at all, so it falls back to the default; the only assignment is in the deploy-recovery step.
- **On the live host:** the container mounts `platform/vault/config.hcl`, that file has **0** flag lines, and `POST sys/generate-root/attempt` answers **405** (absent-path control: 403). Nothing persists `VAULT_CONFIG_FILE` in any host env file or shell profile.

## The window — and proof the guard has teeth

Run [30783449270](https://github.com/jonhill90/Hill90/actions/runs/30783449270), every step green:

```
Regain root from the unseal key    ✓ Root regained ... policies: root
ASSERT ... shut again              POST sys/generate-root/attempt -> 405  (405 = closed)
Confirm OIDC survived              positive 500 / negative 403 / target 400 -> MOUNTED
```

A green assertion is only worth something if it can go red, so I ran the workflow's assert logic **verbatim** against a throwaway vault that *is* on the recovery config: it returns 200, prints the `::error::` and exits 1. The guard is real.

## The login — and proof the binding gates

```
✓ authorize URL issued for role admin-sso, pointing at auth.hill90.com realm platform
✓ Keycloak served a login form
✓ Keycloak issued an authorization code
✓ OpenBao issued a token (value not printed)
✓ policies: default,policy-oidc-admin
```

A positive alone doesn't show the claim *gates* anything. Negative control — same user, same flow, throwaway role bound to `a-role-nobody-holds`:

```
{"errors":["OpenBao login failed. error validating claims: claim \"realm_roles\"
 does not match any associated bound claim values"]}
```

Refused, explicitly on the claim. Role deleted; `bao list auth/oidc/role` → `['admin-sso']`.

Shipped as `scripts/checks/vault-oidc-login-test.sh`.

## A real defect found on the way

The first attempts returned `{"errors":["permission denied"]}` with **nothing in the OpenBao log** — indistinguishable from a rejected claim.

**The API callback is `/v1/auth/oidc/oidc/callback`.** The method is mounted at `oidc` and the plugin's own route is also `oidc/callback`. `setup-oidc` registered `/v1/auth/oidc/callback`, which is not a route, so the request never reached the OIDC backend. The **UI** redirect was always correct, which is why browser logins were unaffected and this went unnoticed.

Fixed in `scripts/vault.sh`, `scripts/keycloak.sh`, `scripts/local.sh`, `platform/auth/keycloak/platform-realm.json`. Diagnostic worth keeping: *`permission denied` with no OIDC log line means the path is wrong; a claim failure names the claim.*

## AppRole, independently

Re-proved **twice** — after the OIDC work, and again after the root revoke. `db`, `auth`, `infra`, `observability`, each with its own policy. Measured separately every time, never inferred from OIDC.

## Root token: revoked, file removed — and which end state, and why

`revoke-root` reported `✓ Root token revoked and confirmed dead` (it re-looks-up the token, because `token revoke -self` exits 0 even for a token that never existed) then `✓ Removed /opt/hill90/secrets/openbao-root.token`.

**The file is absent.** That is the end state I chose: it holds no value, live or dead, so there is nothing for a future session to mistake for root — which is precisely the trap it was. `openbao-unseal.key` is untouched, since it is the input to any future recovery.

Proof the estate works with no root token anywhere: a fresh OIDC login still returns `policy-oidc-admin`, and all four AppRoles still authenticate.

## Loose ends, stated rather than left

- **`TEST_USER_PASSWORD` does not authenticate `testuser01`** — found while looking for a negative-control user. Store-versus-realm drift, same shape as the `GRAFANA_OIDC_CLIENT_SECRET` finding in #635. Not investigated; it blocks nothing.
- **The host checkout was 5 commits behind with a dirty `prod.enc.env`.** Byte-identical to `origin/main`, so the reset was safe and AppRole was re-proved straight after. `preflight-checkout.sh` would have halted the deploy first — the guard working.
- While writing the redirect fix I put prose inside `setup-oidc`'s single-quoted python block; an apostrophe terminated the quote. Caught by `shellcheck --severity=error` before commit, and there is now a comment saying not to do it.

## Verification

- All `scripts/checks/*` pass; `shellcheck --severity=error scripts/*.sh` clean; realm JSON and all workflows parse; the real `role_json` block extracted from `vault.sh` and rendered to confirm the corrected URIs.
- **Baseline after every deploy and after the revoke: 16 by name, 0 unhealthy**, tenant's 7 alongside.
- No token or secret value printed at any point.

**Not merged.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)