### PR TITLE
docs: "shelved" is not stale prose here — it is false, and it is in the first files read

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,9 @@ provisioning, Traefik edge routing, an observability stack, SOPS/OpenBao
 secrets, and Tailscale-secured SSH.
 
 > **Scope:** Hill90 is not an application host. The AI agent application that
-> once lived here was shelved in June 2026 and removed in July 2026. See
+> once lived here was removed in July 2026 — not shelved: it runs in production
+> as a **tenant** of this platform, from
+> [`hill90-app`](https://github.com/jonhill90/hill90-app). See
 > [Infra/app separation](docs/decisions/infra-app-separation.md); the code is
 > preserved at the `archive/app-stack-final` tag.
 

--- a/PRD.md
+++ b/PRD.md
@@ -97,7 +97,9 @@ template is a separate parallel effort.
 - **Not a rewrite of the infrastructure.** Traefik, the observability stack, the
   deploy scripts and the secrets model are kept as they are. This is subtraction,
   not redesign.
-- **Not a re-litigation of the shelving decision.** The application is shelved.
+- **Not a re-litigation of the separation decision.** The application left this
+  repository; it was not shelved, and has run as a tenant of this platform since
+  2026-07-29.
 - **Not a cleanup of pre-existing infra drift.** Known DNS drift
   (`vps.hill90.com` and `openclaw.hill90.com` still pointing at a stale address)
   is recorded, not fixed here.

--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ observability, and secrets — automated end to end.
 
 Hill90 is not an application host. It is the automation that takes a bare VPS to
 a running, TLS-terminated, observable, Tailscale-secured Docker host, and keeps
-it there. An AI agent application previously lived here; it was shelved in June
-2026 and removed in July 2026. See
+it there. An AI agent application previously lived here and was removed in July
+2026. It was not shelved: it runs in production as a **tenant** of this platform,
+from [`hill90-app`](https://github.com/jonhill90/hill90-app). See
 [Infra/app separation](docs/decisions/infra-app-separation.md) for the record,
 and the `archive/app-stack-final` tag for the code.
 

--- a/docs/decisions/platform-primitives.md
+++ b/docs/decisions/platform-primitives.md
@@ -103,8 +103,9 @@ also removed their Prometheus scrape targets, Grafana dashboards and the
 
 ## What this does not change
 
-The application strip itself was correct. The AI agent app is shelved, lives in
-`hill90-app`, and is not coming back into this repository. Removing
+The application strip itself was correct. The AI agent app lives in
+`hill90-app` and is not coming back into this repository — it was moved out, not
+shelved, and runs there as a tenant of this platform. Removing
 `services/api`, `services/ai`, `services/ui`, `services/mcp`,
 `services/knowledge` and `services/agentbox` stands. LiteLLM and the model-router
 were application components and stay gone.


### PR DESCRIPTION
Substantially closes #647. Most of that issue is already done — the app-repo half landed in #109, the Hill90 half in #654, and four of the six dated session logs are gone. **What survives is mostly correct and stays.**

I read every candidate rather than counting hits, because a grep-based inventory of exactly this was wrong three times before.

## What I corrected — four claims that are wrong, not merely aged

**The application is not shelved. It is running**: 7 tenant containers, `hill90.com` 200, serving as a tenant of this platform since 2026-07-29.

| File | The false claim |
|---|---|
| `README.md` | *"it was shelved in June 2026 and removed in July 2026"* |
| `CONTRIBUTING.md` | the same sentence, in the scope banner |
| `PRD.md` | *"The application is shelved."* — flat present tense |
| `platform-primitives.md` | *"The AI agent app is shelved, lives in `hill90-app`"* — self-contradictory in one sentence |

README and CONTRIBUTING are the first two files a stranger opens, and **this repository is public**. A reader following them concludes the application is dormant and that `hill90-app` is an archive. Both are false.

## What I kept, and why

The test is whether a cold reader would be **misled**, not whether a word appears.

- **`SPEC.md`** — carries a *"Historical: this specifies the 2026-07-26 strip as planned, not the estate as it stands"* banner and points at current truth. Its usages sit inside a warned historical spec.
- **`infra-app-separation.md`** — already a 46-line stub headed *"SUPERSEDED by events. Kept as a stub because six documents cite it."* States what was decided, that **none** of it happened, and preserves the durable technical note (kubeadm v1.35 + containerd + Calico confirmed on AlmaLinux 10).
- **`2026-07-30-credential-exposures.md`** — *"The point of writing it down is the shared shape and the fix, not the incidents."* A lesson, not a log.
- **`2026-07-31-handoff.md`** — *"A statement of current truth, not a changelog."* Its one hit is **the rule itself**: *"decision records preserve, status trackers expire… that is why `infra-app-separation.md` still says the application is shelved and is correct as such."* That is the best statement of the principle in the estate.
- **`PRD.md` "Not a repo split."** — a scope boundary saying what the work is not.

## And in hill90-app, nothing needed changing — checked, not assumed

- `PRD.md` — the hits are a **self-correction**: *"This section used to say the opposite… Both statements outlived the thing they described."* It keeps a reader right.
- `PROVENANCE.md` — the relocation table, which is its purpose.
- `CLAUDE.md` — *"Its resurrection was the quietest of the three"* is about **app-minio** coming back, a different sense of the word.
- `SPEC.md` — the extraction decision table, plus a correction of the shelved framing.

**Of the eleven files the issue named, four needed a fix and seven were already right** — and three of those seven are the false positives the original grep-based inventory produced.

Markdown links pass. Documentation only; no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)