### PR TITLE
docs(claude): the four realm roles do not exist — CLAUDE.md still described them

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,15 +109,29 @@ an Entra analogy — you do not create a second tenant for one organisation; one
 directory, controlled with roles and groups. An earlier version of this file said
 *"one Keycloak does not mean one realm"*; that was wrong.
 
-**The realm-role collision is resolved in fact, and that is now evidence rather
-than design intent.** It was the whole justification for choosing client roles, so
-state it plainly: in realm `platform`, the realm role `admin` exists and **has zero
-holders**, as do `user`, `editor` and `viewer`. `jon`, `hill90admin` and
-`testuser01` hold only `default-roles-platform` as a realm role. Their app
-permissions are client roles — `jon` = `hill90-ui:admin,user`, `hill90admin` =
-`hill90-ui:admin`, `testuser01` = `hill90-ui:user`. **The Grafana Admin and OpenBao
-grant that hangs off the realm `admin` role is therefore unreachable by any app
-user.** Measured, not asserted.
+**The realm-role collision is resolved by deletion, not merely by nobody holding
+the roles.** It was the whole justification for choosing client roles, so state it
+plainly. `Verified 2026-08-03`:
+
+- **The realm roles `admin`, `user`, `editor` and `viewer` no longer exist.** They
+  were deleted in #670 after every consumer was repointed. The realm now carries
+  `platform-admin`, `platform-editor`, `platform-viewer` and Keycloak's own
+  `default-roles-platform`, `offline_access` and `uma_authorization`.
+- **App permissions are client roles on `hill90-ui`** — `jon` =
+  `hill90-ui:admin,user`, `hill90admin` = `hill90-ui:admin`, `testuser01` =
+  `hill90-ui:user`. Unchanged, and untouched by the deletion: the client roles
+  share two names with the deleted realm roles and are different objects.
+- **Realm roles held:** `jon` has `platform-admin`; `hill90admin` and `testuser01`
+  have none beyond the three Keycloak grants everyone gets.
+
+**This paragraph previously said those four roles "exist and have zero holders",
+that all three accounts "hold only `default-roles-platform`", and that the Grafana
+and OpenBao grants "hang off the realm `admin` role".** All three were true when
+written and all three are now false — `jon` holds `platform-admin`, and Grafana's
+`role_attribute_path` and OpenBao's `admin-sso` bound claim were repointed to
+`platform-admin` in #637 and #667 before the old roles were removed. The
+zero-holder argument is superseded by a stronger one: a role that does not exist
+cannot be granted by accident.
 
 > **Two caveats that the good news must not bury.**
 >


### PR DESCRIPTION
**The first file a cold agent session reads, in a public repository, asserted three things that are false.** `AGENTS.md` is a symlink to it, so this is the orientation document for every session in both harnesses.

## What it said, versus measured reality

| Claim | Truth, `Verified 2026-08-03` |
|---|---|
| *"the realm role `admin` exists and has zero holders, as do `user`, `editor` and `viewer`"* | **All four were deleted in #670.** The realm carries `platform-admin`, `platform-editor`, `platform-viewer` + Keycloak's own three. |
| *"`jon`, `hill90admin` and `testuser01` hold only `default-roles-platform`"* | **`jon` also holds `platform-admin`.** |
| *"The Grafana Admin and OpenBao grant that hangs off the realm `admin` role"* | **Neither hangs off it.** Repointed to `platform-admin` in #637/#667 — *before* the deletion, which is why the deletion was safe. |

```
jon          default-roles-platform, offline_access, platform-admin, uma_authorization
hill90admin  default-roles-platform, offline_access, uma_authorization
testuser01   default-roles-platform, offline_access, uma_authorization
```

All three were true when written. Each is a confident statement that outlived its subject — the same failure #683 found in README, CONTRIBUTING, PRD and platform-primitives, and the same one that made four issues stale enough to close today.

## The argument survives, and is stronger

The paragraph exists to justify choosing **client** roles over realm roles. Its evidence was that the realm roles had no holders — **contingent**, one grant away from false. It is now **structural**: a role that does not exist cannot be granted by accident.

The client roles are unchanged and untouched. Stated explicitly, because two of them share names with deleted realm roles and are different objects — the hazard #670 had to navigate.

## Correction kept in the text

Rather than silently overwritten, matching the convention this file already uses twice (*"An earlier version of this file said … that was wrong"*). A reader who saw the old claim elsewhere needs to know it moved, not just that the file now reads differently.

## Checked and not changed

`hill90-app/CLAUDE.md` — its *"no `admin` in `realm_access.roles`"* is recorded token output, now true a fortiori; *"authorization by client roles … not realm roles"* still holds.

Markdown links pass. Documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)