### PR TITLE
fix(deploy): a refusing pre-up hook must ABORT, and seed what the render needs

### DIFF
--- a/scripts/checks/check_vault_covers_compose.py
+++ b/scripts/checks/check_vault_covers_compose.py
@@ -28,6 +28,13 @@ Services that declare NO vault paths are skipped: since #655 vault_load_secrets
 returns non-zero for them and the deploy takes the SOPS path, which has
 everything. minio is deliberately in that category.
 
+PRE-UP HOOKS ARE PART OF THE SURFACE, and leaving them out was this check's own
+blind spot. It originally read compose files only. SMTP_PASSWORD never appears in
+a compose file — it reaches Alertmanager through a config rendered by
+render-alertmanager-config.sh — so the check passed green while every vault-path
+observability deploy skipped the render (#669). A hook runs inside the same
+exported environment as compose, so it is the same exposure.
+
 This is the static half of #665. The runtime guard — refusing a deploy whose
 resolved value is empty — is still wanted, because this cannot see a key that is
 present in vault but blank.
@@ -92,6 +99,30 @@ def seeded_keys_by_path() -> dict[str, set[str]]:
     return out
 
 
+def hook_vars(service_compose: Path) -> tuple[str, set[str]]:
+    """The pre-up hook for THIS service, and the $VARS it reads.
+
+    Association is by case ARM, not by proximity. A first attempt searched a
+    fixed window after the compose filename and attributed observability's
+    alertmanager hook to auth, db, minio and vault — four false positives, caught
+    by reading the first red run instead of trusting it. deploy.sh's dispatcher is
+    a `case` whose arms end in `;;`, so the arm is the unit that means "this
+    service", and a hook set in another arm is another service's.
+    """
+    dep = (ROOT / "scripts/deploy.sh").read_text()
+    for arm in dep.split(";;"):
+        if service_compose.name not in arm:
+            continue
+        m = re.search(r'pre_up_hook="([^"]+)"', arm)
+        if not m:
+            continue
+        hook = ROOT / "scripts" / m.group(1)
+        if not hook.exists():
+            return m.group(1), set()
+        return m.group(1), set(re.findall(r"\$\{?([A-Z][A-Z0-9_]{3,})", hook.read_text()))
+    return "", set()
+
+
 def main() -> int:
     secrets = sops_key_names()
     decl = declared()
@@ -104,6 +135,16 @@ def main() -> int:
     for f in sorted(COMPOSE_DIR.glob("docker-compose.*.yml")):
         service = f.stem.replace("docker-compose.", "")
         needed = {v for v in re.findall(r"\$\{([A-Z0-9_]+)", f.read_text()) if v in secrets}
+
+        # The pre-up hook runs in the SAME exported environment as compose, so a
+        # variable it reads is exposed identically. ALERT_EMAIL_TO is excluded
+        # because deploy.sh derives it from ACME_EMAIL, which IS checked.
+        hook_name, hvars = hook_vars(f)
+        hook_needed = {v for v in hvars if v in secrets}
+        if hook_needed:
+            print(f"  ....  {service:<14} pre-up hook {hook_name} reads {', '.join(sorted(hook_needed))}")
+        needed |= hook_needed
+
         if not needed:
             continue
         paths = decl.get(service)
@@ -116,8 +157,11 @@ def main() -> int:
         missing = sorted(needed - have)
         print(f"  {'MISS' if missing else 'ok  '}  {service:<14} needs {len(needed)}, vault carries {len(needed) - len(missing)}")
         for k in missing:
+            # Name the real consumer. A hook variable reported as "needed by the
+            # compose file" sends the reader to the wrong file.
+            where = f"pre-up hook {hook_name}" if k in hook_needed else f.name
             problems.append(
-                f"{service}: {k} is needed by {f.name} and is in SOPS, but no vault path "
+                f"{service}: {k} is needed by {where} and is in SOPS, but no vault path "
                 f"the service declares ({', '.join(paths)}) carries it. The deploy will "
                 f"export it EMPTY and report success."
             )

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -502,9 +502,27 @@ cmd_service() {
             # path above for why a bare call silently continues.
             vault_load_secrets "$service" "$secrets_file" || exit 1
 
+            # `|| exit 1` IS LOAD-BEARING, for the third time in this file.
+            #
+            # A pre-up hook can REFUSE — render-alertmanager-config.sh calls die
+            # when SMTP_PASSWORD or ALERT_EMAIL_TO is empty, precisely so a blank
+            # config is never written. That refusal was being swallowed: `set -e`
+            # is suppressed inside a compound command on the left of `||`, and
+            # this subshell is exactly that, so a failing hook printed its error
+            # and the deploy carried on and reported success.
+            #
+            # Observed, not theorised: both observability deploys on 2026-08-03
+            # logged "ERROR: SMTP_PASSWORD is not set. Refusing to render the
+            # Alertmanager config." and both went green. The Alertmanager config
+            # had not been re-rendered since 1 August and nobody knew.
+            #
+            # Same shape as the vault_load_secrets bug (#652) and the revoke-step
+            # condition (#663): a guard whose failure is ignored is worse than no
+            # guard, because it reads as coverage. `exit` is not subject to the
+            # suppression; `return` and a bare call are.
             if [ -n "$pre_up_hook" ]; then
                 export ALERT_EMAIL_TO="${ALERT_EMAIL_TO:-${ACME_EMAIL:-}}"
-                bash "$SCRIPT_DIR/$pre_up_hook"
+                bash "$SCRIPT_DIR/$pre_up_hook" || exit 1
             fi
 
             if [ "$deploy_mode" = "stateful" ]; then

--- a/scripts/vault.sh
+++ b/scripts/vault.sh
@@ -720,6 +720,7 @@ cmd_seed() {
         KC_ADMIN_PASSWORD
         GRAFANA_OIDC_CLIENT_SECRET
         VAULT_OIDC_CLIENT_SECRET
+        SMTP_PASSWORD
     )
     local missing=()
     local key
@@ -756,10 +757,22 @@ cmd_seed() {
     # which is true and useless: "none empty" describes the keys vault RETURNED,
     # not the keys the compose file NEEDS. Local admin login kept working, so
     # nothing looked wrong.
+    #
+    # SMTP_PASSWORD and ACME_EMAIL are here for the SAME reason one level out:
+    # observability's pre-up hook renders the Alertmanager config and reads both
+    # (ACME_EMAIL via deploy.sh's ALERT_EMAIL_TO fallback). Neither is in any
+    # compose file, so the outage's fix did not cover them and every vault-path
+    # observability deploy has been skipping the render — see #669.
+    #
+    # ACME_EMAIL is seeded rather than a new ALERT_EMAIL_TO key: it already IS
+    # the live recipient (verified against the running config, not assumed), and
+    # a second key holding the same address is a second thing to keep in step.
     echo "Seeding secret/observability/grafana..."
     bao_exec_env kv put secret/observability/grafana \
         "GRAFANA_ADMIN_PASSWORD=$(get_secret GRAFANA_ADMIN_PASSWORD)" \
-        "GRAFANA_OIDC_CLIENT_SECRET=$(get_secret GRAFANA_OIDC_CLIENT_SECRET)"
+        "GRAFANA_OIDC_CLIENT_SECRET=$(get_secret GRAFANA_OIDC_CLIENT_SECRET)" \
+        "SMTP_PASSWORD=$(get_secret SMTP_PASSWORD)" \
+        "ACME_EMAIL=$(get_secret ACME_EMAIL)"
 
     # Seed shared/database and auth/config.
     #

--- a/tests/scripts/pre-up-hook-aborts-control.bats
+++ b/tests/scripts/pre-up-hook-aborts-control.bats
@@ -1,0 +1,97 @@
+#!/usr/bin/env bats
+
+# POSITIVE CONTROL: a refusing pre-up hook must STOP the deploy.
+#
+# On 2026-08-03 both observability deploys logged
+#   ERROR: SMTP_PASSWORD is not set. Refusing to render the Alertmanager config.
+# and both reported success. The hook refused correctly; the caller ignored it.
+#
+# `set -e` is suppressed inside a compound command on the left of `||`, and the
+# deploy's vault branch is exactly `( ... ) || { sops fallback }`. So a bare
+# `bash "$hook"` that fails does not stop the subshell.
+#
+# These tests do not merely grep for `|| exit 1`. They demonstrate the SEMANTICS
+# in both directions, and they run the REAL render script with a real empty
+# variable to prove the guard it depends on actually refuses.
+
+setup() {
+  ROOT="$BATS_TEST_DIRNAME/../.."
+}
+
+# ---------------------------------------------------------------------------
+# The semantics, shown failing before they are shown fixed.
+# ---------------------------------------------------------------------------
+
+@test "CONTROL: the OLD shape swallows a failing hook — the bug, reproduced" {
+  run bash -c '
+    set -e
+    hook() { return 1; }
+    ( hook; echo "DEPLOY CONTINUED" ) || echo "FALLBACK FIRED"
+  '
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"DEPLOY CONTINUED"* ]]
+  [[ "$output" != *"FALLBACK FIRED"* ]]
+}
+
+@test "the FIXED shape stops the subshell and trips the fallback" {
+  run bash -c '
+    set -e
+    hook() { return 1; }
+    ( hook || exit 1; echo "DEPLOY CONTINUED" ) || echo "FALLBACK FIRED"
+  '
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"FALLBACK FIRED"* ]]
+  [[ "$output" != *"DEPLOY CONTINUED"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# The real script must actually refuse, or the abort above has nothing to catch.
+# ---------------------------------------------------------------------------
+
+@test "render-alertmanager-config.sh REFUSES with an empty SMTP_PASSWORD" {
+  OUT="$BATS_TEST_TMPDIR/alertmanager.yml"
+  run env -u SMTP_PASSWORD \
+      ALERT_EMAIL_TO="ops@example.invalid" \
+      ALERTMANAGER_CONFIG_OUTPUT="$OUT" \
+      bash "$ROOT/scripts/render-alertmanager-config.sh"
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"SMTP_PASSWORD"* ]]
+  # And it must not have left a half-written file behind.
+  [ ! -f "$OUT" ]
+}
+
+@test "render-alertmanager-config.sh REFUSES with an empty ALERT_EMAIL_TO" {
+  OUT="$BATS_TEST_TMPDIR/alertmanager2.yml"
+  run env -u ALERT_EMAIL_TO \
+      SMTP_PASSWORD="not-a-real-password" \
+      ALERTMANAGER_CONFIG_OUTPUT="$OUT" \
+      bash "$ROOT/scripts/render-alertmanager-config.sh"
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"ALERT_EMAIL_TO"* ]]
+  [ ! -f "$OUT" ]
+}
+
+# ---------------------------------------------------------------------------
+# And the caller must use the form that propagates it.
+# ---------------------------------------------------------------------------
+
+@test "deploy.sh calls the pre-up hook with || exit 1" {
+  run grep -c 'bash "$SCRIPT_DIR/$pre_up_hook" || exit 1' "$ROOT/scripts/deploy.sh"
+  [ "$status" -eq 0 ]
+  [ "$output" -ge 1 ]
+}
+
+@test "deploy.sh has NO bare pre-up hook invocation left" {
+  # A bare call is the defect. Any occurrence not followed by `|| exit 1` fails.
+  run bash -c "grep -n 'bash \"\$SCRIPT_DIR/\$pre_up_hook\"' '$ROOT/scripts/deploy.sh' | grep -v '|| exit 1' | wc -l"
+  [ "$output" -eq 0 ]
+}
+
+# The same swallowed-guard shape has now appeared three times. Pin the sibling
+# so a future edit cannot quietly undo the #652 fix while this one stands.
+@test "deploy.sh still calls vault_load_secrets with || exit 1" {
+  run bash -c "grep -c 'vault_load_secrets \"[^\"]*\" \"\$secrets_file\" || exit 1' '$ROOT/scripts/deploy.sh'"
+  [ "$output" -ge 2 ]
+}

