### PR TITLE
fix(vault): seed the OIDC client secrets — an empty one broke Grafana SSO

### DIFF
--- a/scripts/checks/check_vault_covers_compose.py
+++ b/scripts/checks/check_vault_covers_compose.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Vault must carry every secret a service's compose file needs.
+
+    python3 scripts/checks/check_vault_covers_compose.py
+
+WHY THIS EXISTS — an outage on 2026-08-03, caused by a deploy that reported
+success. `deploy.sh` is vault-first: on the generic service path it exports ONLY
+the keys vault returns for that service, and does not merge SOPS underneath. So
+a variable the compose file needs but the vault path does not hold resolves to
+the empty string, and compose substitutes nothing.
+
+`secret/observability/grafana` held one key. Deploying observability therefore
+started Grafana with GRAFANA_OIDC_CLIENT_SECRET empty, and SSO failed with
+`unauthorized_client`. The deploy printed:
+
+    vault: loaded 1 variables for observability, none empty
+
+which is true and worthless — "none empty" describes the keys vault RETURNED,
+not the keys the service NEEDS. Nothing was reported, and local admin login kept
+working, so the failure was invisible from the outside.
+
+WHAT IT CHECKS. For every prod compose file, take the ${VARS} it interpolates,
+keep the ones that are SOPS-backed — that is the definition of a secret here,
+taken from the store rather than from a hand-maintained list — and require each
+to be written by cmd_seed into one of the paths the service declares.
+
+Services that declare NO vault paths are skipped: since #655 vault_load_secrets
+returns non-zero for them and the deploy takes the SOPS path, which has
+everything. minio is deliberately in that category.
+
+This is the static half of #665. The runtime guard — refusing a deploy whose
+resolved value is empty — is still wanted, because this cannot see a key that is
+present in vault but blank.
+"""
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+COMPOSE_DIR = ROOT / "deploy/compose/prod"
+COMMON = ROOT / "scripts/_common.sh"
+VAULT = ROOT / "scripts/vault.sh"
+STORE = ROOT / "infra/secrets/prod.enc.env"
+
+
+def sops_key_names() -> set[str]:
+    """KEY NAMES from the store. Names only — no value is bound or printed."""
+    env = {"SOPS_AGE_KEY_FILE": str(ROOT / "infra/secrets/keys/age-prod.key")}
+    import os
+
+    for candidate in (env["SOPS_AGE_KEY_FILE"], "/opt/hill90/secrets/keys/keys.txt"):
+        if Path(candidate).exists():
+            env["SOPS_AGE_KEY_FILE"] = candidate
+            break
+    try:
+        out = subprocess.run(
+            ["sops", "-d", str(STORE)],
+            capture_output=True, text=True, check=True,
+            env=dict(os.environ, **env),
+        ).stdout
+    except Exception as e:  # noqa: BLE001
+        sys.exit(f"cannot decrypt the store, so this check cannot run: {e}")
+    return {m.group(1) for m in re.finditer(r"^([A-Z0-9_]+)=", out, re.M)}
+
+
+def declared() -> dict[str, list[str]]:
+    body = COMMON.read_text()
+    m = re.search(r"vault_paths_for_service\(\)\s*\{(.*?)\n\}", body, re.S)
+    out: dict[str, list[str]] = {}
+    for arm in re.finditer(r"^\s*([a-z0-9_|]+)\)\s*echo\s+\"([^\"]*)\"", m.group(1), re.M):
+        service, paths = arm.group(1), arm.group(2).split()
+        if service == "*" or not paths:
+            continue
+        for name in service.split("|"):
+            out[name] = paths
+    return out
+
+
+def seeded_keys_by_path() -> dict[str, set[str]]:
+    body = VAULT.read_text()
+    m = re.search(r"^cmd_seed\(\)\s*\{(.*?)^\}", body, re.S | re.M)
+    text = "\n".join(
+        ln for ln in m.group(1).splitlines()
+        if not ln.lstrip().startswith(("#", "echo", "printf"))
+    )
+    out: dict[str, set[str]] = {}
+    for blk in re.finditer(r"kv put\s+(secret/\S+)((?:.|\n)*?)(?=\n\s*\n|kv put|\Z)", text):
+        out.setdefault(blk.group(1), set()).update(re.findall(r'"([A-Z0-9_]+)=', blk.group(2)))
+    return out
+
+
+def main() -> int:
+    secrets = sops_key_names()
+    decl = declared()
+    seeded = seeded_keys_by_path()
+    problems: list[str] = []
+
+    print("Vault must carry every secret the compose file needs")
+    print("====================================================")
+
+    for f in sorted(COMPOSE_DIR.glob("docker-compose.*.yml")):
+        service = f.stem.replace("docker-compose.", "")
+        needed = {v for v in re.findall(r"\$\{([A-Z0-9_]+)", f.read_text()) if v in secrets}
+        if not needed:
+            continue
+        paths = decl.get(service)
+        if not paths:
+            print(f"  skip  {service:<14} declares no vault paths -> SOPS path, which has all keys")
+            continue
+        have: set[str] = set()
+        for p in paths:
+            have |= seeded.get(p, set())
+        missing = sorted(needed - have)
+        print(f"  {'MISS' if missing else 'ok  '}  {service:<14} needs {len(needed)}, vault carries {len(needed) - len(missing)}")
+        for k in missing:
+            problems.append(
+                f"{service}: {k} is needed by {f.name} and is in SOPS, but no vault path "
+                f"the service declares ({', '.join(paths)}) carries it. The deploy will "
+                f"export it EMPTY and report success."
+            )
+
+    print()
+    if problems:
+        print(f"FAIL — {len(problems)} problem(s):\n")
+        for p in problems:
+            print(f"  {p}")
+        print(
+            "\ndeploy.sh does not merge SOPS underneath vault on the generic path, so a\n"
+            "key vault does not hold is a blank in the container, not a fallback."
+        )
+        return 1
+    print("PASS — every SOPS-backed compose variable is carried by a declared vault path")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/vault.sh
+++ b/scripts/vault.sh
@@ -718,6 +718,8 @@ cmd_seed() {
         DB_NAME
         KC_ADMIN_USERNAME
         KC_ADMIN_PASSWORD
+        GRAFANA_OIDC_CLIENT_SECRET
+        VAULT_OIDC_CLIENT_SECRET
     )
     local missing=()
     local key
@@ -744,9 +746,20 @@ cmd_seed() {
         "HOSTINGER_API_KEY=$(get_secret HOSTINGER_API_KEY)"
 
     # Seed observability/grafana
+    # GRAFANA_OIDC_CLIENT_SECRET belongs here, and its absence caused an outage.
+    #
+    # The generic deploy path exports ONLY what vault returns for the service. On
+    # 2026-08-03 this path held one key, so `deploy.sh observability` started
+    # Grafana with GRAFANA_OIDC_CLIENT_SECRET empty and SSO broke with
+    # `unauthorized_client`. The deploy reported
+    #     vault: loaded 1 variables for observability, none empty
+    # which is true and useless: "none empty" describes the keys vault RETURNED,
+    # not the keys the compose file NEEDS. Local admin login kept working, so
+    # nothing looked wrong.
     echo "Seeding secret/observability/grafana..."
     bao_exec_env kv put secret/observability/grafana \
-        "GRAFANA_ADMIN_PASSWORD=$(get_secret GRAFANA_ADMIN_PASSWORD)"
+        "GRAFANA_ADMIN_PASSWORD=$(get_secret GRAFANA_ADMIN_PASSWORD)" \
+        "GRAFANA_OIDC_CLIENT_SECRET=$(get_secret GRAFANA_OIDC_CLIENT_SECRET)"
 
     # Seed shared/database and auth/config.
     #
@@ -767,10 +780,15 @@ cmd_seed() {
         "DB_PASSWORD=$(get_secret DB_PASSWORD)" \
         "DB_NAME=$(get_secret DB_NAME)"
 
+    # VAULT_OIDC_CLIENT_SECRET is the same latent gap, not yet triggered:
+    # docker-compose.auth.yml needs it and no vault path carried it, so the auth
+    # deploy has been exporting it empty. It did not surface because
+    # keycloak.sh apply does not rewrite an existing client secret.
     echo "Seeding secret/auth/config..."
     bao_exec_env kv put secret/auth/config \
         "KC_ADMIN_USERNAME=$(get_secret KC_ADMIN_USERNAME)" \
-        "KC_ADMIN_PASSWORD=$(get_secret KC_ADMIN_PASSWORD)"
+        "KC_ADMIN_PASSWORD=$(get_secret KC_ADMIN_PASSWORD)" \
+        "VAULT_OIDC_CLIENT_SECRET=$(get_secret VAULT_OIDC_CLIENT_SECRET)"
 
     rm -f "$temp_file"
     trap - RETURN

--- a/tests/scripts/vault-covers-compose-control.bats
+++ b/tests/scripts/vault-covers-compose-control.bats
@@ -1,0 +1,81 @@
+#!/usr/bin/env bats
+
+# POSITIVE CONTROL for scripts/checks/check_vault_covers_compose.py.
+#
+# The defect it guards caused a real outage: `secret/observability/grafana` held
+# one key, deploy.sh exported only what vault returned, and Grafana started with
+# GRAFANA_OIDC_CLIENT_SECRET blank. The deploy said "loaded 1 variables for
+# observability, none empty" and succeeded.
+#
+# NEEDS THE STORE. The check reads SOPS key NAMES to decide what counts as a
+# secret, so it cannot run without the age key. These tests SKIP rather than fail
+# in that case — a check that cannot see must not report a clean bill of health,
+# and a control that cannot run must not report a passing one either.
+
+setup() {
+  ROOT="$BATS_TEST_DIRNAME/../.."
+  if [ ! -f "$ROOT/infra/secrets/keys/age-prod.key" ] && [ ! -f /opt/hill90/secrets/keys/keys.txt ]; then
+    skip "no age key available — the check cannot read the store"
+  fi
+  CTL="$BATS_TEST_TMPDIR/ctl"
+  mkdir -p "$CTL/scripts/checks" "$CTL/deploy/compose/prod" "$CTL/infra/secrets"
+  cp "$ROOT/scripts/checks/check_vault_covers_compose.py" "$CTL/scripts/checks/"
+  cp "$ROOT/scripts/vault.sh" "$ROOT/scripts/_common.sh" "$CTL/scripts/"
+  cp "$ROOT"/deploy/compose/prod/docker-compose.*.yml "$CTL/deploy/compose/prod/"
+  cp -R "$ROOT/infra/secrets/." "$CTL/infra/secrets/"
+  CHECK="$CTL/scripts/checks/check_vault_covers_compose.py"
+}
+
+@test "CONTROL: passes on the real, unmutated tree" {
+  run python3 "$CHECK"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"PASS"* ]]
+}
+
+@test "CONTROL: every service with vault paths is actually examined" {
+  run python3 "$CHECK"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"observability"* ]]
+  [[ "$output" == *"auth"* ]]
+  [[ "$output" == *"db"* ]]
+  [[ "$output" == *"infra"* ]]
+}
+
+@test "removing GRAFANA_OIDC_CLIENT_SECRET from the seed — the outage — turns it red" {
+  sed -i.bak '/"GRAFANA_OIDC_CLIENT_SECRET=\$(get_secret GRAFANA_OIDC_CLIENT_SECRET)"/d' "$CTL/scripts/vault.sh"
+  sed -i.bak2 's/"GRAFANA_ADMIN_PASSWORD=$(get_secret GRAFANA_ADMIN_PASSWORD)" \\/"GRAFANA_ADMIN_PASSWORD=$(get_secret GRAFANA_ADMIN_PASSWORD)"/' "$CTL/scripts/vault.sh"
+  rm -f "$CTL/scripts/vault.sh".bak*
+
+  run python3 "$CHECK"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"GRAFANA_OIDC_CLIENT_SECRET"* ]]
+  [[ "$output" == *"export it EMPTY"* ]]
+}
+
+@test "removing VAULT_OIDC_CLIENT_SECRET from the seed turns it red" {
+  sed -i.bak '/"VAULT_OIDC_CLIENT_SECRET=\$(get_secret VAULT_OIDC_CLIENT_SECRET)"/d' "$CTL/scripts/vault.sh"
+  sed -i.bak2 's/"KC_ADMIN_PASSWORD=$(get_secret KC_ADMIN_PASSWORD)" \\/"KC_ADMIN_PASSWORD=$(get_secret KC_ADMIN_PASSWORD)"/' "$CTL/scripts/vault.sh"
+  rm -f "$CTL/scripts/vault.sh".bak*
+
+  run python3 "$CHECK"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"VAULT_OIDC_CLIENT_SECRET"* ]]
+}
+
+# A service that declares a vault path but seeds nothing into it is the same
+# defect in its most complete form.
+@test "a declared path with an empty seed turns it red" {
+  python3 - "$CTL/scripts/_common.sh" <<'PY'
+import sys
+p = sys.argv[1]
+t = open(p).read()
+t2 = t.replace('        infra)         echo "secret/infra/traefik" ;;',
+               '        infra)         echo "secret/infra/nothinghere" ;;', 1)
+assert t2 != t
+open(p, "w").write(t2)
+PY
+
+  run python3 "$CHECK"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"infra"* ]]
+}


### PR DESCRIPTION
**Grafana SSO is broken in production right now, and I broke it.** This PR is the fix; it is not live until merged and seeded.

## What happened

Deploying observability ([run 30796168293](https://github.com/jonhill90/Hill90/actions/runs/30796168293)) started Grafana with `GRAFANA_OIDC_CLIENT_SECRET` empty:

```
authn.service level=error msg="Failed to authenticate request"
  client=auth.client.generic_oauth
  error="failed to exchange code to token: oauth2: \"unauthorized_client\"
         \"Invalid client or Invalid client credentials\""
```

Keycloak and SOPS **agree** on the secret — both length 44, same hash. The Grafana container's copy is **length zero**. Local admin login still works, which is why nothing looked wrong from outside.

## Why

`deploy.sh` is vault-first and, on the generic service path, exports **only** the keys vault returns — it does not merge SOPS underneath. `secret/observability/grafana` held exactly one key. Every other SOPS-backed variable the compose file needs became the empty string, and the deploy reported:

```
vault: loaded 1 variables for observability, none empty
```

True and worthless. **"none empty" describes the keys vault returned, not the keys the service needs.** This is #665's class, and worse than described there, because the message reads like a guard that passed.

## Fixed, plus a latent second instance

- `GRAFANA_OIDC_CLIENT_SECRET` → `secret/observability/grafana`
- `VAULT_OIDC_CLIENT_SECRET` → `secret/auth/config`

The second was found by looking rather than by waiting for it: `docker-compose.auth.yml` needs it and no vault path carried it, so the auth deploy has been exporting it empty. It never surfaced because `keycloak.sh apply` does not rewrite an existing client secret — verified, all five client secrets are intact and non-empty.

## Guard

`check_vault_covers_compose.py` takes the `${VARS}` each prod compose file interpolates, keeps the ones the SOPS store defines — **the store is the definition of "secret", not a hand-maintained list** — and requires each to be seeded into a path the service declares. Services declaring no vault paths are skipped, because since #655 they take the SOPS path, which has everything.

**Red before green.** Against the tree that caused the outage it names both gaps:

```
MISS  observability  needs 2, vault carries 1
FAIL — 2 problem(s):
  auth: VAULT_OIDC_CLIENT_SECRET ... will export it EMPTY and report success
  observability: GRAFANA_OIDC_CLIENT_SECRET ... will export it EMPTY and report success
```

Five control tests mutate a copy and require red. They **skip** without an age key rather than pass — a check that cannot read the store must not report a clean bill of health.

**Static half only.** The runtime guard #665 asks for is still wanted: this cannot see a key that is present in vault but blank.

## Verification

- `bats tests/scripts/` — **418 passing, 0 failing**
- Baseline throughout: 16 by name, 0 unhealthy, 0 restarting
- No secret printed; comparisons are by length and hash

## To restore service after merge

1. `Vault Regain Root` with `run_seed=true` — writes the two keys
2. Redeploy observability
3. Re-run the Grafana login proof

🤖 Generated with [Claude Code](https://claude.com/claude-code)