### PR TITLE
fix(deploy): wire the MinIO policy-name check — orphan batch 1 of 4

### DIFF
--- a/.github/workflows/reusable-deploy-service.yml
+++ b/.github/workflows/reusable-deploy-service.yml
@@ -138,6 +138,33 @@ jobs:
       # that was #663 — but verifying a deploy that did not happen proves nothing
       # and would fail for the wrong reason. Cleanup needs always(); verification
       # needs success().
+      # PROVE NO MINIO POLICY IS NAMED AFTER AN AUTOMATIC REALM ROLE.
+      #
+      # MinIO grants the UNION of every claim value that names a policy. Three
+      # values ride in EVERY token in realm `platform` — offline_access,
+      # uma_authorization and default-roles-platform — because Keycloak grants
+      # them to every account. So a MinIO policy named after any of those is
+      # granted to everyone who can log in, with nobody having asked for it.
+      #
+      # Demonstrated rather than theorised in #655: policies called
+      # uma_authorization and offline_access gave `jon` list and write purely for
+      # being a realm member.
+      #
+      # minio.sh apply prints "Verify with: …minio-policy-names-test.sh" after it
+      # runs. That is a sentence, not a call — the check was invoked by nothing
+      # (#689) and had been since it was written. This is it being connected, the
+      # same way #688 connected the Grafana SSO check.
+      #
+      # `success()` for the same reason as that one: this VERIFIES a deploy, and
+      # verifying a deploy that did not happen proves nothing. Cleanup needs
+      # always(); verification needs success().
+      - name: Prove no MinIO policy collides with an automatic realm role
+        if: success() && inputs.service == 'minio'
+        run: |
+          ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
+            deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
+            'cd /opt/hill90/app && export SOPS_AGE_KEY_FILE=/opt/hill90/secrets/keys/keys.txt && bash scripts/checks/minio-policy-names-test.sh'
+
       - name: Prove Grafana SSO still yields the expected role
         if: success() && inputs.service == 'observability'
         run: |

--- a/scripts/checks/check_silent_success.py
+++ b/scripts/checks/check_silent_success.py
@@ -61,6 +61,11 @@ ALLOWLIST_A = {
 # --- shape B ---------------------------------------------------------------
 # Steps whose name reads like cleanup/assertion but whose skip-on-failure is correct.
 ALLOWLIST_B = {
+    ("reusable-deploy-service.yml", "Prove no MinIO policy collides with an automatic realm role"): (
+        "a VERIFICATION, not a cleanup — same reasoning as the Grafana entry "
+        "below. success() is correct: verifying a deploy that did not happen "
+        "proves nothing. Matched on the word 'Prove'."
+    ),
     ("reusable-deploy-service.yml", "Prove Grafana SSO still yields the expected role"): (
         "a VERIFICATION, not a cleanup. success() is correct here: verifying a "
         "deploy that did not happen proves nothing and would fail for the wrong "


### PR DESCRIPTION
First batch from #689. Wired **exactly as #688 wired the Grafana SSO check**, so the pattern is one thing rather than two and the next orphan has an obvious shape.

## What it guards — a live over-grant, not a hypothetical

MinIO grants the **union** of every claim value that names a policy. Three values ride in **every** token in realm `platform` — `offline_access`, `uma_authorization`, `default-roles-platform` — because Keycloak grants them to every account. So a MinIO policy named after any of those is granted to everyone who can log in, with nobody having asked for it.

Demonstrated rather than argued in #655: policies called `uma_authorization` and `offline_access` gave `jon` list **and write** purely for being a realm member.

## Why it was an orphan

`minio.sh apply` prints *"Verify with: …minio-policy-names-test.sh"* when it finishes. **That is a sentence, not a call.** The check was invoked by nothing and had been since it was written — prose standing in for automation, the same defect as a check that cannot fail.

## Passes on the current state first

A guard that fails on a correct estate is worse than none.

```
MinIO policies: consoleAdmin diagnostics platform-admin platform-viewer
                readonly readwrite tenant-hill90-app writeonly
✓ no policy named offline_access / uma_authorization / default-roles-platform
NO UNIVERSAL-ROLE COLLISIONS.                                       exit=0
```

The legacy `admin`/`editor`/`viewer` warnings this check used to emit are gone — #670 deleted those policies along with the realm roles they were named after.

## Positive control, on the real MinIO

Planted a policy named `offline_access`; the check refused:

```
✗ COLLISION: policy 'offline_access' is granted to every account in realm platform
COLLISION — a policy is named after a role every user holds.        exit=1
```

**The planted body was an explicit `Deny` of `s3:*` on all resources**, so the collision was real by *name* — which is what this check tests — while granting nothing during the seconds it existed. A control that creates the very over-grant it is demonstrating is not one to run on production.

Removed afterwards and re-verified: `exit=0`, eight policies, `minio` healthy, `storage.hill90.com` 200.

## Condition

`check_silent_success.py` flagged the step because *"Prove"* reads as an assertion. Recorded in `ALLOWLIST_B` with the reason, beside the Grafana entry: **cleanup needs `always()`; verification needs `success()`.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)