### PR TITLE
fix(firewall): drop cockpit from the public zone, and assert it stays out

### DIFF
--- a/infra/ansible/playbooks/02-firewall.yml
+++ b/infra/ansible/playbooks/02-firewall.yml
@@ -22,3 +22,59 @@
     - http
     - https
     - ssh
+
+# ---------------------------------------------------------------------------
+# Services the BASE IMAGE opened that this estate does not want
+# ---------------------------------------------------------------------------
+#
+# The AlmaLinux cloud image ships `cockpit` enabled in the public zone. Nothing
+# in this repository asked for it, and 04-ssh-lockdown.yml later removes `ssh`
+# from public — so on a configured host the public zone should carry http and
+# https only.
+#
+# Measured on the running host 2026-08-03:
+#
+#   public (default, active)
+#     services: cockpit dhcpv6-client http https
+#
+# cockpit is a ROOT-CAPABLE WEB ADMIN CONSOLE on 9090. It is currently inert
+# here — `cockpit.socket` is inactive and not-enabled, and nothing listens on
+# 9090 — so this is not an open door today. It is an open doorway waiting for a
+# door: anything that starts the socket, including a package update or a future
+# playbook, becomes immediately reachable from the public internet with no
+# further change. Removing the firewall permission means starting the service is
+# no longer sufficient to expose it.
+#
+# This is deliberately NOT bundled with a claim that it was exploitable. It was
+# not. It is removed because an allowance nobody asked for should not outlive the
+# reason it was never noticed.
+- name: Remove base-image services this estate does not serve publicly
+  firewalld:
+    service: "{{ item }}"
+    permanent: yes
+    state: disabled
+    immediate: yes
+  loop:
+    - cockpit
+  failed_when: false   # absent on images that never shipped it; not an error
+
+- name: Read the effective public zone
+  command: firewall-cmd --zone=public --list-services
+  register: fw_public
+  changed_when: false
+
+# The assertion that would have caught this. A firewall rule nobody reads is the
+# same class as a config file nobody reads: 04-ssh-lockdown.yml exists precisely
+# because `sshd_config` said one thing and `sshd -T` said another.
+- name: Assert the public zone carries only what this estate serves
+  assert:
+    that:
+      - "'cockpit' not in fw_public.stdout"
+    fail_msg: |
+      The public firewall zone still permits cockpit, a root-capable web admin
+      console on 9090, reachable from the internet.
+
+      Effective public services: {{ fw_public.stdout }}
+
+      Inspect with: sudo firewall-cmd --zone=public --list-all
+    success_msg: "Public zone verified: cockpit is not permitted ({{ fw_public.stdout }})"


### PR DESCRIPTION
Part of #539, which I re-scoped after verifying it on the host. **Its severity was wrong and the title is corrected** — details on the issue.

## What changed

The AlmaLinux cloud image ships `cockpit` enabled in the public zone. Nothing here asked for it:

```
public (default, active)
  services: cockpit dhcpv6-client http https
```

`cockpit` is a **root-capable web admin console on 9090**. It is inert here — socket inactive, not-enabled, nothing listening — so this is **not an open door**. It is an open **doorway**: anything that starts the socket, including a package update, becomes publicly reachable with no further change.

Deliberately not dressed up as exploitable. It wasn't. It goes because an allowance nobody asked for shouldn't outlive the reason nobody noticed it.

Added the assertion that would have caught it, in the same shape as `04-ssh-lockdown`'s `sshd -T` check: read the **effective** zone and fail if cockpit is still permitted.

## What I did NOT do, and why

**Did not install fail2ban.** `04-ssh-lockdown.yml` already documents the decision against it: it is in no repository enabled on this host, the old tasks failed under `ignore_errors: yes` and **reported success while installing nothing** — the same silent-success defect this repo spent today removing. Restoring it means enabling **EPEL on a hardened host**, and its value is limited precisely because SSH is not publicly reachable, which I verified rather than assumed. Silently overriding a documented decision is the defect, not the fix.

**Did not apply the sshd hardening.** It doesn't need writing — #545 already rewrote `04-ssh-lockdown.yml` correctly and it is in `main`. It has never **run**: `Config VPS` last executed **2026-02-02**, months before that commit. Applying it means `config-vps.yml`, which runs playbooks 01–08 plus bootstrap — including `05-docker` (bounces every container) and `03-tailscale` (reconfigures the only access path) — then auto-triggers `deploy-infra`. That is a blast-radius decision, not something to fire off inside a hygiene change.

## The finding that matters most

On the issue rather than here, because it is about the estate:

```
remote-user=jonhill90@github     557 sessions   (interactive)
remote-user=tag:github-actions   189 sessions   (deploy pipeline)
sshd Accepted logins in 24h        0
```

**Every connection to this host is served by Tailscale SSH, not `sshd`.** The real access control is the Tailscale ACL. `docs/architecture/security.md` describes `sshd` as the boundary and is wrong about which mechanism protects the host. Hardening `sshd` remains worth doing as defence in depth — it just isn't the control that is currently holding.

## Verification

`bats tests/scripts/` — 466 passing, 0 failing. YAML parses. No production change; this reaches the host only when the ansible playbooks next run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)