### PR TITLE
docs(security): record that Tailscale SSH answers, not sshd — the ACL is the control

### DIFF
--- a/docs/architecture/security.md
+++ b/docs/architecture/security.md
@@ -13,6 +13,39 @@ restricting administration to a private network.
   for the evidence and for the surfaces that are deliberately public.
 - SSH access is restricted to the Tailscale CIDR (`100.64.0.0/10`) via firewall
   rules.
+- **`sshd` is not what answers.** Measured 2026-08-03 over 24 hours:
+
+  | server | sessions |
+  |---|---|
+  | Tailscale SSH, `remote-user=jonhill90@github` (interactive) | 557 |
+  | Tailscale SSH, `remote-user=tag:github-actions` (deploy pipeline) | 189 |
+  | `sshd`, accepted logins | **0** |
+
+  Tailscale SSH intercepts port 22 on the tailnet and serves it itself, so
+  **connections authenticate on tailnet identity and the Tailscale ACL, not on
+  anything in `sshd_config`**. Both humans and the deploy pipeline arrive this
+  way. The evidence is `tailscaled be-child ssh --remote-user=… --local-user=deploy`
+  in the journal; `sshd`'s own log records no accepted authentication at all.
+
+  Three consequences worth holding together:
+
+  - **The ACL is the access control.** Changing who can reach this host means
+    changing the Tailscale ACL (`.github/workflows/tailscale.yml`), not
+    `sshd_config`. A review that hardens `sshd` and stops there has not
+    changed who can get in.
+  - **The `sshd` hardening below is defence in depth, and still worth applying.**
+    It becomes load-bearing the moment Tailscale SSH is disabled, the ACL is
+    widened, or the firewall rule changes — none of which would announce
+    themselves.
+  - **It also means applying it cannot lock anyone out**, because nothing
+    currently authenticates through `sshd`. That is a measurement, not an
+    assumption, and it is the reason the runbook's two-terminal check is a
+    formality rather than the thing standing between you and a lockout.
+
+  A client-side `ssh -o PreferredAuthentications=publickey` proves nothing here:
+  those options are interpreted by the local client and ignored by the server
+  that actually answers. Confirm which server served a session from the host
+  side, in the journal.
 
 ## Identity And Secrets
 


### PR DESCRIPTION
## A correction first

In #679 I wrote that this document *"describes sshd as the boundary and is wrong"*. **It does not, and it is not.** I quoted #539's framing — accurate when that issue was filed — and asserted it as current fact without reading the file.

`security.md` already states the hardening lives in the `00-` drop-in rather than `sshd_config`, that it is **not yet applied** and `sshd -T` still reports `passwordauthentication yes`, and that fail2ban is not installed *and this document previously said otherwise*. It was ahead of the issue. Corrections posted on #679 and #539.

Its own line is a better formulation of the severity than mine was:

> **Documented hardening not in force is not the same as an exposed host.**

## What is genuinely absent

This file does not mention Tailscale SSH at all. Measured over 24 hours:

| server | sessions |
|---|---|
| Tailscale SSH, `remote-user=jonhill90@github` (interactive) | 557 |
| Tailscale SSH, `remote-user=tag:github-actions` (deploy pipeline) | 189 |
| `sshd`, accepted logins | **0** |

Tailscale SSH intercepts port 22 on the tailnet and serves it itself, so connections authenticate on **tailnet identity and the ACL**, not on anything in `sshd_config`.

Three consequences, recorded together because separating them is how the wrong conclusion gets drawn:

- **The ACL is the access control.** Changing who can reach this host means changing the Tailscale ACL, not `sshd_config`. A review that hardens `sshd` and stops there has not changed who can get in.
- **The `sshd` hardening is still worth applying** — defence in depth that becomes load-bearing the moment Tailscale SSH is disabled, the ACL widens, or the firewall rule changes. None of those announce themselves.
- **It also means applying it cannot lock anyone out**, because nothing authenticates through `sshd` today. A measurement, not an assumption — and the reason the runbook's two-terminal check is a formality rather than the thing standing between you and a lockout.

## One method note, because it cost me a false positive

A client-side `ssh -o PreferredAuthentications=publickey` **proves nothing here**: those options are interpreted by the local client and ignored by the server that actually answers. I ran exactly that as a lockout safety check and was about to report key auth confirmed. Confirm which server served a session **from the host side**, in the journal.

Markdown links pass. `bats tests/scripts/` — 466 passing, 0 failing. Documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)