### PR TITLE
docs: describe what Hill90 is, not where the application went — #696, Hill90 half

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,12 +4,10 @@ Hill90 is homelab infrastructure for a single Hostinger VPS: Ansible
 provisioning, Traefik edge routing, an observability stack, SOPS/OpenBao
 secrets, and Tailscale-secured SSH.
 
-> **Scope:** Hill90 is not an application host. The AI agent application that
-> once lived here was removed in July 2026 — not shelved: it runs in production
-> as a **tenant** of this platform, from
-> [`hill90-app`](https://github.com/jonhill90/hill90-app). See
-> [Infra/app separation](docs/decisions/infra-app-separation.md); the code is
-> preserved at the `archive/app-stack-final` tag.
+> **Scope:** Hill90 is not an application host. It provides identity, data and
+> storage; the [`hill90-app`](https://github.com/jonhill90/hill90-app) AI
+> application consumes them as a **tenant**. The contract is
+> [App tenancy on the VPS](docs/decisions/app-tenancy-on-the-vps.md).
 
 ## Issue Tracking
 

--- a/README.md
+++ b/README.md
@@ -5,11 +5,10 @@ observability, and secrets — automated end to end.
 
 Hill90 is not an application host. It is the automation that takes a bare VPS to
 a running, TLS-terminated, observable, Tailscale-secured Docker host, and keeps
-it there. An AI agent application previously lived here and was removed in July
-2026. It was not shelved: it runs in production as a **tenant** of this platform,
-from [`hill90-app`](https://github.com/jonhill90/hill90-app). See
-[Infra/app separation](docs/decisions/infra-app-separation.md) for the record,
-and the `archive/app-stack-final` tag for the code.
+it there. The [`hill90-app`](https://github.com/jonhill90/hill90-app) AI
+application runs on it as a **tenant**, consuming this platform's identity,
+database and object storage. What the platform offers a tenant, and what it does
+not, is in [App tenancy on the VPS](docs/decisions/app-tenancy-on-the-vps.md).
 
 ## What runs
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -5,13 +5,10 @@
 ## System Architecture
 
 Hill90 is homelab infrastructure on a single Hostinger VPS running AlmaLinux 10.
-It is not an application host — the AI agent application that once ran here was
-removed in July 2026. It was **not** left shelved: since 2026-07-29 it runs on this
-VPS as a **tenant** of the platform, serving `hill90.com` from
-[hill90-app](https://github.com/jonhill90/hill90-app). See
-[Infra/app separation](../decisions/infra-app-separation.md) for the superseded
-decision and [App tenancy on the VPS](../decisions/app-tenancy-on-the-vps.md) for
-the contract that replaced it.
+It is not an application host: it provides identity, data and storage, and the
+[hill90-app](https://github.com/jonhill90/hill90-app) AI application consumes them
+as a **tenant**, serving `hill90.com`. The contract is
+[App tenancy on the VPS](../decisions/app-tenancy-on-the-vps.md).
 
 ### Components
 

--- a/docs/decisions/platform-primitives.md
+++ b/docs/decisions/platform-primitives.md
@@ -103,9 +103,8 @@ also removed their Prometheus scrape targets, Grafana dashboards and the
 
 ## What this does not change
 
-The application strip itself was correct. The AI agent app lives in
-`hill90-app` and is not coming back into this repository — it was moved out, not
-shelved, and runs there as a tenant of this platform. Removing
+This decision does not bring the application back. The AI agent app lives in
+`hill90-app` and runs against this platform as a tenant. Removing
 `services/api`, `services/ai`, `services/ui`, `services/mcp`,
 `services/knowledge` and `services/agentbox` stands. LiteLLM and the model-router
 were application components and stay gone.


### PR DESCRIPTION
Eight files in scope. **Four edited, two kept, two proposed for deletion** rather than trimmed — per the issue's instruction to say so instead of doing it.

**The rule is not accuracy.** Three of the four sentences removed here were written **earlier today**, correcting false "shelved" claims, and the issue quotes one of them as an example of what is still unwanted. They were right, and they still narrated the split.

## Edited — four

**`README.md`, `CONTRIBUTING.md`, `docs/architecture/overview.md`** each opened with the same genealogy: *"previously lived here"*, *"was removed in July 2026"*, *"not shelved"*, a pointer to `infra-app-separation.md` *"for the record"*, and the archive tag.

Replaced with the current arrangement — the platform provides identity, data and storage; `hill90-app` consumes them as a tenant — pointing at `app-tenancy-on-the-vps.md`, which is the contract a reader actually needs. Someone who never knew the history now learns **the relationship that exists** rather than the sequence that produced it.

**`docs/decisions/platform-primitives.md`** — *"The application strip itself was correct … it was moved out, not shelved."* The decision's **scope** is worth stating; the genealogy is not. Now: *"This decision does not bring the application back."*

## Kept — two, deliberately

- **`docs/runbooks/tenant-app-deployment.md`** — a procedure, and its status header is **operational state** (which phases are executed, what is deployed and healthy), not family history. Someone following the runbook needs to know Phase A is done. That *is* what the thing is.
- **`docs/decisions/2026-07-31-handoff.md`** — *"A statement of current truth, not a changelog."* Its dated verification markers say what is true now and how well it is known — the opposite of genealogy. Removing them would make it weaker and less honest, not cleaner.

## Proposed for deletion — two, not deleted

| File | Its own first paragraph |
|---|---|
| `PRD.md` | *"Historical: this is the requirements document for the 2026-07-26 app/infra strip, not a description of Hill90 today."* |
| `SPEC.md` | *"Historical: this specifies the 2026-07-26 app/infra strip as planned, not the estate as it stands."* |

Both are the paperwork of a completed one-off operation, and both say so themselves. They are **not** decision records with live reasoning — `infra-app-separation.md` is that, and the issue explicitly protects it. **Trimming the genealogy out of these two would leave nothing, because genealogy is what they are.**

I have not deleted them. Each is cited by `CONTRIBUTING.md` and `infra-app-separation.md`, and `SPEC.md` cites `PRD.md` — so a deletion needs those three citations repointed in the same change (the `RESURRECTION.md` lesson). Say the word and I'll do it with the citation map.

Markdown links pass. `bats tests/scripts/` — 480 passing, 0 failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)