### PR TITLE
docs: the app-minio retention window expired, and a convention for dated claims

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -368,3 +368,18 @@ the correct expectation to hold about them.
 *(Measured during the 2026-07-26 branch audit, which covered 168 remote branches. That
 audit's inventory is spent — the repository carries 25 today — but this property of the
 tags is not, so it is recorded here rather than left to die with the audit.)*
+
+## Dated claims: state what becomes true, not that the date is coming
+
+A future-tense sentence about a date reads as *not yet due* forever, so it fails silently
+the moment it passes. Worse, a `Verified <timestamp>` on one is misleading **in both
+directions at once**: it certifies when the claim was checked, while the sentence describes
+a moment that has since arrived.
+
+Write `expired 2026-08-01 01:41 UTC; after that it is an untaken decision` rather than
+`expires 2026-08-01 01:41 UTC`. The first is true before **and** after; the second is only
+true before.
+
+Found on 2026-08-03 by sweeping both repos: 2 instances in 107 markdown files, both the same
+`app-minio` retention window. Rare, not systemic — which is why this is a convention and not
+a CI check.

--- a/docs/decisions/2026-07-31-handoff.md
+++ b/docs/decisions/2026-07-31-handoff.md
@@ -250,8 +250,11 @@ These are half the value and are recorded so nobody pays for them twice.
    retirement banners rather than deleted.
 3. **A reboot, to validate the vault auto-unseal path.** Cheap, and the only thing that
    converts "the unit is enabled" into "the unit works". Nothing else is waiting on it.
-4. **`app-minio`'s removal.** Its retention window expires **2026-08-01 01:41 UTC** — a day
-   after it stopped. Removing the container is reversible while `prod_app-minio-data`
+4. **`app-minio`'s removal.** Its retention window **EXPIRED 2026-08-01 01:41 UTC** — a day
+   after it stopped, and now over two days ago, so this is an untaken decision rather than
+   a pending deadline. `Verified 2026-08-03`: container `Exited (0)`, volume still present.
+   *(Written prospectively — "expires" — which reads as not-yet-due for as long as it
+   stands. See CONTRIBUTING on stating what becomes true at a date.)* Removing the container is reversible while `prod_app-minio-data`
    exists; deleting that volume is the irreversible step and should be a separate decision.
    `Re-verified 2026-07-31 11:20 UTC`: still `Exited (0)`, volume still present.
 5. **Run Config VPS, to put the SSH hardening in force.** The drop-in is in this repository


### PR DESCRIPTION
The handoff said the window **"expires 2026-08-01 01:41 UTC"**. It expired, over two days ago.

`Verified 2026-08-03`: container `Exited (0)`, volume `prod_app-minio-data` still present. So it is an **untaken decision, not a pending deadline** — and the sentence read as *not yet due* the entire time.

CLAUDE.md's copy of this claim was already corrected by another session today with the same finding. This is the handoff copy, which a sweep found.

## The convention (added to CONTRIBUTING)

> **State what becomes true at a date, not that the date is coming.**
>
> A future-tense sentence reads as *not yet due* forever, so it fails silently the moment it passes. A `Verified` stamp on one is misleading **in both directions at once**: it certifies when the claim was checked, while the sentence describes a moment that has since arrived.
>
> `expired 2026-08-01; after that it is an untaken decision` is true **before and after**. `expires 2026-08-01` is only true before.

## Scope, so nobody over-corrects

Sweeping both repos found **2 instances in 107 markdown files**, both this same window. **Rare, not systemic** — which is why this is a convention and not a CI check.

The sweep over-matched on `until`, retrospective by construction (*"until 2026-07-26 this project tracked work in Linear"*), so six of eight raw hits were correct as written. Recorded as instrument behaviour rather than quietly filtered.

`check_md_links.py` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)