### PR TITLE
fix(vault): an assertion must not pass on absence — and say why auto-unseal may

### DIFF
--- a/.github/workflows/vault-init.yml
+++ b/.github/workflows/vault-init.yml
@@ -221,8 +221,12 @@ jobs:
             deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
             'cd /opt/hill90/app && bash scripts/vault.sh revoke-root'
 
+      # always(), because this reports the location of a LIVE CREDENTIAL. A run
+      # that fails after `init` has minted one leaves it on the host, and that is
+      # exactly the run where the operator most needs to be told where it is.
+      # Gated on the input alone, it was skipped precisely then. See #674.
       - name: Report where the root token is
-        if: ${{ !inputs.revoke_root }}
+        if: ${{ always() && !inputs.revoke_root }}
         run: |
           echo "Root token left at /opt/hill90/secrets/openbao-root.token (0600 deploy:deploy)."
           echo "Run setup / seed / setup-sync-token, then revoke it with:"

--- a/.github/workflows/vault-regain-root.yml
+++ b/.github/workflows/vault-regain-root.yml
@@ -260,8 +260,12 @@ jobs:
             exit 1
           fi
 
+      # always(), because this VERIFIES the thing the config swap is most likely
+      # to have broken. Gated on the input alone it was skipped whenever an
+      # earlier step failed — removing the check at the only moment it would have
+      # told you something. See #674.
       - name: Confirm OIDC survived the config swap
-        if: ${{ inputs.run_setup_oidc }}
+        if: ${{ always() && inputs.run_setup_oidc }}
         run: |
           ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
             deploy@${{ steps.get-ip.outputs.tailscale_ip }} \

--- a/scripts/checks/check_silent_success.py
+++ b/scripts/checks/check_silent_success.py
@@ -148,12 +148,11 @@ def shape_b() -> list[str]:
 # "this is a defect we have named and not yet closed". A baseline entry that no
 # longer matches is ALSO a failure — otherwise a fix leaves dead scaffolding and
 # the next reader cannot tell which entries are real.
-BASELINE = {
-    # deploy.sh:236 and :243 were here and are FIXED — removed in the same change
-    # that fixed them, which is what the stale-entry check exists to force.
-    "vault-init.yml:init step 18": "root-token location not reported on failure (#674 rank 2.4)",
-    "vault-regain-root.yml:regain step 20": "OIDC survival unverified on failure (#674 rank 2.3)",
-}
+# EMPTY, and that is the point: every finding the sweep made has been fixed and
+# its entry removed in the same change. deploy.sh:236/:243 went with #676; the
+# two workflow conditions went with this one. An entry left behind after a fix
+# fails as stale, which is what keeps this honest rather than decorative.
+BASELINE: dict[str, str] = {}
 
 
 def split_baseline(problems: list[str]) -> tuple[list[str], list[str]]:

--- a/scripts/vault.sh
+++ b/scripts/vault.sh
@@ -43,7 +43,7 @@ Commands:
   backup        Backup OpenBao data volume
   export        Export all KV v2 secrets to stdout (requires BAO_TOKEN)
   auto-unseal         Wait for container + unseal (for systemd/deploy hooks)
-  assert-unsealed     Exit non-zero if OpenBao is deployed but still sealed
+  assert-unsealed     Exit non-zero if OpenBao is sealed OR not deployed (an assertion)
   sync-to-sops        Sync vault secrets back to SOPS backup (requires BAO_TOKEN)
   setup-sync-token    Create a read-only sync token and store in SOPS (requires BAO_TOKEN)
   bootstrap-approles  Generate AppRole credentials for all services and store in SOPS
