### PR TITLE
fix(vault): restore the seed for shared/database and auth/config, and guard the class

### DIFF
--- a/.github/workflows/vault-regain-root.yml
+++ b/.github/workflows/vault-regain-root.yml
@@ -42,6 +42,11 @@ on:
         required: false
         default: true
         type: boolean
+      run_seed:
+        description: 'Seed KV v2 from SOPS with the recovered token. Writing a secret needs root like policy-apply does, so this is the only pipeline route to it. Idempotent: kv put overwrites a path with the same values, creating a new version.'
+        required: false
+        default: false
+        type: boolean
       revoke_root_at_end:
         description: 'Revoke the recovered root token when finished. Safe once OIDC is enabled; assert_safe_to_revoke refuses otherwise.'
         required: false
@@ -192,6 +197,33 @@ jobs:
           ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
             deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
             'cd /opt/hill90/app && export SOPS_AGE_KEY_FILE=/opt/hill90/secrets/keys/keys.txt && export BAO_TOKEN="$(cat /opt/hill90/secrets/openbao-root.token)" && bash scripts/vault.sh policy-apply'
+
+      # SEEDING NEEDS ROOT FOR THE SAME REASON POLICY-APPLY DOES, so it has the
+      # same problem: no deploy path calls it, `vault.sh setup` is a bootstrap,
+      # and the only identity that can write a secret is the one this window
+      # mints. A policy without data is exactly as inert as data without a
+      # policy — #661 is the second half of #660.
+      #
+      # Off by default. Policies are declarative and re-applying them is a no-op;
+      # seeding writes credentials and creates a new KV version each time, so it
+      # is something to ask for rather than something to get by default.
+      - name: Seed KV v2 from SOPS
+        if: ${{ inputs.run_seed }}
+        run: |
+          ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
+            deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
+            'cd /opt/hill90/app && export SOPS_AGE_KEY_FILE=/opt/hill90/secrets/keys/keys.txt && export BAO_TOKEN="$(cat /opt/hill90/secrets/openbao-root.token)" && bash scripts/vault.sh seed'
+
+      # The name-only comparison #650 asks for, run while a token still exists.
+      # It CANNOT run outside this window: an unauthenticated bao read returns
+      # empty, and empty from a missing token looks exactly like empty from a
+      # missing secret — which is the confusion that hid this defect for months.
+      - name: Compare vault against SOPS by name
+        if: ${{ always() && inputs.run_seed }}
+        run: |
+          ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
+            deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
+            'cd /opt/hill90/app && export SOPS_AGE_KEY_FILE=/opt/hill90/secrets/keys/keys.txt && export BAO_TOKEN="$(cat /opt/hill90/secrets/openbao-root.token)" && bash scripts/checks/vault-sops-name-parity.sh'
 
       # ---- Close the window, and PROVE it closed ------------------------------
 

