### PR TITLE
docs: the remaining shelved claims — and two that had become instructions to do the wrong thing

### DIFF
--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -6,8 +6,12 @@
 
 Hill90 is homelab infrastructure on a single Hostinger VPS running AlmaLinux 10.
 It is not an application host — the AI agent application that once ran here was
-shelved in June 2026 and removed in July 2026. See
-[Infra/app separation](../decisions/infra-app-separation.md).
+removed in July 2026. It was **not** left shelved: since 2026-07-29 it runs on this
+VPS as a **tenant** of the platform, serving `hill90.com` from
+[hill90-app](https://github.com/jonhill90/hill90-app). See
+[Infra/app separation](../decisions/infra-app-separation.md) for the superseded
+decision and [App tenancy on the VPS](../decisions/app-tenancy-on-the-vps.md) for
+the contract that replaced it.
 
 ### Components
 

--- a/docs/architecture/secrets-model.md
+++ b/docs/architecture/secrets-model.md
@@ -91,13 +91,21 @@ At deploy time, `deploy.sh` injects the AppRole credentials as environment varia
 
 ## Admin Access — Token Only
 
-Vault UI and CLI access is **token-based**. There is no SSO.
+Vault UI and CLI access is by **OIDC single sign-on or token**. `Verified 2026-08-03`
+by a completed authorization-code login: `jon` authenticates through Keycloak realm
+`platform` and receives `policy-oidc-admin`. Reproduce with
+`bash scripts/checks/vault-oidc-login-test.sh`.
 
-OIDC single sign-on through Keycloak was removed when the Keycloak stack was
-retired alongside the shelved application; the `hill90-vault` client was its only
-remaining consumer, and carrying a full identity provider for one operator was
-not worth the surface. This was a deliberate trade, not an oversight — do not
-re-add `vault.sh setup-oidc` without first re-introducing an identity provider.
+**This section said the opposite and must not be followed.** It read "There is no
+SSO", explained that OIDC "was removed when the Keycloak stack was retired
+alongside the shelved application", and instructed the reader: *"do not re-add
+`vault.sh setup-oidc` without first re-introducing an identity provider."* That was
+true in June 2026. Keycloak returned as a **platform** service in July, the
+identity provider that instruction asked for exists, and `setup-oidc` has since
+been run — so the instruction now forbids work that is already done and working.
+
+Token access remains, and is the break-glass path when OIDC or Keycloak is
+unavailable.
 
 To obtain a token:
 

--- a/docs/runbooks/observability.md
+++ b/docs/runbooks/observability.md
@@ -40,8 +40,15 @@ All signals ──→ Grafana (query + visualize)
 | Portainer | — | Promtail | — |
 | OpenBao | — | Promtail | — |
 
-Tempo is deployed and receiving-capable, but nothing currently emits traces —
-tracing was used by the shelved application. It is retained for future use.
+Tempo is deployed and **receiving traces**. `Verified 2026-08-03`: 108 tag names
+are present and `service.name` carries `ai`, `api`, `keycloak`, `knowledge` and
+`mcp` — the tenant application's four services plus Keycloak.
+
+This paragraph said "nothing currently emits traces — tracing was used by the
+shelved application. It is retained for future use." Both halves are false: the
+application is not shelved, it runs as a tenant, and it emits. Check with
+`docker exec tempo wget -qO- http://localhost:3200/api/search/tag/service.name/values`
+rather than assuming either way.
 
 ## Deployment
 

--- a/docs/runbooks/tenant-app-deployment.md
+++ b/docs/runbooks/tenant-app-deployment.md
@@ -171,9 +171,15 @@ No such file or directory
 ```
 
 No deploy script, no secrets store, no age key, no vault AppRole, no CI deploy
-workflow. `RESURRECTION.md` §2 states this plainly and has been right the whole
+workflow. The extraction record states this plainly and has been right the whole
 time: "The deploy tooling — `scripts/deploy.sh`, the `Makefile` targets, and the
 per-service GitHub Actions deploy workflows all stayed in Hill90."
+
+*(Quoted from `RESURRECTION.md` §2, which was removed from hill90-app on
+2026-07-31 with its durable sections relocated to
+[`docs/extraction/PROVENANCE.md`](https://github.com/jonhill90/hill90-app/blob/main/docs/extraction/PROVENANCE.md).
+The quotation is preserved here because it is still accurate; the file it came
+from is not somewhere a reader can now follow.)*
 
 And there is no checkout on the host. `/opt/hill90/app` is a **Hill90** clone
 despite the name:
@@ -395,8 +401,10 @@ rather than pre-empting.
   be deployed and reached.
 - **Data migration.** The app's databases would be provisioned empty. Whether
   anything needs restoring into them is not addressed.
-- **`services/cli` and `services/discord-bot`**, which per `RESURRECTION.md` §6
-  have never been part of any automated deploy.
+- **`services/cli` and `services/discord-bot`**, which have never been part of any
+  automated deploy — recorded in hill90-app's
+  [`docs/extraction/PROVENANCE.md`](https://github.com/jonhill90/hill90-app/blob/main/docs/extraction/PROVENANCE.md)
+  (formerly `RESURRECTION.md` §6, removed 2026-07-31).
 - **Rollback.** Hill90's `rollback.sh` knows its own stacks only, with the same
   closed allowlist as `deploy.sh`. A tenant rollback path is part of the tooling
   that needs building, and is not designed here.


### PR DESCRIPTION
**Eleven Hill90 files carry the word, not twelve.** Read each. **Four changed, seven kept.** Two of the four were worse than stale framing.

## Changed — four

**`docs/architecture/secrets-model.md` — the sharpest.** It said *"Vault UI and CLI access is token-based. There is no SSO"*, explained OIDC was removed *"alongside the shelved application"*, and instructed:

> *"do not re-add `vault.sh setup-oidc` without first re-introducing an identity provider."*

`Verified 2026-08-03` by a completed authorization-code login: `jon` authenticates through Keycloak realm `platform` and receives `policy-oidc-admin`. Keycloak returned as a **platform** service in July, the identity provider that instruction demanded **exists**, and `setup-oidc` has been run.

**The instruction now forbids work that is already done and working** — a document that does not merely misinform but misdirects.

**`docs/runbooks/observability.md`** — said *"nothing currently emits traces — tracing was used by the shelved application."* Tempo is receiving: **108 tag names**, `service.name` carries `ai`, `api`, `keycloak`, `knowledge`, `mcp`. Both halves false. Added the one-line command to check rather than assume in either direction.

**`docs/architecture/overview.md`** — the #683 sentence, in the architecture entry point.

**`docs/runbooks/tenant-app-deployment.md`** — cited `RESURRECTION.md` §2 and §6. That file was removed on 2026-07-31. A live runbook pointing at a file a reader cannot open; repointed at `PROVENANCE.md` and **kept the quotation**, which is still accurate. The quote was never the problem — the dead citation was.

## Kept — seven

- **`PRD.md`, `README.md`, `CONTRIBUTING.md`, `platform-primitives.md`** — their only hits **are** the #683 corrections: *"it was not shelved, and has run as a tenant"*. Deleting these would delete the correction and restore the error.
- **`SPEC.md`** — two hits, kept **against the steer**, with evidence. It opens: *"Historical: this specifies the 2026-07-26 app/infra strip as planned, not the estate as it stands"*, pointing at what replaced it. Its usages sit inside a spec the reader has already been told is historical. Removing the word from a record of what was *specified* would make it a worse record without making anyone better informed.
- **`infra-app-separation.md`** — the stub headed *"SUPERSEDED by events"*.
- **`2026-07-31-handoff.md`** — the rule itself.

## The count

The grep said twelve files; there are **eleven**. Of those, **four are the corrections** and **three are historical records** — so **six of eleven hits would have been wrong to remove.** Which is why each was read rather than counted.

Markdown links pass. Documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)