### PR TITLE
feat(ci): fail when the tenant's copy of our container list stops matching ours

### DIFF
--- a/.github/workflows/tenant-baseline-agreement.yml
+++ b/.github/workflows/tenant-baseline-agreement.yml
@@ -1,0 +1,56 @@
+name: Tenant Baseline Agreement
+
+# Does hill90-app's copy of our container list still match ours?
+#
+# WHERE THE TENANT'S FILE COMES FROM, and why not a path on someone's laptop:
+# it is checked out from jonhill90/hill90-app into this runner's workspace. The
+# check itself takes a PATH and hardcodes nothing, so it runs identically here,
+# on a developer's machine against a sibling clone, or anywhere else. Nothing in
+# this repo depends on a particular directory existing.
+#
+# hill90-app is PRIVATE and this repo is PUBLIC, so the checkout needs a token
+# with read access to it: TENANT_BASELINE_TOKEN. Until that secret exists the
+# checkout fails and this job is RED — deliberately. A missing credential is a
+# reason this check cannot see, and a check that cannot see must not report
+# agreement.
+#
+# NOT a pull_request trigger. Secrets are not available to fork pull requests,
+# so a PR gate would fail for a reason unrelated to its change. Catching drift
+# on the push that causes it, plus daily, is weaker than blocking the PR and is
+# the trade taken. If a PR gate is wanted, it can be added for same-repo PRs.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      # The only commits that can move the number.
+      - 'deploy/compose/prod/**'
+      - 'scripts/checks/check_tenant_baseline_agrees.py'
+  schedule:
+    # Daily, because the tenant's copy can also go stale by THEIR edit, which no
+    # push to this repo would catch.
+    - cron: '30 6 * * *'
+  workflow_dispatch:
+
+jobs:
+  agree:
+    name: tenant baseline agrees
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout this platform
+        uses: actions/checkout@v4
+
+      - name: Checkout the tenant, for its baseline copy only
+        uses: actions/checkout@v4
+        with:
+          repository: jonhill90/hill90-app
+          token: ${{ secrets.TENANT_BASELINE_TOKEN }}
+          path: tenant
+          sparse-checkout: |
+            scripts/checks/hill90-platform-baseline.txt
+          sparse-checkout-cone-mode: false
+
+      - name: Compare the two lists
+        run: |
+          python3 scripts/checks/check_tenant_baseline_agrees.py \
+            tenant/scripts/checks/hill90-platform-baseline.txt