--- a/scripts/checks/check_declared_paths_are_seeded.py
+++ b/scripts/checks/check_declared_paths_are_seeded.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Every vault path a service declares must be one the seed actually writes.
+
+    python3 scripts/checks/check_declared_paths_are_seeded.py
+
+WHY THIS EXISTS. `vault_paths_for_service` in scripts/_common.sh is what deploy
+time reads a service's secrets from. `cmd_seed` in scripts/vault.sh is what puts
+them there. Nothing tied the two together, and they drifted for months:
+
+  #495  removed Keycloak and Postgres, and with them the seed blocks for
+        secret/shared/database and secret/auth/config. Correct at the time.
+  #531  brought both services back and restored their DECLARATIONS — but not
+        the seed. From then on `db` and `auth` pointed at paths that had never
+        existed on the live vault.
+
+That is the 404 underneath the 2026-08-03 auth outage. The missing AppRole policy
+(#660) produced a 403 on top of it, so every diagnosis stopped at the 403 and the
+absent data was never reached. Fixing the policy alone changed "permission
+denied" into "No value found" — a different error and an identical outcome.
+
+The same shape has now cost this estate three separate defects: one list
+enumerating something a second list must match, with nothing checking. The policy
+files were the first (#653), the seed is this one. So this check exists as much
+for the NEXT pair as for these two.
+
+Exit 0 if every declared path is seeded.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+COMMON = ROOT / "scripts/_common.sh"
+VAULT = ROOT / "scripts/vault.sh"
+
+
+def declared_paths() -> dict[str, list[str]]:
+    """Parse the case arms of vault_paths_for_service()."""
+    body = COMMON.read_text()
+    m = re.search(r"vault_paths_for_service\(\)\s*\{(.*?)\n\}", body, re.S)
+    if not m:
+        sys.exit("could not find vault_paths_for_service() in scripts/_common.sh")
+
+    out: dict[str, list[str]] = {}
+    for arm in re.finditer(r"^\s*([a-z0-9_|]+)\)\s*echo\s+\"([^\"]*)\"", m.group(1), re.M):
+        service, paths = arm.group(1), arm.group(2).split()
+        if service == "*" or not paths:
+            continue
+        for name in service.split("|"):
+            out[name] = paths
+    return out
+
+
+def seeded_paths() -> set[str]:
+    """Paths cmd_seed actually writes.
+
+    Matches `kv put secret/...` invocations only. A path named in a comment or
+    echoed as advice is not a write — the same distinction that made
+    check_root_revoke_fails_closed.py misread a summary step as a revoke.
+    """
+    body = VAULT.read_text()
+    m = re.search(r"^cmd_seed\(\)\s*\{(.*?)^\}", body, re.S | re.M)
+    if not m:
+        sys.exit("could not find cmd_seed() in scripts/vault.sh")
+
+    lines = [
+        ln for ln in m.group(1).splitlines()
+        if not ln.lstrip().startswith(("#", "echo", "printf"))
+    ]
+    return set(re.findall(r"kv put\s+(secret/\S+)", "\n".join(lines)))
+
+
+def required_keys() -> set[str]:
+    body = VAULT.read_text()
+    m = re.search(r"local required_keys=\((.*?)\)", body, re.S)
+    return set(m.group(1).split()) if m else set()
+
+
+def seeded_keys(path: str) -> set[str]:
+    """The KEY NAMES a given kv put writes. Names only — this never touches a value."""
+    body = VAULT.read_text()
+    m = re.search(rf"kv put\s+{re.escape(path)}\s+((?:.|\n)*?)(?=\n\n|\n    [a-z#])", body)
+    if not m:
+        return set()
+    return set(re.findall(r"\"([A-Z0-9_]+)=", m.group(1)))
+
+
+def main() -> int:
+    declared = declared_paths()
+    seeded = seeded_paths()
+    required = required_keys()
+
+    problems: list[str] = []
+    all_declared: set[str] = set()
+
+    print("Declared vault paths must be seeded")
+    print("===================================")
+    for service in sorted(declared):
+        for path in declared[service]:
+            all_declared.add(path)
+            ok = path in seeded
+            print(f"  {'ok  ' if ok else 'MISS'}  {service:<14} {path}")
+            if not ok:
+                problems.append(
+                    f"service {service!r} declares {path} but cmd_seed never writes it — "
+                    f"the role will authenticate, be authorised, and read nothing"
+                )
+
+    # The reverse direction is not an error, but it is worth surfacing: a seeded
+    # path no service declares is dead weight, and dead weight is where the next
+    # stale credential hides.
+    orphans = sorted(seeded - all_declared)
+
+    # A seeded key that is not in required_keys can be written BLANK, because
+    # get_secret returns "" for an absent key and `kv put K=` accepts it. That is
+    # the CF_DNS_API_TOKEN failure mode the seed already documents.
+    unguarded: list[str] = []
+    for path in sorted(seeded):
+        for key in sorted(seeded_keys(path)):
+            if key not in required:
+                unguarded.append(f"{path} writes {key}, which is not in required_keys")
+
+    print()
+    if orphans:
+        print(f"  note: seeded but declared by no service: {', '.join(orphans)}")
+    for u in unguarded:
+        problems.append(u + " — an absent key seeds as an empty string")
+
+    if problems:
+        print(f"\nFAIL — {len(problems)} problem(s):\n")
+        for p in problems:
+            print(f"  {p}")
+        print(
+            "\nA declared-but-unseeded path is invisible until something reads it, and\n"
+            "then it looks like a vault fault rather than a missing write."
+        )
+        return 1
+
+    print("\nPASS — every declared path is seeded, and every seeded key is guarded")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/checks/vault-sops-name-parity.sh
+++ b/scripts/checks/vault-sops-name-parity.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# What is in the vault, and what is in SOPS — by NAME, never by value.
+#
+#   BAO_TOKEN=... bash scripts/checks/vault-sops-name-parity.sh
+#
+# #650 asks the question this answers: "compare SOPS against vault, names only,
+# to find anything else the re-seed dropped". It is deliberately a separate
+# question from #661's, which was about two specific paths.
+#
+# NAMES ONLY, AND THAT IS ENFORCED BY CONSTRUCTION, not by care: every read is
+# piped straight into a key extractor and the values are never bound to a
+# variable, printed, or written. What this can tell you is which KEYS exist on
+# each side. It cannot tell you whether their values agree, and it must not —
+# that comparison would require both plaintexts in one place.
+#
+# AN AUTHENTICATED READ, ALWAYS. An unauthenticated `bao` command returns empty
+# output, and empty output from a missing token is indistinguishable from empty
+# output from a missing secret. This script refuses to run without a token
+# rather than report an absence it cannot see.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+source "$ROOT/scripts/_common.sh"
+
+CONTAINER="${OPENBAO_CONTAINER:-openbao}"
+SECRETS_FILE="${SECRETS_FILE:-$ROOT/infra/secrets/prod.enc.env}"
+
+[ -n "${BAO_TOKEN:-}" ] || {
+    echo "BAO_TOKEN is required. Without it every read returns empty, and an empty"
+    echo "result would be reported as a missing secret when it is a missing token."
+    exit 2
+}
+
+RED=$'\033[31m'; GREEN=$'\033[32m'; YEL=$'\033[33m'; BOLD=$'\033[1m'; OFF=$'\033[0m'
+
+# The canonical paths, taken from vault.sh rather than restated here so this
+# cannot drift from what the seed writes.
+PATHS=$(sed -n '/^cmd_export()/,/^}/p' "$ROOT/scripts/vault.sh" | grep -oE 'secret/[a-z/]+' | sort -u)
+[ -n "$PATHS" ] || { echo "could not read the canonical path list from scripts/vault.sh"; exit 1; }
+
+# --- names on each side ------------------------------------------------------
+
+# Authenticated LIST of the mount. Proves which paths exist, as distinct from
+# which paths we happened to ask about.
+echo "${BOLD}Mount contents (authenticated list)${OFF}"
+for top in $(BAO_TOKEN="$BAO_TOKEN" docker exec -e BAO_ADDR=http://127.0.0.1:8200 -e BAO_TOKEN \
+                "$CONTAINER" bao list -format=json secret/metadata 2>/dev/null \
+              | python3 -c 'import sys,json;print("\n".join(json.load(sys.stdin)))' 2>/dev/null); do
+    printf '  %s\n' "secret/${top}"
+    BAO_TOKEN="$BAO_TOKEN" docker exec -e BAO_ADDR=http://127.0.0.1:8200 -e BAO_TOKEN \
+        "$CONTAINER" bao list -format=json "secret/metadata/${top%/}" 2>/dev/null \
+      | python3 -c 'import sys,json
+try:
+    [print("    " + x) for x in json.load(sys.stdin)]
+except Exception:
+    pass' 2>/dev/null
+done
+echo
+
+vault_keys() {  # path -> key NAMES, one per line. Values never leave the pipe.
+    BAO_TOKEN="$BAO_TOKEN" docker exec -e BAO_ADDR=http://127.0.0.1:8200 -e BAO_TOKEN \
+        "$CONTAINER" bao read -format=json "secret/data/${1#secret/}" 2>/dev/null \
+      | python3 -c 'import sys,json
+try:
+    print("\n".join(sorted(json.load(sys.stdin)["data"]["data"])))
+except Exception:
+    pass'
+}
+
+sops_keys() {   # SOPS key NAMES only — cut at the first = and discard the rest.
+    SOPS_AGE_KEY_FILE="${SOPS_AGE_KEY_FILE:-$ROOT/infra/secrets/keys/age-prod.key}" \
+        sops -d "$SECRETS_FILE" 2>/dev/null | grep -oE '^[A-Z0-9_]+' | sort -u
+}
+
+SOPS_NAMES="$(sops_keys)"
+[ -n "$SOPS_NAMES" ] || { echo "could not decrypt $SECRETS_FILE"; exit 1; }
+echo "${BOLD}SOPS${OFF} holds $(printf '%s\n' "$SOPS_NAMES" | wc -l | tr -d ' ') key names"
+echo
+
+# --- the comparison ----------------------------------------------------------
+
+fail=0
+missing_paths=()
+echo "${BOLD}Per-path key parity (names only)${OFF}"
+for p in $PATHS; do
+    keys="$(vault_keys "$p")"
+    if [ -z "$keys" ]; then
+        printf '  %sABSENT%s  %-34s not present on the vault\n' "$RED" "$OFF" "$p"
+        missing_paths+=("$p"); fail=$((fail+1)); continue
+    fi
+    n=$(printf '%s\n' "$keys" | wc -l | tr -d ' ')
+    printf '  %sok%s      %-34s %s key(s)\n' "$GREEN" "$OFF" "$p" "$n"
+    while IFS= read -r k; do
+        [ -z "$k" ] && continue
+        if ! printf '%s\n' "$SOPS_NAMES" | grep -qx "$k"; then
+            printf '            %s%s%s is in the vault but NOT in SOPS — nothing backs it up\n' "$YEL" "$k" "$OFF"
+            fail=$((fail+1))
+        fi
+    done <<<"$keys"
+done
+
+echo
+if [ "${#missing_paths[@]}" -gt 0 ]; then
+    printf '%s%d canonical path(s) absent from the vault:%s %s\n' \
+        "$RED" "${#missing_paths[@]}" "$OFF" "${missing_paths[*]}"
+fi
+if [ "$fail" -gt 0 ]; then
+    printf '%s%d parity problem(s).%s\n' "$RED" "$fail" "$OFF"
+    exit 1
+fi
+printf '%severy canonical path exists and every vault key name is backed by SOPS%s\n' "$GREEN" "$OFF"

--- a/scripts/vault.sh
+++ b/scripts/vault.sh
@@ -713,6 +713,11 @@ cmd_seed() {
         CF_DNS_API_TOKEN
         HOSTINGER_API_KEY
         GRAFANA_ADMIN_PASSWORD
+        DB_USER
+        DB_PASSWORD
+        DB_NAME
+        KC_ADMIN_USERNAME
+        KC_ADMIN_PASSWORD
     )
     local missing=()
     local key
@@ -742,6 +747,30 @@ cmd_seed() {
     echo "Seeding secret/observability/grafana..."
     bao_exec_env kv put secret/observability/grafana \
         "GRAFANA_ADMIN_PASSWORD=$(get_secret GRAFANA_ADMIN_PASSWORD)"
+
+    # Seed shared/database and auth/config.
+    #
+    # RESTORED, NOT NEW. #495 removed both blocks when Keycloak and Postgres left
+    # the estate, which was correct at the time. #531 brought those services back
+    # and restored their DECLARATIONS in vault_paths_for_service — db ->
+    # secret/shared/database, auth -> secret/shared/database + secret/auth/config
+    # — but not the seed that fills them. So the two roles have been declared,
+    # later policied, and pointed at paths that never existed.
+    #
+    # This is why the 2026-08-03 auth outage read as a vault problem. The 403
+    # from the missing policy sat on top of a 404 from this, and fixing only the
+    # policy turned "permission denied" into "No value found" — a different
+    # error, an identical outcome for the caller.
+    echo "Seeding secret/shared/database..."
+    bao_exec_env kv put secret/shared/database \
+        "DB_USER=$(get_secret DB_USER)" \
+        "DB_PASSWORD=$(get_secret DB_PASSWORD)" \
+        "DB_NAME=$(get_secret DB_NAME)"
+
+    echo "Seeding secret/auth/config..."
+    bao_exec_env kv put secret/auth/config \
+        "KC_ADMIN_USERNAME=$(get_secret KC_ADMIN_USERNAME)" \
+        "KC_ADMIN_PASSWORD=$(get_secret KC_ADMIN_PASSWORD)"
 
     rm -f "$temp_file"
     trap - RETURN
@@ -780,6 +809,8 @@ cmd_export() {
         "secret/infra/traefik"
         "secret/infra/vps"
         "secret/observability/grafana"
+        "secret/shared/database"
+        "secret/auth/config"
     )
 
     for p in "${paths[@]}"; do
@@ -806,6 +837,8 @@ cmd_sync_to_sops() {
         "secret/infra/traefik"
         "secret/infra/vps"
         "secret/observability/grafana"
+        "secret/shared/database"
+        "secret/auth/config"
     )
 
     # Create timestamped backup before modifying SOPS

--- a/tests/scripts/declared-paths-seeded-control.bats
+++ b/tests/scripts/declared-paths-seeded-control.bats
@@ -1,0 +1,132 @@
+#!/usr/bin/env bats
+
+# POSITIVE CONTROL for scripts/checks/check_declared_paths_are_seeded.py.
+#
+# The defect it guards is a list disagreeing with a list: #495 removed the seed
+# blocks for secret/shared/database and secret/auth/config, #531 restored the
+# DECLARATIONS for those paths and not the seed, and the gap survived months and
+# two outage investigations because nothing compared them.
+#
+# So this does not merely assert the repo passes today. Each test mutates a copy
+# and requires the check to go red for one specific reason. Same pattern as
+# tests/scripts/vault-revoke-order-control.bats (#659) and
+# root-revoke-fails-closed-control.bats (#663).
+
+setup() {
+  ROOT="$BATS_TEST_DIRNAME/../.."
+  CTL="$BATS_TEST_TMPDIR/ctl"
+  mkdir -p "$CTL/scripts/checks"
+  cp "$ROOT/scripts/checks/check_declared_paths_are_seeded.py" "$CTL/scripts/checks/"
+  cp "$ROOT/scripts/vault.sh" "$ROOT/scripts/_common.sh" "$CTL/scripts/"
+  CHECK="$CTL/scripts/checks/check_declared_paths_are_seeded.py"
+}
+
+@test "CONTROL: the check PASSES on the real, unmutated scripts" {
+  run python3 "$CHECK"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"PASS"* ]]
+}
+
+# NOT VACUOUS: if the declaration parser stops finding arms, every path silently
+# passes. Pin that all five declared pairs are actually examined.
+@test "CONTROL: all four services and their paths are discovered" {
+  run python3 "$CHECK"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"db"* ]]
+  [[ "$output" == *"auth"* ]]
+  [[ "$output" == *"infra"* ]]
+  [[ "$output" == *"observability"* ]]
+  [[ "$output" == *"secret/shared/database"* ]]
+  [[ "$output" == *"secret/auth/config"* ]]
+}
+
+@test "removing the shared/database seed — the exact #495 regression — turns it red" {
+  python3 - "$CTL/scripts/vault.sh" <<'PY'
+import re, sys
+p = sys.argv[1]
+t = open(p).read()
+t2 = re.sub(r'    echo "Seeding secret/shared/database\.\.\."\n(?:.*\n)*?        "DB_NAME=[^\n]*\n', "", t)
+assert t2 != t, "mutation did not apply"
+open(p, "w").write(t2)
+PY
+
+  run python3 "$CHECK"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"FAIL"* ]]
+  [[ "$output" == *"secret/shared/database"* ]]
+  [[ "$output" == *"cmd_seed never writes it"* ]]
+}
+
+@test "removing the auth/config seed turns it red" {
+  python3 - "$CTL/scripts/vault.sh" <<'PY'
+import re, sys
+p = sys.argv[1]
+t = open(p).read()
+t2 = re.sub(r'    echo "Seeding secret/auth/config\.\.\."\n(?:.*\n)*?        "KC_ADMIN_PASSWORD=[^\n]*\n', "", t)
+assert t2 != t, "mutation did not apply"
+open(p, "w").write(t2)
+PY
+
+  run python3 "$CHECK"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"secret/auth/config"* ]]
+}
+
+# The other direction of the same drift: a service gains a path and nobody seeds
+# it. This is how the gap would reappear tomorrow.
+@test "declaring a brand-new path with no seed turns it red" {
+  python3 - "$CTL/scripts/_common.sh" <<'PY'
+import sys
+p = sys.argv[1]
+t = open(p).read()
+t2 = t.replace('        infra)         echo "secret/infra/traefik" ;;',
+               '        infra)         echo "secret/infra/traefik secret/infra/brandnew" ;;', 1)
+assert t2 != t, "mutation did not apply"
+open(p, "w").write(t2)
+PY
+
+  run python3 "$CHECK"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"secret/infra/brandnew"* ]]
+}
+
+# A seeded key absent from required_keys is written as an EMPTY STRING when the
+# SOPS key is missing — the CF_DNS_API_TOKEN failure mode cmd_seed already
+# documents, and the same empty-is-not-absent class as the #650 outage.
+@test "seeding a key that is not in required_keys turns it red" {
+  python3 - "$CTL/scripts/vault.sh" <<'PY'
+import sys
+p = sys.argv[1]
+t = open(p).read()
+t2 = t.replace('        "DB_NAME=$(get_secret DB_NAME)"',
+               '        "DB_NAME=$(get_secret DB_NAME)" \\\n        "DB_UNGUARDED=$(get_secret DB_UNGUARDED)"', 1)
+assert t2 != t, "mutation did not apply"
+open(p, "w").write(t2)
+PY
+
+  run python3 "$CHECK"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"DB_UNGUARDED"* ]]
+  [[ "$output" == *"empty string"* ]]
+}
+
+# PROSE IS NOT AN ACTION — the same trap that made an earlier check read an
+# echoed command as a real one. A path named only in a comment is not seeded.
+@test "a path mentioned only in a comment does not count as seeded" {
+  python3 - "$CTL/scripts/vault.sh" <<'PY'
+import re, sys
+p = sys.argv[1]
+t = open(p).read()
+# Remove the real seed, then name the path in a comment and an echo instead.
+t2 = re.sub(r'    echo "Seeding secret/auth/config\.\.\."\n(?:.*\n)*?        "KC_ADMIN_PASSWORD=[^\n]*\n',
+            '    # kv put secret/auth/config would go here\n'
+            '    echo "remember to kv put secret/auth/config"\n', t)
+assert t2 != t, "mutation did not apply"
+open(p, "w").write(t2)
+PY
+
+  run python3 "$CHECK"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"secret/auth/config"* ]]
+  [[ "$output" == *"cmd_seed never writes it"* ]]
+}


