### PR TITLE
fix(deploy): wire the Grafana SSO check that was connected to nothing

### DIFF
--- a/.github/workflows/reusable-deploy-service.yml
+++ b/.github/workflows/reusable-deploy-service.yml
@@ -113,6 +113,38 @@ jobs:
             deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
             "cd /opt/hill90/app && bash scripts/deploy.sh verify ${{ inputs.service }}"
 
+      # PROVE SSO STILL WORKS, not just that the container is healthy.
+      #
+      # On 2026-08-03 an observability deploy started Grafana with an empty
+      # GRAFANA_OIDC_CLIENT_SECRET. The container was healthy, `deploy.sh verify`
+      # passed, the local admin login still worked — and every SSO login failed
+      # with `unauthorized_client` at token exchange. Nothing in this workflow
+      # could see it, and nothing did for the rest of the deploy.
+      #
+      # scripts/checks/grafana-role-login-test.sh was written that day to prove
+      # the opposite case and then wired to NOTHING. It sat in the tree
+      # referenced by no workflow, no test and no runbook — a guard that cannot
+      # fail because it never runs, which is the same defect as a check that
+      # reports success without looking. This is it being connected.
+      #
+      # testuser01 rather than a real person: it drives a full authorization-code
+      # flow and creates a genuine Keycloak login event, and the account exists
+      # for exactly this. Viewer is its correct role with no platform-editor
+      # grant, so a wrong answer here means the mapping or the exchange broke,
+      # not that someone's permissions changed.
+      #
+      # ON THE CONDITION, because this file now contains both shapes: `success()`
+      # is CORRECT for a verification. A cleanup must run when the run fails —
+      # that was #663 — but verifying a deploy that did not happen proves nothing
+      # and would fail for the wrong reason. Cleanup needs always(); verification
+      # needs success().
+      - name: Prove Grafana SSO still yields the expected role
+        if: success() && inputs.service == 'observability'
+        run: |
+          ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
+            deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
+            'cd /opt/hill90/app && export SOPS_AGE_KEY_FILE=/opt/hill90/secrets/keys/keys.txt && bash scripts/checks/grafana-role-login-test.sh testuser01 Viewer'
+
       - name: Signal post-deploy hooks
         if: success() && inputs.service == 'auth'
         uses: peter-evans/repository-dispatch@v3

--- a/scripts/checks/check_silent_success.py
+++ b/scripts/checks/check_silent_success.py
@@ -61,6 +61,13 @@ ALLOWLIST_A = {
 # --- shape B ---------------------------------------------------------------
 # Steps whose name reads like cleanup/assertion but whose skip-on-failure is correct.
 ALLOWLIST_B = {
+    ("reusable-deploy-service.yml", "Prove Grafana SSO still yields the expected role"): (
+        "a VERIFICATION, not a cleanup. success() is correct here: verifying a "
+        "deploy that did not happen proves nothing and would fail for the wrong "
+        "reason. The rule this check enforces is about CLEANUP — a revoke, a "
+        "restore, an assertion about disposal — which must survive a failed run. "
+        "Matched on the word 'Prove'."
+    ),
     ("vault-regain-root.yml", "Refuse without the typed confirmation"): (
         "the FIRST step of the job — nothing can have failed before it, so the "
         "implicit success() is unreachable. Matched on the word 'Refuse'."


### PR DESCRIPTION
**The third instance of the shape**, found by auditing our own guards: *a check that cannot fail because nothing runs it.* Functionally identical to a confident wrong sentence — both assert something nobody verified.

`scripts/checks/grafana-role-login-test.sh` was written on 2026-08-03 in #667, run by hand twice, and referenced by **no workflow, no test, no Makefile target and no runbook**. Confirmed both directions: the only occurrences of its name in the repository are inside the file itself.

## Why it matters — not hypothetical

Hours earlier the same day, an observability deploy started Grafana with an empty `GRAFANA_OIDC_CLIENT_SECRET`. The container was **healthy**, `deploy.sh verify` **passed**, the local admin login still **worked** — and every SSO login failed with `unauthorized_client` at token exchange. Nothing in the deploy could see it.

**The check that would have caught it already existed by then, and was attached to nothing.**

It now runs after every observability deploy. `testuser01` rather than a real person: it drives a full authorization-code flow and creates a genuine Keycloak login event, the account exists for exactly that, and `Viewer` is its correct role with no `platform-editor` grant — so a wrong answer means the mapping or the exchange broke, not that someone's permissions changed.

## On the condition — both shapes now live in this file

`success()` is **correct for a verification**: verifying a deploy that did not happen proves nothing and would fail for the wrong reason. A **cleanup** is the opposite — it must survive a failed run, which is #663.

> Cleanup needs `always()`; verification needs `success()`.

`check_silent_success.py` flagged the new step, correctly, because *"Prove"* reads as an assertion. Recorded in `ALLOWLIST_B` with that reasoning rather than silenced — **an entry is a decision, silence is a failure.** First real use of that escape hatch, working as designed.

## What the audit found, in full

```
30 checks examined
 1 orphan       grafana-role-login-test.sh — fixed here
 3 manual-only  minio-policy-names, vault-approle-paths, vault-oidc-login —
                all three need the live estate and cannot run on a runner.
                Expected; left alone, but named so it is a known fact.
26 wired        into CI, a workflow, a bats control or the Makefile
 0 unable to fail — every check has a reachable non-zero exit
```

## Two instrument errors of mine inside this audit

- A **keyword grep** classified `check_alert_series.py`, `realm-tenant-serves-test.sh` and `tenant-db-isolation-test.sh` as lacking a non-empty guard. All three have one. **Three false positives.**
- A **case-sensitive grep** for failure paths reported `platform-baseline-test.sh`, `check_destructive_commands.sh` and `vault-approle-paths-test.sh` as unable to fail. All three use `FAIL=1` / `exit "$FAIL"` — uppercase. **Three more.**

The baseline one is sharp: I have quoted *"BASELINE INTACT"* all day, and for a few minutes my own audit claimed that check could not fail. Reading it took thirty seconds; the grep was wrong, not the check.

Test counts from CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)