### PR TITLE
docs(claude): sweep the whole file against the host — three claims aged, six held

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -267,9 +267,11 @@ the migration run — but say "nothing worth preserving", not "empty".
 **MinIO is settled and shipped — this entry used to say it was never addressed.** A
 platform MinIO runs (`Verified 2026-07-31 06:21 UTC`, healthy) and the tenant was cut over
 to it; storage moved *up*, as the governing principle indicated. `app-minio` was stopped
-2026-07-31 01:40:43 UTC and is **not yet removed**: its retention window expires
-**2026-08-01 01:41 UTC**, and deleting `prod_app-minio-data` is a separate, irreversible
-decision.
+2026-07-31 01:40:43 UTC and is **still not removed**. Its retention window expired
+**2026-08-01 01:41 UTC** — over two days ago — so this is no longer a pending deadline
+but an untaken decision. `Verified 2026-08-03 13:45 UTC`: the container exists in state
+`Exited (0)` and the volume `prod_app-minio-data` is still present. Deleting that volume
+is irreversible and is Jon's call.
 
 **What is genuinely open now is Jon's, not a lane's** — repository visibility for
 hill90-app with the history-rewrite costs, whether the tenant's local stack moves onto the
@@ -285,9 +287,14 @@ bash scripts/deploy.sh verify <service> prod
 gh workflow run deploy.yml -f service=all
 ```
 
-- **Alerts reach a human, as of 2026-07-31.** 16 rules, 8 groups, delivered by
-  Alertmanager over email to `ACME_EMAIL` via the SMTP account the estate already
-  had. Delivery is proven end to end, not assumed. Before that date there was **no
+- **Alerts reach a human.** `Verified 2026-08-03 13:45 UTC` by firing two real alerts and
+  reading Alertmanager's own counters: `notifications_total{integration="email"}`
+  incremented and every `notifications_failed_total` stayed at 0. **18 rules in 9
+  groups** — this entry said 16 and 8, counted before #617 and never re-counted.
+  Delivered over email to `ACME_EMAIL` via the SMTP account the estate already
+  had. Delivery is proven end to end, not assumed — but note the boundary: this
+  proves Alertmanager handed the message to the mail server, not that it reached
+  an inbox. Before that date there was **no
   receiver at all** and every rule was inert — `ServiceDown` fired for ≥48 hours in
   the week to 2026-07-26 and reached nobody. Start at
   [`docs/decisions/alerting-audit.md`](docs/decisions/alerting-audit.md).
@@ -307,7 +314,7 @@ gh workflow run deploy.yml -f service=all
   `python3 scripts/checks/check_alert_series.py` **on the VPS**, which asks the live
   Prometheus.
 - Platform baseline is **16 containers by name, 0 unhealthy** —
-  `Verified 2026-07-31 09:58 UTC`, after #617 deployed `alertmanager` and
+  `Verified 2026-08-03 13:45 UTC`, unchanged since #617 deployed `alertmanager` and
   `blackbox-exporter`. With the tenant's 7 that is **23 running in total**.
   The full 16: `alertmanager blackbox-exporter cadvisor grafana keycloak loki
   minio node-exporter openbao portainer postgres postgres-exporter prometheus


### PR DESCRIPTION
#684 fixed the realm-roles entry. This checks the rest, because today's twelve merged changes touched much of what this file asserts, and it is the first thing every cold session reads.

**Every claim was verified against the host or the code, not against another document.** Both halves are reported below — a sweep listing only edits leaves the next reader unable to tell *verified* from *skipped*.

## Changed — three

**Alerting counts were wrong, not merely aged.**

| | |
|---|---|
| said | 16 rules, 8 groups |
| measured | **18 rules, 9 groups** (Prometheus `/api/v1/rules`) |

Counted before #617 and never re-counted. Delivery re-proven today by firing two real alerts and reading Alertmanager's counters — `notifications_total{integration="email"}` incremented, every `notifications_failed_total` stayed 0. Added the boundary: **this proves delivery to the mail server, not to an inbox** — the distinction the July `ServiceDown` outage turned on.

**`app-minio`'s retention window expired two days ago.** It said *"not yet removed: its retention window expires 2026-08-01 01:41 UTC"*. Measured: container present, `Exited (0)`; volume `prod_app-minio-data` still present. The sentence described a pending deadline; the deadline passed and nothing happened, which makes it an **untaken decision, not a countdown**. Reworded and dated — the deletion stays Jon's call because it is irreversible.

**Baseline date was three days stale.** Re-verified: 16 platform by name, 0 unhealthy, tenant 7, 23 total. Same numbers, new stamp, per this file's own dating rule.

## Checked and still correct — six, left alone

- **cAdvisor emits zero Docker container series** — `count(container_memory_usage_bytes{name!=""})` = **0** on the live Prometheus. Still exactly true; still a trap.
- **Platform 16 / tenant 7 / 23 total, and the named list** — counted on the host, all sixteen names match.
- **`app-auth.hill90.com` is gone and returns 404** — 0 `app-keycloak` containers including stopped; hostname returns 404.
- **Public vs Tailscale-only split** — `hill90.com`/`auth` → `76.13.26.69` (public); `traefik`/`portainer`/`grafana`/`vault` → `100.88.29.112` (tailnet). Exactly as described.
- **The realm-roles entry from #684** — re-read against the live realm; still accurate.
- **Instrument-verification and "two traps"** — practice, not perishable state.

## Checked and found absent — four things asked about that this file does not claim

MinIO policy names, the Grafana `role_attribute_path` arms, AppRole/vault path status, and anything asserting `sshd` is the access control. **CLAUDE.md makes no assertion about any of them**, so there was nothing to correct here. The `sshd` claim lives in `docs/architecture/security.md` and was handled in #680; the Grafana mapping appears only inside the #684 passage and is correct there.

`shelved` appears **zero** times in this file — #683 handled README, CONTRIBUTING, PRD and platform-primitives.

Reporting absence explicitly rather than silently: *"I did not change it"* and *"there was nothing to change"* are different statements, and only one means the area was examined.

Markdown links pass. Documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)