--- a/tests/scripts/vault-covers-compose-control.bats
+++ b/tests/scripts/vault-covers-compose-control.bats
@@ -20,7 +20,7 @@ setup() {
   CTL="$BATS_TEST_TMPDIR/ctl"
   mkdir -p "$CTL/scripts/checks" "$CTL/deploy/compose/prod" "$CTL/infra/secrets"
   cp "$ROOT/scripts/checks/check_vault_covers_compose.py" "$CTL/scripts/checks/"
-  cp "$ROOT/scripts/vault.sh" "$ROOT/scripts/_common.sh" "$CTL/scripts/"
+  cp "$ROOT/scripts/vault.sh" "$ROOT/scripts/_common.sh" "$ROOT/scripts/deploy.sh" "$ROOT/scripts/render-alertmanager-config.sh" "$CTL/scripts/"
   cp "$ROOT"/deploy/compose/prod/docker-compose.*.yml "$CTL/deploy/compose/prod/"
   cp -R "$ROOT/infra/secrets/." "$CTL/infra/secrets/"
   CHECK="$CTL/scripts/checks/check_vault_covers_compose.py"
@@ -78,4 +78,26 @@ PY
   run python3 "$CHECK"
   [ "$status" -eq 1 ]
   [[ "$output" == *"infra"* ]]
+}
+
+# HOOK COVERAGE — this check's own blind spot until #669. SMTP_PASSWORD appears
+# in no compose file; it reaches Alertmanager through a rendered config.
+@test "removing SMTP_PASSWORD from the seed turns it red, naming the hook" {
+  sed -i.bak '/"SMTP_PASSWORD=\$(get_secret SMTP_PASSWORD)"/d' "$CTL/scripts/vault.sh"
+  rm -f "$CTL/scripts/vault.sh".bak*
+
+  run python3 "$CHECK"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"SMTP_PASSWORD"* ]]
+  [[ "$output" == *"pre-up hook render-alertmanager-config.sh"* ]]
+}
+
+# The association must be by CASE ARM. A proximity match attributed the
+# observability hook to auth, db, minio and vault — four false positives.
+@test "the alertmanager hook is attributed to observability only" {
+  run python3 "$CHECK"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"observability  pre-up hook render-alertmanager-config.sh"* ]]
+  run bash -c "python3 '$CHECK' | grep -c 'pre-up hook'"
+  [ "$output" -eq 1 ]
 }