--- a/scripts/checks/check_tenant_baseline_agrees.py
+++ b/scripts/checks/check_tenant_baseline_agrees.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""The tenant's copy of our container list must still match ours.
+
+    TENANT_BASELINE=<path> python3 scripts/checks/check_tenant_baseline_agrees.py
+    python3 scripts/checks/check_tenant_baseline_agrees.py <path>
+
+WHY THIS EXISTS, AND WHY HERE. hill90-app checks after every deploy that this
+platform's containers are present BY NAME, because its own step called "Hill90
+baseline unchanged" ran only `docker ps --filter health=unhealthy` — and a
+container that has VANISHED is not unhealthy, it is absent, which is precisely
+what a baseline check exists to catch (hill90-app#176).
+
+To do that the tenant had to COPY our list of names. Deriving it from our compose
+files at deploy time was deliberately rejected on their side: a tenant reading
+the platform's internals is a tenancy-boundary question, not a convenience.
+
+So the list now lives in two repositories. This check is the one that compares
+them, and it belongs HERE because THIS repo is the one that changes the number.
+The tenant cannot know its copy has gone stale — by construction, the staleness
+is caused by a commit it never sees (Hill90#699, hill90-app#177).
+
+IT MUST FAIL IN BOTH DIRECTIONS. A container we REMOVE makes the tenant assert a
+name that will never appear again: loud, and it would be noticed. A container we
+ADD is the dangerous one — the tenant's list simply lacks it, every check on that
+side still passes, and nothing anywhere reports that a new platform service is
+unmonitored by the tenant. Silent agreement with a stale list is the failure this
+exists to prevent, so a GAIN is a failure here exactly as a LOSS is.
+
+DERIVING OUR OWN SIDE IS FINE. Reading our compose files is this repo reading its
+own internals, which is what makes the asymmetry legitimate: we derive, they
+copy, and this check reconciles.
+
+Exit codes:
+  0  the two lists agree
+  1  they disagree — every difference named, in both directions
+  2  CANNOT COMPARE (tenant file missing, unreadable or empty; or our own set
+     came out empty). Never a pass: a check that cannot see the thing it
+     compares must not report agreement, which is the rule this estate has
+     re-learned in six other places.
+"""
+from __future__ import annotations
+
+import os
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+COMPOSE_DIR = ROOT / "deploy/compose/prod"
+
+# A container declared with `restart: "no"` that runs a one-shot command is not
+# part of the running baseline. openbao-init chowns a directory and exits; the
+# tenant would never see it in `docker ps`, so demanding it would make their
+# check fail forever.
+ONE_SHOT_RESTART = {'"no"', "'no'", "no"}
+
+
+def platform_containers() -> set[str]:
+    """The long-lived containers this platform declares, by name."""
+    names: set[str] = set()
+    for path in sorted(COMPOSE_DIR.glob("*.yml")):
+        text = path.read_text()
+        # Service blocks are two-space indented under `services:`. Walk them so a
+        # container_name can be paired with its own restart policy rather than
+        # with the file's.
+        for block in re.split(r"\n(?=  [A-Za-z0-9_.-]+:\n)", text):
+            m = re.search(r"^\s*container_name:\s*(\S+)", block, re.M)
+            if not m:
+                continue
+            raw = m.group(1)
+            # Names are written as ${CONTAINER_PREFIX:-}foo. The prefix defaults
+            # to empty and is empty in production; strip the interpolation so the
+            # comparison is against what actually appears in `docker ps`.
+            name = re.sub(r"\$\{[^}]*\}", "", raw).strip().strip('"').strip("'")
+            if not name:
+                continue
+            r = re.search(r"^\s*restart:\s*(\S+)", block, re.M)
+            if r and r.group(1) in ONE_SHOT_RESTART:
+                continue
+            names.add(name)
+    return names
+
+
+def tenant_containers(path: Path) -> set[str]:
+    names = set()
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        names.add(line)
+    return names
+
+
+def main() -> int:
+    raw = sys.argv[1] if len(sys.argv) > 1 else os.environ.get("TENANT_BASELINE", "")
+    if not raw:
+        print(
+            "::error::No tenant baseline supplied. Pass a path or set TENANT_BASELINE. "
+            "NOTHING WAS COMPARED, which is not agreement.",
+            file=sys.stderr,
+        )
+        return 2
+
+    tenant_path = Path(raw)
+    if not tenant_path.is_file():
+        print(
+            f"::error::Tenant baseline not readable at {tenant_path}. NOTHING WAS COMPARED — "
+            "this is not a pass. The file lives in hill90-app at "
+            "scripts/checks/hill90-platform-baseline.txt.",
+            file=sys.stderr,
+        )
+        return 2
+
+    ours = platform_containers()
+    if not ours:
+        print(
+            f"::error::No container_name entries found under {COMPOSE_DIR}. Refusing to "
+            "report agreement against an empty platform set — this check would pass "
+            "vacuously if the compose layout moved.",
+            file=sys.stderr,
+        )
+        return 2
+
+    theirs = tenant_containers(tenant_path)
+    if not theirs:
+        print(
+            f"::error::Tenant baseline {tenant_path} lists no names. NOTHING WAS COMPARED.",
+            file=sys.stderr,
+        )
+        return 2
+
+    we_added = sorted(ours - theirs)
+    we_removed = sorted(theirs - ours)
+
+    if not we_added and not we_removed:
+        print(f"Tenant baseline agrees: {len(ours)} containers, both lists identical.")
+        return 0
+
+    print(
+        f"::error::TENANT BASELINE IS STALE: this platform declares {len(ours)} containers, "
+        f"the tenant's copy lists {len(theirs)}.",
+        file=sys.stderr,
+    )
+    if we_added:
+        print(
+            "  WE ADDED, and the tenant does not know: " + ", ".join(we_added),
+            file=sys.stderr,
+        )
+        print(
+            "    This is the silent direction. The tenant's check still passes; it simply\n"
+            "    never asserts these, so a new platform container is unmonitored by them.",
+            file=sys.stderr,
+        )
+    if we_removed:
+        print(
+            "  WE REMOVED, and the tenant still expects: " + ", ".join(we_removed),
+            file=sys.stderr,
+        )
+        print(
+            "    Their deploy will fail on a container we deliberately took away.",
+            file=sys.stderr,
+        )
+    print(
+        "  Fix: update hill90-app/scripts/checks/hill90-platform-baseline.txt in the same\n"
+        "  change that moved the number here, and say why in that commit.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scripts/tenant-baseline-agreement-control.bats
+++ b/tests/scripts/tenant-baseline-agreement-control.bats
@@ -1,0 +1,118 @@
+#!/usr/bin/env bats
+
+# POSITIVE CONTROL for scripts/checks/check_tenant_baseline_agrees.py.
+#
+# The tenant copies our container list (hill90-app#176) because deriving it from
+# our compose would have it reading our internals. That leaves the list in two
+# repos, and this check is the one that compares them — here, because this repo
+# is the one that changes the number.
+#
+# THE LOAD-BEARING CASES are the two that would otherwise be silent:
+#   - we ADD a container and the tenant's copy simply lacks it. Their check keeps
+#     passing; nothing anywhere says a new platform service is unmonitored.
+#   - the tenant file cannot be read. Reporting agreement then would be agreeing
+#     with a file we never opened.
+
+setup() {
+    CHECK="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)/scripts/checks/check_tenant_baseline_agrees.py"
+    TENANT="$BATS_TEST_TMPDIR/baseline.txt"
+    # The real platform set, derived the same way the check does, so these tests
+    # do not hardcode a number that will drift.
+    OURS=$(cd "$(dirname "$CHECK")/../.." && python3 - <<'PY'
+import re, pathlib
+d = pathlib.Path("deploy/compose/prod")
+names = set()
+for p in sorted(d.glob("*.yml")):
+    for block in re.split(r"\n(?=  [A-Za-z0-9_.-]+:\n)", p.read_text()):
+        m = re.search(r"^\s*container_name:\s*(\S+)", block, re.M)
+        if not m:
+            continue
+        r = re.search(r"^\s*restart:\s*(\S+)", block, re.M)
+        if r and r.group(1).strip('"\'') == "no":
+            continue
+        names.add(re.sub(r"\$\{[^}]*\}", "", m.group(1)).strip().strip('"\''))
+print("\n".join(sorted(n for n in names if n)))
+PY
+)
+    printf '%s\n' "$OURS" > "$TENANT"
+}
+
+@test "agrees when the tenant's copy matches this platform" {
+    run python3 "$CHECK" "$TENANT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"agrees"* ]]
+}
+
+@test "FIRES, and this is the silent direction: WE ADDED a container the tenant does not list" {
+    # The tenant's check still passes in this state — it simply never asserts the
+    # new name. Nothing but this reports it.
+    printf '%s\n' "$OURS" | grep -Fxv traefik > "$TENANT"
+    run python3 "$CHECK" "$TENANT"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"WE ADDED"* ]]
+    [[ "$output" == *"traefik"* ]]
+}
+
+@test "FIRES: WE REMOVED a container the tenant still expects" {
+    printf '%s\nghost-service\n' "$OURS" > "$TENANT"
+    run python3 "$CHECK" "$TENANT"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"WE REMOVED"* ]]
+    [[ "$output" == *"ghost-service"* ]]
+}
+
+@test "FIRES in both directions at once, and names both" {
+    printf '%s\nghost-service\n' "$OURS" | grep -Fxv traefik > "$TENANT"
+    run python3 "$CHECK" "$TENANT"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"WE ADDED"* ]]
+    [[ "$output" == *"traefik"* ]]
+    [[ "$output" == *"WE REMOVED"* ]]
+    [[ "$output" == *"ghost-service"* ]]
+}
+
+@test "NEVER A PASS: a tenant file that does not exist exits 2" {
+    run python3 "$CHECK" "$BATS_TEST_TMPDIR/absent.txt"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"NOTHING WAS COMPARED"* ]]
+}
+
+@test "NEVER A PASS: no path supplied at all exits 2" {
+    run env -u TENANT_BASELINE python3 "$CHECK"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"NOTHING WAS COMPARED"* ]]
+}
+
+@test "NEVER A PASS: a tenant file of only comments exits 2, not 0" {
+    printf '# all comment\n\n' > "$TENANT"
+    run python3 "$CHECK" "$TENANT"
+    [ "$status" -eq 2 ]
+}
+
+@test "the path can come from TENANT_BASELINE as well as argv" {
+    run env TENANT_BASELINE="$TENANT" python3 "$CHECK"
+    [ "$status" -eq 0 ]
+}
+
+@test "comments and blank lines in the tenant file are ignored, not treated as names" {
+    { echo "# a header"; echo; printf '%s\n' "$OURS"; } > "$TENANT"
+    run python3 "$CHECK" "$TENANT"
+    [ "$status" -eq 0 ]
+}
+
+@test "one-shot containers are excluded — openbao-init must not be demanded of the tenant" {
+    # It is restart:"no" running a chown and exits, so it never appears in the
+    # tenant's `docker ps`. Demanding it would fail their deploy forever.
+    run python3 "$CHECK" "$TENANT"
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"openbao-init"* ]]
+}
+
+@test "names are compared exactly — a prefix does not satisfy a longer name" {
+    # We declare postgres AND postgres-exporter. A substring comparison would
+    # call the tenant's list agreeing when it is missing one of them.
+    printf '%s\n' "$OURS" | grep -Fxv postgres > "$TENANT"
+    run python3 "$CHECK" "$TENANT"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"postgres"* ]]
+}


### PR DESCRIPTION
> Implements #699. Left **CLEAN**.

## Why the check lives here

hill90-app copies our 16 container names because deriving them from our compose would be a tenant reading the platform's internals — rejected there on tenancy grounds. That leaves the list in two repos, and **this repo is the one that changes the number**. The tenant cannot know its copy has gone stale, by construction: the staleness is caused by a commit it never sees.

## It fails in both directions, and the ADD direction is the point

| Direction | What happens today without this |
|---|---|
| **We remove** a container | Loud on their side — their deploy fails on a container we deliberately took away |
| **We add** a container | **Silent.** Their list simply lacks the new name, every check they run still passes, and nothing anywhere reports that a new platform service is unmonitored by the tenant |

Both are exit 1, every difference named, with the two directions labelled separately because they need different fixes.

## Never passes vacuously

Exit **2**, not 0, when: no path is supplied, the tenant file does not exist, it contains no names, or **our own compose yields no `container_name` entries**. That last one matters — if the compose layout moved, deriving nothing and reporting agreement would be exactly the failure this check exists to catch.

## Where the tenant's file comes from — the thing I had to choose

The check takes a **path** and hardcodes none, so it runs identically in CI, against a sibling clone, or anywhere else. **Nothing in this repo depends on a directory existing on someone's machine.**

The workflow supplies it by sparse-checking-out that single file from `jonhill90/hill90-app`.

### This needs one thing from you

`hill90-app` is **private** and this repo is **public**, so the checkout needs a secret — `TENANT_BASELINE_TOKEN`, read access to hill90-app. **Until it exists, this job is red, deliberately:** a missing credential is a reason the check cannot see, and a check that cannot see must not report agreement.

Worth naming as a security consideration: that token lets this public repo's CI read a private repo. Secrets are not exposed to fork PRs and are never printed, and the data read is a list of container names already public in our compose — but it is a new credential and the decision is yours. **If you would rather not add it**, the alternatives are to make that one file publicly readable, or to accept scheduled checking from the tenant side (which re-introduces the coupling #699 rejected).

### Trigger choice

Not `pull_request`: secrets are unavailable to fork PRs, so a PR gate would fail for reasons unrelated to the change. It runs on pushes to `main` touching `deploy/compose/prod/**`, **daily** (the tenant's copy can also go stale by *their* edit, which no push here would catch), and on dispatch. Catching drift at the push that causes it is weaker than blocking the PR — that is the trade, and a same-repo-PR gate can be added if you prefer.

## Verified against the real pair

```
our derived set vs hill90-app's committed copy:
Tenant baseline agrees: 16 containers, both lists identical.
```

11 bats control cases — both failure directions, all four exit-2 paths, and that a prefix does not satisfy a longer name, since we declare both `postgres` and `postgres-exporter`. `openbao-init` is excluded: `restart: "no"` running a one-shot chown, it never appears in their `docker ps`, and demanding it would fail their deploy forever.

491 bats pass; `check_checks_are_wired.py` passes; python compiles; shellcheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)