### PR TITLE
fix(deploy): empty is not success — a vault read that returns nothing must fail

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -163,6 +163,23 @@ vault_login() {
         python3 -c "import sys,json; print(json.load(sys.stdin)['auth']['client_token'])"
 }
 
+# Read one KV v2 path. NON-ZERO if the path cannot be read for ANY reason.
+#
+# THIS FUNCTION CAUSED A PRODUCTION OUTAGE ON 2026-08-03 by succeeding quietly.
+# It sent stderr to /dev/null and piped into python, so the pipeline's exit
+# status was python's — and python exits 0 after printing nothing when its input
+# is empty. A 403, a missing path and a genuinely empty secret were therefore
+# indistinguishable from a successful read, all reported as success.
+#
+# Downstream that meant `vault_load_secrets` exported NOTHING and returned 0, the
+# SOPS fallback never fired because nothing had failed, and Keycloak deployed with
+# KC_BOOTSTRAP_ADMIN_PASSWORD empty. It then refused to boot with
+# "bootstrap-admin-username available only when bootstrap admin password is set"
+# and auth.hill90.com 404d for 20 minutes.
+#
+# The rule this encodes: EMPTY IS NOT SUCCESS. Vault being unreachable is not the
+# only way the vault path can fail to produce a secret, and it was the only one
+# being handled.
 vault_read_kv() {
     local token="$1"
     local path="$2"
@@ -170,14 +187,32 @@ vault_read_kv() {
     # through, where `-e NAME=value` would put the token in the docker CLI's
     # command line for any local user to read with `ps`. Same reasoning as
     # scripts/keycloak.sh's kc_login and scripts/vault.sh's bao_exec_env.
-    BAO_TOKEN="$token" docker exec -e "BAO_ADDR=http://127.0.0.1:8200" -e BAO_TOKEN openbao \
-        bao kv get -format=json "$path" 2>/dev/null | \
-        python3 -c "
+    local raw
+    raw=$(BAO_TOKEN="$token" docker exec -e "BAO_ADDR=http://127.0.0.1:8200" -e BAO_TOKEN openbao \
+        bao kv get -format=json "$path" 2>&1) || {
+        warn "vault: cannot read ${path} — $(printf '%s' "$raw" | grep -oE '\* .*' | head -1)"
+        return 1
+    }
+
+    # Parse separately from the read so a JSON shape change is not read as an
+    # empty secret. python exits non-zero on a shape it does not recognise, and
+    # that status is now the function's.
+    printf '%s' "$raw" | python3 -c "
 import sys, json, shlex
-data = json.load(sys.stdin)['data']['data']
+try:
+    data = json.load(sys.stdin)['data']['data']
+except Exception as e:
+    sys.stderr.write(f'unparseable response: {e}\n')
+    sys.exit(1)
+if not data:
+    sys.stderr.write('path exists but holds no keys\n')
+    sys.exit(1)
 for k, v in data.items():
     print(f'{k}={shlex.quote(str(v))}')
-"
+" || {
+        warn "vault: ${path} did not yield usable data"
+        return 1
+    }
 }
 
 vault_paths_for_service() {
@@ -207,14 +242,58 @@ vault_load_secrets() {
     # shellcheck disable=SC2064
     trap "rm -f '$temp_file'" RETURN
 
+    # A path this service DECLARES it needs and cannot read is a failure, not a
+    # zero-length contribution. Returning non-zero here is what makes the caller
+    # fall back to SOPS — the fallback exists in both deploy paths and was simply
+    # never reached, because nothing ever failed.
     for path in $paths; do
-        vault_read_kv "$token" "$path" >> "$temp_file"
+        vault_read_kv "$token" "$path" >> "$temp_file" || {
+            warn "vault: ${service} declares ${path} but it could not be read — falling back to SOPS"
+            return 1
+        }
     done
+
+    # THE GENERIC EMPTY-VALUE GUARD.
+    #
+    # deploy.sh had one of these for TRAEFIK_ADMIN_PASSWORD_HASH on the infra path
+    # only — somebody learned this lesson once, for one variable, in one branch.
+    # The generic service path had none, which is why an empty KC_ADMIN_PASSWORD
+    # reached Keycloak on 2026-08-03. Checking one known variable per service does
+    # not scale and does not generalise: this asserts that NOTHING vault hands
+    # back is empty, whatever it is called.
+    #
+    # An empty value in vault is never a legitimate deploy input here. If one is
+    # ever wanted, it belongs in SOPS as an explicit empty, not arriving silently
+    # from a gap in the store.
+    local empty_keys=()
+    local line key
+    while IFS= read -r line; do
+        case "$line" in ''|'#'*) continue ;; esac
+        key="${line%%=*}"
+        # The values are shlex-quoted, so an empty one is exactly '' or "".
+        case "${line#*=}" in
+            "''"|'""'|'') empty_keys+=("$key") ;;
+        esac
+    done < "$temp_file"
+
+    if [ ${#empty_keys[@]} -gt 0 ]; then
+        warn "vault: ${service} — these resolved EMPTY from OpenBao: ${empty_keys[*]}"
+        warn "vault: refusing to deploy an empty credential; falling back to SOPS"
+        return 1
+    fi
+
+    local count
+    count=$(grep -cE '^[A-Za-z_][A-Za-z0-9_]*=' "$temp_file" 2>/dev/null || echo 0)
+    if [ "$count" -eq 0 ]; then
+        warn "vault: ${service} — the declared paths yielded no variables at all; falling back to SOPS"
+        return 1
+    fi
 
     set -a
     # shellcheck disable=SC1090
     source "$temp_file"
     set +a
+    info "vault: loaded ${count} variables for ${service}, none empty"
 
     rm -f "$temp_file"
     trap - RETURN

--- a/tests/scripts/vault-empty-guard.bats
+++ b/tests/scripts/vault-empty-guard.bats
@@ -1,0 +1,120 @@
+#!/usr/bin/env bats
+
+# The guard that would have prevented the 2026-08-03 auth outage.
+#
+# Keycloak deployed with KC_BOOTSTRAP_ADMIN_PASSWORD empty and refused to boot.
+# The chain: the `auth` AppRole holds a policy that does not exist, so its KV
+# reads returned 403; `vault_read_kv` discarded stderr and piped into python,
+# which exits 0 after printing nothing; `vault_load_secrets` therefore exported
+# nothing and RETURNED SUCCESS; the SOPS fallback never fired because nothing had
+# failed; and the generic deploy path had no empty-value guard — only the infra
+# path had one, for one named variable.
+#
+# These tests are the positive control. They make a key resolve empty, and a path
+# resolve unreadable, and assert the loader REFUSES. A guard that has never been
+# seen to fail is not a guard.
+#
+# `docker` is stubbed, so no vault and no VPS are involved.
+
+setup() {
+  STUB="$BATS_TEST_TMPDIR/bin"
+  mkdir -p "$STUB"
+  PATH="$STUB:$PATH"
+
+  # sops is called by vault_login; feed it credentials so login succeeds and the
+  # test exercises the READ, which is what broke.
+  cat > "$STUB/sops" <<'EOF'
+#!/usr/bin/env bash
+echo "VAULT_AUTH_ROLE_ID=rid"
+echo "VAULT_AUTH_SECRET_ID=sid"
+EOF
+  chmod +x "$STUB/sops"
+
+  ROOT="$BATS_TEST_DIRNAME/../.."
+}
+
+# $1 = the JSON (or error text) the stubbed `bao kv get` returns
+# $2 = exit code for `bao kv get`
+make_docker_stub() {
+  cat > "$STUB/docker" <<EOF
+#!/usr/bin/env bash
+# args end with: bao <subcommand> ...
+for a in "\$@"; do last="\$a"; done
+case " \$* " in
+  *"auth/approle/login"*)
+      echo '{"auth":{"client_token":"s.faketoken"}}'; exit 0 ;;
+  *" kv get "*)
+      cat <<'PAYLOAD'
+$1
+PAYLOAD
+      exit $2 ;;
+  *" status "*)
+      echo '{"sealed":false}'; exit 0 ;;
+esac
+exit 0
+EOF
+  chmod +x "$STUB/docker"
+}
+
+load_and_run() {
+  cd "$ROOT"
+  # shellcheck disable=SC1091
+  PROJECT_ROOT="$ROOT" source scripts/_common.sh
+  vault_load_secrets "auth" "$ROOT/infra/secrets/prod.enc.env"
+}
+
+@test "a healthy read still succeeds and exports the values" {
+  make_docker_stub '{"data":{"data":{"KC_ADMIN_USERNAME":"admin","KC_ADMIN_PASSWORD":"realsecret"}}}' 0
+  run load_and_run
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"loaded"*"none empty"* ]]
+}
+
+@test "REFUSES when a value resolves EMPTY — the outage condition" {
+  make_docker_stub '{"data":{"data":{"KC_ADMIN_USERNAME":"admin","KC_ADMIN_PASSWORD":""}}}' 0
+  run load_and_run
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"KC_ADMIN_PASSWORD"* ]]
+  [[ "$output" == *"EMPTY"* ]]
+  [[ "$output" == *"falling back to SOPS"* ]]
+}
+
+@test "the empty check is GENERIC — it names whatever key is empty, not a hardcoded one" {
+  make_docker_stub '{"data":{"data":{"SOME_UNRELATED_KEY":"","OTHER":"fine"}}}' 0
+  run load_and_run
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"SOME_UNRELATED_KEY"* ]]
+}
+
+@test "REFUSES on a 403 — the actual production failure, which used to return success" {
+  make_docker_stub 'Error making API request.
+
+Code: 403. Errors:
+
+* preflight capability check returned 403' 1
+  run load_and_run
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"cannot read"* ]]
+}
+
+@test "REFUSES when the path exists but holds no keys" {
+  make_docker_stub '{"data":{"data":{}}}' 0
+  run load_and_run
+  [ "$status" -ne 0 ]
+}
+
+@test "REFUSES on an unparseable response rather than reading it as empty" {
+  make_docker_stub 'not json at all' 0
+  run load_and_run
+  [ "$status" -ne 0 ]
+}
+
+@test "a failing load returns non-zero so deploy.sh reaches its SOPS fallback" {
+  # Both deploy paths wrap the vault branch in `( ... ) || { warn; _deploy_with_sops; }`.
+  # That fallback is only reachable if the subshell fails, which is precisely
+  # what did not happen during the outage.
+  grep -q 'retrying with SOPS fallback' "$ROOT/scripts/deploy.sh"
+  make_docker_stub '{"data":{"data":{"KC_ADMIN_PASSWORD":""}}}' 0
+  run load_and_run
+  [ "$status" -ne 0 ]
+}