### PR DESCRIPTION
Closes #669. Two distinct defects; fixing either alone leaves the other.

## Defect B — the swallowed guard, and the important half

```diff
- bash "$SCRIPT_DIR/$pre_up_hook"
+ bash "$SCRIPT_DIR/$pre_up_hook" || exit 1
```

`render-alertmanager-config.sh` refuses when `SMTP_PASSWORD` or `ALERT_EMAIL_TO` is empty, precisely so a blank config is never written. That refusal was discarded: `set -e` is suppressed inside a compound command on the left of `||`, and the deploy's vault branch is exactly `( ... ) || { sops fallback }`.

**Observed, not theorised.** Both observability deploys on 2026-08-03 logged `ERROR: SMTP_PASSWORD is not set. Refusing to render the Alertmanager config.` and both went green, while the config on disk stayed as rendered on 1 August.

Third instance of this shape after #652 (`vault_load_secrets`) and #663 (the revoke step's condition).

## Defect A — seed what the render needs

`SMTP_PASSWORD` and `ACME_EMAIL` into `secret/observability/grafana`. The hook runs in the same exported environment as compose, and the generic deploy path exports only what vault returns.

`ACME_EMAIL` rather than a new `ALERT_EMAIL_TO` key: `deploy.sh` already derives `ALERT_EMAIL_TO` from it, and it **is** the live recipient — verified against the running config, not assumed.

