### PR TITLE
fix(ansible): remove letsencrypt_env, a knob that was read by nothing

### DIFF
--- a/infra/ansible/inventory/group_vars/all.yml
+++ b/infra/ansible/inventory/group_vars/all.yml
@@ -39,9 +39,29 @@ domain: hill90.com
 acme_email: jonhill90@live.com
 
 # Let's Encrypt configuration
-# IMPORTANT: Use staging for testing to avoid rate limits (50/week for production)
-# Set to 'production' only when ready for real certificates
-letsencrypt_env: production  # 'staging' or 'production'
+#
+# THERE IS NO letsencrypt_env HERE, DELIBERATELY. It used to sit at this line as
+# `letsencrypt_env: production  # 'staging' or 'production'`, above a comment
+# telling the reader to switch it for testing. It was defined here and read
+# NOWHERE — no playbook, template or script referenced it. Setting it to
+# 'staging' changed nothing, which is worse than having no knob at all: a
+# control that appears to work and does not is how somebody concludes they are
+# testing against staging while issuing production certificates.
+#
+# THE REAL CONTROL is ACME_CA_SERVER, held in the SOPS store and rendered into
+# platform/edge/traefik.generated.yml by scripts/render-traefik-config.sh. It has
+# NO DEFAULT on purpose: an unset value refuses the render rather than quietly
+# selecting staging, which is what #543 was about.
+#
+#   inspect   make secrets-view KEY=ACME_CA_SERVER
+#   change    make secrets-update KEY=ACME_CA_SERVER VALUE=<acme directory url>
+#   verify    grep caServer platform/edge/traefik.generated.yml
+#
+# Read docs/architecture/certificates.md before changing it. Switching CA is not
+# free: Traefik will not reissue a certificate it still considers valid, and
+# acme-dns.json holds all four DNS-01 certificates in one file, so recovering
+# from an accidental staging issuance means clearing that file and reissuing
+# every public name at once.
 
 # Traefik admin password - stored in encrypted secrets
 # Generate with: htpasswd -nb admin yourpassword


### PR DESCRIPTION
Closes #537. Substantially closes #543 — see below.

**#543 and #537 are the same `ACME_CA_SERVER` question from two directions, and both are already fixed in code.** The safe change left is one variable. Saying so rather than performing the larger change the titles imply.

## Already done — verified against the code, not the doc

| Issue | State | Evidence |
|---|---|---|
| **#543** staging default | fixed | `render-traefik-config.sh:47` refuses when `ACME_CA_SERVER` is unset. The only `:-<staging>` strings left in the repo are **comments describing the old behaviour**. Positive-controlled: running it with the variable unset prints *"Refusing to render the Traefik config"* and exits non-zero. |
| **#537** inert wiring | fixed | `caServer` is rendered **into** `traefik.generated.yml` (template lines 110/119), not passed as a CLI flag Traefik discards. Live host: **2 production `caServer` lines, 0 staging**. Today's infra deploy printed `2 resolver(s), CA: acme-v02…`. |

## Still wrong — and the whole of this change

```yaml
# Let's Encrypt configuration
# IMPORTANT: Use staging for testing to avoid rate limits
# Set to 'production' only when ready for real certificates
letsencrypt_env: production  # 'staging' or 'production'
```

Defined once in `group_vars/all.yml`, **referenced nowhere** — no playbook, template or script reads it. Setting it to `staging` changed nothing, under a comment block instructing the reader to do exactly that.

**That is worse than having no knob.** A control that appears to work and does not is how somebody concludes they are testing against staging while issuing production certificates — the same family as every defect closed today, in the one place where being wrong costs a full reissue of every public name.

Replaced with a pointer to the real control (`ACME_CA_SERVER` in SOPS), why it has **no default**, the three commands to inspect/change/verify, and the warning from `certificates.md` that matters most: Traefik will not reissue a certificate it still considers valid, and `acme-dns.json` holds **all four DNS-01 certificates in one file**, so recovering from an accidental staging issuance means clearing that file and reissuing every public name at once.

## No behaviour change

The variable was read by nothing, so removing it cannot alter a deploy. **Certificate issuance is untouched** — no CA switch, no `acme-dns.json` change, nothing that could trigger a reissue. That was the hazard to avoid here, and this change does not go near it.

## On #543

Its remaining substance is documentation-only: the default is gone and guarded. I'd close it on this evidence rather than leave it implying a live risk, but it is a second issue so I have not closed it unilaterally.

## Test counts

Reported from CI rather than locally — two local runs were killed by a shell timeout partway (at 261 and 251 of 466), and **a truncated count is not a result**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)