### PR DESCRIPTION
Closes #661. Answers #650's third ask.

## Why they are missing — and both issues have the cause wrong

#661 and #650 both attribute this to the #643 rebuild's re-seed. It isn't, and the correction points at a different defect:

```
git log -S 'secret/shared/database' -- scripts/vault.sh
  92a55c80 refactor: remove Keycloak, Postgres and MinIO (JON-28) (#495)
```

- **#495** removed Keycloak and Postgres, and with them the seed blocks for `secret/shared/database` and `secret/auth/config`. Correct at the time.
- **#531** brought both services back and restored their **declarations** in `vault_paths_for_service` — but not the seed.

So the paths have **never existed** on this vault, for months. No re-seed dropped them. #495 also removed them from `cmd_export` and `SYNC_PATHS`, so once seeded they would still have been invisible to export and to `sync-to-sops`. Both lists are restored here too.

This is the 404 underneath the 2026-08-03 auth outage. The missing AppRole policy (#660) put a 403 on top, every diagnosis stopped there, and fixing the policy alone turned *permission denied* into *No value found* — a different error, an identical outcome.

## Restored

The two `kv put` blocks, with their keys added to `required_keys` so a missing SOPS key **refuses the seed** instead of writing a blank credential. All five (`DB_USER`, `DB_PASSWORD`, `DB_NAME`, `KC_ADMIN_USERNAME`, `KC_ADMIN_PASSWORD`) are present and non-empty in the store — confirmed by byte count, never by value.

## Guarded, because this is the third time

One list silently disagreeing with another has now produced three defects: the policy files (#653), the revoke conditions (#663), and this. `check_declared_paths_are_seeded.py` fails when a declared path is not seeded, and when a seeded key is absent from `required_keys` and could therefore be written empty.

```
ok 1 CONTROL: the check PASSES on the real, unmutated scripts
ok 2 CONTROL: all four services and their paths are discovered
ok 3 removing the shared/database seed — the exact #495 regression — turns it red
ok 4 removing the auth/config seed turns it red
ok 5 declaring a brand-new path with no seed turns it red
ok 6 seeding a key that is not in required_keys turns it red
ok 7 a path mentioned only in a comment does not count as seeded
```

Test 2 exists because the check passes **vacuously** if the declaration parser stops finding arms.

## Pipeline route

`run_seed` on Vault Regain Root, **off by default**. Seeding needs root for the same reason `policy-apply` does, and no deploy path calls it. Off by default because policies are declarative and re-applying is a no-op, while seeding writes credentials and creates a new KV version.

## #650's third ask

`vault-sops-name-parity.sh` compares the two stores **by name**. Names only *by construction* rather than by care — values are never bound to a variable, printed or written. It **refuses to run without `BAO_TOKEN`**, because an unauthenticated read returns empty and empty-from-no-token is indistinguishable from empty-from-no-secret. That confusion is what hid this defect for months.

It also does an authenticated **list of the mount**, so absence is established rather than assumed from a read of a path we happened to name.

## Verification

- `bats tests/scripts/` — **407 passing, 0 failing** (up from 400)
- `check_declared_paths_are_seeded.py` — PASS after, and it reports the three real misses when run against the pre-fix tree
- **Not yet applied to the live vault.** That needs the workflow, which needs this merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)