### PR TITLE
fix(deploy): the failed vault load must ABORT the subshell, not just report

### DIFF
--- a/scripts/checks/platform-baseline-test.sh
+++ b/scripts/checks/platform-baseline-test.sh
@@ -74,6 +74,24 @@ else
     FAIL=1
 fi
 
+# RESTARTING IS THE GAP THAT HID AN OUTAGE.
+#
+# On 2026-08-03 Keycloak crash-looped for 39 minutes while this check reported
+# the baseline intact. A restart-looping container is PRESENT by name — so the
+# name sweep above passes — and it reports NO health status at all, because the
+# healthcheck never gets a chance to run, so `--filter health=unhealthy` does not
+# match it either. Both instruments were blind to it in the same way.
+#
+# `docker ps` lists restarting containers, which is why the name sweep saw it.
+# State is what distinguishes them.
+RESTARTING="$(docker ps --filter status=restarting --format '{{.Names}}')"
+if [ -z "$RESTARTING" ]; then
+    echo "  ✓ 0 restarting"
+else
+    echo "  ✗ RESTARTING (crash loop): $(printf '%s' "$RESTARTING" | tr '\n' ' ')"
+    FAIL=1
+fi
+
 # Informational: a tenant's containers are not part of the baseline, but a
 # tenant that vanished during a platform action is worth seeing immediately.
 TENANT_COUNT=$(printf '%s\n' "$RUNNING" | grep -c '^app-' || true)

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -206,7 +206,23 @@ cmd_infra() {
 
     if [ "$vault_ok" = true ]; then
         (
-            vault_load_secrets "infra" "$secrets_file"
+            # `|| exit 1` IS LOad-BEARING — do not reduce it to a bare call.
+            #
+            # `set -e` is SUPPRESSED inside a compound command on the left of
+            # `||`, and this subshell is exactly that: `( ... ) || { fallback }`.
+            # So a bare `vault_load_secrets` that returns non-zero does NOT stop
+            # the subshell; it prints its warning and the deploy carries on with
+            # no secrets loaded. Demonstrable in three lines:
+            #
+            #   set -e; f(){ return 1; }
+            #   ( f; echo "still running" ) || echo "fallback"   -> still running
+            #   ( f || exit 1; echo x )    || echo "fallback"    -> fallback
+            #
+            # This is the second half of the 2026-08-03 auth outage. The first
+            # fix (#651) made vault_load_secrets return non-zero correctly, and
+            # the deploy ignored it and shipped a container with every variable
+            # blank. `exit` is not subject to the suppression; `return` is.
+            vault_load_secrets "infra" "$secrets_file" || exit 1
 
             echo "Generating Traefik basic auth credentials..."
             mkdir -p platform/edge/dynamic
@@ -405,10 +421,24 @@ cmd_service() {
     echo "${banner} - ${env}"
     echo "================================"
 
-    # Pre-deploy backup for stateful services
+    # Pre-deploy backup for stateful services.
+    #
+    # `auth` has no volume of its own: Keycloak keeps realms, clients and users in
+    # the platform Postgres `keycloak` database. So `backup.sh backup auth` was
+    # never a valid target and died with "Unknown service for backup: auth" —
+    # warned, continued, and the pre-deploy safety net for the IDENTITY PROVIDER
+    # silently did nothing. Observed on the 2026-08-03 outage deploy.
+    #
+    # Backing up `db` is what "back up auth before touching it" actually means.
     if [ "$stateful" = true ]; then
-        echo "Running pre-deploy backup for ${service}..."
-        bash "$SCRIPT_DIR/backup.sh" backup "$service" || warn "Pre-deploy backup failed (continuing deploy)"
+        local backup_target="$service"
+        [ "$service" = "auth" ] && backup_target="db"
+        if [ "$backup_target" != "$service" ]; then
+            echo "Running pre-deploy backup for ${service} (its state lives in ${backup_target})..."
+        else
+            echo "Running pre-deploy backup for ${service}..."
+        fi
+        bash "$SCRIPT_DIR/backup.sh" backup "$backup_target" || warn "Pre-deploy backup failed (continuing deploy)"
     fi
 
     # Vault-first, SOPS-fallback for service secrets
@@ -468,7 +498,9 @@ cmd_service() {
         # Subshell: load secrets + deploy. If vault_load_secrets fails
         # transiently, fall through to SOPS.
         (
-            vault_load_secrets "$service" "$secrets_file"
+            # `|| exit 1` is load-bearing — see the identical guard on the infra
+            # path above for why a bare call silently continues.
+            vault_load_secrets "$service" "$secrets_file" || exit 1
 
             if [ -n "$pre_up_hook" ]; then
                 export ALERT_EMAIL_TO="${ALERT_EMAIL_TO:-${ACME_EMAIL:-}}"

--- a/tests/scripts/vault-empty-guard.bats
+++ b/tests/scripts/vault-empty-guard.bats
@@ -118,3 +118,38 @@ Code: 403. Errors:
   run load_and_run
   [ "$status" -ne 0 ]
 }
+
+# ---------------------------------------------------------------------------
+# The SECOND half of the 2026-08-03 outage.
+#
+# #651 made vault_load_secrets return non-zero correctly — and auth STILL
+# deployed with every variable blank, because `set -e` is SUPPRESSED inside a
+# compound command on the left of `||`. deploy.sh wraps the vault branch in
+# `( ... ) || { warn; _deploy_with_sops; }`, so a bare call that returns 1 does
+# not stop the subshell: it warns, carries on, and runs docker compose with no
+# secrets. The compose log showed all six variables "not set".
+#
+# `exit` is not subject to the suppression. `return` is. These tests pin that.
+# ---------------------------------------------------------------------------
+
+@test "bash really does suppress set -e inside a subshell on the left of ||" {
+  run bash -c 'set -e; f(){ return 1; }; ( f; echo REACHED ) || echo FALLBACK'
+  [[ "$output" == *"REACHED"* ]]
+  [[ "$output" != *"FALLBACK"* ]]
+}
+
+@test "... and || exit 1 defeats it" {
+  run bash -c 'set -e; f(){ return 1; }; ( f || exit 1; echo REACHED ) || echo FALLBACK'
+  [[ "$output" == *"FALLBACK"* ]]
+  [[ "$output" != *"REACHED"* ]]
+}
+
+@test "EVERY vault_load_secrets call site aborts its subshell explicitly" {
+  cd "$BATS_TEST_DIRNAME/../.."
+  # A bare call here means a failed secret load deploys blank credentials.
+  run grep -nE '^[[:space:]]*vault_load_secrets ' scripts/deploy.sh
+  [ "$status" -eq 0 ]
+  while IFS= read -r line; do
+    [[ "$line" == *"|| exit"* ]] || { echo "unguarded call site: $line"; return 1; }
+  done <<< "$output"
+}


### PR DESCRIPTION
**OUTAGE FIX, part 2. Merging this is the restore step** — the pipeline deploys `origin/main`.

#651 was necessary and not sufficient, exactly as you said. The guard fires correctly; the deploy ignored it.

## Cause

The compose log is unambiguous — **all six** variables `"not set. Defaulting to a blank string"`, so the SOPS environment was never applied. The vault branch printed my warning and carried straight on.

**`set -e` is suppressed inside a compound command on the left of `||`**, and the vault branch is exactly `( ... ) || { warn; _deploy_with_sops; }`. A bare call returning 1 does not stop the subshell:

```
set -e; f(){ return 1; }
( f; echo REACHED ) || echo FALLBACK        -> REACHED     (fallback never runs)
( f || exit 1; echo REACHED ) || echo FALL  -> FALLBACK
```

`exit` is not subject to the suppression; `return` is. Both call sites now use `|| exit 1`, and a test asserts **every** call site does, so a future bare call fails CI.

## Also in here

- **`platform-baseline-test.sh` now fails on RESTARTING containers.** This is the gap that hid the outage: a crash-looping container is *present by name* so the name sweep passes, and it reports *no health status at all* so `--filter health=unhealthy` misses it too. Both instruments were blind in the same way — which is why your sweep and mine both said "baseline intact" while SSO was down.
- **Pre-deploy backup for `auth` targets `db`.** `auth` has no volume; Keycloak's state is in the platform Postgres. `backup.sh backup auth` died with "Unknown service for backup", so the pre-deploy safety net for the identity provider silently did nothing.

## Still open after this (next PR, not blocking restore)

- The **403 itself**: the `auth` AppRole holds `policy-auth`, which does not exist — there is no `policy-auth.hcl` or `policy-db.hcl` in `platform/vault/policies/`, and `cmd_setup` attaches `policy-<svc>` regardless. Audit of every AppRole against its declared paths follows.
- `cmd_seed` writes only three paths and never `secret/auth/config` or `secret/shared/database`, so the vault path for `auth` has never worked since the #643 rebuild.
- The SOPS-versus-vault name comparison.

🤖 Generated with [Claude Code](https://claude.com/claude-code)