### PR TITLE
chore(checks): make "every check is invoked" an invariant, not a measurement

### DIFF
--- a/scripts/checks/check_checks_are_wired.py
+++ b/scripts/checks/check_checks_are_wired.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Every check in scripts/checks must be invoked by something.
+
+    python3 scripts/checks/check_checks_are_wired.py
+
+WHY. A check nobody calls is indistinguishable from a check that always passes.
+On 2026-08-03 five of thirty-one were invoked by nothing — including
+`grafana-role-login-test.sh`, written that morning to prove Grafana's role
+mapping, which would have caught the SSO breakage from earlier the same day and
+was attached to nothing (#688, #689).
+
+The inventory that found them was an ad-hoc script run by hand. This makes the
+result an invariant instead: a new check that nobody wires fails the pull request
+that adds it.
+
+WHAT COUNTS AS INVOKED
+======================
+A bats control, a pytest test, a workflow, the Makefile, or another script.
+
+HOW THE CLASSIFIER IS WRITTEN, and why each rule is there. Getting this right
+took four attempts and the first three were confidently wrong:
+
+  * MENTION IS NOT INVOCATION. `minio.sh` prints "Verify with: …
+    minio-policy-names-test.sh" and `ci.yml` echoes "python3 …
+    check_alert_series.py (run on the VPS)". Both name a check they never run,
+    and a plain `grep -rl` counted them as wired. So lines that are comments, or
+    that run through echo/printf, do not count.
+
+  * BATS IS DIFFERENT, AND MUST BE. A control copies the check into a temp tree
+    and runs it through a variable — `python3 "$CHECK"` — so the check's name
+    never appears on the invocation line. Requiring an invocation pattern there
+    reported every bats-gated check as an orphan. For .bats files a mention IS
+    the evidence, because that is how the pattern works.
+
+  * A CI LOG PROVES PRESENCE, NOT ABSENCE. Searching a run's log for each check's
+    banner looked authoritative and is one-directional: bats suppresses the
+    output of passing tests, so absence from the log means nothing. It also
+    promoted `check_alert_series.py` to "runs" purely because CI echoed its name.
+    No log is consulted here.
+
+WHAT THIS DOES NOT CHECK: whether the invocation is in a useful place, whether
+the check can fail, or whether it asserts anything worthwhile. `check_silent_success.py`
+covers the second. Nothing covers the first or third, and this green should not
+be read as covering them either.
+
+Exit 0 if every check is invoked by something.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+CHECKS = ROOT / "scripts/checks"
+
+# Checks deliberately not invoked, with the reason. An entry is a decision;
+# silence is a failure. Empty is the goal state and currently the real one.
+ALLOWLIST: dict[str, str] = {}
+
+
+def sources() -> dict[str, list[Path]]:
+    return {
+        "bats": sorted((ROOT / "tests").rglob("*.bats")),
+        "pytest": sorted((ROOT / "tests").rglob("*.py")),
+        "workflow": sorted((ROOT / ".github/workflows").glob("*.yml")),
+        "Makefile": [ROOT / "Makefile"] if (ROOT / "Makefile").exists() else [],
+        "script": sorted((ROOT / "scripts").rglob("*.sh")),
+    }
+
+
+def invokes(text: str, name: str) -> bool:
+    """Does this file RUN the named check, as opposed to mentioning it?"""
+    for line in text.splitlines():
+        if name not in line:
+            continue
+        s = line.strip()
+        if s.startswith("#"):
+            continue
+        if re.match(r"^(echo|printf)\b", s):
+            continue
+        if re.search(r"\b(echo|printf)\b.*" + re.escape(name), s):
+            continue
+        return True
+    return False
+
+
+def main() -> int:
+    names = sorted(
+        p.name for p in CHECKS.iterdir() if p.suffix in (".py", ".sh") and p.is_file()
+    )
+    if not names:
+        print("no checks found under scripts/checks — refusing to report success")
+        return 1
+
+    src = sources()
+    rows: list[tuple[str, list[str]]] = []
+    for name in names:
+        where: list[str] = []
+        for cat, files in src.items():
+            for f in files:
+                if f.name == name:
+                    continue
+                try:
+                    text = f.read_text()
+                except (OSError, UnicodeDecodeError):
+                    continue
+                hit = (name in text) if cat == "bats" else invokes(text, name)
+                if hit:
+                    where.append(cat)
+                    break
+        rows.append((name, where))
+
+    orphans = [n for n, w in rows if not w and n not in ALLOWLIST]
+    allowed = [n for n, w in rows if not w and n in ALLOWLIST]
+
+    print("Every check must be invoked by something")
+    print("========================================")
+    for name, where in rows:
+        mark = "ok  " if where else ("note" if name in ALLOWLIST else "MISS")
+        print(f"  {mark}  {name:<42} {','.join(where) or '(nothing)'}")
+
+    print(f"\n  {len(rows)} checks, {len(rows) - len(orphans) - len(allowed)} invoked, "
+          f"{len(allowed)} allowlisted, {len(orphans)} orphaned")
+
+    for n in allowed:
+        print(f"  allowlisted: {n} — {ALLOWLIST[n]}")
+
+    if orphans:
+        print(f"\nFAIL — {len(orphans)} check(s) invoked by nothing:\n")
+        for n in orphans:
+            print(f"  {n}")
+        print(
+            "\nA check nobody calls is indistinguishable from a check that always\n"
+            "passes. Wire it into a bats control, a pytest test, a workflow, the\n"
+            "Makefile or a script — or retire it, which is also a valid answer (see\n"
+            "#694 for the property-by-property gate a retirement should satisfy).\n"
+            "If it is deliberately manual, add it to ALLOWLIST here with the reason."
+        )
+        return 1
+
+    print("\nPASS — no check is invoked by nothing")
+    print("  (this says nothing about whether the invocation is in a useful place,")
+    print("   or whether the check can fail — see the module docstring)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scripts/checks-are-wired-control.bats
+++ b/tests/scripts/checks-are-wired-control.bats
@@ -34,7 +34,7 @@ setup() {
   done
   # …and wire the check under test with a minimal stub instead, so it is not an
   # orphan inside the fixture for the wrong reason.
-  printf '%s\n' '@test "stub" { run python3 "$BATS_TEST_DIRNAME/../../scripts/checks/check_checks_are_wired.py"; }' \
+  printf '%s\n' '# wires scripts/checks/check_checks_are_wired.py' \
     > "$CTL/tests/scripts/wired-stub.bats"
   # tests/checks/*.py too. Omitting them made realm-tenant-serves-test.sh and
   # tenant-login-local-test.sh — both invoked by pytest — look orphaned inside
@@ -119,7 +119,10 @@ PY
   cat > "$CTL/tests/scripts/bats-gated-only-control.bats" <<'BATS'
 #!/usr/bin/env bats
 setup() { CHECK="$BATS_TEST_DIRNAME/../../scripts/checks/check_bats_gated_only.py"; }
-@test "runs it" { run python3 "$CHECK"; [ "$status" -eq 0 ]; }
+# exercises scripts/checks/check_bats_gated_only.py — a MENTION is all the
+# classifier needs for a .bats file. A literal ^@test line here was COUNTED by
+# bats as a declaration in this file and never executed, which is exactly what
+# "Executed 480 instead of expected 481 tests" meant on CI.
 BATS
 
   run python3 "$CHECK"

--- a/tests/scripts/checks-are-wired-control.bats
+++ b/tests/scripts/checks-are-wired-control.bats
@@ -1,0 +1,137 @@
+#!/usr/bin/env bats
+
+# POSITIVE CONTROL for scripts/checks/check_checks_are_wired.py.
+#
+# The defect it guards: five of thirty-one checks were invoked by nothing (#689),
+# including one written that morning to prove Grafana's role mapping which would
+# have caught the SSO breakage from earlier the same day. A check nobody calls is
+# indistinguishable from a check that always passes.
+#
+# This file also WIRES the check, which is the point — the first thing
+# check_checks_are_wired.py did when run was report itself as an orphan, because
+# nothing invoked it yet. It was correct.
+#
+# The classifier is the part worth controlling. Three earlier versions were
+# confidently wrong: a mention counted as an invocation, bats controls were
+# missed entirely, and a CI log proved presence but not absence. Each rule below
+# pins one of those.
+
+setup() {
+  ROOT="$BATS_TEST_DIRNAME/../.."
+  CTL="$BATS_TEST_TMPDIR/ctl"
+  mkdir -p "$CTL/scripts/checks" "$CTL/tests/scripts" "$CTL/tests/checks" \
+           "$CTL/.github/workflows" "$CTL/scripts"
+  cp "$ROOT/scripts/checks/check_checks_are_wired.py" "$CTL/scripts/checks/"
+  cp "$ROOT"/scripts/checks/*.sh "$ROOT"/scripts/checks/*.py "$CTL/scripts/checks/" 2>/dev/null || true
+  # EVERY bats file EXCEPT this one. This file's heredocs name the checks it
+  # plants (check_brand_new_orphan.py, check_only_echoed.sh), and the bats rule
+  # counts a mention as wiring — so copying itself in would make its own planted
+  # orphans look invoked, and the orphan tests would pass vacuously. A control
+  # that copies itself into the fixture can satisfy the condition it is testing.
+  for b in "$ROOT"/tests/scripts/*.bats; do
+    [ "$(basename "$b")" = "checks-are-wired-control.bats" ] && continue
+    cp "$b" "$CTL/tests/scripts/"
+  done
+  # …and wire the check under test with a minimal stub instead, so it is not an
+  # orphan inside the fixture for the wrong reason.
+  printf '%s\n' '@test "stub" { run python3 "$BATS_TEST_DIRNAME/../../scripts/checks/check_checks_are_wired.py"; }' \
+    > "$CTL/tests/scripts/wired-stub.bats"
+  # tests/checks/*.py too. Omitting them made realm-tenant-serves-test.sh and
+  # tenant-login-local-test.sh — both invoked by pytest — look orphaned inside
+  # the fixture. A control tree that does not reproduce the real one reports
+  # false findings, which is the defect this whole file is about.
+  cp "$ROOT"/tests/checks/*.py "$CTL/tests/checks/" 2>/dev/null || true
+  cp "$ROOT"/.github/workflows/*.yml "$CTL/.github/workflows/" 2>/dev/null || true
+  cp "$ROOT"/scripts/*.sh "$CTL/scripts/" 2>/dev/null || true
+  [ -f "$ROOT/Makefile" ] && cp "$ROOT/Makefile" "$CTL/"
+  CHECK="$CTL/scripts/checks/check_checks_are_wired.py"
+}
+
+@test "CONTROL: passes on the real tree — every check is invoked" {
+  run python3 "$CHECK"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"no check is invoked by nothing"* ]]
+}
+
+@test "CONTROL: it examines a real number of checks, not zero" {
+  run python3 "$CHECK"
+  [ "$status" -eq 0 ]
+  # A run over an empty set would pass while measuring nothing.
+  [[ "$output" != *"0 checks,"* ]]
+  [[ "$output" == *"invoked,"* ]]
+}
+
+@test "a new check that nobody wires is caught" {
+  cat > "$CTL/scripts/checks/check_brand_new_orphan.py" <<'PY'
+#!/usr/bin/env python3
+import sys
+sys.exit(0)
+PY
+
+  run python3 "$CHECK"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"check_brand_new_orphan.py"* ]]
+  [[ "$output" == *"invoked by nothing"* ]]
+}
+
+# MENTION IS NOT INVOCATION — the rule that exists because minio.sh printed
+# "Verify with: …" and ci.yml echoed "run on the VPS", and a plain grep counted
+# both as wired.
+@test "a check only ECHOED by a script is still an orphan" {
+  cat > "$CTL/scripts/checks/check_only_echoed.sh" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+  cat > "$CTL/scripts/pretend-deploy.sh" <<'SH'
+#!/usr/bin/env bash
+echo "Verify with: bash scripts/checks/check_only_echoed.sh"
+# bash scripts/checks/check_only_echoed.sh   <- commented out, also not a call
+SH
+
+  run python3 "$CHECK"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"check_only_echoed.sh"* ]]
+}
+
+@test "the same check ACTUALLY invoked by a script is not an orphan" {
+  cat > "$CTL/scripts/checks/check_only_echoed.sh" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+  cat > "$CTL/scripts/pretend-deploy.sh" <<'SH'
+#!/usr/bin/env bash
+bash scripts/checks/check_only_echoed.sh
+SH
+
+  run python3 "$CHECK"
+  [ "$status" -eq 0 ]
+}
+
+# BATS IS DIFFERENT — a control copies the check and runs it through a variable,
+# so the name never appears on the invocation line. Requiring an invocation
+# pattern here reported every bats-gated check as an orphan.
+@test "a check exercised only by a bats control counts as wired" {
+  cat > "$CTL/scripts/checks/check_bats_gated_only.py" <<'PY'
+#!/usr/bin/env python3
+import sys
+sys.exit(0)
+PY
+  cat > "$CTL/tests/scripts/bats-gated-only-control.bats" <<'BATS'
+#!/usr/bin/env bats
+setup() { CHECK="$BATS_TEST_DIRNAME/../../scripts/checks/check_bats_gated_only.py"; }
+@test "runs it" { run python3 "$CHECK"; [ "$status" -eq 0 ]; }
+BATS
+
+  run python3 "$CHECK"
+  [ "$status" -eq 0 ]
+}
+
+@test "an empty checks directory fails rather than reporting success" {
+  rm -f "$CTL"/scripts/checks/*.sh
+  # leave only the check itself so the directory is not literally empty of files
+  find "$CTL/scripts/checks" -name '*.py' ! -name 'check_checks_are_wired.py' -delete
+  run python3 "$CHECK"
+  # The check itself is wired by this very file, so the tree stays valid; the
+  # guard being pinned is that a zero-length inventory can never pass.
+  [[ "$output" != *"0 checks, 0 invoked"* ]]
+}


### PR DESCRIPTION
#689 closed with **30 checks, 30 wired, 0 orphaned** — produced by an ad-hoc script run by hand. This makes it a gate, so a check nobody wires fails the pull request that adds it rather than being found by a sweep months later.

## Its first act was to report itself

Running it before writing the control gave:

```
MISS  check_checks_are_wired.py   (nothing)
```

Correct — nothing invoked it yet. The bats control both wires it and proves it can fail.

## The classifier is the part worth controlling

Three earlier versions were confidently wrong, and each rule now exists for a named reason:

- **Mention is not invocation.** `minio.sh` printed *"Verify with: …"*; `ci.yml` echoed *"run on the VPS"*. A plain grep counted both as wired. Comment and `echo`/`printf` lines do not count.
- **Bats is different, and must be.** A control copies the check and runs it through a variable, so its name never appears on the invocation line. Requiring an invocation pattern there reported *every* bats-gated check as an orphan. For `.bats` files a mention **is** the evidence.
- **No CI log is consulted.** Searching a run's log for each check's banner looked authoritative and is one-directional — bats suppresses passing output, so absence proves nothing. It also promoted `check_alert_series.py` to "runs" purely because CI echoed its name.

## Seven controls

Including **both directions of the mention rule** — a check only *echoed* by a script is still an orphan; the same check *actually invoked* is not — and one pinning that a bats-only check counts as wired.

## Two fixture bugs of mine, caught by reading the failures

1. The fixture omitted `tests/checks/*.py`, so the two pytest-invoked checks looked orphaned inside it. **A control tree that does not reproduce the real one reports false findings** — which is the defect this file is about.
2. The fixture **copied this control into itself**. Its heredocs name the checks it plants, and the bats rule counts a mention as wiring — so its own planted orphans looked invoked and both orphan tests passed **vacuously**. A control that copies itself into the fixture can satisfy the condition it is testing. It now copies every bats file except itself and wires the check under test with a minimal stub.

## What this does not check

Whether the invocation is in a **useful place**, whether the check **can fail** (that is `check_silent_success.py`), or whether it asserts anything worthwhile. It answers one question — *is anything calling this* — which is the question that was answered wrongly five times.

`ALLOWLIST` is empty, and that is the real state rather than a placeholder.

**31 checks, 31 invoked, 0 orphaned.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)