### PR TITLE
fix(deploy): wire the alert-series check — orphan batch 2 of 4

### DIFF
--- a/.github/workflows/reusable-deploy-service.yml
+++ b/.github/workflows/reusable-deploy-service.yml
@@ -165,6 +165,32 @@ jobs:
             deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
             'cd /opt/hill90/app && export SOPS_AGE_KEY_FILE=/opt/hill90/secrets/keys/keys.txt && bash scripts/checks/minio-policy-names-test.sh'
 
+      # PROVE EVERY ALERT RULE CAN ACTUALLY MATCH A SERIES.
+      #
+      # A rule can be health=ok and still never fire, if its selector names a
+      # label or metric production does not emit. Two shipped that way. promtool
+      # cannot catch it because the test author supplies the labels — only the
+      # live Prometheus can, which is why this runs here and not in CI.
+      #
+      # ci.yml:66 ECHOES "python3 scripts/checks/check_alert_series.py (run on
+      # the VPS)" as a reminder. It therefore appears in every CI log while never
+      # executing — the check CONTRIBUTING credits with "independently
+      # rediscovering the two rules already known to be unfireable" ran only when
+      # somebody remembered (#689). This connects it.
+      #
+      # The check fails closed on its own: if Prometheus is unreachable it prints
+      # "A check that cannot run must not report success" and exits 1, so a
+      # network problem cannot be mistaken for a clean result.
+      #
+      # success(), as with the two verifications below it: verifying a deploy
+      # that did not happen proves nothing. Cleanup needs always().
+      - name: Prove every alert rule matches a live series
+        if: success() && inputs.service == 'observability'
+        run: |
+          ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
+            deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
+            'cd /opt/hill90/app && python3 scripts/checks/check_alert_series.py'
+
       - name: Prove Grafana SSO still yields the expected role
         if: success() && inputs.service == 'observability'
         run: |

--- a/scripts/checks/check_silent_success.py
+++ b/scripts/checks/check_silent_success.py
@@ -61,6 +61,11 @@ ALLOWLIST_A = {
 # --- shape B ---------------------------------------------------------------
 # Steps whose name reads like cleanup/assertion but whose skip-on-failure is correct.
 ALLOWLIST_B = {
+    ("reusable-deploy-service.yml", "Prove every alert rule matches a live series"): (
+        "a VERIFICATION, not a cleanup — same reasoning as the two entries below. "
+        "success() is correct: verifying a deploy that did not happen proves "
+        "nothing. Matched on the word 'Prove'."
+    ),
     ("reusable-deploy-service.yml", "Prove no MinIO policy collides with an automatic realm role"): (
         "a VERIFICATION, not a cleanup — same reasoning as the Grafana entry "
         "below. success() is correct: verifying a deploy that did not happen "


### PR DESCRIPTION
Same shape as #692 and #688: wired at the point that matters, positive-controlled, confirmed passing against the current correct state **first**.

## Why this one matters

A rule can be `health=ok` and still **never fire**, if its selector names a metric or label production does not emit. **Two shipped that way.** `promtool test` cannot catch it, because the test author supplies the labels — only the live Prometheus can. That is why this runs post-deploy on the VPS and not in CI, and why it is the one check in this batch that could not have been made hermetic.

## Why it was an orphan — the sharpest of the four

`ci.yml:66` **echoes**:

```
python3 scripts/checks/check_alert_series.py   (run on the VPS)
```

So the check's own name appears in **every CI log while the check never runs**. It looked wired *from the log* and was not — the same prose-as-action defect that hid `minio-policy-names-test.sh` behind `minio.sh`'s "Verify with:" line.

`CONTRIBUTING.md` credits this check with *"independently rediscovering the two rules already known to be unfireable."* That credit was resting on a human remembering.

## Passes on current state first

```
22 selectors checked
every selector matches a live series, or is declared absent with a reason
exit=0
```

## Positive control, against the live Prometheus

Planted a rule selecting `hill90_metric_that_does_not_exist_control`:

```
1 SELECTOR(S) MATCH NOTHING:
  ControlOnlyUnfireable: hill90_metric_that_does_not_exist_control  (no series)
A rule matching no series never fires and looks exactly like health.
exit=1
```

Restored from a backup taken first; `git status --porcelain` on the VPS shows **0 dirty lines**; re-ran clean at 22 selectors, exit 0. The plant was in the **VPS checkout**, not the repository, so nothing could be committed by accident and a deploy would have reset it regardless.

## It already fails closed

Worth recording rather than assuming: if Prometheus is unreachable it prints *"A check that cannot run must not report success"* and exits 1. A network problem cannot be mistaken for a clean result — the property the rest of today's work has been adding, already present here.

## Remaining orphans: two, and neither is a wiring job

| Orphan | Why | Recommendation |
|---|---|---|
| `vault-approle-paths-test.sh` | superseded by `vault-approle-real-read-test.sh`, which **is** wired into `vault-regain-root.yml` | **delete with evidence** — today proved the two disagree: the capability check reported all four roles denied when two could read |
| `vault-oidc-login-test.sh` | referenced in docs only | **your call** — wiring it creates a real Keycloak login event for a real person on every relevant deploy |

🤖 Generated with [Claude Code](https://claude.com/claude-code)