@@ -1171,8 +1171,14 @@ cmd_auto_unseal() {
     echo "Auto-unseal: waiting for ${CONTAINER_NAME}..."
     while ! docker container inspect "$CONTAINER_NAME" --format '{{.State.Running}}' 2>/dev/null | grep -q "true"; do
         if [ $waited -ge $max_wait ]; then
-            # Container not running — may not be deployed yet (not an error on fresh VPS)
-            echo "Container ${CONTAINER_NAME} not running after ${max_wait}s — skipping auto-unseal"
+            # BEST EFFORT BY CONTRACT — see the note above cmd_assert_unsealed.
+            # Returning 0 here is deliberate and is NOT the silent-success defect:
+            # the caller is the boot-time systemd unit, and a host without OpenBao
+            # deployed is a legitimate state for it to meet. Say so explicitly so
+            # that a reader does not have to infer intent from a bare `return 0`.
+            echo "auto-unseal: container ${CONTAINER_NAME} not running after ${max_wait}s."
+            echo "auto-unseal: nothing to unseal — this is a NO-OP, not a success."
+            echo "auto-unseal: if you expected it deployed, use: bash scripts/vault.sh assert-unsealed"
             return 0
         fi
         sleep 5
@@ -1229,10 +1235,40 @@ cmd_auto_unseal() {
 #
 # `bao status` exits 0 unsealed, 2 sealed, 1 on error — so anything non-zero
 # here is a real problem, and an error is reported as one rather than swallowed.
+# ---------------------------------------------------------------------------
+# TWO COMMANDS, TWO DELIBERATELY DIFFERENT CONTRACTS ON ABSENCE
+#
+# Both of these meet a missing container, and they must answer differently. The
+# distinction is written here rather than left for a reader to infer from a
+# `return 0`, because inferring it wrongly is what put both on the #674 sweep.
+#
+#   auto-unseal      BEST EFFORT. Returns 0 when the container is absent.
+#                    Its caller is the boot-time systemd unit, which runs on
+#                    every start of a host that may legitimately not have
+#                    OpenBao deployed yet. "Nothing to unseal" is a real and
+#                    correct outcome there, not a failure to report.
+#
+#   assert-unsealed  AN ASSERTION. Returns NON-ZERO when the container is
+#                    absent. An assertion that passes because it could not look
+#                    is the defect this estate spent 2026-08-03 removing: it
+#                    reports the state you wanted rather than the state there is.
+#                    Its only callers are in vault-regain-root.yml, both AFTER a
+#                    deploy, so an absent container there means the deploy did
+#                    not produce one — precisely the thing worth failing on.
+#
+# The rule that separates them: a command that ACTS may no-op on absence; a
+# command that ASSERTS may not.
+# ---------------------------------------------------------------------------
+
 cmd_assert_unsealed() {
     if ! docker container inspect "$CONTAINER_NAME" >/dev/null 2>&1; then
-        echo "OpenBao container '${CONTAINER_NAME}' is not deployed — nothing to assert."
-        return 0
+        # Was `return 0` — an assertion passing because it cannot see. See the
+        # contract note above.
+        die "Cannot assert OpenBao is unsealed: container '${CONTAINER_NAME}' is NOT DEPLOYED.
+This is a failure, not a pass. Every caller of this command runs it after a
+deploy that is supposed to have produced the container, so an absent one means
+the deploy did not. Deploy it first: bash scripts/deploy.sh vault prod
+If you want a best-effort check that tolerates absence, that is auto-unseal."
     fi
 
     local rc=0

--- a/tests/scripts/silent-success-sweep-control.bats
+++ b/tests/scripts/silent-success-sweep-control.bats
@@ -23,14 +23,15 @@ setup() {
   [[ "$output" == *"no NEW instance beyond the tracked baseline"* ]]
 }
 
-@test "CONTROL: the sweep actually looks — it reports the known findings" {
+@test "CONTROL: the baseline is EMPTY — every sweep finding has been fixed" {
+  # All four are closed: deploy.sh:236/:243 with #676, the two workflow
+  # conditions with this change. An empty baseline is the goal state, not a
+  # broken check — tests 3 and 4 prove the sweep can still see.
   run python3 "$CHECK"
   [ "$status" -eq 0 ]
-  # The two deploy.sh findings were FIXED and removed from the baseline, so
-  # the remaining tracked set is the two workflow ones.
-  [[ "$output" == *"Report where the root token is"* ]]
-  [[ "$output" == *"Confirm OIDC survived the config swap"* ]]
-  [[ "$output" == *"known and tracked (baseline): 2"* ]]
+  [[ "$output" == *"known and tracked (baseline): 0"* ]]
+  [[ "$output" == *"A. swallowed inside a fallback subshell: 0"* ]]
+  [[ "$output" == *"B. cleanup/assertion skipped on failure: 0"* ]]
 }
 
 # REGRESSION OF #671 — the pre-up hook whose refusal was discarded.
@@ -70,14 +71,15 @@ PY
 }
 
 # A BASELINE THAT ROTS IS SCAFFOLDING. Fixing a finding must force its removal.
-@test "fixing a baseline finding without removing the entry FAILS as stale" {
-  # The deploy.sh pair is fixed already, so this mutates a still-baselined
-  # workflow finding instead.
-  python3 - "$CTL/.github/workflows/vault-init.yml" <<'PY'
+@test "a baseline entry with nothing matching it FAILS as stale" {
+  # The baseline is empty now, so plant one and confirm the staleness rule still
+  # bites. Without this, emptying the baseline would silently retire the rule.
+  python3 - "$CHECK" <<'PY'
 import sys
 p = sys.argv[1]
 t = open(p).read()
-t2 = t.replace("if: ${{ !inputs.revoke_root }}", "if: ${{ always() && !inputs.revoke_root }}")
+t2 = t.replace("BASELINE: dict[str, str] = {}",
+               'BASELINE = {"deploy.sh:999": "a finding that no longer exists"}')
 assert t2 != t, "mutation did not apply"
 open(p, "w").write(t2)
 PY

--- a/tests/scripts/unseal-contracts-control.bats
+++ b/tests/scripts/unseal-contracts-control.bats
@@ -25,15 +25,42 @@ setup() {
   ABSENT="hill90-definitely-absent-$$"
 }
 
+# EVERY command that could wait runs through this.
+#
+# The first version of this file set VAULT_AUTO_UNSEAL_MAX_WAIT, which vault.sh
+# does not read — it reads VAULT_AUTO_UNSEAL_TIMEOUT, default 120. So the
+# auto-unseal test waited the full two minutes instead of one second. It did not
+# hang forever, but it outlasted anyone watching it, and a test that neither
+# passes nor fails within a human's patience teaches nothing — which is the
+# family this whole change is closing.
+#
+# A wrong variable name must now produce a FAILURE, not a wait. `timeout` returns
+# 124 when it fires, and that is asserted explicitly rather than left to look
+# like any other non-zero status.
+bounded() {  # bounded <seconds> <command...>
+  local secs="$1"; shift
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$secs" "$@"
+  elif command -v gtimeout >/dev/null 2>&1; then
+    gtimeout "$secs" "$@"
+  else
+    # perl is present on every platform this repo runs on, and alarm(2) is a
+    # hard bound rather than a cooperative one.
+    perl -e 'alarm shift; exec @ARGV' "$secs" "$@"
+  fi
+}
+
 @test "assert-unsealed FAILS when the container is absent" {
-  run env VAULT_CONTAINER="$ABSENT" bash "$ROOT/scripts/vault.sh" assert-unsealed
+  run bounded 20 env VAULT_CONTAINER="$ABSENT" bash "$ROOT/scripts/vault.sh" assert-unsealed
+  [ "$status" -ne 124 ]   # 124 = timed out, i.e. it waited instead of asserting
   [ "$status" -ne 0 ]
   [[ "$output" == *"NOT DEPLOYED"* ]]
   [[ "$output" == *"failure, not a pass"* ]]
 }
 
 @test "assert-unsealed names the alternative rather than just refusing" {
-  run env VAULT_CONTAINER="$ABSENT" bash "$ROOT/scripts/vault.sh" assert-unsealed
+  run bounded 20 env VAULT_CONTAINER="$ABSENT" bash "$ROOT/scripts/vault.sh" assert-unsealed
+  [ "$status" -ne 124 ]
   [ "$status" -ne 0 ]
   # The next person should not have to work out what to run instead.
   [[ "$output" == *"deploy.sh vault prod"* ]]
@@ -53,8 +80,11 @@ setup() {
 }
 
 @test "auto-unseal returns 0 on absence — deliberate, and says it is a NO-OP" {
-  run env VAULT_CONTAINER="$ABSENT" VAULT_AUTO_UNSEAL_MAX_WAIT=1 \
+  # VAULT_AUTO_UNSEAL_TIMEOUT — the name vault.sh actually reads. Bounded well
+  # above it so a future rename fails here instead of stalling the suite.
+  run bounded 30 env VAULT_CONTAINER="$ABSENT" VAULT_AUTO_UNSEAL_TIMEOUT=1 \
       bash "$ROOT/scripts/vault.sh" auto-unseal
+  [ "$status" -ne 124 ]
   [ "$status" -eq 0 ]
   [[ "$output" == *"NO-OP, not a success"* ]]
   [[ "$output" == *"assert-unsealed"* ]]
@@ -94,4 +124,18 @@ d=yaml.safe_load(open('$ROOT/.github/workflows/vault-regain-root.yml'))
 s=[x for x in d['jobs']['regain']['steps'] if x.get('name')=='Confirm OIDC survived the config swap'][0]
 print(s['if'])"
   [[ "$output" == *"always()"* ]]
+}
+
+# THE CLASS, guarded. Three times now I have set an environment variable that the
+# script under test does not read — TRAEFIK_CONFIG for TRAEFIK_CONFIG_OUTPUT, and
+# VAULT_AUTO_UNSEAL_MAX_WAIT for VAULT_AUTO_UNSEAL_TIMEOUT. Both produced a test
+# that exercised the DEFAULT rather than the fixture: one passed for the wrong
+# reason, one waited two minutes. A name nothing reads is a silent no-op.
+@test "every VAULT_/TRAEFIK_ variable this file sets is actually read by a script" {
+  local unread=""
+  for v in $(grep -oE '\b(VAULT|TRAEFIK|ALERT|ALERTMANAGER|SMTP)_[A-Z0-9_]+=' \
+             "$BATS_TEST_FILENAME" | tr -d '=' | sort -u); do
+    grep -q "$v" "$ROOT"/scripts/*.sh || unread="$unread $v"
+  done
+  [ -z "$unread" ] || { echo "set but read by no script:$unread"; false; }
 }

--- a/tests/scripts/unseal-contracts-control.bats
+++ b/tests/scripts/unseal-contracts-control.bats
@@ -1,0 +1,97 @@
+#!/usr/bin/env bats
+
+# POSITIVE CONTROL for the two deliberately-different contracts on absence.
+#
+# THE DECISION, stated so the tests are readable as intent and not just as
+# assertions:
+#
+#   assert-unsealed  MUST FAIL when the container is absent. An assertion that
+#                    passes because it could not look reports the state you
+#                    wanted rather than the state there is. Both callers run it
+#                    after a deploy that is supposed to have produced the
+#                    container, so absence there means the deploy did not.
+#
+#   auto-unseal      MAY return 0 when the container is absent. Its caller is the
+#                    boot-time systemd unit on a host that may legitimately not
+#                    have OpenBao deployed. It must SAY it did nothing.
+#
+# The separating rule: a command that ACTS may no-op on absence; a command that
+# ASSERTS may not.
+
+setup() {
+  ROOT="$BATS_TEST_DIRNAME/../.."
+  # A container name that certainly does not exist, so "absent" is the real
+  # condition under test rather than something inferred.
+  ABSENT="hill90-definitely-absent-$$"
+}
+
+@test "assert-unsealed FAILS when the container is absent" {
+  run env VAULT_CONTAINER="$ABSENT" bash "$ROOT/scripts/vault.sh" assert-unsealed
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"NOT DEPLOYED"* ]]
+  [[ "$output" == *"failure, not a pass"* ]]
+}
+
+@test "assert-unsealed names the alternative rather than just refusing" {
+  run env VAULT_CONTAINER="$ABSENT" bash "$ROOT/scripts/vault.sh" assert-unsealed
+  [ "$status" -ne 0 ]
+  # The next person should not have to work out what to run instead.
+  [[ "$output" == *"deploy.sh vault prod"* ]]
+  [[ "$output" == *"auto-unseal"* ]]
+}
+
+# CONTROL FOR THE CONTROL: if the old behaviour came back, the test above must be
+# the thing that catches it. This pins the exact regression.
+@test "CONTROL: the OLD assert-unsealed behaviour would have passed on absence" {
+  run bash -c '
+    absent() { return 1; }
+    # The shape that shipped: absence -> report -> return 0.
+    ( absent || { echo "not deployed — nothing to assert"; exit 0; }; echo "checked" )
+  '
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"nothing to assert"* ]]
+}
+
+@test "auto-unseal returns 0 on absence — deliberate, and says it is a NO-OP" {
+  run env VAULT_CONTAINER="$ABSENT" VAULT_AUTO_UNSEAL_MAX_WAIT=1 \
+      bash "$ROOT/scripts/vault.sh" auto-unseal
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"NO-OP, not a success"* ]]
+  [[ "$output" == *"assert-unsealed"* ]]
+}
+
+@test "the two contracts are documented in the code, not only in a PR" {
+  run grep -c "TWO COMMANDS, TWO DELIBERATELY DIFFERENT CONTRACTS ON ABSENCE" "$ROOT/scripts/vault.sh"
+  [ "$output" -eq 1 ]
+  run grep -c "a command that ACTS may no-op on absence; a" "$ROOT/scripts/vault.sh"
+  [ "$output" -eq 1 ]
+}
+
+@test "the usage line no longer claims assert-unsealed tolerates absence" {
+  run grep -c 'assert-unsealed     Exit non-zero if OpenBao is sealed OR not deployed' "$ROOT/scripts/vault.sh"
+  [ "$output" -eq 1 ]
+  # The old wording said "if OpenBao is deployed but still sealed", which
+  # described the defect as the contract.
+  run bash -c "grep -c 'if OpenBao is deployed but still sealed' '$ROOT/scripts/vault.sh' || true"
+  [ "$output" -eq 0 ]
+}
+
+# --- 2.3 and 2.4: the workflow cleanup conditions --------------------------
+
+@test "vault-init 'Report where the root token is' runs on failure" {
+  run python3 -c "
+import yaml
+d=yaml.safe_load(open('$ROOT/.github/workflows/vault-init.yml'))
+s=[x for x in d['jobs']['init']['steps'] if x.get('name')=='Report where the root token is'][0]
+print(s['if'])"
+  [[ "$output" == *"always()"* ]]
+}
+
+@test "vault-regain-root 'Confirm OIDC survived the config swap' runs on failure" {
+  run python3 -c "
+import yaml
+d=yaml.safe_load(open('$ROOT/.github/workflows/vault-regain-root.yml'))
+s=[x for x in d['jobs']['regain']['steps'] if x.get('name')=='Confirm OIDC survived the config swap'][0]
+print(s['if'])"
+  [[ "$output" == *"always()"* ]]
+}

--- a/tests/scripts/vault.bats
+++ b/tests/scripts/vault.bats
@@ -441,10 +441,19 @@
   grep -q 'assert-unsealed)' scripts/vault.sh
 }
 
-@test "assert-unsealed exits 0 when the container is absent" {
+# INVERTED, and the inversion is the decision — see the contract note above
+# cmd_assert_unsealed in scripts/vault.sh.
+#
+# This test pinned the DEFECT: an assertion that passed because it could not
+# look. Both callers run assert-unsealed after a deploy that is supposed to have
+# produced the container, so absence means the deploy did not — the single most
+# useful thing it could report, and it reported success instead. Found by the
+# #674 sweep as rank 2.2.
+@test "assert-unsealed FAILS when the container is absent — an assertion must not pass on absence" {
   run env VAULT_CONTAINER=definitely-not-a-container-h90 bash scripts/vault.sh assert-unsealed
-  [ "$status" -eq 0 ]
-  [[ "$output" == *"not deployed"* ]]
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"NOT DEPLOYED"* ]]
+  [[ "$output" == *"failure, not a pass"* ]]
 }
 
 @test "assert-unsealed fails loudly when seal state cannot be determined" {
@@ -465,7 +474,10 @@
   fi
   run env VAULT_AUTO_UNSEAL_TIMEOUT=1 bash scripts/vault.sh auto-unseal
   [ "$status" -eq 0 ]
-  [[ "$output" == *"skipping auto-unseal"* ]]
+  # Message changed with #674 rank 2.1: the tolerance is unchanged and
+  # deliberate, but it now states that it is a NO-OP rather than implying
+  # success, and points at assert-unsealed for the case where absence is a fault.
+  [[ "$output" == *"NO-OP, not a success"* ]]
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Rank 2 of the sweep (#674) — all four remaining findings. **The baseline in `check_silent_success.py` is now empty.**

## The decision, made explicitly

Both commands meet a missing container and must answer differently:

| Command | On absence | Why |
|---|---|---|
| `auto-unseal` | **returns 0** | Best effort. Its caller is the boot-time systemd unit, running on a host that may legitimately not have OpenBao deployed. "Nothing to unseal" is a correct outcome there. |
| `assert-unsealed` | **now non-zero** | An assertion. It previously returned 0 with *"nothing to assert"* — passing because it could not look. Both callers are in `vault-regain-root.yml`, both **after** a deploy that is supposed to have produced the container, so absence means the deploy did not. |

**The separating rule — now a comment block above both, not only here:**

> A command that ACTS may no-op on absence; a command that ASSERTS may not.

`auto-unseal` keeps its tolerance and stops implying success: it prints *"this is a NO-OP, not a success"* and names `assert-unsealed` for callers where absence is a fault.

The usage line said *"Exit non-zero if OpenBao is **deployed but** still sealed"* — which described the defect **as** the contract. Now: *"if OpenBao is sealed OR not deployed (an assertion)"*.

## 2.3 and 2.4 — one line each, same defect as #663

```
vault-init         Report where the root token is  ->  always() && !revoke_root
vault-regain-root  Confirm OIDC survived the swap  ->  always() && run_setup_oidc
```

The first reports the location of a **live credential** and was skipped exactly on runs that failed after minting one. The second verifies the thing the config swap is most likely to have broken.

## Did #675's sweep catch its own findings?

**Two of four — and it declared the limit in advance rather than missing them silently.**

- **2.3, 2.4 — yes.** Shape B found them; they *were* the baseline entries.
- **2.1, 2.2 — no.** Shape C, *"a function returning 0 having done nothing"*, is documented in the check's own docstring as **not machine-detectable**: judging whether a `return 0` is correct idempotence or a silent no-op needs intent, and a regex that guessed would be noise. Both were found **by hand** during the same sweep and recorded in #674.

So the sweep did not miss them; it said up front it could not see them. **An undeclared blind spot is a defect; a declared one is a boundary** — and it remains a boundary, because this change does not make shape C detectable. If that bothers us, the fix is a convention (every `return 0` on an absence path carries a marker) rather than a cleverer regex.

## One test inverted, and the inversion is the decision

`vault.bats` pinned *"assert-unsealed exits 0 when the container is absent"* — **a test asserting the defect**. It now requires the opposite, with the reasoning in the test body. A second test's message expectation moved with `auto-unseal`'s new wording; its tolerance is unchanged.

## Controls — eight new

Including one that **reproduces the old `assert-unsealed` shape** to show what would have passed, one pinning that the contract note exists in the code, and one that **plants a bogus BASELINE entry** to prove the staleness rule still bites now that the baseline is empty — otherwise emptying it would silently retire the rule.

## Verification

- `bats tests/scripts/` — **465 passing, 0 failing**, run before the commit
- `check_silent_success.py` — shape A **0**, shape B **0**, baseline **0**
- `check_root_revoke_fails_closed.py` — PASS

No production change in this PR; `assert-unsealed`'s new behaviour reaches the estate the next time `vault-regain-root` runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)