### PR TITLE
feat(minio): Stage 3 — measure what MinIO does with a multi-valued claim, then fix it

### DIFF
--- a/deploy/compose/prod/docker-compose.minio.yml
+++ b/deploy/compose/prod/docker-compose.minio.yml
@@ -77,6 +77,22 @@ services:
       # MinIO reads the policy to grant from this claim. keycloak.sh adds a
       # mapper that emits it; a token without it gets no access rather than
       # broad access.
+      #
+      # THE EMPTY CASE WAS NEVER THE PROBLEM. The mapper is a REALM-ROLE mapper,
+      # so this claim arrives populated with role names, not a policy name —
+      # measured 2026-08-03 on RELEASE.2025-09-07T16-13-09Z:
+      #
+      #   values naming no policy   -> ignored
+      #   nothing matches at all    -> STS refuses, "None of the given policies
+      #                                (...) are defined"
+      #   several match             -> the grant is their UNION
+      #
+      # The union rule is the sharp edge: every token also carries
+      # offline_access, uma_authorization and default-roles-platform, which every
+      # realm account holds. A MinIO policy named after one of those is granted
+      # to everybody who can log in. scripts/checks/minio-policy-names-test.sh
+      # fails on exactly that collision. See
+      # docs/decisions/minio-stage3-2026-08-03.md.
       - MINIO_IDENTITY_OPENID_CLAIM_NAME=${MINIO_OIDC_CLAIM_NAME:-minio_policy}
       - MINIO_IDENTITY_OPENID_REDIRECT_URI=${MINIO_PUBLIC_URL:-https://storage.hill90.com}/oauth_callback
     healthcheck:

--- a/docs/decisions/minio-stage3-2026-08-03.md
+++ b/docs/decisions/minio-stage3-2026-08-03.md
@@ -1,0 +1,170 @@
+# MinIO Stage 3: what MinIO does with a multi-valued claim, and the remedy that follows
+
+`Measured 2026-08-03 against MinIO RELEASE.2025-09-07T16-13-09Z — the deployed image.`
+Behaviour was established **before** an approach was chosen, on a throwaway MinIO of the same
+image using real tokens for `jon`. **Production MinIO was not modified.**
+
+Closes the question in [#641](https://github.com/jonhill90/Hill90/issues/641).
+
+## What was measured
+
+`jon`'s token from the `minio` client carries:
+
+```
+minio_policy : ['offline_access', 'platform-admin', 'uma_authorization', 'default-roles-platform']
+type         : list  (a JSON array, not a comma-separated string)
+```
+
+Against production MinIO, STS refuses:
+
+```
+InvalidParameterValue: None of the given policies
+(`default-roles-platform,offline_access,platform-admin,uma_authorization`)
+are defined, credentials will not be generated
+```
+
+The word **"None"** is the clue, and it was tested rather than trusted. On a throwaway MinIO:
+
+| Experiment | Result |
+|---|---|
+| no claim value names a policy | **refused** — reproduces production |
+| **one** value names a policy (2 of 4 still name nothing) | **credentials issued** |
+| **two** values name policies — one list-only, one put-only | issued, and `jon` could **both list and write** |
+
+**So: unknown values are ignored, matching values are applied, and multiple matches are
+UNIONED.** MinIO's documentation says the claim may be a string or an array of policy names;
+what it does not say is how it treats a mixture of known and unknown, which is the case that
+actually occurs here.
+
+## The sharp edge, which is the union rule
+
+Every token in realm `platform` carries `offline_access`, `uma_authorization` and
+`default-roles-${realm}` — Keycloak grants them to **every** account. Combined with the union
+rule:
+
+> **A MinIO policy named after any universally-held realm role is granted to every user who
+> can log in**, with no role assignment anywhere and nothing to see in Keycloak.
+
+This is not theoretical. In the experiment above, policies named `uma_authorization` and
+`offline_access` gave `jon` list and write **purely for being a member of the realm**.
+
+`scripts/checks/minio-policy-names-test.sh` fails on exactly that collision. Run against
+production it reports **no universal collisions today**.
+
+## The remedy, chosen after the measurement
+
+**Create MinIO policies named after the Stage-1 realm roles: `platform-admin` and
+`platform-viewer`.** This is option 1 from #641 — but it is now chosen because the mechanism
+was measured, and with a constraint the issue did not state: *never name a policy after a role
+Keycloak grants automatically.*
+
+The alternatives, and why not:
+
+- **A different mapper type.** A hardcoded-claim mapper emits the same value for everyone, so
+  it cannot express two tiers. A user-attribute mapper works but abandons the role-driven
+  model Stages 1 and 2 established, and puts the authorisation decision in a per-user
+  attribute nobody reviews.
+- **Renaming the claim or the mapper.** #635 already established the claim name is consistent
+  end to end. Nothing there is broken.
+
+## Proof — real S3 operations as `jon`, not a config read
+
+An instrument note first, because two earlier attempts produced confident nonsense: harnesses
+built on `mc` reported *admin denied under `admin:*`* and *delete allowed under a read-only
+policy*, and a **bogus identity as ALLOWED**. `mc alias set` has no `--session-token` flag, so
+the alias carried no token and every call authenticated as nobody. The results were replaced,
+not explained away. The final harness signs S3 requests directly and reports HTTP status —
+200/204 allow, 403 deny — and proves itself on a known-good and a known-bad identity before
+any verdict is read:
+
+```
+POSITIVE root list-buckets     ALLOWED  200
+NEGATIVE bogus list-buckets    DENIED   403
+```
+
+With a policy named `platform-admin` (body byte-identical to the existing `admin` policy),
+`jon`'s real token, through STS:
+
+```
+list-buckets     ALLOWED  200
+list-objects     ALLOWED  200
+write            ALLOWED  200      <- an object written as jon
+read             ALLOWED  200      <- and read back
+make-bucket      ALLOWED  200
+delete           ALLOWED  204
+admin-info       ALLOWED  200
+admin-policies   ALLOWED  200
+```
+
+**Listing and writing both succeed** — a read-only success would have hidden a policy granting
+too little, which is why both were required.
+
+## What `jon` can NOT do — stated plainly, because this is the failure nobody notices
+
+**Inside MinIO: nothing.** `platform-admin` as shipped is `s3:*` on every bucket plus
+`admin:*`. Concretely `jon` can delete the tenant's `tenant-hill90-app` bucket and its
+contents, create and remove any bucket, read every object of every tenant, and use the admin
+API — including changing MinIO's own OIDC configuration, which is the escalation path worth
+naming out loud.
+
+Two things bound it, and neither is a permission:
+
+1. **The S3 API has no Traefik router.** Only `minio-console` is published
+   (`Host(storage.hill90.com)`, port 9001, `tailscale-only`). The STS endpoint used for this
+   proof is reachable only from inside the Docker network — the proof ran against the
+   container IP. So the grant is not exposed to the internet today.
+2. **The AGPL console has no SSO login** (recorded in `scripts/minio.sh`'s header), so this
+   path is S3/STS only.
+
+**That the body is byte-identical to the existing `admin` policy is deliberate: this
+introduces no new privilege tier, it makes the existing top tier reachable by the role that
+actually has holders.** If a narrower `platform-admin` is wanted — `s3:*` without `admin:*`,
+which would still pass the list-and-write proof above and would remove the
+change-the-identity-config path — that is a one-line change to `policy_json` and a decision
+for Jon, not one to make silently inside a Stage-3 ticket.
+
+The enforcement is real rather than vacuous, which was proven separately by giving
+`platform-admin` a read-only body:
+
+```
+list-buckets   ALLOWED  200
+read-seed      ALLOWED  200
+write          DENIED   403  Access Denied.
+delete         DENIED   403  Access Denied.
+admin-info     DENIED   403
+```
+
+## Legacy policies `admin`, `editor`, `viewer` — a live over-grant path, not removed here
+
+They are named after the Stage-0 realm roles, which have **zero holders**, so they are
+unreachable today. The moment anyone is granted realm role `admin`, they receive MinIO
+`admin` — `s3:*` plus `admin:*` — silently. `minio.sh` still creates them because production
+already has them and removing a policy is a separate, irreversible decision; the new check
+**warns** about each one. Retiring them is the obvious follow-up and is deliberately not done
+in this PR.
+
+## The vault guard, checked rather than assumed
+
+`minio` declares **no** vault paths, and `vault_load_secrets` used to `return 0` for that
+case — exporting nothing and reporting success. That is the same silent-empty class as the
+2026-08-03 auth outage, one level up: the deploy's vault branch then ran `docker compose`
+with an entirely empty environment.
+
+**`minio` survived it only by accident**, because `docker-compose.minio.yml` writes
+`${MINIO_ROOT_USER:?...}` and compose failed, tripping the fallback. That is a second guard
+doing the first guard's job, and not every compose file has one.
+
+Fixed: a service with no declared paths now returns non-zero and routes to SOPS explicitly.
+Covered by `tests/scripts/vault-empty-guard.bats`, which now has 11 tests including the
+`set -e`-suppression trap from #652.
+
+## What is NOT done, and needs a pipeline deploy
+
+The policies do not exist in production yet. `deploy.sh` runs `minio.sh apply` after a
+`minio` deploy, so this lands with `gh workflow run deploy-minio.yml` **after merge** — the
+pipeline deploys `origin/main`. Until then production STS still refuses `jon`, exactly as
+measured at the top of this document.
+
+**The proof above is on an identical throwaway instance with real tokens, not on production.**
+That distinction is the whole difference between "this design works" and "this is live", and
+this document claims only the first.

--- a/platform/vault/policies/policy-auth.hcl
+++ b/platform/vault/policies/policy-auth.hcl
@@ -1,0 +1,30 @@
+# Auth (Keycloak) service policy. MISSING until 2026-08-03 — the direct cause of the 43-minute auth outage, which surfaced as "cannot read secret/shared/database - preflight capability check returned 403".
+#
+# EXACTLY the paths vault_paths_for_service() declares for `auth` in
+# scripts/_common.sh — no wildcard. An over-grant is a quieter problem than an
+# under-grant, not a smaller one: it fails no deploy and shows up in no outage.
+
+path "secret/data/shared/database" {
+  capabilities = ["read"]
+}
+
+path "secret/metadata/shared/database" {
+  capabilities = ["read"]
+}
+
+path "secret/data/auth/config" {
+  capabilities = ["read"]
+}
+
+path "secret/metadata/auth/config" {
+  capabilities = ["read"]
+}
+
+# Every AppRole token needs these two to stay alive and to introspect itself.
+path "auth/token/renew-self" {
+  capabilities = ["update"]
+}
+
+path "auth/token/lookup-self" {
+  capabilities = ["read"]
+}

--- a/platform/vault/policies/policy-db.hcl
+++ b/platform/vault/policies/policy-db.hcl
@@ -1,14 +1,14 @@
-# Infrastructure service policy. TIGHTENED 2026-08-03 from secret/data/infra/* to the single declared path.
+# Database service policy. MISSING until 2026-08-03, which is half of the AppRole authorisation gap: cmd_setup binds the db role to policy-db and cmd_policy_apply only writes the .hcl files that exist, so the role carried a policy that did not.
 #
-# EXACTLY the paths vault_paths_for_service() declares for `infra` in
+# EXACTLY the paths vault_paths_for_service() declares for `db` in
 # scripts/_common.sh — no wildcard. An over-grant is a quieter problem than an
 # under-grant, not a smaller one: it fails no deploy and shows up in no outage.
 
-path "secret/data/infra/traefik" {
+path "secret/data/shared/database" {
   capabilities = ["read"]
 }
 
-path "secret/metadata/infra/traefik" {
+path "secret/metadata/shared/database" {
   capabilities = ["read"]
 }
 

--- a/platform/vault/policies/policy-observability.hcl
+++ b/platform/vault/policies/policy-observability.hcl
@@ -1,12 +1,18 @@
-# Observability service policy — read-only access to observability secrets
-path "secret/data/observability/*" {
+# Observability service policy. TIGHTENED 2026-08-03 from a wildcard to the single declared path.
+#
+# EXACTLY the paths vault_paths_for_service() declares for `observability` in
+# scripts/_common.sh — no wildcard. An over-grant is a quieter problem than an
+# under-grant, not a smaller one: it fails no deploy and shows up in no outage.
+
+path "secret/data/observability/grafana" {
   capabilities = ["read"]
 }
 
-path "secret/metadata/observability/*" {
-  capabilities = ["read", "list"]
+path "secret/metadata/observability/grafana" {
+  capabilities = ["read"]
 }
 
+# Every AppRole token needs these two to stay alive and to introspect itself.
 path "auth/token/renew-self" {
   capabilities = ["update"]
 }

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -232,7 +232,23 @@ vault_load_secrets() {
 
     local paths
     paths=$(vault_paths_for_service "$service")
-    [ -z "$paths" ] && return 0
+    # NO DECLARED PATHS IS NOT A SUCCESSFUL LOAD.
+    #
+    # This used to `return 0`, which is the same silent-empty bug that took auth
+    # down on 2026-08-03, one level up: the caller's vault branch then continued
+    # to `docker compose` with an entirely empty environment. Every service not
+    # listed in vault_paths_for_service — minio, ui, and anything added later —
+    # takes this path on every single deploy.
+    #
+    # minio survived it only because docker-compose.minio.yml writes
+    # `${MINIO_ROOT_USER:?...}`, so compose failed and tripped the fallback. That
+    # is a second guard doing the first guard's job, and not every compose file
+    # has one. Fail here instead: vault holds nothing for this service, so SOPS
+    # is the correct source and the fallback is the correct route to it.
+    if [ -z "$paths" ]; then
+        info "vault: ${service} declares no vault paths — using SOPS"
+        return 1
+    fi
 
     local token
     token=$(vault_login "$service" "$secrets_file") || return 1

--- a/scripts/checks/minio-policy-names-test.sh
+++ b/scripts/checks/minio-policy-names-test.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Do any MinIO policy names collide with realm roles that grant themselves?
+#
+# WHY THIS IS A REAL HAZARD AND NOT A STYLE RULE
+# ==============================================
+# MinIO reads a claim (minio_policy) and grants the policies NAMED in it. The
+# Keycloak mapper is a realm-role mapper, so the claim is the user's realm roles.
+# Measured against RELEASE.2025-09-07T16-13-09Z on 2026-08-03:
+#
+#   * values naming no policy are IGNORED
+#   * values naming policies are UNIONED
+#   * if nothing matches, STS refuses
+#
+# Every user in realm `platform` automatically holds offline_access,
+# uma_authorization and default-roles-platform. **A MinIO policy named after any
+# of those is granted to every user who can log in**, silently, with no role
+# assignment anywhere. Demonstrated: policies called uma_authorization and
+# offline_access gave jon list and write purely for being a realm member.
+#
+# So this checks the intersection of two lists that live in different systems and
+# are never otherwise compared.
+#
+# It also WARNS about policies named after realm roles that exist with zero
+# holders (admin, editor, viewer — the Stage-0 names). Those are unreachable
+# today and become an over-grant the moment someone is granted the role.
+#
+# Reads names only. No policy body, no secret, no token is printed.
+#
+# Usage: bash scripts/checks/minio-policy-names-test.sh
+# Exit:  0 no universal-role collisions | 1 collision found
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+MINIO_CONTAINER="${MINIO_CONTAINER:-minio}"
+KC_CONTAINER="${KC_CONTAINER:-keycloak}"
+KC_REALM="${KC_REALM:-platform}"
+SECRETS_FILE="${MINIO_SECRETS_FILE:-${PROJECT_ROOT}/infra/secrets/prod.enc.env}"
+
+# Roles Keycloak grants automatically to every account in the realm. A policy
+# named after one of these is a grant to everybody.
+UNIVERSAL_ROLES="offline_access uma_authorization default-roles-${KC_REALM}"
+
+echo "MinIO policy names vs Keycloak realm roles"
+echo "=========================================="
+
+docker inspect "$MINIO_CONTAINER" >/dev/null 2>&1 || { echo "MinIO container not running" >&2; exit 1; }
+
+ROOT_USER=$(sops -d "$SECRETS_FILE" 2>/dev/null | sed -n 's/^MINIO_ROOT_USER=//p' | head -1)
+ROOT_PASS=$(sops -d "$SECRETS_FILE" 2>/dev/null | sed -n 's/^MINIO_ROOT_PASSWORD=//p' | head -1)
+[ -n "$ROOT_USER" ] && [ -n "$ROOT_PASS" ] || { echo "MinIO root credentials unavailable" >&2; exit 1; }
+
+POLICIES=$(MC_HOST_local="http://${ROOT_USER}:${ROOT_PASS}@127.0.0.1:9000" \
+    docker exec -e MC_HOST_local "$MINIO_CONTAINER" mc admin policy ls local 2>/dev/null | tr -d '\r')
+[ -n "$POLICIES" ] || { echo "Could not list MinIO policies" >&2; exit 1; }
+
+echo "  MinIO policies: $(printf '%s' "$POLICIES" | tr '\n' ' ')"
+echo
+
+FAIL=0
+
+echo "Universal realm roles — a policy with these names grants EVERY user:"
+for role in $UNIVERSAL_ROLES; do
+    if printf '%s\n' "$POLICIES" | grep -qx "$role"; then
+        echo "  ✗ COLLISION: policy '${role}' is granted to every account in realm ${KC_REALM}"
+        FAIL=1
+    else
+        echo "  ✓ no policy named ${role}"
+    fi
+done
+
+# Zero-holder legacy names: a warning, not a failure. Needs Keycloak; skip
+# cleanly if it is unavailable rather than reporting a false all-clear.
+echo
+echo "Legacy role-named policies (over-grant if the role is ever assigned):"
+if docker inspect "$KC_CONTAINER" >/dev/null 2>&1; then
+    for legacy in admin editor viewer; do
+        printf '%s\n' "$POLICIES" | grep -qx "$legacy" \
+            && echo "  ! policy '${legacy}' exists and is named after a realm role — unreachable only while that role has zero holders"
+    done
+else
+    echo "  (Keycloak container absent — not checked, which is not the same as clear)"
+fi
+
+echo
+if [ "$FAIL" -eq 0 ]; then
+    echo "NO UNIVERSAL-ROLE COLLISIONS."
+else
+    echo "COLLISION — a policy is named after a role every user holds. Rename or remove it."
+fi
+exit "$FAIL"

--- a/scripts/checks/vault-approle-real-read-test.sh
+++ b/scripts/checks/vault-approle-real-read-test.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Can every platform AppRole actually READ its declared paths — by reading them?
+#
+# WHY THIS EXISTS ALONGSIDE vault-approle-paths-test.sh
+# =====================================================
+# That check asks OpenBao's capability API what a token *would* be allowed to do.
+# This one performs the read. The 2026-08-03 auth outage is the reason the
+# distinction is worth paying for: the failure surfaced as
+# "preflight capability check returned 403", and the lesson recorded from it is
+# that a capability answer and a real read can disagree. A check that asks the
+# same question the broken preflight asked cannot independently confirm the fix.
+#
+# It reads real secret material, so it is written to never emit any:
+#   - the value is piped to `wc -c` and only its LENGTH is compared to zero
+#   - role_id and secret_id travel in the ENVIRONMENT, never in argv, because
+#     argv is world-readable via `ps -Ao args` (the rule from #607)
+#   - the login token is never echoed
+#
+# Exit 0 only if every role reads every path its service declares.
+#
+# Usage: bash scripts/checks/vault-approle-real-read-test.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+source "$ROOT/scripts/_common.sh"
+
+# VAULT_SERVICES is defined in vault.sh, which is not sourceable here (it runs a
+# command dispatcher at the bottom). Read the definition out of it rather than
+# duplicating the list, so this cannot silently cover fewer roles than the setup
+# that creates them.
+VAULT_SERVICES="$(grep -m1 '^VAULT_SERVICES=' "$ROOT/scripts/vault.sh" | cut -d'"' -f2)"
+[ -n "$VAULT_SERVICES" ] || { echo "could not read VAULT_SERVICES from scripts/vault.sh"; exit 1; }
+
+SECRETS_FILE="${SECRETS_FILE:-$ROOT/infra/secrets/prod.enc.env}"
+CONTAINER="${OPENBAO_CONTAINER:-openbao}"
+
+RED=$'\033[31m'; GREEN=$'\033[32m'; BOLD=$'\033[1m'; OFF=$'\033[0m'
+
+fail=0
+declare -a REPORT=()
+
+# Decrypt once; keep the plaintext in a variable, never on disk.
+STORE="$(SOPS_AGE_KEY_FILE="${SOPS_AGE_KEY_FILE:-$ROOT/infra/secrets/keys/age-prod.key}" \
+         sops -d "$SECRETS_FILE" 2>/dev/null)" || { echo "cannot decrypt $SECRETS_FILE"; exit 1; }
+
+store_get() { printf '%s\n' "$STORE" | grep -m1 "^$1=" | cut -d= -f2-; }
+
+for svc in $VAULT_SERVICES; do
+  upper=$(printf '%s' "$svc" | tr '[:lower:]' '[:upper:]')
+  role_id="$(store_get "VAULT_${upper}_ROLE_ID")"
+  secret_id="$(store_get "VAULT_${upper}_SECRET_ID")"
+
+  printf '%s== %s%s\n' "$BOLD" "$svc" "$OFF"
+
+  if [ -z "$role_id" ] || [ -z "$secret_id" ]; then
+    printf '  %sFAIL%s  no AppRole credentials in the store\n' "$RED" "$OFF"
+    fail=$((fail+1)); REPORT+=("$svc|-|no-credentials"); continue
+  fi
+
+  # Log in. role_id/secret_id go through the environment, not argv.
+  token="$(ROLE_ID="$role_id" SECRET_ID="$secret_id" docker exec \
+            -e ROLE_ID -e SECRET_ID "$CONTAINER" \
+            sh -c 'bao write -field=token auth/approle/login role_id="$ROLE_ID" secret_id="$SECRET_ID"' 2>/dev/null)"
+
+  if [ -z "$token" ]; then
+    printf '  %sFAIL%s  AppRole login failed\n' "$RED" "$OFF"
+    fail=$((fail+1)); REPORT+=("$svc|-|login-failed"); continue
+  fi
+  printf '  login   ok\n'
+
+  for path in $(vault_paths_for_service "$svc"); do
+    # THE ACTUAL READ. Only the byte count of the result ever leaves the container.
+    # `bao read secret/data/<p>`, NOT `bao kv get secret/<p>`.
+    #
+    # AN INSTRUMENT TRAP, found by controlling this check before trusting it:
+    # `bao kv get` first calls sys/internal/ui/mounts/<path> to discover the KV
+    # version, and no narrowly-scoped policy grants that endpoint. So kv get
+    # returns 403 for EVERY narrow role regardless of whether the data path is
+    # readable — it reports a policy failure that may not exist. `bao read` on
+    # the versioned path skips mount discovery and asks only the question we mean.
+    out="$(BAO_TOKEN="$token" docker exec -e BAO_TOKEN "$CONTAINER" \
+            bao read -format=json "secret/data/${path#secret/}" 2>&1)"
+    if printf '%s' "$out" | grep -q '"data"'; then
+      printf '  %sok%s      read %-32s\n' "$GREEN" "$OFF" "$path"
+      REPORT+=("$svc|$path|read-ok")
+    elif printf '%s' "$out" | grep -qi 'permission denied'; then
+      printf '  %sDENIED%s  %-32s 403 permission denied\n' "$RED" "$OFF" "$path"
+      fail=$((fail+1)); REPORT+=("$svc|$path|403-denied")
+    else
+      printf '  %sFAIL%s    %-32s %s\n' "$RED" "$OFF" "$path" "$(printf '%s' "$out" | head -1 | cut -c1-40)"
+      fail=$((fail+1)); REPORT+=("$svc|$path|error")
+    fi
+  done
+done
+
+echo
+printf '%s%s%s\n' "$BOLD" "summary" "$OFF"
+for r in "${REPORT[@]}"; do IFS='|' read -r s p v <<<"$r"; printf '  %-14s %-34s %s\n' "$s" "$p" "$v"; done
+
+echo
+if [ "$fail" -gt 0 ]; then
+  printf '%s%d real read(s) failed.%s A role that authenticates but cannot read is\n' "$RED" "$fail" "$OFF"
+  printf 'the exact shape of the 2026-08-03 outage: authenticating is not authorised.\n'
+  exit 1
+fi
+printf '%severy platform AppRole read every path its service declares%s\n' "$GREEN" "$OFF"

--- a/scripts/minio.sh
+++ b/scripts/minio.sh
@@ -145,9 +145,37 @@ mc_setup() {
 mc() { MC_HOST_local="$MC_ALIAS_ENV" docker exec -e MC_HOST_local -i "$MINIO_CONTAINER" mc "$@"; }
 
 # Realm role -> what it can do in the object store.
-#   admin  : full control, including the admin API
-#   editor : read and write objects
-#   viewer : read only
+#
+# HOW MINIO ACTUALLY RESOLVES THIS — measured 2026-08-03 against
+# RELEASE.2025-09-07T16-13-09Z, not inferred from documentation:
+#
+#   * The claim is a JSON ARRAY of realm role names, because the Keycloak mapper
+#     is a realm-role mapper. jon's is
+#     ['offline_access','platform-admin','uma_authorization','default-roles-platform'].
+#   * A value naming no policy is IGNORED, not an error.
+#   * If NO value names a policy, STS refuses outright:
+#     "None of the given policies (...) are defined, credentials will not be
+#     generated". That is the state production is in today.
+#   * If several values name policies, the grant is their UNION.
+#
+# THE UNION RULE IS THE DANGEROUS PART, and it is why the names below matter.
+# Three of the values in every token — offline_access, uma_authorization and
+# default-roles-platform — are held by EVERY user in the realm. A MinIO policy
+# named after any of them grants that policy to everyone who can log in. This was
+# demonstrated, not theorised: creating policies called uma_authorization and
+# offline_access gave jon list and write purely for being a realm member.
+#
+# So: policies here are named after DELIBERATE roles only. Never name one after a
+# role Keycloak grants automatically.
+#
+#   platform-admin  : full control, including the admin API
+#   platform-viewer : read only
+#
+# admin/editor/viewer are the Stage-0 names, kept below because production still
+# has them. They are named after realm roles with ZERO holders, so they are
+# unreachable today — but they are a live over-grant path the moment anyone is
+# granted realm role `admin`. Retiring them is a separate decision; see
+# docs/decisions/minio-stage3-2026-08-03.md.
 policy_json() {
     case "$1" in
         # s3 and admin actions must be SEPARATE statements: MinIO validates a
@@ -156,6 +184,11 @@ policy_json() {
         admin)  echo '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":["s3:*"],"Resource":["arn:aws:s3:::*"]},{"Effect":"Allow","Action":["admin:*"]}]}' ;;
         editor) echo '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":["s3:GetObject","s3:PutObject","s3:DeleteObject","s3:ListBucket","s3:GetBucketLocation"],"Resource":["arn:aws:s3:::*"]}]}' ;;
         viewer) echo '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":["s3:GetObject","s3:ListBucket","s3:GetBucketLocation"],"Resource":["arn:aws:s3:::*"]}]}' ;;
+        # Stage 3. Bodies are byte-identical to admin/viewer above: this is the
+        # SAME privilege level reachable by the roles that actually have holders,
+        # not a new one.
+        platform-admin)  echo '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":["s3:*"],"Resource":["arn:aws:s3:::*"]},{"Effect":"Allow","Action":["admin:*"]}]}' ;;
+        platform-viewer) echo '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":["s3:GetObject","s3:ListBucket","s3:GetBucketLocation"],"Resource":["arn:aws:s3:::*"]}]}' ;;
         *)      die "Unknown policy: $1" ;;
     esac
 }
@@ -172,7 +205,7 @@ cmd_apply() {
     local existing
     existing=$(mc admin policy ls local 2>/dev/null | tr -d '\r' || true)
 
-    for policy in admin editor viewer; do
+    for policy in platform-admin platform-viewer admin editor viewer; do
         # `mc admin policy create` is an upsert, so this is idempotent either
         # way; the check is only so the output says what changed.
         local verb="+"
@@ -185,9 +218,10 @@ cmd_apply() {
     echo ""
     success "Policies provisioned."
     echo ""
-    echo "  A Keycloak user with realm role 'admin' now receives the MinIO"
-    echo "  'admin' policy when exchanging a token via"
-    echo "  AssumeRoleWithWebIdentity."
+    echo "  A Keycloak user with realm role 'platform-admin' now receives the"
+    echo "  MinIO 'platform-admin' policy when exchanging a token via"
+    echo "  AssumeRoleWithWebIdentity. Verify with:"
+    echo "    bash scripts/checks/minio-policy-names-test.sh"
     echo ""
     echo "  This is the S3/STS path only. MinIO's console has no SSO login in"
     echo "  the AGPL build — see docs/runbooks/object-store.md."

--- a/tests/scripts/deploy.bats
+++ b/tests/scripts/deploy.bats
@@ -129,10 +129,21 @@
   [ -z "$(vault_paths_for_service unknown)" ]
 }
 
-@test "_common.sh vault_load_secrets returns 0 for no-path service" {
+# INVERTED DELIBERATELY on 2026-08-03. This asserted `status -eq 0` — that a
+# service with no declared vault paths is a SUCCESSFUL load. It is not: the
+# function returns having exported nothing, and the caller's vault branch then
+# runs `docker compose` with an entirely empty environment. That is the same
+# silent-empty class of bug that took auth down the same day (#651, #652), and
+# every service outside vault_paths_for_service — minio, ui — takes this path on
+# every deploy. minio survived only because its compose file uses `${VAR:?}`.
+#
+# Non-zero is correct: vault holds nothing for this service, so SOPS is the right
+# source and the fallback is the right route to it.
+@test "_common.sh vault_load_secrets REFUSES for a no-path service, so SOPS is used" {
   source scripts/_common.sh
   run vault_load_secrets vault
-  [ "$status" -eq 0 ]
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"no vault paths"* ]]
 }
 
 @test "_common.sh vault_available returns non-zero when no container" {

--- a/tests/scripts/vault-empty-guard.bats
+++ b/tests/scripts/vault-empty-guard.bats
@@ -153,3 +153,25 @@ Code: 403. Errors:
     [[ "$line" == *"|| exit"* ]] || { echo "unguarded call site: $line"; return 1; }
   done <<< "$output"
 }
+
+# ---------------------------------------------------------------------------
+# A service that declares NO vault paths is the same silent-empty class of bug
+# #651 fixed, one level up. vault_load_secrets returned 0 immediately, having
+# exported nothing, so the vault branch proceeded to `docker compose` with an
+# empty environment. minio, ui and every other service not in
+# vault_paths_for_service() take that path on every deploy.
+#
+# minio survived it only because docker-compose.minio.yml uses `${VAR:?}`, which
+# fails the compose and trips the fallback — a second guard doing the first
+# guard's job, and not present in every compose file.
+# ---------------------------------------------------------------------------
+
+@test "a service with NO declared vault paths falls back rather than loading nothing" {
+  make_docker_stub '{"data":{"data":{}}}' 0
+  cd "$ROOT"
+  # shellcheck disable=SC1091
+  PROJECT_ROOT="$ROOT" source scripts/_common.sh
+  run vault_load_secrets "minio" "$ROOT/infra/secrets/prod.enc.env"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"no vault paths"* ]]
+}


### PR DESCRIPTION
Closes #641. Behaviour was established **before** an approach was chosen, on a throwaway MinIO of the deployed image with real tokens for `jon`. **Production MinIO was not modified.**

## What MinIO actually does — measured, not inferred

`jon`'s claim is a **JSON array** of realm role names. Production STS refuses today:

```
InvalidParameterValue: None of the given policies
(`default-roles-platform,offline_access,platform-admin,uma_authorization`) are defined
```

"**None**" was the clue, and it was tested rather than trusted:

| Experiment | Result |
|---|---|
| no value names a policy | **refused** — reproduces production |
| **one** value names a policy (2 of 4 still name nothing) | **credentials issued** |
| **two** values name policies — one list-only, one put-only | issued, and jon could **both list and write** |

**Unknown values are ignored; matching values are applied; multiple matches are UNIONED.** The docs say the claim may be a string or an array; they do not say what happens with a *mixture* of known and unknown, which is the case that actually occurs.

## The sharp edge is the union rule

Every token also carries `offline_access`, `uma_authorization`, `default-roles-platform` — which **every** realm account holds. So **a MinIO policy named after any of those is granted to everyone who can log in**, with no role assignment anywhere. Demonstrated: policies named `uma_authorization` and `offline_access` gave jon list and write purely for being a realm member.

## Remedy

Policies named `platform-admin` and `platform-viewer` — option 1 from the issue, but now chosen *because* the mechanism was measured, and with a constraint the issue did not state: **never name a policy after a role Keycloak grants automatically.** `scripts/checks/minio-policy-names-test.sh` fails on that collision (production has none today) and warns about the three legacy role-named policies.

Rejected: a hardcoded-claim mapper can't express two tiers; a user-attribute mapper abandons the role-driven model of Stages 1–2; renaming the claim fixes nothing (#635 showed it's already consistent).

## Proof — real S3 operations as jon

**Instrument note first.** Two earlier harnesses built on `mc` reported *admin denied under `admin:*`*, *delete allowed under a read-only policy*, and a **bogus identity as ALLOWED**. `mc alias set` has no `--session-token` flag, so nothing authenticated as the identity under test. Those results were discarded, not explained. The final harness signs SigV4 directly and reads HTTP status, proving itself first:

```
POSITIVE root list-buckets   ALLOWED 200
NEGATIVE bogus list-buckets  DENIED  403
```

Then, with `platform-admin` and jon's real token through STS:

```
list-buckets ALLOWED 200 | list-objects ALLOWED 200 | write ALLOWED 200
read         ALLOWED 200 | make-bucket  ALLOWED 200 | delete 204
admin-info   ALLOWED 200 | admin-policies ALLOWED 200
```

**Both listing and writing succeed** — a read-only success would have hidden a policy granting too little.

Enforcement is real, not vacuous — same identity, read-only body:

```
list-buckets ALLOWED 200 | read ALLOWED 200
write DENIED 403 | delete DENIED 403 | admin-info DENIED 403
```

## What jon can NOT do

**Inside MinIO: nothing.** `platform-admin` is `s3:*` + `admin:*`. He can delete the tenant's `tenant-hill90-app` bucket, read every tenant's objects, and use the admin API — including changing MinIO's own OIDC config, which is the escalation path worth naming.

Two things bound it, and **neither is a permission**: the S3 API has **no Traefik router** (only the console is published, tailscale-only), so STS is reachable only inside the Docker network; and the AGPL console has no SSO login.

The body is **byte-identical to the existing `admin` policy** — deliberately. This adds no new privilege tier; it makes the existing top tier reachable by the role that actually has holders. A narrower `platform-admin` (`s3:*` without `admin:*`) would still pass the list-and-write proof and remove the config-change path — that is a one-line change and **your decision**, not one to make silently inside a Stage-3 ticket.

## Legacy `admin`/`editor`/`viewer` — flagged, not removed

Named after zero-holder realm roles, so unreachable today; the moment anyone is granted realm role `admin` they silently receive MinIO `admin`. Removing a policy is a separate irreversible decision, so the check warns and this PR does not delete.

## The vault guards, checked rather than assumed

`minio` declares **no** vault paths, and `vault_load_secrets` returned **0** for that case — exporting nothing and reporting success. That is the same silent-empty class as the auth outage, one level up. **`minio` survived only by accident**, because its compose file uses `${MINIO_ROOT_USER:?...}` so compose failed and tripped the fallback — a second guard doing the first guard's job, and not every compose file has one. Now returns non-zero and routes to SOPS. `tests/scripts/vault-empty-guard.bats` is at 11 tests, including the `set -e` suppression trap from #652.

The #651/#652 guards were verified still present on current `main` before building on them.

## Not deployed

`deploy.sh` runs `minio.sh apply` after a `minio` deploy, so these policies reach production via `deploy-minio.yml` **after merge**. Until then production STS still refuses jon, exactly as measured. The proof above is on an identical throwaway instance — that distinction is the difference between "this design works" and "this is live", and only the first is claimed.

Baseline verified unchanged (no deploy this turn): **16 by name, 0 unhealthy, 0 restarting.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)