### PR TITLE
fix(vault): give policy-apply a pipeline route, and gate it on a real read

### DIFF
--- a/.github/workflows/vault-regain-root.yml
+++ b/.github/workflows/vault-regain-root.yml
@@ -37,6 +37,11 @@ on:
         required: false
         default: true
         type: boolean
+      run_policy_apply:
+        description: 'Apply platform/vault/policies/*.hcl with the recovered token. Writing a policy needs sys/policy, which only root has — so this is the ONLY pipeline route to it.'
+        required: false
+        default: true
+        type: boolean
       revoke_root_at_end:
         description: 'Revoke the recovered root token when finished. Safe once OIDC is enabled; assert_safe_to_revoke refuses otherwise.'
         required: false
@@ -167,6 +172,27 @@ jobs:
             deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
             'cd /opt/hill90/app && export SOPS_AGE_KEY_FILE=/opt/hill90/secrets/keys/keys.txt && export BAO_TOKEN="$(cat /opt/hill90/secrets/openbao-root.token)" && bash scripts/vault.sh setup-oidc'
 
+      # POLICIES BEFORE THE WINDOW CLOSES, for the same reason as OIDC above.
+      #
+      # WHY THIS LIVES IN THE BREAK-GLASS WORKFLOW AND NOT A ROUTINE DEPLOY.
+      # Writing a policy is a `sys/policy/*` update, and the only identity on this
+      # vault holding it is root, which is revoked by design. No deploy path calls
+      # policy-apply — `vault.sh setup` does, and setup is a bootstrap. So there
+      # was NO pipeline route to apply a policy at all, which is how the 2026-08-03
+      # AppRole gap stayed live after its fix merged: the .hcl files reached main,
+      # reached the box through the bind mount at docker-compose.vault.yml:68, and
+      # the vault was never told. Merging a policy file applies nothing.
+      #
+      # Duplicating the open/mint/close sequence into a dedicated workflow was the
+      # alternative and is worse: the assertion below that PROVES the door shut
+      # again is the delicate part, and two copies of it is one copy that rots.
+      - name: Apply the AppRole policies
+        if: ${{ inputs.run_policy_apply }}
+        run: |
+          ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
+            deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
+            'cd /opt/hill90/app && export SOPS_AGE_KEY_FILE=/opt/hill90/secrets/keys/keys.txt && export BAO_TOKEN="$(cat /opt/hill90/secrets/openbao-root.token)" && bash scripts/vault.sh policy-apply'
+
       # ---- Close the window, and PROVE it closed ------------------------------
 
       - name: Restore the production config
@@ -219,6 +245,18 @@ jobs:
           ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
             deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
             'cd /opt/hill90/app && bash scripts/checks/vault-approle-login-test.sh'
+
+      # AND THEN THE READ, because the step above only proves authentication.
+      # The 2026-08-03 outage is precisely the state where all four roles log in
+      # and two of them can read nothing: authenticating is not being authorised.
+      # A login test passes clean through that failure, which is why it is not the
+      # gate for a run that just rewrote the policies.
+      - name: PROVE every AppRole can READ its declared paths
+        if: always()
+        run: |
+          ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
+            deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
+            'cd /opt/hill90/app && export SOPS_AGE_KEY_FILE=/opt/hill90/secrets/keys/keys.txt && bash scripts/checks/vault-approle-real-read-test.sh'
 
       - name: Revoke the recovered root token
         if: ${{ inputs.revoke_root_at_end }}


### PR DESCRIPTION
Closes the last step of #658.

**The gap this closes is not a policy. It is that nothing could apply one.**

#655 landed `policy-auth.hcl` and `policy-db.hcl` in `main`. The deploy in #658 carried them to `/opt/hill90/app`, where `docker-compose.vault.yml:68` bind-mounts the directory into the container. Measured on the live vault immediately afterwards, with the files sitting in the mount:

```
db             secret/shared/database             403-denied
auth           secret/shared/database             403-denied
auth           secret/auth/config                 403-denied
infra          secret/infra/traefik               read-ok
observability  secret/observability/grafana       read-ok
```

**Merging a policy file applies nothing.** The vault was never told.

## Why there was no route

Writing a policy is a `sys/policy/*` update, and the only identity on this vault holding it is **root — deliberately revoked**. No deploy path calls `policy-apply`; `vault.sh setup` does, and setup is a bootstrap, not something to point at a running estate. The sync token is read-only on KV by design and cannot write policies.

So the AppRole fix could merge, deploy, and still be inert. That is exactly what happened.

## The change

`run_policy_apply` (default true) on **Vault Regain Root**, running `policy-apply` with the recovered token **inside the window that already exists for `setup-oidc`** — the same reasoning the file already states: *whatever is not configured while root exists needs another recovery run afterwards.*

**Deliberately not a dedicated workflow.** That would duplicate the open/mint/close sequence, and the delicate part of it is the assertion that proves unauthenticated root generation is shut again. Two copies of that is one copy that rots.

## And a read-level gate

The run already re-proved AppRole with `vault-approle-login-test.sh` — which **passes clean through this exact outage**: all four roles do log in, and two read nothing. Added `vault-approle-real-read-test.sh` after the window closes, so the evidence is the end state rather than the transient one, and a run that rewrites policies cannot report success on an authentication test alone.

Step order checked: apply at 14 inside the window; restore, auto-unseal and the shut-door assertion at 15–17; the read proof at 20.

## Verification

- `bats tests/ --recursive` — **390 passing, 0 failing**
- Workflow parses; inputs `confirm, run_setup_oidc, run_policy_apply, revoke_root_at_end`
- The check was run on the VPS exactly as the workflow invokes it, and reproduced the red state above
- No secret value printed; the recovered token stays in a file on the box read into the environment, never argv

**This PR cannot fix the live vault until it is merged** — `workflow_dispatch` only offers a workflow that exists on the default branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)