### PR TITLE
fix(vault): wire the OIDC login check — orphan batch 4 of 4, WIRE not retire

### DIFF
--- a/.github/workflows/vault-regain-root.yml
+++ b/.github/workflows/vault-regain-root.yml
@@ -271,6 +271,35 @@ jobs:
             deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
             'cd /opt/hill90/app && bash scripts/checks/vault-oidc-enabled-test.sh'
 
+      # MOUNTED IS NOT WORKING — the same distinction that retired
+      # vault-approle-paths-test.sh in #694.
+      #
+      # The step above asks whether the OIDC auth method is MOUNTED. It answers
+      # without a token, which is exactly why it exists, and it is satisfied by a
+      # mount that authorises nobody. This drives the full authorization-code
+      # flow and asserts the POLICY the login yields, so it covers the chain the
+      # mount check cannot see: Keycloak mapper -> claim -> bound_claims ->
+      # policy. Four documents cite it as the proof that vault SSO works —
+      # secrets-model.md, security.md, and two decision records — and until now
+      # nothing ran it (#689).
+      #
+      # HERE rather than on every deploy, deliberately. A completed login writes
+      # a real LOGIN event for a real person into Keycloak's event log, and that
+      # log exists so "did jon sign in, and when" is answerable. Wiring it to
+      # routine deploys would fill that answer with synthetic entries. This
+      # workflow is dispatched by hand with a typed confirmation, is rare, and is
+      # the run after which OIDC is most likely to be broken — the config swap it
+      # performs is precisely what the step above was added to check.
+      #
+      # always(), matching the step above: a failed run is when you most need to
+      # know whether SSO survived.
+      - name: Prove the OIDC login actually yields policy-oidc-admin
+        if: ${{ always() && inputs.run_setup_oidc }}
+        run: |
+          ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
+            deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
+            'cd /opt/hill90/app && export SOPS_AGE_KEY_FILE=/opt/hill90/secrets/keys/keys.txt && bash scripts/checks/vault-oidc-login-test.sh'
+
       # ---- Independent re-proof ----------------------------------------------
 
       # AppRole is a DIFFERENT auth method. Nothing above tested it, and a vault


### PR DESCRIPTION
Last orphan from #689. The answer is **wire**, and the reasoning is the mirror of #694's retire.

## Why not retire

It asserts something nothing else does: the full chain from the Keycloak mapper through the claim, the `bound_claims`, and out to the vault policy.

Its wired sibling `vault-oidc-enabled-test.sh` asks only whether the OIDC auth method is **mounted** — answered without a token, which is why it exists, and **satisfied by a mount that authorises nobody**. That is the identical weak-instrument distinction that retired `vault-approle-paths-test.sh`: *mounted is not working*, exactly as *capability is not read*.

**Four documents cite it** as the proof that vault SSO works — `secrets-model.md`, `security.md`, and two decision records. Retiring would have created four dangling citations and removed the artefact they point at. Two of those I edited earlier today to say *"reproduce with this command"*.

## Where — the part I hesitated on

A completed login writes a real **LOGIN event for a real person** into Keycloak's event log, and that log exists so *"did jon sign in, and when"* is answerable. Wiring it to routine deploys would fill that answer with synthetic entries — a check that degrades the evidence it shares a system with.

`vault-regain-root.yml` resolves it: dispatched by hand with a typed confirmation, rare, and the run after which OIDC is most likely to be broken — the config swap it performs is exactly what the mount check beside it was added to detect. **One deliberate login per deliberate recovery is proportionate; one per deploy is not.**

Placed immediately after *"Confirm OIDC survived the config swap"*, carrying the same `always() && inputs.run_setup_oidc`, so the stronger check cannot be skipped in the runs where the weaker one still reports.

## Verified both ways on the live estate

```
jon (has platform-admin)
  ✓ policies: default,policy-oidc-admin
  LOGIN PROVEN — jon authenticated by OIDC and received policy-oidc-admin.   exit 0

hill90admin (no platform-admin) — POSITIVE CONTROL
  ✗ OpenBao did not issue a token.
    "error validating claims: claim \"realm_roles\" does not match any
     associated bound claim values"                                          exit 1
```

The control is the better half: it proves the bound claim is **genuinely enforced** rather than decorative, and does so without granting anybody anything.

`check_silent_success.py` and `check_root_revoke_fails_closed.py` both still PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)