### PR TITLE
fix(vault): revoke the root token even when the run fails, and prove it

### DIFF
--- a/.github/workflows/vault-init.yml
+++ b/.github/workflows/vault-init.yml
@@ -196,14 +196,26 @@ jobs:
       # with no OIDC method and no credential able to add one on 2026-08-02.
       # scripts/checks/check_vault_revoke_order.py fails if this ordering is undone.
       - name: Enable OIDC auth before anything can revoke root
-        if: ${{ inputs.revoke_root }}
+        if: ${{ always() && inputs.revoke_root }}
         run: |
           ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
             deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
             'cd /opt/hill90/app && export SOPS_AGE_KEY_FILE=/opt/hill90/secrets/keys/keys.txt && export BAO_TOKEN="$(cat /opt/hill90/secrets/openbao-root.token)" && bash scripts/vault.sh setup-oidc'
 
+      # always() here for the reason set out in vault-regain-root.yml: a custom
+      # `if:` is ANDed with GitHub's implicit success(), so this used to be
+      # skipped by any earlier failure — leaving a live root token exactly when
+      # the run had already gone wrong. Run 30791332461 hit that on the sibling
+      # workflow. See #662.
+      #
+      # The step ABOVE is always() for the same property rather than for its own
+      # sake: revoking is only safe once OIDC exists, assert_safe_to_revoke
+      # refuses otherwise, and a revoke that refuses is a live token. Enabling
+      # OIDC has to survive the same failure the revoke now survives, or the
+      # revoke inherits a guard it cannot satisfy. If init itself failed there is
+      # no token file and cmd_revoke_root exits 0 on "nothing to revoke".
       - name: Revoke root token
-        if: ${{ inputs.revoke_root }}
+        if: ${{ always() && inputs.revoke_root }}
         run: |
           ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
             deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
@@ -247,8 +259,10 @@ jobs:
           echo "after systemd unit run, bao status exit: $RC (expect 0)"
           [ "$RC" = "0" ] || { echo "::error::hill90-vault-unseal.service did not unseal the vault (exit $RC)"; exit 1; }
 
+      # always(), or the confirmation vanishes precisely when it matters — a run
+      # that failed is the one whose token disposal most needs proving.
       - name: Confirm root token is gone