## Read before overwriting

The live file is intact and **consistent with #669** — 4416 bytes, `smtp_auth_password` 30 chars matching the store by length, correct smarthost and recipient, full HTML and text templates, zero unsubstituted placeholders. Nothing contradicts the issue.

## An error of mine, corrected before it reached the fix

I first measured `ACME_EMAIL` as **different** from the live recipient and began adding an `ALERT_EMAIL_TO` key to preserve the address. The comparison was against an **empty string** — the `sudo grep` reading the recipient had failed silently. Re-read via a YAML parse, they are equal. The store change was reverted; nothing shipped from the wrong measurement.

Same class as every instrument failure this estate keeps finding: an empty result from a broken reader looks exactly like a real value.

## Positive control — both directions, not a grep for the fix

```
ok 1 CONTROL: the OLD shape swallows a failing hook — the bug, reproduced
ok 2 the FIXED shape stops the subshell and trips the fallback
ok 3 render-alertmanager-config.sh REFUSES with an empty SMTP_PASSWORD
ok 4 render-alertmanager-config.sh REFUSES with an empty ALERT_EMAIL_TO
ok 5 deploy.sh calls the pre-up hook with || exit 1
ok 6 deploy.sh has NO bare pre-up hook invocation left
ok 7 deploy.sh still calls vault_load_secrets with || exit 1
```

Tests 3 and 4 run the **real** render script with a real empty variable, so the abort has something to catch. Test 7 pins #652's sibling so a future edit cannot quietly undo it while this one stands.

## The check's own blind spot, closed

`check_vault_covers_compose.py` (#668) read compose files only, so it passed green while this was broken — `SMTP_PASSWORD` is in no compose file. It now also reads the service's pre-up hook, and names the hook in the failure rather than misattributing it to the compose file.

**A second error caught by reading the first red run:** associating hooks by proximity attributed observability's hook to `auth`, `db`, `minio` and `vault` — four false positives. Now associated by case **arm**, with a control pinning that exactly one service has a hook.

## Verification

- `bats tests/scripts/` — **434 passing, 0 failing** (up from 425)
- No secret printed; the config was inspected with values redacted by length

**Not yet applied.** Seeding needs the root window; the abort reaches production with the next observability deploy. Alerting is unaffected meanwhile — the existing config is intact and alertmanager is healthy. After merge I would seed, redeploy observability, confirm the render actually runs, and **prove delivery by firing a real alert** rather than assuming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)