### PR DESCRIPTION
**OUTAGE FIX — merging this is the restore step.** The pipeline deploys `origin/main`, so `auth` cannot be redeployed with the fix until this lands. Full write-up follows in a second PR; this one is deliberately minimal.

## Cause — not a missing key

`vault_read_kv` discarded stderr and piped into python, which exits 0 after printing nothing on empty input. A **403**, an **absent path** and a **real secret** were therefore indistinguishable, all reported as success. `vault_load_secrets` exported nothing and returned 0, so the SOPS fallback — which exists in *both* deploy paths — was never reached, because nothing failed. The generic service path also had no empty-value guard; only the infra path had one, for one named variable.

## Fix, generic as requested

- `vault_read_kv` → non-zero on unreadable path, unparseable response, or a path holding no keys, naming which.
- `vault_load_secrets` → refuses when **any** value resolves empty (naming the keys), or when the declared paths yield nothing; reports the count loaded.
- Both make the subshell fail, which is what reaches the existing fallback.

## Positive control

`tests/scripts/vault-empty-guard.bats` stubs `docker`, makes a key resolve empty, and asserts refusal. **7/7 pass against this fix; against the pre-fix code the outage case returns status 0** — the fault reproduced as a test.

SOPS verified able to serve the fallback: 78 keys decrypt, `KC_ADMIN_USERNAME` and `KC_ADMIN_PASSWORD` both present and non-empty.

Touches no deploy-filtered path, so merging does not auto-deploy; `deploy-auth.yml` is dispatched explicitly afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)