-        if: ${{ inputs.revoke_root }}
+        if: ${{ always() && inputs.revoke_root }}
         run: |
           GONE=$(ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
             deploy@${{ steps.get-ip.outputs.tailscale_ip }} \

--- a/.github/workflows/vault-regain-root.yml
+++ b/.github/workflows/vault-regain-root.yml
@@ -258,12 +258,46 @@ jobs:
             deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
             'cd /opt/hill90/app && export SOPS_AGE_KEY_FILE=/opt/hill90/secrets/keys/keys.txt && bash scripts/checks/vault-approle-real-read-test.sh'
 
+      # always() IS LOAD-BEARING, NOT TIDINESS.
+      #
+      # This read `if: ${{ inputs.revoke_root_at_end }}`, and a custom `if:` does
+      # not replace GitHub's implicit success() — it is ANDed with it unless the
+      # expression names always(), failure() or cancelled(). So the revoke ran
+      # only when nothing had failed, which inverts the intent: the run that goes
+      # wrong is exactly the run you least want leaving a standing root token.
+      #
+      # Run 30791332461 did precisely that. It failed at the read-proof step,
+      # skipped this one, and left a VALID root token on the production host. The
+      # shut-door assertion above passed the whole time — shutting the door and
+      # holding a key are different things.
+      #
+      # Revoking after a FAILED run is safe: cmd_revoke_root calls
+      # assert_safe_to_revoke, which refuses when OIDC is not enabled, and exits
+      # non-zero on a token that survives. So the worst case is a loud failure
+      # here rather than a silent live token.
       - name: Revoke the recovered root token
-        if: ${{ inputs.revoke_root_at_end }}
+        if: ${{ always() && inputs.revoke_root_at_end }}
         run: |
           ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
             deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
             'cd /opt/hill90/app && bash scripts/vault.sh revoke-root'
+
+      # And PROVE it, the same way the shut-door assertion does. cmd_revoke_root
+      # already refuses to report success on a live token, but that is a log line
+      # inside an ssh session; this makes a failed disposal fail the RUN.
+      - name: ASSERT the root token is dead
+        if: ${{ always() && inputs.revoke_root_at_end }}
+        run: |
+          STATE=$(ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
+            deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
+            'if [ -s /opt/hill90/secrets/openbao-root.token ]; then
+               BAO_TOKEN="$(cat /opt/hill90/secrets/openbao-root.token)" docker exec -e BAO_ADDR=http://127.0.0.1:8200 -e BAO_TOKEN openbao bao token lookup >/dev/null 2>&1 && echo live || echo dead
+             else echo absent; fi')
+          echo "root token after revoke: $STATE  (absent or dead = disposed, live = EXPOSED)"
+          if [ "$STATE" = "live" ]; then
+            echo "::error::A VALID root token is still on the production host. Revoke it before walking away: ssh deploy@remote.hill90.com 'cd /opt/hill90/app && bash scripts/vault.sh revoke-root'"
+            exit 1
+          fi
 
       - name: Final baseline
         if: always()

--- a/.github/workflows/vault-reinitialize.yml
+++ b/.github/workflows/vault-reinitialize.yml
@@ -1,5 +1,14 @@
 name: Vault Reinitialize (Prod)
 
+# ROOT-TOKEN-DISPOSAL: deliberate — this workflow mints a root token and does NOT
+# revoke it, by design. The "What is left to do" summary hands the operator the
+# revoke command and says "Deliberately not automated", because on
+# OpenBao >= 2.5.3 revoking is a one-way door and the whole point of a
+# reinitialise is to leave the vault configurable while its behaviour is checked.
+# Declared here so that scripts/checks/check_root_revoke_fails_closed.py sees a
+# decision rather than an omission — a workflow that simply forgot still fails
+# that check. See #662.
+
 # The whole reinitialize decision as ONE action.
 #
 # docs/decisions/vault-vs-sops.md describes reinitializing as seven ordered

--- a/scripts/checks/check_root_revoke_fails_closed.py
+++ b/scripts/checks/check_root_revoke_fails_closed.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""A run that mints a root token must revoke it even when it fails.
+
+    python3 scripts/checks/check_root_revoke_fails_closed.py
+
+WHY THIS EXISTS. Run 30791332461 dispatched vault-regain-root with
+revoke_root_at_end=true, failed at the final verification step, and left a VALID
+root token on the production host. The revoke was not attempted-and-failed; it
+was never attempted. Its condition read
+
+    if: ${{ inputs.revoke_root_at_end }}
+
+and a custom `if:` does NOT replace GitHub's implicit success() — it is ANDed
+with it unless the expression contains always(), failure() or cancelled(). So
+the revoke ran only when nothing before it had failed, which inverts the intent:
+the run that goes wrong is exactly the run you least want leaving a standing
+root token.
+
+The workflow already asserted that unauthenticated root generation was shut
+again, and that assertion passed. Shutting the door and holding a key are
+different things, and only one of them was checked.
+
+WHAT THIS CHECKS, AND WHY IT SIMULATES RATHER THAN READS. Reading the YAML and
+looking for `always()` would re-encode the same assumption that was wrong the
+first time. Instead this models GitHub's skip rule once, in runs_after_failure()
+below, and then DERIVES the answer: inject a failure at every step from the mint
+onwards, and assert the revoke still executes in each case. If the rule is
+modelled wrongly the control tests in tests/scripts/root-revoke-fails-closed-control.bats
+catch it, because they mutate a copy and require this to go red.
+
+The gated inputs are taken as TRUE: the property is "when the operator asks for
+the token to be revoked, a failure cannot silently skip it". An operator who
+passes revoke_root=false is choosing to keep the token and is not this check's
+business.
+
+Exit 0 if every root-minting workflow fails closed.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOWS = ROOT / ".github/workflows"
+
+# Steps are identified by the vault.sh subcommand they invoke, not by their
+# display name — a name is prose and gets edited, an invocation is behaviour.
+MINT = ("vault.sh regain-root", "vault.sh init")
+REVOKE = "vault.sh revoke-root"
+
+# A step that verifies the token is actually gone. cmd_revoke_root already
+# refuses to report success on a live token, but a workflow-level confirmation
+# is what makes a failed revoke fail the RUN rather than a log line nobody reads.
+CONFIRM_MARKERS = ("openbao-root.token", "root token is gone", "token lookup")
+
+STATUS_FUNCTIONS = ("always(", "failure(", "cancelled(")
+
+# A workflow may deliberately hand the root token to a human instead of revoking
+# it — vault-reinitialize.yml does, and says "Deliberately not automated" for a
+# stated reason. That is a decision, and this check has no business overturning
+# it. But it must be DECLARED in the file, so that a workflow which simply forgot
+# still fails. Silence is the failure; an explicit line is the exemption.
+OPT_OUT = "ROOT-TOKEN-DISPOSAL: deliberate"
+
+
+def runs_after_failure(cond) -> bool:
+    """GitHub's rule, modelled in one place.
+
+    A step with no `if:` carries an implicit success(). A step WITH an `if:`
+    still carries it — the custom expression is ANDed with success() — unless
+    the expression names a status function. That last clause is the whole bug.
+    """
+    if cond is None:
+        return False
+    return any(fn in str(cond) for fn in STATUS_FUNCTIONS)
+
+
+def invocations(step: dict) -> str:
+    """The commands a step RUNS, with prose stripped out.
+
+    Necessary because these workflows end in a step that echoes the remaining
+    manual steps into the job summary, and that prose names `vault.sh
+    revoke-root`. Matching it read a instruction to a human as a revoke the
+    workflow performs — a summary line is not an action, and counting it as one
+    would have reported vault-reinitialize.yml as revoking a token it never
+    touches. Caught by inspecting the first red run rather than trusting it.
+    """
+    body = str(step.get("run", ""))
+    lines = [
+        ln
+        for ln in body.splitlines()
+        if not ln.lstrip().startswith(("echo", "printf", "#"))
+    ]
+    return "\n".join(lines)
+
+
+def step_text(step: dict) -> str:
+    """Everything that identifies a step, for the confirmation heuristics."""
+    return " ".join(str(step.get(k, "")) for k in ("name", "uses", "with")) + "\n" + invocations(step)
+
+
+def simulate(steps: list[dict], fail_at: int) -> set[int]:
+    """Which step indices execute, given the step at fail_at fails?
+
+    Steps before it already ran. It ran, and failed. Everything after runs only
+    if its condition survives a failed job status.
+    """
+    executed = set(range(fail_at + 1))
+    for i in range(fail_at + 1, len(steps)):
+        if runs_after_failure(steps[i].get("if")):
+            executed.add(i)
+    return executed
+
+
+def audit(path: Path) -> list[str]:
+    raw = path.read_text()
+    doc = yaml.safe_load(raw)
+    problems: list[str] = []
+    opted_out = OPT_OUT in raw
+
+    for job_name, job in (doc.get("jobs") or {}).items():
+        steps = job.get("steps") or []
+        texts = [step_text(s) for s in steps]
+        runs = [invocations(s) for s in steps]
+
+        mints = [i for i, t in enumerate(runs) if any(m in t for m in MINT)]
+        if not mints:
+            continue
+        mint = mints[0]
+
+        revokes = [i for i, t in enumerate(runs) if REVOKE in t]
+        if not revokes:
+            if opted_out:
+                continue
+            problems.append(
+                f"{path.name}:{job_name} mints a root token at step {mint + 1} "
+                f"({steps[mint].get('name')!r}) and never revokes it. If that is "
+                f"intended, say so in the file with a comment containing "
+                f"{OPT_OUT!r} and the reason."
+            )
+            continue
+        revoke = revokes[0]
+
+        # THE PROPERTY. Fail at each step from the mint onwards; the revoke must
+        # still execute every time.
+        for fail_at in range(mint, len(steps)):
+            if fail_at >= revoke:
+                # A failure at or after the revoke cannot skip it.
+                continue
+            if revoke not in simulate(steps, fail_at):
+                problems.append(
+                    f"{path.name}:{job_name} step {fail_at + 1} "
+                    f"({steps[fail_at].get('name')!r}) fails "
+                    f"-> step {revoke + 1} ({steps[revoke].get('name')!r}) is SKIPPED, "
+                    f"leaving a live root token. Its condition is "
+                    f"{steps[revoke].get('if')!r}; it needs always()."
+                )
+                break  # one report per job is enough; the cause is the condition
+
+        # A revoke that is never verified at the workflow level can fail quietly.
+        confirms = [
+            i
+            for i, t in enumerate(texts)
+            if i > revoke and any(m in t.lower() for m in CONFIRM_MARKERS)
+        ]
+        if not confirms:
+            problems.append(
+                f"{path.name}:{job_name} revokes at step {revoke + 1} but never "
+                f"confirms the token is dead afterwards"
+            )
+        else:
+            for c in confirms:
+                if not runs_after_failure(steps[c].get("if")):
+                    problems.append(
+                        f"{path.name}:{job_name} step {c + 1} "
+                        f"({steps[c].get('name')!r}) confirms the token is gone but is "
+                        f"skipped on failure — the confirmation disappears exactly when "
+                        f"it matters. Its condition is {steps[c].get('if')!r}."
+                    )
+    return problems
+
+
+def main() -> int:
+    files = sorted(WORKFLOWS.glob("*.yml"))
+    if not files:
+        print(f"no workflows found under {WORKFLOWS}")
+        return 1
+
+    problems: list[str] = []
+    minting: list[str] = []
+    for f in files:
+        try:
+            doc = yaml.safe_load(f.read_text())
+        except yaml.YAMLError as e:
+            print(f"FAIL — {f.name} is not valid YAML: {e}")
+            return 1
+        if not isinstance(doc, dict):
+            continue
+        mints_here = any(
+            any(m in invocations(s) for m in MINT)
+            for job in (doc.get("jobs") or {}).values()
+            for s in (job.get("steps") or [])
+        )
+        if mints_here:
+            minting.append(f.name)
+        problems.extend(audit(f))
+
+    print("Root-token cleanup must survive a failed run")
+    print("===========================================")
+    print(f"  workflows that mint a root token: {', '.join(minting) or 'none'}")
+    print()
+
+    if problems:
+        print(f"FAIL — {len(problems)} problem(s):\n")
+        for p in problems:
+            print(f"  {p}")
+        print(
+            "\nA custom `if:` is ANDed with success(). To run after a failure the\n"
+            "expression must name always(), failure() or cancelled(). This is not a\n"
+            "style point: it is how run 30791332461 left root live on production."
+        )
+        return 1
+
+    print("PASS — every root-minting workflow revokes and verifies on failure")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scripts/root-revoke-fails-closed-control.bats
+++ b/tests/scripts/root-revoke-fails-closed-control.bats
@@ -1,0 +1,179 @@
+#!/usr/bin/env bats
+
+# POSITIVE CONTROL for scripts/checks/check_root_revoke_fails_closed.py.
+#
+# #662 asked for the property to be PROVEN rather than read off the YAML: a run
+# that fails at any step after the root token is minted must still revoke it.
+# Reading the file for `always()` would re-encode the very assumption that was
+# wrong — the author of the original condition also read it and believed it ran.
+#
+# So each test MUTATES a copy and requires the check to go red for that specific
+# reason. If a future edit makes the check vacuous, these go green-when-red and
+# CI notices. Modelled on tests/scripts/vault-revoke-order-control.bats from #659,
+# which established the pattern for this estate.
+#
+# The mutations are of different KINDS on purpose: reverting a condition to the
+# exact broken form from run 30791332461, deleting a cleanup step outright,
+# removing a declared exemption, and adding prose that must NOT be mistaken for
+# an action.
+
+setup() {
+  ROOT="$BATS_TEST_DIRNAME/../.."
+  CTL="$BATS_TEST_TMPDIR/ctl"
+  mkdir -p "$CTL/scripts/checks" "$CTL/.github/workflows"
+  cp "$ROOT/scripts/checks/check_root_revoke_fails_closed.py" "$CTL/scripts/checks/"
+  cp "$ROOT"/.github/workflows/*.yml "$CTL/.github/workflows/"
+  CHECK="$CTL/scripts/checks/check_root_revoke_fails_closed.py"
+}
+
+# Replace a step's `if:` condition, identified by the step name above it.
+set_condition() {
+  local file="$1" step="$2" cond="$3"
+  python3 - "$file" "$step" "$cond" <<'PY'
+import re, sys
+path, step, cond = sys.argv[1], sys.argv[2], sys.argv[3]
+t = open(path).read()
+parts = re.split(r"(?m)^(?=      - name:)", t)
+head, steps = parts[0], parts[1:]
+i = next(i for i, s in enumerate(steps) if step in s.splitlines()[0])
+assert re.search(r"(?m)^        if: .*$", steps[i]), f"step {step!r} has no if: to replace"
+steps[i] = re.sub(r"(?m)^        if: .*$", f"        if: {cond}", steps[i], count=1)
+open(path, "w").write(head + "".join(steps))
+PY
+}
+
+delete_step() {
+  local file="$1" step="$2"
+  python3 - "$file" "$step" <<'PY'
+import re, sys
+path, step = sys.argv[1], sys.argv[2]
+t = open(path).read()
+parts = re.split(r"(?m)^(?=      - name:)", t)
+head, steps = parts[0], parts[1:]
+i = next(i for i, s in enumerate(steps) if step in s.splitlines()[0])
+del steps[i]
+open(path, "w").write(head + "".join(steps))
+PY
+}
+
+@test "CONTROL: the check PASSES on the real, unmutated workflows" {
+  run python3 "$CHECK"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"PASS"* ]]
+}
+
+# NOT VACUOUS: if the mint is no longer recognised, every audit below silently
+# skips and the whole file passes for the wrong reason. Pin the discovery.
+@test "CONTROL: all three root-minting workflows are actually discovered" {
+  run python3 "$CHECK"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"vault-init.yml"* ]]
+  [[ "$output" == *"vault-regain-root.yml"* ]]
+  [[ "$output" == *"vault-reinitialize.yml"* ]]
+}
+
+@test "reverting the revoke to the exact broken condition from run 30791332461 turns it red" {
+  # This is verbatim what production shipped, and what left a live root token.
+  set_condition "$CTL/.github/workflows/vault-regain-root.yml" \
+    "Revoke the recovered root token" '${{ inputs.revoke_root_at_end }}'
+
+  run python3 "$CHECK"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"FAIL"* ]]
+  [[ "$output" == *"Revoke the recovered root token"* ]]
+  [[ "$output" == *"SKIPPED"* ]]
+  [[ "$output" == *"live root token"* ]]
+}
+
+@test "the same break in vault-init.yml turns it red" {
+  set_condition "$CTL/.github/workflows/vault-init.yml" \
+    "Revoke root token" '${{ inputs.revoke_root }}'
+
+  run python3 "$CHECK"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"vault-init.yml"* ]]
+  [[ "$output" == *"Revoke root token"* ]]
+}
+
+@test "a revoke that runs but is never verified turns it red" {
+  delete_step "$CTL/.github/workflows/vault-regain-root.yml" "ASSERT the root token is dead"
+
+  run python3 "$CHECK"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"never confirms the token is dead"* ]]
+}
+
+@test "a verification that is skipped on failure turns it red" {
+  set_condition "$CTL/.github/workflows/vault-init.yml" \
+    "Confirm root token is gone" '${{ inputs.revoke_root }}'
+
+  run python3 "$CHECK"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Confirm root token is gone"* ]]
+  [[ "$output" == *"skipped on failure"* ]]
+}
+
+@test "deleting the revoke step entirely turns it red" {
+  delete_step "$CTL/.github/workflows/vault-regain-root.yml" "Revoke the recovered root token"
+
+  run python3 "$CHECK"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"never revokes it"* ]]
+}
+
+@test "removing the declared exemption from vault-reinitialize turns it red" {
+  # The opt-out is what separates "decided" from "forgot". Without it, a
+  # workflow that mints and never revokes must not pass quietly.
+  local wf="$CTL/.github/workflows/vault-reinitialize.yml"
+  grep -q "ROOT-TOKEN-DISPOSAL: deliberate" "$wf"
+  sed -i.bak 's/ROOT-TOKEN-DISPOSAL: deliberate/(declaration removed)/' "$wf" && rm -f "$wf.bak"
+
+  run python3 "$CHECK"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"never revokes it"* ]]
+  [[ "$output" == *"ROOT-TOKEN-DISPOSAL: deliberate"* ]]
+}
+
+# PROSE IS NOT AN ACTION. The first red run of this check reported
+# vault-reinitialize.yml as revoking a token, because its closing summary echoes
+# the revoke command as an instruction to a human. A mention must never satisfy
+# the requirement.
+@test "an echoed revoke command does not count as revoking" {
+  local wf="$CTL/.github/workflows/vault-reinitialize.yml"
+  sed -i.bak 's/ROOT-TOKEN-DISPOSAL: deliberate/(declaration removed)/' "$wf" && rm -f "$wf.bak"
+
+  run python3 "$CHECK"
+  [ "$status" -eq 1 ]
+  # It already echoes `bash scripts/vault.sh revoke-root` in its summary step.
+  # If prose counted, this would report a skipped revoke instead of an absent one.
+  [[ "$output" == *"never revokes it"* ]]
+  [[ "$output" != *"is SKIPPED"* ]]
+}
+
+# The property itself, stated as a test rather than inferred: inject a NEW
+# failing step at each position after the mint and require the check to still
+# pass — that is what "fails closed at ANY step" means.
+@test "a failure injected at any step after the mint still leaves the revoke reachable" {
+  python3 - "$CTL/.github/workflows/vault-regain-root.yml" <<'PY'
+import re, sys
+path = sys.argv[1]
+t = open(path).read()
+parts = re.split(r"(?m)^(?=      - name:)", t)
+head, steps = parts[0], parts[1:]
+mint = next(i for i, s in enumerate(steps) if "vault.sh regain-root" in s)
+revoke = next(i for i, s in enumerate(steps) if "vault.sh revoke-root" in s)
+injected = "      - name: INJECTED FAILURE\n        run: exit 1\n\n"
+# Insert at every position between the mint and the revoke, one file at a time
+# is unnecessary — inserting them all at once is strictly harsher.
+out = steps[: mint + 1]
+for i in range(mint + 1, revoke + 1):
+    out.append(injected)
+    out.append(steps[i])
+out += steps[revoke + 1 :]
+open(path, "w").write(head + "".join(out))
+PY
+
+  run python3 "$CHECK"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"PASS"* ]]
+}


### PR DESCRIPTION
Closes #662.

Run [30791332461](https://github.com/jonhill90/Hill90/actions/runs/30791332461) dispatched `vault-regain-root` with `revoke_root_at_end=true`, failed at the final verification step, and left a **valid root token on the production host**. The revoke was not attempted-and-failed. It was never attempted.

## The rule, observed rather than assumed

A custom `if:` does not replace GitHub's implicit `success()` — it is ANDed with it unless the expression names `always()`, `failure()` or `cancelled()`. Both halves are visible in that one run, after the step-21 failure:

```
step 22  skipped  Revoke the recovered root token   if: ${{ inputs.revoke_root_at_end }}
step 23  success  Final baseline                    if: always()
```

Same run, same failure, opposite outcomes. The input was `true`; the condition was simply never reached. So the revoke ran only when nothing had failed — which inverts the intent: **the run that goes wrong is the one you least want leaving a standing root token.** The workflow's shut-door assertion passed the whole time. Shutting the door and holding a key are different things, and only one was asserted.

## Fixed in both places — the pattern was not isolated

| Workflow | Step | Now |
|---|---|---|
| `vault-regain-root` | Revoke the recovered root token | `always() && input` |
| `vault-init` | Revoke root token | `always() && input` |
| `vault-init` | Enable OIDC … before revoke | `always() && input` |
| `vault-init` | Confirm root token is gone | `always() && input` |

The OIDC step is included **deliberately, not swept in**: revoking is only safe once OIDC exists, `assert_safe_to_revoke` refuses otherwise, and a revoke that refuses is a live token. It has to survive the same failure the revoke now survives, or the revoke inherits a guard it cannot satisfy. Safe in the other direction too — `cmd_revoke_root` exits non-zero on a surviving token and returns 0 when there is no token file at all.

Added an **ASSERT the root token is dead** step to `vault-regain-root`, mirroring the shut-door assertion. `cmd_revoke_root` already refuses to claim success on a live token, but that is a log line inside an ssh session; this makes a failed disposal fail the run.

## Proven, not read

`scripts/checks/check_root_revoke_fails_closed.py` models GitHub's skip rule in **one function** and *derives* the answer: inject a failure at every step from the mint onwards, and require the revoke to still execute. Reading the YAML for `always()` would re-encode the assumption that was wrong the first time — the author of the original condition also read it and believed it ran.

`tests/scripts/root-revoke-fails-closed-control.bats` mutates a copy per test and requires red. **Red before green:** against the unfixed workflows the check reported 5 problems, including the two real defects above; it passes only after the fix.

```
ok 1  CONTROL: the check PASSES on the real, unmutated workflows
ok 2  CONTROL: all three root-minting workflows are actually discovered
ok 3  reverting the revoke to the exact broken condition from run 30791332461 turns it red
ok 4  the same break in vault-init.yml turns it red
ok 5  a revoke that runs but is never verified turns it red
ok 6  a verification that is skipped on failure turns it red
ok 7  deleting the revoke step entirely turns it red
ok 8  removing the declared exemption from vault-reinitialize turns it red
ok 9  an echoed revoke command does not count as revoking
ok 10 a failure injected at any step after the mint still leaves the revoke reachable
```

Test 2 exists because the check fails **vacuously** if the mint stops being recognised — every audit would skip silently and the file would pass for the wrong reason.

## Two things the first red run caught, both mine

1. It reported `vault-reinitialize` as revoking a token it never touches. Its closing summary **echoes** the revoke command as an instruction to a human. A mention is not an action — the matcher now strips `echo`/`printf`/comment lines, and test 9 pins that prose cannot satisfy the requirement.
2. `vault-reinitialize` genuinely mints root and never revokes — and says *"Deliberately not automated"* with a reason, because revoking is a one-way door and the point of a reinitialise is a configurable vault. **That is a decision, not a defect**, so the check takes a declared exemption rather than overturning it. Silence still fails; test 8 removes the declaration and requires red.

## What is not proven here

`always() && inputs.x` is the boolean AND of two behaviours observed in that run — it is not itself an observation. **No workflow was dispatched to demonstrate it**, because doing so would open unauthenticated root generation on production to test a conditional.

## Verification

- `bats tests/scripts/` — **400 passing, 0 failing** (up from 390)
- CI runs exactly `bats tests/scripts/`, so the check is gated on every pull request through control test 1
- No production change; no secret value printed

🤖 Generated with [Claude Code](https://claude.com/claude-code)