### PR TITLE
fix: port hill90-app's three deploy-path defects — SIGPIPE, bootstrap deadlock, no drift alarm (#705)

### DIFF
--- a/.github/workflows/deploy-drift.yml
+++ b/.github/workflows/deploy-drift.yml
@@ -1,0 +1,178 @@
+name: Deploy Drift Alarm
+
+# Is what the host has CHECKED OUT the same as what was MERGED?
+#
+# hill90-app hit this on 2026-08-03: a merged security fix was not running for
+# 23 minutes because two defects in that repo's deploy path each failed the
+# deploy, and nothing reported it. Nothing COULD: every health check answers
+# from the running container, so it correctly reports the OLD code as
+# healthy. This repo has the identical deploy shape in five places (app#140,
+# ported here as #705) and, before this workflow, nothing here compared
+# deployed against merged either.
+#
+# WHY THE COMPARISON HAPPENS ON THE RUNNER. The host is asked one question —
+# `git rev-parse HEAD` — and every judgement is made here, against this
+# checkout. Running the check from the host's copy would rebuild the
+# bootstrap deadlock (app#139's shape) inside the alarm itself: a stale
+# checkout deciding whether it is stale.
+#
+# WHY IT IS NOT `deployed != main`. This repo's deploys are workflow_dispatch,
+# or gated by deploy.yml's push path filters — not "every merge ships" — so
+# drift is the NORMAL state between deploys. The rules that decide what is
+# actionable live in scripts/checks/check_deploy_drift.sh and are
+# positive-controlled in tests/scripts/deploy-drift-control.bats.
+#
+# SCOPE: this checks the CHECKOUT only, deliberately not which commit any
+# running container was built from — see the comment at the top of
+# check_deploy_drift.sh for why, and hill90-app's #158 for the gap this leaves.
+
+on:
+  schedule:
+    # Every four hours. The grace window is four hours by default, so a fix
+    # that is merged and forgotten is named within roughly eight — fast enough
+    # to matter, slow enough that a normal working day of merges stays quiet.
+    - cron: '37 */4 * * *'
+  workflow_dispatch:
+    inputs:
+      grace_hours:
+        description: 'Hours a deployable commit may wait before this alarms'
+        required: false
+        default: '4'
+        type: string
+      deployed_sha_override:
+        description: >-
+          POSITIVE CONTROL. Pretend the host is on this SHA instead of asking it.
+          Use a deliberately stale commit to watch the alarm fire, so it has been
+          seen red before it is trusted green.
+        required: false
+        default: ''
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-drift
+  cancel-in-progress: false
+
+jobs:
+  drift:
+    name: deployed vs main
+    runs-on: ubuntu-latest
+    environment: production
+    env:
+      VPS_APP_PATH: /opt/hill90/app
+
+    steps:
+      # Full history: the check walks deployed..origin/main and reads commit
+      # dates. A shallow clone would make every comparison unresolvable, which
+      # this check reports as exit 2 rather than passing — but a permanently
+      # unknown alarm is a broken one.
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Preflight — required secrets are present
+        if: inputs.deployed_sha_override == ''
+        env:
+          TS_OAUTH_CLIENT_ID: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          TS_OAUTH_SECRET: ${{ secrets.TS_OAUTH_SECRET }}
+          VPS_SSH_PRIVATE_KEY: ${{ secrets.VPS_SSH_PRIVATE_KEY }}
+          SOPS_AGE_KEY: ${{ secrets.SOPS_AGE_KEY }}
+        run: |
+          missing=()
+          for name in TS_OAUTH_CLIENT_ID TS_OAUTH_SECRET VPS_SSH_PRIVATE_KEY SOPS_AGE_KEY; do
+            [ -n "${!name}" ] || missing+=("$name")
+          done
+          if [ ${#missing[@]} -ne 0 ]; then
+            echo "::error::Deploy drift alarm cannot run: missing secret(s) ${missing[*]}. This is not a pass — nothing was compared."
+            exit 1
+          fi
+
+      - name: Setup Tailscale
+        if: inputs.deployed_sha_override == ''
+        uses: tailscale/github-action@v2
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:github-actions
+
+      - name: Setup SSH key
+        if: inputs.deployed_sha_override == ''
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.VPS_SSH_PRIVATE_KEY }}" > ~/.ssh/vps_key
+          chmod 600 ~/.ssh/vps_key
+
+      - name: Setup SOPS/age
+        if: inputs.deployed_sha_override == ''
+        env:
+          SOPS_VERSION: '3.9.4'
+        run: |
+          SOPS_URL="https://github.com/getsops/sops/releases/download/v${SOPS_VERSION}/sops-v${SOPS_VERSION}.linux.amd64"
+          curl -fsSL -o /tmp/sops "$SOPS_URL"
+          if file /tmp/sops | grep -q "HTML"; then
+            echo "::error::SOPS download returned HTML instead of binary — check URL: $SOPS_URL"
+            exit 1
+          fi
+          chmod +x /tmp/sops
+          sudo mv /tmp/sops /usr/local/bin/sops
+          mkdir -p ~/.config/sops/age
+          echo "${{ secrets.SOPS_AGE_KEY }}" > ~/.config/sops/age/keys.txt
+          chmod 600 ~/.config/sops/age/keys.txt
+
+      - name: Get Tailscale IP from secrets
+        id: get-ip
+        if: inputs.deployed_sha_override == ''
+        run: |
+          TAILSCALE_IP=$(sops -d --extract '["TAILSCALE_IP"]' infra/secrets/prod.enc.env)
+          if [ -z "$TAILSCALE_IP" ]; then
+            echo "::error::TAILSCALE_IP is empty or absent in infra/secrets/prod.enc.env"
+            exit 1
+          fi
+          echo "::add-mask::$TAILSCALE_IP"
+          echo "tailscale_ip=$TAILSCALE_IP" >> $GITHUB_OUTPUT
+
+      # One question, read-only. No fetch, no reset — this must not change what
+      # it is measuring, and it must never be able to "fix" the drift it reports.
+      - name: Ask the host which commit it is running
+        id: host
+        if: inputs.deployed_sha_override == ''
+        run: |
+          sha=$(ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no -o ConnectTimeout=15 \
+            deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
+            "cd ${VPS_APP_PATH} && git rev-parse HEAD" 2>/dev/null | tr -d '[:space:]')
+          # Deliberately NOT failing here on an empty answer. An unreachable or
+          # unreadable host is exactly the state the check reports as exit 2,
+          # and routing it through the check keeps one place that decides what
+          # "cannot tell" means.
+          echo "sha=${sha}" >> $GITHUB_OUTPUT
+          if [ -z "$sha" ]; then
+            echo "::warning::Could not read a SHA from the host; the check will report this as UNKNOWN."
+          fi
+
+      - name: Compare deployed against main
+        env:
+          DEPLOYED_SHA: ${{ inputs.deployed_sha_override != '' && inputs.deployed_sha_override || steps.host.outputs.sha }}
+          GRACE_HOURS: ${{ inputs.grace_hours || '4' }}
+          TARGET_REF: origin/main
+          LABEL: Hill90 (${{ env.VPS_APP_PATH }})
+        run: |
+          if [ -n "${{ inputs.deployed_sha_override }}" ]; then
+            echo "::notice::POSITIVE CONTROL — pretending the host is on ${{ inputs.deployed_sha_override }}. The host was not contacted."
+          fi
+          # `|| rc=$?` is load-bearing. GitHub runs this with `bash -e {0}`, so a
+          # bare invocation of a check that exits 1 aborts the step immediately
+          # and the case below never runs — the exit code would be right and the
+          # explanation absent. Same shape as the swallowed hook this estate has
+          # hit before.
+          rc=0
+          bash scripts/checks/check_deploy_drift.sh || rc=$?
+          case "$rc" in
+            0) echo "::notice::No actionable deploy drift." ;;
+            1) echo "Deploy the affected stacks, or record why not." ;;
+            2) echo "The alarm could not determine what is running. Treat as unverified, not as fine." ;;
+            *) echo "::error::Unrecognised exit code $rc from check_deploy_drift.sh — a new state was added without a branch here. Treat as unverified." ;;
+          esac
+          exit $rc

--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -68,21 +68,24 @@ jobs:
           ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no -o ConnectTimeout=10 \
             deploy@${{ steps.get-ip.outputs.tailscale_ip }} 'echo "SSH connection successful"'
 
+      # The preflight is a GUARD, so it runs from THIS checkout, piped over ssh —
+      # not from the copy lying on the VPS. See reusable-deploy-service.yml for
+      # the fuller note; ported to all five deploy-path sites (app#139).
+      - name: Checkout preflight (this repo's copy, not the host's)
+        run: |
+          ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
+            deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
+            "cd /opt/hill90/app && git fetch origin && git diff --stat HEAD origin/main"
+          ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
+            deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
+            "cd /opt/hill90/app && bash -s" < scripts/preflight-checkout.sh
+
       - name: Deploy infrastructure
         run: |
           echo "Deploying infrastructure services..."
-          # Existence check before the call: the preflight ships in this repository
-          # and is absent from the box until one deploy includes it, so calling it
-          # directly dies at exit 127 with no explanation. Message is byte-identical
-          # across all four deploy workflows and pinned by
-          # tests/scripts/preflight-checkout.bats — see the fuller note in
-          # reusable-deploy-service.yml for why this is not shared code.
           ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
             deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
             "cd /opt/hill90/app && \
-             git fetch origin && \
-             { [ -f scripts/preflight-checkout.sh ] || { echo '::error::scripts/preflight-checkout.sh is missing from /opt/hill90/app on the VPS. It ships in this repository, so it exists on the box only AFTER one deploy that includes it. Fix: ssh to the VPS as deploy, run cd /opt/hill90/app && git pull, then re-run this workflow. Do not remove the guard to get past this.'; exit 1; }; } && \
-             bash scripts/preflight-checkout.sh && \
              git reset --hard origin/main && \
              export SOPS_AGE_KEY_FILE=/opt/hill90/secrets/keys/keys.txt && \
              export ACME_REQUIRE_PRODUCTION=1 && \

--- a/.github/workflows/reusable-deploy-service.yml
+++ b/.github/workflows/reusable-deploy-service.yml
@@ -64,45 +64,40 @@ jobs:
           ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no -o ConnectTimeout=10 \
             deploy@${{ steps.get-ip.outputs.tailscale_ip }} 'echo "SSH connection successful"'
 
+      # The preflight is a GUARD, so it runs from THIS checkout, piped over ssh —
+      # not from the copy lying on the VPS.
+      #
+      # It used to run the host's copy, which is the copy `git reset --hard` has
+      # not updated yet, so the guard protecting a deploy was always one deploy
+      # older than the deploy it protected: a fix landed in scripts/preflight-
+      # checkout.sh could not reach production until a deploy succeeded, and the
+      # only thing standing between the host and a successful deploy was the
+      # unfixed guard. hill90-app hit this first (app#139) and its fix is ported
+      # here, to all five sites that run this preflight — not just this one.
+      #
+      # `bash -s` runs the script we just checked out, on the host, in the
+      # checkout directory. It sources nothing and does not read $0, so stdin
+      # execution is equivalent to running the file. This also removes the old
+      # "preflight-checkout.sh is missing from the box" guard entirely: that
+      # failure mode existed only because the host's own copy was being invoked,
+      # and running the runner's copy over stdin cannot fail that way.
+      - name: Checkout preflight (this repo's copy, not the host's)
+        run: |
+          ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
+            deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
+            "cd /opt/hill90/app && git fetch origin && git diff --stat HEAD origin/main"
+          ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
+            deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
+            "cd /opt/hill90/app && bash -s" < scripts/preflight-checkout.sh
+
       - name: Deploy ${{ inputs.service }}
         run: |
           # deploy.sh automatically runs pre-deploy backup for stateful services
           # (vault, observability) before the down/up cycle.
           echo "Deploying ${{ inputs.service }}..."
-          # The preflight ships in THIS repository, so it does not exist on
-          # /opt/hill90/app until one deploy has included it. Without this check
-          # bash fails with exit 127 and no explanation — verified on 2026-07-29,
-          # when the script was absent from the box and the checkout was four
-          # commits behind main, so every deploy would have died that way.
-          #
-          # Halting is correct; halting silently is not. hill90-app hit this first
-          # and its fix is ported here.
-          #
-          # WHY THIS IS DUPLICATED IN FOUR WORKFLOWS RATHER THAN SHARED:
-          #   * The check has to be INLINE in the remote command. Its whole job is
-          #     to report that the repository's own scripts/ is not on the box, so
-          #     it cannot live in scripts/ — that is the condition it detects.
-          #   * A composite action cannot help: this runs in the REMOTE shell over
-          #     ssh, not on the runner.
-          #   * deploy-infra, vault-init and vault-reinitialize do not call this
-          #     reusable workflow (verified: zero `uses:` references), so there is
-          #     no shared path to hang it on.
-          #   * Two sites wrap the remote command in double quotes and two in
-          #     single quotes, so even a shared snippet needs per-site quoting.
-          #     The MESSAGE is byte-identical anyway — it deliberately contains no
-          #     quote characters of either kind, which is what lets one string
-          #     survive both.
-          #
-          # Drift is prevented by a test, not an abstraction:
-          # tests/scripts/preflight-checkout.bats holds the canonical message and
-          # fails if any of the four differs.
           ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
             deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
             "cd /opt/hill90/app && \
-             git fetch origin && \
-             git diff --stat HEAD origin/main && \
-             { [ -f scripts/preflight-checkout.sh ] || { echo '::error::scripts/preflight-checkout.sh is missing from /opt/hill90/app on the VPS. It ships in this repository, so it exists on the box only AFTER one deploy that includes it. Fix: ssh to the VPS as deploy, run cd /opt/hill90/app && git pull, then re-run this workflow. Do not remove the guard to get past this.'; exit 1; }; } && \
-             bash scripts/preflight-checkout.sh && \
              git reset --hard origin/main && \
              export SOPS_AGE_KEY_FILE=/opt/hill90/secrets/keys/keys.txt && \
              bash scripts/deploy.sh ${{ inputs.service }} prod"

--- a/.github/workflows/vault-init.yml
+++ b/.github/workflows/vault-init.yml
@@ -110,17 +110,25 @@ jobs:
             exit 1
           fi
 
-      - name: Sync host checkout to main
+      # The preflight is a GUARD, so it runs from THIS checkout, piped over ssh —
+      # not from the copy lying on the VPS. See reusable-deploy-service.yml for
+      # the fuller note; ported to all five deploy-path sites (app#139). This is
+      # one of the three vault-recovery workflows, reached for when something is
+      # already wrong — the least convenient place for the old deadlock to bite.
+      - name: Checkout preflight (this repo's copy, not the host's)
         run: |
-          # Existence check before the call: the preflight ships in this repository
-          # and is absent from the box until one deploy includes it, so calling it
-          # directly dies at exit 127 with no explanation. Message is byte-identical
-          # across all four deploy workflows and pinned by
-          # tests/scripts/preflight-checkout.bats — see the fuller note in
-          # reusable-deploy-service.yml for why this is not shared code.
           ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
             deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
-            'cd /opt/hill90/app && git fetch origin && { [ -f scripts/preflight-checkout.sh ] || { echo "::error::scripts/preflight-checkout.sh is missing from /opt/hill90/app on the VPS. It ships in this repository, so it exists on the box only AFTER one deploy that includes it. Fix: ssh to the VPS as deploy, run cd /opt/hill90/app && git pull, then re-run this workflow. Do not remove the guard to get past this."; exit 1; }; } && bash scripts/preflight-checkout.sh && git reset --hard origin/main'
+            'cd /opt/hill90/app && git fetch origin && git diff --stat HEAD origin/main'
+          ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
+            deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
+            'cd /opt/hill90/app && bash -s' < scripts/preflight-checkout.sh
+
+      - name: Sync host checkout to main
+        run: |
+          ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
+            deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
+            'cd /opt/hill90/app && git reset --hard origin/main'
 
       # Writes the unseal key and root token to 0600 files owned by deploy.
       # Prints neither.

--- a/.github/workflows/vault-regain-root.yml
+++ b/.github/workflows/vault-regain-root.yml
@@ -132,14 +132,25 @@ jobs:
 
       # ---- Open the window ---------------------------------------------------
 
+      # The preflight is a GUARD, so it runs from THIS checkout, piped over ssh —
+      # not from the copy lying on the VPS. See reusable-deploy-service.yml for
+      # the fuller note; ported to all five deploy-path sites (app#139). This is
+      # one of the three vault-recovery workflows, reached for when something is
+      # already wrong — the least convenient place for the old deadlock to bite.
+      - name: Checkout preflight (this repo's copy, not the host's)
+        run: |
+          ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
+            deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
+            "cd /opt/hill90/app && git fetch origin && git diff --stat HEAD origin/main"
+          ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
+            deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
+            "cd /opt/hill90/app && bash -s" < scripts/preflight-checkout.sh
+
       - name: Deploy the RECOVERY config
         run: |
           ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
             deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
             "cd /opt/hill90/app && \
-             git fetch origin && \
-             { [ -f scripts/preflight-checkout.sh ] || { echo '::error::scripts/preflight-checkout.sh is missing from /opt/hill90/app on the VPS. It ships in this repository, so it exists on the box only AFTER one deploy that includes it. Fix: ssh to the VPS as deploy, run cd /opt/hill90/app && git pull, then re-run this workflow. Do not remove the guard to get past this.'; exit 1; }; } && \
-             bash scripts/preflight-checkout.sh && \
              git reset --hard origin/main && \
              export SOPS_AGE_KEY_FILE=/opt/hill90/secrets/keys/keys.txt && \
              export VAULT_CONFIG_FILE=config.recovery.hcl && \

--- a/.github/workflows/vault-reinitialize.yml
+++ b/.github/workflows/vault-reinitialize.yml
@@ -179,17 +179,25 @@ jobs:
             exit 1
           fi
 
-      - name: Sync host checkout to main
+      # The preflight is a GUARD, so it runs from THIS checkout, piped over ssh —
+      # not from the copy lying on the VPS. See reusable-deploy-service.yml for
+      # the fuller note; ported to all five deploy-path sites (app#139). This is
+      # one of the three vault-recovery workflows, reached for when something is
+      # already wrong — the least convenient place for the old deadlock to bite.
+      - name: Checkout preflight (this repo's copy, not the host's)
         run: |
-          # Existence check before the call: the preflight ships in this repository
-          # and is absent from the box until one deploy includes it, so calling it
-          # directly dies at exit 127 with no explanation. Message is byte-identical
-          # across all four deploy workflows and pinned by
-          # tests/scripts/preflight-checkout.bats — see the fuller note in
-          # reusable-deploy-service.yml for why this is not shared code.
           ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
             deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
-            'cd /opt/hill90/app && git fetch origin && { [ -f scripts/preflight-checkout.sh ] || { echo "::error::scripts/preflight-checkout.sh is missing from /opt/hill90/app on the VPS. It ships in this repository, so it exists on the box only AFTER one deploy that includes it. Fix: ssh to the VPS as deploy, run cd /opt/hill90/app && git pull, then re-run this workflow. Do not remove the guard to get past this."; exit 1; }; } && bash scripts/preflight-checkout.sh && git reset --hard origin/main'
+            'cd /opt/hill90/app && git fetch origin && git diff --stat HEAD origin/main'
+          ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
+            deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
+            'cd /opt/hill90/app && bash -s' < scripts/preflight-checkout.sh
+
+      - name: Sync host checkout to main
+        run: |
+          ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
+            deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
+            'cd /opt/hill90/app && git reset --hard origin/main'
 
       # ---- The destructive part ---------------------------------------------
 

--- a/scripts/checks/check_deploy_drift.sh
+++ b/scripts/checks/check_deploy_drift.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+#
+# Is the host's CHECKOUT the same as what was MERGED?
+#
+# NOT "is what is running the same as what was merged" — this compares one git
+# SHA read from the host against origin/main. A deploy resets the whole
+# checkout but rebuilds only the stacks that changed, so a running container
+# can be older than the checkout reports. Ported from hill90-app's
+# check_deploy_drift.sh, deliberately WITHOUT that repo's later per-container
+# revision-stamp comparison (app#158 and its follow-ups) — this is the
+# checkout-only version, matching that repo's own first cut. Scope it up if
+# this repo grows the same gap between "checkout is current" and "container is
+# current".
+#
+# WHY THIS EXISTS. On 2026-08-03, in hill90-app, a security fix was merged and
+# did not reach production for 23 minutes because two defects in the deploy
+# path each failed the deploy — and nothing anywhere said the fix was not
+# running. It could not have: every health check answers from the running
+# container, so they all report the OLD code as healthy — correctly. This
+# repository has the identical deploy shape in five places (app#140, ported
+# here as #705) and, before this file, nothing here compared deployed against
+# merged either.
+#
+# WHY NOT SIMPLY `deployed != main`. This repo's deploys are workflow_dispatch
+# or gated by path filters (deploy.yml), not "every merge ships" — so drift is
+# the NORMAL state between deploys, and an alarm on any difference at all would
+# be red most of the time and ignored inside a day.
+#
+# So it alarms on the difference that can actually hurt:
+#
+#   1. undeployed commits touching DEPLOYABLE paths — a docs commit that has
+#      not shipped is not an outage, a platform/ or scripts/ commit that has
+#      not shipped may be one;
+#   2. that have been waiting longer than a grace window — a deploy takes
+#      minutes and nobody deploys on every merge, so recent drift is expected;
+#   3. or ANY commit on the host that is not on main — that direction is never
+#      normal. It means someone edited production, and `git reset --hard` is
+#      about to destroy it.
+#
+# THE THIRD EXIT CODE IS THE POINT. If the deployed SHA cannot be determined,
+# this exits 2 and says so. It does not pass. An assertion that succeeds on
+# absence is the failure mode this estate has hit repeatedly, most recently in
+# `vault.sh assert-unsealed` — a check that cannot see the thing is not
+# evidence the thing is fine.
+#
+# This runs on the RUNNER, against this repository's checkout, and is given the
+# host's SHA as an input. It deliberately does NOT run from the host's copy:
+# that is the bootstrap deadlock this same issue found in five workflows here
+# (app#139's shape), where the guard is read from the very checkout it is
+# meant to be judging.
+#
+# Usage:
+#   DEPLOYED_SHA=<sha> bash scripts/checks/check_deploy_drift.sh
+#
+# Exit codes:
+#   0  no actionable drift  (in sync, docs-only, or inside the grace window)
+#   1  ACTIONABLE DRIFT     (deployable code merged and not running, or host ahead)
+#   2  CANNOT DETERMINE     (no usable deployed SHA — never silent, never green)
+#
+# NOT CHECKED, DELIBERATELY: which commit a running CONTAINER was built from.
+# A deploy resets the checkout but rebuilds one stack, so the checkout can be
+# current while a service still runs older code. hill90-app's #158 is the
+# record of that gap and its fix; porting it is future work, not this file's.
+
+set -uo pipefail
+
+DEPLOYED_SHA="${DEPLOYED_SHA:-}"
+TARGET_REF="${TARGET_REF:-origin/main}"
+GRACE_HOURS="${GRACE_HOURS:-4}"
+LABEL="${LABEL:-Hill90}"
+
+# Paths whose content is actually shipped to the host and executed there.
+# .github/workflows is deliberately ABSENT: since the app#139 port, the deploy
+# path runs the runner's copy of what matters for the preflight, so a workflow
+# change is live the moment it is merged and can never be "undeployed" in the
+# sense this check cares about.
+DEPLOYABLE_PREFIXES="${DEPLOYABLE_PREFIXES:-platform/ deploy/compose/prod/ scripts/ infra/secrets/}"
+
+say()  { printf '%s\n' "$*"; }
+fail() { printf '::error::%s\n' "$*" >&2; }
+
+say "Deploy drift — ${LABEL}"
+say "=============================================="
+say "  SCOPE: compares the git CHECKOUT on the host against ${TARGET_REF}."
+say "  NOT CHECKED: which commit any running CONTAINER was built from."
+say ""
+
+# ---------------------------------------------------------------- unknown ---
+if [ -z "$DEPLOYED_SHA" ]; then
+    fail "DEPLOY DRIFT UNKNOWN for ${LABEL}: no checkout SHA was supplied. This is NOT a pass — nothing was compared."
+    exit 2
+fi
+
+if ! git rev-parse --verify --quiet "${DEPLOYED_SHA}^{commit}" >/dev/null; then
+    fail "DEPLOY DRIFT UNKNOWN for ${LABEL}: deployed SHA '${DEPLOYED_SHA}' is not a commit in this repository. The host may be on a branch that was force-pushed or deleted. Nothing was compared."
+    exit 2
+fi
+
+if ! git rev-parse --verify --quiet "${TARGET_REF}^{commit}" >/dev/null; then
+    fail "DEPLOY DRIFT UNKNOWN for ${LABEL}: '${TARGET_REF}' does not resolve. Fetch before running this."
+    exit 2
+fi
+
+target_sha=$(git rev-parse "$TARGET_REF")
+deployed_sha=$(git rev-parse "$DEPLOYED_SHA")
+
+say "  host checkout: ${deployed_sha:0:12}"
+say "  ${TARGET_REF}: ${target_sha:0:12}"
+say ""
+
+# ------------------------------------------------------------- host ahead ---
+# Never normal. Commits that exist only on the host are undeployable by
+# definition and `git reset --hard` destroys them silently.
+ahead=$(git rev-list --count "${target_sha}..${deployed_sha}" 2>/dev/null || echo 0)
+if [ "$ahead" -gt 0 ]; then
+    fail "HOST AHEAD of ${TARGET_REF} for ${LABEL}: ${ahead} commit(s) exist on the deployed host and nowhere else. The next deploy's git reset --hard will destroy them."
+    git --no-pager log --oneline -n 20 "${target_sha}..${deployed_sha}" | sed 's/^/    /'
+    exit 1
+fi
+
+# ---------------------------------------------------------------- in sync ---
+if [ "$deployed_sha" = "$target_sha" ]; then
+    say "  PASS: the host checkout matches ${TARGET_REF}."
+    exit 0
+fi
+
+behind=$(git rev-list --count "${deployed_sha}..${target_sha}")
+say "  ${behind} commit(s) merged and not in the host checkout."
+
+# --------------------------------------------------- deployable or not? ----
+# shellcheck disable=SC2086
+mapfile -t deployable < <(
+    git rev-list "${deployed_sha}..${target_sha}" | while read -r sha; do
+        files=$(git show --name-only --format="" "$sha")
+        for prefix in $DEPLOYABLE_PREFIXES; do
+            if printf '%s\n' "$files" | grep -q "^${prefix}"; then
+                printf '%s\n' "$sha"
+                break
+            fi
+        done
+    done
+)
+
+if [ "${#deployable[@]}" -eq 0 ]; then
+    say "  PASS: none of them touch a deployable path (${DEPLOYABLE_PREFIXES})."
+    say "  Documentation and CI-only drift is not an outage. Reported, not alarmed."
+    exit 0
+fi
+
+say "  ${#deployable[@]} of them touch deployable paths:"
+for sha in "${deployable[@]}"; do
+    git --no-pager log -1 --format='    %h %s' "$sha"
+done
+say ""
+
+# ------------------------------------------------------------ grace window --
+# The OLDEST undeployed deployable commit is the one that has waited longest.
+# Measuring the newest would reset the clock every time anything merged, so a
+# permanently-undeployed fix would stay inside the window forever as long as
+# the repository stayed busy.
+oldest_sha="${deployable[${#deployable[@]}-1]}"
+oldest_epoch=$(git log -1 --format='%ct' "$oldest_sha")
+now_epoch=$(date +%s)
+age_hours=$(( (now_epoch - oldest_epoch) / 3600 ))
+
+say "  oldest undeployed deployable commit is ${age_hours}h old (grace: ${GRACE_HOURS}h)"
+
+if [ "$age_hours" -lt "$GRACE_HOURS" ]; then
+    say "  PASS: inside the grace window."
+    exit 0
+fi
+
+fail "DEPLOY DRIFT for ${LABEL}: ${#deployable[@]} commit(s) touching deployable paths have been merged for ${age_hours}h and are NOT IN THE HOST CHECKOUT. The oldest is $(git log -1 --format='%h %s' "$oldest_sha"). They are certainly not running. Deploy, or say why not."
+exit 1

--- a/scripts/preflight-checkout.sh
+++ b/scripts/preflight-checkout.sh
@@ -113,11 +113,17 @@ report_drift() {
     fi
     echo "  ################################################################"
     if [ "$behind" -gt 0 ]; then
-        git --no-pager log --oneline HEAD..origin/main 2>/dev/null | sed 's/^/    /' | head -20
+        # -n 20, not `| head -20`. head closes the pipe after twenty lines, the
+        # writer takes SIGPIPE, and `set -o pipefail` turns that into a nonzero
+        # exit — which aborts the preflight, and with it the deploy, BEFORE
+        # `git reset --hard`. hill90-app hit exactly this in production on
+        # 2026-08-03 at 55 commits behind (app#137); ported here before this
+        # repo hit it too.
+        git --no-pager log --oneline -n 20 HEAD..origin/main 2>/dev/null | sed 's/^/    /'
     fi
     if [ "$ahead" -gt 0 ]; then
         echo "    commits only on this host:"
-        git --no-pager log --oneline origin/main..HEAD 2>/dev/null | sed 's/^/      /' | head -20
+        git --no-pager log --oneline -n 20 origin/main..HEAD 2>/dev/null | sed 's/^/      /'
     fi
     echo ""
 }

--- a/tests/scripts/deploy-drift-control.bats
+++ b/tests/scripts/deploy-drift-control.bats
@@ -1,0 +1,293 @@
+#!/usr/bin/env bats
+#
+# POSITIVE CONTROL for scripts/checks/check_deploy_drift.sh.
+#
+# Ported from hill90-app's deploy-drift-control.bats (app#140, this repo's port
+# is #705) — the CHECKOUT-only subset. This script deliberately does not carry
+# hill90-app's later per-container revision comparison (their #158 and
+# follow-ups); scope that up here if this repo grows the same "checkout is
+# current, container is not" gap.
+#
+# An alarm nobody has SEEN FIRE is the same object as the checks that could not
+# fire — so every case here builds a real repository, points the check at a
+# deliberately stale deployment, and requires red. The green cases exist
+# because an alarm that fires on everything gets muted, and a muted alarm is
+# also one that cannot fire.
+#
+# Each fixture is a real git repository with real commits and real timestamps.
+# Nothing is mocked: the check reads git, so the control gives it git.
+
+CHECK="" # set in setup
+
+# Commit with a controlled age. GIT_COMMITTER_DATE is what the check reads (%ct),
+# and setting only AUTHOR_DATE would leave the committer date at now — a fixture
+# that looks aged and is not, which is how a grace-window test passes for the
+# wrong reason.
+commit_at() {
+    local hours_ago="$1" path="$2" msg="$3"
+    local when
+    when=$(( $(date +%s) - hours_ago * 3600 ))
+    mkdir -p "$(dirname "$path")"
+    echo "$RANDOM" > "$path"
+    git add "$path"
+    GIT_AUTHOR_DATE="@${when} +0000" GIT_COMMITTER_DATE="@${when} +0000" \
+        git commit -qm "$msg"
+}
+
+setup() {
+    CHECK="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)/scripts/checks/check_deploy_drift.sh"
+    REPO="$BATS_TEST_TMPDIR/repo"
+    mkdir -p "$REPO"
+    cd "$REPO"
+    git init -q -b main .
+    git config user.email t@example.com
+    git config user.name t
+    commit_at 200 "README.md" "base"
+    # A local ref standing in for origin/main, so the fixture needs no network.
+    git branch -f origin-main main
+    export TARGET_REF=origin-main
+    export LABEL=fixture
+}
+
+# ------------------------------------------------------------ CANNOT TELL ---
+# These matter most. A check that cannot see the thing must not report green.
+
+@test "no deployed SHA exits 2 and says nothing was compared — never a pass" {
+    run env DEPLOYED_SHA= bash "$CHECK"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"UNKNOWN"* ]]
+    [[ "$output" == *"NOT a pass"* ]]
+}
+
+@test "a deployed SHA this repo has never heard of exits 2, not 0" {
+    run env DEPLOYED_SHA=0000000000000000000000000000000000000000 bash "$CHECK"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"not a commit in this repository"* ]]
+}
+
+@test "an unresolvable target ref exits 2" {
+    run env DEPLOYED_SHA="$(git rev-parse HEAD)" TARGET_REF=origin/nope bash "$CHECK"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"does not resolve"* ]]
+}
+
+# --------------------------------------------------------- THE REAL ALARM ---
+
+@test "FIRES: a deployable commit merged longer ago than the grace window" {
+    # This is hill90-app's 2026-08-03 incident, replayed here: a platform/ fix
+    # merged and not running, while every health check stays green because it
+    # answers from the container that is running the old code.
+    deployed=$(git rev-parse HEAD)
+    commit_at 9 "platform/observability/prometheus/alerts.yml" "fix: a bad alert selector"
+    git branch -f origin-main main
+
+    run env DEPLOYED_SHA="$deployed" GRACE_HOURS=4 bash "$CHECK"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"DEPLOY DRIFT for fixture"* ]]
+    [[ "$output" == *"a bad alert selector"* ]]
+    [[ "$output" == *"9h"* ]]
+}
+
+@test "FIRES: the host carries a commit that is on no branch — reset will destroy it" {
+    # The direction that is never normal. Someone edited production.
+    commit_at 1 "platform/observability/hand-edit.yml" "hand edit made directly on the VPS"
+    deployed=$(git rev-parse HEAD)
+    git reset -q --hard origin-main
+
+    run env DEPLOYED_SHA="$deployed" bash "$CHECK"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"HOST AHEAD"* ]]
+    [[ "$output" == *"destroy them"* ]]
+}
+
+@test "the failing message is loud enough to act on without opening the repo" {
+    deployed=$(git rev-parse HEAD)
+    commit_at 30 "scripts/deploy.sh" "fix: the thing"
+    git branch -f origin-main main
+
+    run env DEPLOYED_SHA="$deployed" GRACE_HOURS=4 bash "$CHECK"
+    [ "$status" -eq 1 ]
+    # ::error:: so it surfaces in the Actions UI rather than only in the log body.
+    [[ "$output" == *"::error::"* ]]
+    [[ "$output" == *"fixture"* ]]
+    [[ "$output" == *"Deploy, or say why not"* ]]
+}
+
+# ------------------------------------------------------ AND STAYS QUIET -----
+# This repo's deploys are workflow_dispatch or path-filtered on push, not
+# "every merge ships" — so drift is the NORMAL state between deploys, and an
+# alarm that cannot be quiet here is one that gets muted.
+
+@test "QUIET: checkout SHA equals the target" {
+    run env DEPLOYED_SHA="$(git rev-parse HEAD)" bash "$CHECK"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"the host checkout matches"* ]]
+}
+
+@test "QUIET: old drift that touches only documentation" {
+    deployed=$(git rev-parse HEAD)
+    commit_at 100 "docs/decisions/whatever.md" "docs: a long essay"
+    commit_at 90 "README.md" "docs: correct a date"
+    git branch -f origin-main main
+
+    run env DEPLOYED_SHA="$deployed" GRACE_HOURS=4 bash "$CHECK"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"not an outage"* ]]
+}
+
+@test "QUIET: a deployable commit merged minutes ago" {
+    deployed=$(git rev-parse HEAD)
+    commit_at 0 "scripts/backup.sh" "fix: something"
+    git branch -f origin-main main
+
+    run env DEPLOYED_SHA="$deployed" GRACE_HOURS=4 bash "$CHECK"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"inside the grace window"* ]]
+}
+
+@test "QUIET: a workflow-only change is never actionable, even old and merged alone" {
+    # .github/workflows is deliberately outside DEPLOYABLE_PREFIXES: since the
+    # app#139 port, the preflight runs the runner's copy, so a workflow change
+    # is live the moment it is merged and never "undeployed" in the sense this
+    # check means.
+    deployed=$(git rev-parse HEAD)
+    commit_at 100 ".github/workflows/deploy.yml" "ci: tweak a trigger"
+    git branch -f origin-main main
+
+    run env DEPLOYED_SHA="$deployed" GRACE_HOURS=4 bash "$CHECK"
+    [ "$status" -eq 0 ]
+}
+
+# ------------------------------------------------------------- the mixture --
+
+@test "a docs commit NEWER than an aged deployable one does not reset the clock" {
+    # The bug this pins: measuring the NEWEST undeployed commit would mean a busy
+    # repository could never trip the alarm, because something always merged
+    # recently. The oldest waiting deployable commit is the one that matters.
+    deployed=$(git rev-parse HEAD)
+    commit_at 48 "platform/data/postgres/init.sh" "fix: the security fix nobody deployed"
+    commit_at 1  "docs/note.md" "docs: an unrelated note from an hour ago"
+    git branch -f origin-main main
+
+    run env DEPLOYED_SHA="$deployed" GRACE_HOURS=4 bash "$CHECK"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"the security fix nobody deployed"* ]]
+    [[ "$output" == *"48h"* ]]
+}
+
+@test "a docs commit OLDER than the grace window alone still does not fire" {
+    # The mirror of the case above, so the filter is proven in both directions
+    # rather than only where it happens to agree with the age rule.
+    deployed=$(git rev-parse HEAD)
+    commit_at 500 "README.md" "docs: ancient"
+    git branch -f origin-main main
+
+    run env DEPLOYED_SHA="$deployed" GRACE_HOURS=4 bash "$CHECK"
+    [ "$status" -eq 0 ]
+}
+
+@test "CONTROL: the check is not vacuously green — it can be made to fire by one commit" {
+    # Guards against the whole file passing because the script exits 0 early for
+    # some unrelated reason. Same fixture, one deployable commit is the only
+    # difference between green and red.
+    deployed=$(git rev-parse HEAD)
+    commit_at 50 "docs/only.md" "docs: only"
+    git branch -f origin-main main
+    run env DEPLOYED_SHA="$deployed" GRACE_HOURS=4 bash "$CHECK"
+    [ "$status" -eq 0 ]
+
+    commit_at 50 "scripts/checks/one.sh" "fix: one deployable change"
+    git branch -f origin-main main
+    run env DEPLOYED_SHA="$deployed" GRACE_HOURS=4 bash "$CHECK"
+    [ "$status" -eq 1 ]
+}
+
+# ---------------------------------------------------------------------------
+# THE WORDING IS PART OF THE CHECK.
+#
+# This alarm compares ONE git SHA read from the host against origin/main. It
+# does not inspect a container image, and it must not print anything that
+# could be read as a claim about running code — hill90-app's version made
+# exactly that overclaim before its #162, and the wording tests there pinned
+# the fix so it could not silently regress. This is the same shape, checked
+# against a script that never had the overclaim to begin with — a control that
+# proves it, not just a fixture that happens to pass.
+# ---------------------------------------------------------------------------
+
+@test "WORDING clean: says CHECKOUT, and never claims to know what is running" {
+    run env DEPLOYED_SHA="$(git rev-parse HEAD)" bash "$CHECK"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"the host checkout matches"* ]]
+    [[ "$output" != *"what is running is what was merged"* ]]
+    [[ "$output" != *"is what was merged"* ]]
+}
+
+@test "WORDING clean: carries the NOT CHECKED caveat on every run, pass or fail" {
+    # A green line with no stated limit reads as a broader guarantee than it is.
+    # The caveat is printed in the scope banner, before any verdict, so it
+    # travels with every outcome rather than living only in a comment.
+    run env DEPLOYED_SHA="$(git rev-parse HEAD)" bash "$CHECK"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"NOT CHECKED"* ]]
+    [[ "$output" == *"CONTAINER"* ]]
+
+    deployed=$(git rev-parse HEAD)
+    commit_at 9 "scripts/deploy.sh" "fix: a bound"
+    git branch -f origin-main main
+    run env DEPLOYED_SHA="$deployed" GRACE_HOURS=4 bash "$CHECK"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"NOT CHECKED"* ]]
+}
+
+@test "WORDING: the scope banner states the comparison before any verdict" {
+    # A reader who stops at the first two lines must still not be able to infer
+    # coverage that is absent.
+    run env DEPLOYED_SHA="$(git rev-parse HEAD)" bash "$CHECK"
+    [[ "$output" == *"SCOPE: compares the git CHECKOUT"* ]]
+    scope_line=$(printf '%s\n' "$output" | grep -n "SCOPE:" | head -1 | cut -d: -f1)
+    verdict_line=$(printf '%s\n' "$output" | grep -n "PASS:" | head -1 | cut -d: -f1)
+    [ -n "$scope_line" ]
+    [ -n "$verdict_line" ]
+    [ "$scope_line" -lt "$verdict_line" ]
+}
+
+@test "WORDING drifted: says NOT IN THE HOST CHECKOUT, not 'not running'" {
+    # The same overclaim with the opposite sign. The check knows the commits are
+    # absent from the checkout; that they are not running follows, and the
+    # message may say so — but the thing it VERIFIED must be named first.
+    deployed=$(git rev-parse HEAD)
+    commit_at 9 "scripts/checks/x.sh" "fix: a bound"
+    git branch -f origin-main main
+
+    run env DEPLOYED_SHA="$deployed" GRACE_HOURS=4 bash "$CHECK"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"NOT IN THE HOST CHECKOUT"* ]]
+    [[ "$output" == *"They are certainly not running"* ]]
+}
+
+@test "WORDING drifted: the count line is about the checkout too" {
+    deployed=$(git rev-parse HEAD)
+    commit_at 9 "scripts/checks/x.sh" "fix: a bound"
+    git branch -f origin-main main
+
+    run env DEPLOYED_SHA="$deployed" GRACE_HOURS=4 bash "$CHECK"
+    [[ "$output" == *"not in the host checkout."* ]]
+    [[ "$output" != *"merged and not deployed."* ]]
+}
+
+@test "WORDING unknown: names the checkout, and refuses to imply anything else" {
+    run env DEPLOYED_SHA= bash "$CHECK"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"no checkout SHA was supplied"* ]]
+    [[ "$output" == *"nothing was compared"* ]]
+}
+
+@test "CONTROL: the wording assertions can fail — they are not matching everything" {
+    # Every case above is a string match, and a string match that is always true
+    # proves nothing. Each phrase pinned here is absent from a deliberately
+    # different message.
+    run env DEPLOYED_SHA="$(git rev-parse HEAD)" bash "$CHECK"
+    [[ "$output" != *"NOT IN THE HOST CHECKOUT"* ]]
+    [[ "$output" != *"no checkout SHA was supplied"* ]]
+    [[ "$output" != *"verified the running image"* ]]
+}

--- a/tests/scripts/preflight-checkout.bats
+++ b/tests/scripts/preflight-checkout.bats
@@ -92,17 +92,6 @@ setup() {
   [[ "$output" == *"3 commits behind"* ]]
 }
 
-@test "every deploy path calls the preflight before git reset --hard" {
-  cd "$BATS_TEST_DIRNAME/../.."
-  for wf in .github/workflows/deploy-infra.yml \
-            .github/workflows/reusable-deploy-service.yml \
-            .github/workflows/vault-init.yml \
-            .github/workflows/vault-reinitialize.yml \
-            .github/workflows/vault-regain-root.yml; do
-    grep -q "preflight-checkout.sh" "$wf" || { echo "missing preflight in $wf"; return 1; }
-  done
-}
-
 @test "drift wording is correct when only AHEAD of origin/main" {
   echo "local only" >> docs/readme.md
   git add -A && git commit -qm "local-only commit"
@@ -123,21 +112,21 @@ setup() {
 }
 
 # ---------------------------------------------------------------------------
-# The guard must fail LEGIBLY when it is not on the box yet.
+# THE BOOTSTRAP DEADLOCK (app#139, ported here as app#140's issue #705).
 #
-# The preflight ships in this repository, so it exists on /opt/hill90/app only
-# AFTER one deploy that includes it. Until then every deploy path that calls it
-# dies at `bash: scripts/preflight-checkout.sh: No such file or directory`,
-# exit 127, with nothing saying what to do. Verified on 2026-07-29: the script is
-# absent from the box and the checkout is at #563, four commits behind main, so
-# this is the live state and not a hypothetical.
+# Every one of these five workflows used to run `bash scripts/preflight-
+# checkout.sh` against the VPS's OWN checkout, in the same `&&` chain as the
+# `git reset --hard origin/main` that is the only thing that updates it. So a
+# defect in the guard could not be fixed by merging the fix — the old code
+# decided whether the new code was allowed to run, and the deploy that would
+# have delivered the fix was the deploy the unfixed guard was blocking.
 #
-# Halting is correct — it is the fail-closed direction. Halting without an
-# explanation is not. hill90-app solved this first; these tests port it back.
-#
-# The message must be BYTE-IDENTICAL in every deploy workflow so it is greppable.
-# The four sites cannot share an abstraction (see the comment in the
-# implementation), so a test is what keeps them in step.
+# The fix: run the RUNNER's copy of the script, piped over ssh with
+# `bash -s < scripts/preflight-checkout.sh`, as its own step, strictly BEFORE
+# the step that runs `git reset --hard`. That also retires the old
+# "preflight-checkout.sh is missing from the box" guard entirely — that
+# failure mode existed only because the host's own copy was being invoked, and
+# a script piped over stdin cannot be "missing".
 # ---------------------------------------------------------------------------
 
 DEPLOY_WORKFLOWS=(
@@ -148,64 +137,55 @@ DEPLOY_WORKFLOWS=(
   ".github/workflows/vault-regain-root.yml"
 )
 
-# The canonical text lives here, once. The implementation must match it exactly.
-# It deliberately contains NO quote characters of either kind: two of the four
-# call sites wrap the remote command in double quotes and two in single quotes,
-# so any quote in the message would have to differ per site and stop being
-# greppable.
-EXPECTED_MESSAGE='::error::scripts/preflight-checkout.sh is missing from /opt/hill90/app on the VPS. It ships in this repository, so it exists on the box only AFTER one deploy that includes it. Fix: ssh to the VPS as deploy, run cd /opt/hill90/app && git pull, then re-run this workflow. Do not remove the guard to get past this.'
-
-@test "every deploy path checks the preflight exists before running it" {
+@test "every deploy path pipes the RUNNER's preflight copy over ssh, not the host's" {
   cd "$BATS_TEST_DIRNAME/../.."
   for wf in "${DEPLOY_WORKFLOWS[@]}"; do
-    grep -q -- "-f scripts/preflight-checkout.sh" "$wf" \
-      || { echo "no existence check in $wf — a missing script will exit 127 with no explanation"; return 1; }
+    grep -q -- '< scripts/preflight-checkout.sh' "$wf" \
+      || { echo "$wf does not pipe scripts/preflight-checkout.sh from the runner"; return 1; }
   done
 }
 
-@test "the missing-preflight message is byte-identical in every deploy workflow" {
+@test "every deploy path calls the preflight step BEFORE the step that resets the host" {
+  # THIS COMPARES STEP NAMES, not raw occurrences of "git reset --hard" — a
+  # comment mentioning the old defect (see reusable-deploy-service.yml) also
+  # contains that text, so a naive line-number grep across the whole file can
+  # find a comment above the guard and call the ordering satisfied when it
+  # is not. A step name is the thing that actually orders execution.
   cd "$BATS_TEST_DIRNAME/../.."
   for wf in "${DEPLOY_WORKFLOWS[@]}"; do
-    grep -qF -- "$EXPECTED_MESSAGE" "$wf" \
-      || { echo "message missing or altered in $wf"; return 1; }
+    pf_line=$(grep -n '^      - name: Checkout preflight' "$wf" | head -1 | cut -d: -f1)
+    [ -n "$pf_line" ] || { echo "no preflight step in $wf"; return 1; }
+
+    # The first `git reset --hard` at or after the preflight step's line is the
+    # real invocation; anything earlier in the file is prose about the old bug.
+    reset_line=$(tail -n "+$pf_line" "$wf" | grep -n 'git reset --hard' | head -1 | cut -d: -f1)
+    [ -n "$reset_line" ] || { echo "no git reset --hard found after the preflight step in $wf"; return 1; }
+    reset_line=$((pf_line + reset_line - 1))
+
+    [ "$pf_line" -lt "$reset_line" ] \
+      || { echo "$wf resets before (or without) running the preflight"; return 1; }
   done
 }
 
-@test "the message contains no quote characters — it must survive both quotings" {
-  # Two sites embed the remote command in "..." and two in '...'. A quote in the
-  # message would need escaping that differs per site, which is how four copies
-  # stop being greppable.
-  [[ "$EXPECTED_MESSAGE" != *"'"* ]]
-  [[ "$EXPECTED_MESSAGE" != *'"'* ]]
-}
-
-@test "the message names the exact command that fixes it" {
-  # The reader is someone whose deploy just failed. A diagnosis without a command
-  # is a fifteen-minute detour.
-  [[ "$EXPECTED_MESSAGE" == *"git pull"* ]]
-  [[ "$EXPECTED_MESSAGE" == *"/opt/hill90/app"* ]]
-}
-
-@test "the existence check runs BEFORE the script is invoked, in each workflow" {
+@test "CONTROL: the ordering test can fail — it is not vacuously true" {
+  # Proves the test above actually reads the file rather than passing on any
+  # input: a workflow with the preflight step AFTER the reset must fail it.
   cd "$BATS_TEST_DIRNAME/../.."
-  for wf in "${DEPLOY_WORKFLOWS[@]}"; do
-    check_line=$(grep -n -- "-f scripts/preflight-checkout.sh" "$wf" | head -1 | cut -d: -f1)
-    run_line=$(grep -n -- "bash scripts/preflight-checkout.sh" "$wf" | head -1 | cut -d: -f1)
-    [ -n "$check_line" ] || { echo "no existence check in $wf"; return 1; }
-    [ -n "$run_line" ]   || { echo "no invocation in $wf"; return 1; }
-    # Same line is fine (a one-liner chains both); after is not.
-    [ "$check_line" -le "$run_line" ] \
-      || { echo "$wf checks for the script AFTER trying to run it"; return 1; }
-  done
-}
-
-@test "the guard is still fail-closed — it exits rather than skipping the preflight" {
-  cd "$BATS_TEST_DIRNAME/../.."
-  for wf in "${DEPLOY_WORKFLOWS[@]}"; do
-    # The whole point is halting. A check that warns and continues would deploy
-    # with no preflight at all, which is worse than the 127 it replaces.
-    line=$(grep -- "-f scripts/preflight-checkout.sh" "$wf" | head -1)
-    [[ "$line" == *"exit 1"* ]] \
-      || { echo "$wf checks for the script but does not exit when it is absent"; return 1; }
-  done
+  tmp="$BATS_TEST_TMPDIR/reordered.yml"
+  cat > "$tmp" <<'EOF'
+jobs:
+  deploy:
+    steps:
+      - name: Deploy service
+        run: |
+          ssh host "cd /opt/hill90/app && git reset --hard origin/main"
+      - name: Checkout preflight (this repo's copy, not the host's)
+        run: |
+          ssh host "cd /opt/hill90/app && bash -s" < scripts/preflight-checkout.sh
+EOF
+  pf_line=$(grep -n '^      - name: Checkout preflight' "$tmp" | head -1 | cut -d: -f1)
+  reset_line=$(tail -n "+$pf_line" "$tmp" | grep -n 'git reset --hard' | head -1 | cut -d: -f1)
+  # No reset found AT OR AFTER the (now-last) preflight step confirms the
+  # fixture is genuinely reordered, not an accident of the grep.
+  [ -z "$reset_line" ]
 }

--- a/tests/scripts/preflight-drift-sigpipe.bats
+++ b/tests/scripts/preflight-drift-sigpipe.bats
@@ -1,0 +1,100 @@
+#!/usr/bin/env bats
+
+# The drift report must not kill the deploy.
+#
+# scripts/preflight-checkout.sh runs `set -euo pipefail` and printed the
+# not-yet-deployed commits as:
+#
+#     git --no-pager log --oneline HEAD..origin/main | sed 's/^/    /' | head -20
+#
+# `head -20` closes the pipe after twenty lines. The writer upstream then takes
+# SIGPIPE, `pipefail` promotes that to the pipeline's status (141), and `set -e`
+# exits the script. Because the preflight runs in an `&&` chain BEFORE
+# `git reset --hard origin/main`, the deploy stops there: nothing is deployed,
+# and the host keeps running the old image.
+#
+# It is latent until the checkout falls more than twenty commits behind. Ported
+# from hill90-app (app#137), which observed this in production on 2026-08-03,
+# deploying `api`, at 55 commits behind:
+#
+#     # DRIFT: this checkout is 55 commits behind origin/main
+#     ...twenty commit lines...
+#     ##[error]Process completed with exit code 141.
+#
+# This repository's own preflight had the identical `| head -20` shape at the
+# time app#140 (this repo's port: issue #705) was filed — confirmed by reading
+# scripts/preflight-checkout.sh before fixing it, not assumed from the app-repo
+# finding.
+#
+# The fix is to ask git for the cap (`-n 20`) instead of closing a pipe on it,
+# so no writer is ever signalled.
+#
+# This test does not depend on pipe-buffer timing — with only fifty-five short
+# lines the whole output fits in the 64 KiB pipe buffer and the race may not
+# fire at all. It uses a stub `git` that emits far more than a buffer's worth
+# unless it is asked for a limit, which makes the old code fail every time and
+# the new code pass every time.
+
+setup() {
+  SCRIPT="$BATS_TEST_DIRNAME/../../scripts/preflight-checkout.sh"
+  [ -f "$SCRIPT" ] || skip "scripts/preflight-checkout.sh not found"
+
+  STUB_DIR="$BATS_TEST_TMPDIR/stub"
+  mkdir -p "$STUB_DIR"
+
+  # A stand-in for git that answers only what the drift report asks, and floods
+  # `log` with 20000 lines unless given -n. Everything else is inert.
+  cat > "$STUB_DIR/git" <<'STUB'
+#!/usr/bin/env bash
+args="$*"
+case "$args" in
+  *"rev-list --count"*"HEAD..origin/main"*) echo 55 ;;
+  *"rev-list --count"*"origin/main..HEAD"*) echo 0 ;;
+  *"log"*)
+    limit=0
+    prev=""
+    for a in "$@"; do
+      [ "$prev" = "-n" ] && limit="$a"
+      case "$a" in -n[0-9]*) limit="${a#-n}" ;; esac
+      prev="$a"
+    done
+    if [ "$limit" -gt 0 ] 2>/dev/null; then
+      for i in $(seq 1 "$limit"); do echo "abc1234 commit subject line number $i"; done
+    else
+      for i in $(seq 1 20000); do echo "abc1234 commit subject line number $i"; done
+    fi
+    ;;
+  *) exit 0 ;;
+esac
+STUB
+  chmod +x "$STUB_DIR/git"
+}
+
+@test "the drift report survives a checkout far behind origin/main" {
+  # Source the script's drift function alone: running the whole preflight would
+  # need a real checkout, and the defect lives entirely in this function.
+  run env PATH="$STUB_DIR:$PATH" bash -c '
+    set -euo pipefail
+    behind=55
+    ahead=0
+    eval "$(sed -n "/^report_drift()/,/^}/p" "$1")"
+    report_drift
+  ' _ "$SCRIPT"
+
+  [ "$status" -eq 0 ]
+}
+
+@test "the drift report still caps the list at twenty commits" {
+  run env PATH="$STUB_DIR:$PATH" bash -c '
+    set -euo pipefail
+    behind=55
+    ahead=0
+    eval "$(sed -n "/^report_drift()/,/^}/p" "$1")"
+    report_drift
+  ' _ "$SCRIPT"
+
+  # Guards the fix against becoming "print everything", which would bury the
+  # banner under a hundred lines on a checkout that is far behind.
+  commit_lines=$(printf '%s\n' "$output" | grep -c 'commit subject line number' || true)
+  [ "$commit_lines" -eq 20 ]
+}


### PR DESCRIPTION
## Summary

Closes #705. hill90-app#140 found and fixed three stacked deploy-path defects, then found the identical shapes here — worse, because this repo has five deploy-path sites instead of one, and three of them are the vault recovery workflows: the ones you reach for when something is already wrong. **Confirmed each defect was still present here before porting anything**, not assumed from the app-repo finding — see the "Verified" section below.

1. **SIGPIPE abort.** `scripts/preflight-checkout.sh` printed undeployed commits through `git log ... | head -20` under `set -euo pipefail`. `head` closes the pipe after 20 lines, the writer takes SIGPIPE, `pipefail` promotes that to a failure, and the preflight aborts *before* `git reset --hard` — so the more a checkout drifts, the more certainly the next deploy refuses. Fixed with `git log -n 20` in both directions.
2. **Bootstrap deadlock.** All five deploy-path workflows ran the preflight against the VPS's *own* checkout, in the same command chain as the `git reset --hard` that is the only thing that updates it — so a fix to the guard couldn't reach production until a deploy succeeded, and the guard was what stood between the host and a successful deploy. Fixed by piping the runner's copy over ssh (`bash -s < scripts/preflight-checkout.sh`) as its own step, strictly before the reset, across `reusable-deploy-service.yml`, `deploy-infra.yml`, `vault-init.yml`, `vault-reinitialize.yml`, `vault-regain-root.yml`. This also retires the old "preflight-checkout.sh is missing from the box" guard entirely — that failure mode existed only because the host's own copy was being invoked.
3. **No drift alarm.** Nothing compared the host's checkout against `origin/main`. Added `deploy-drift.yml` (scheduled every 4h) + `scripts/checks/check_deploy_drift.sh` — a **checkout-only** port of hill90-app's alarm, deliberately without that repo's later per-container revision comparison (their #158 and follow-ups). Flagged as future work, not silently dropped.

## Test plan

- [x] **Reproduced first**: reverted `scripts/preflight-checkout.sh` and all five workflows to their pre-fix content (via `git show HEAD:... > file`, restored after), ran the new/updated bats tests — 3 failed (the two step-ordering assertions in `preflight-checkout.bats`, and the SIGPIPE reproduction in `preflight-drift-sigpipe.bats`). Restored the fix, all pass.
- [x] `bats tests/scripts/preflight-checkout.bats tests/scripts/preflight-drift-sigpipe.bats tests/scripts/deploy-drift-control.bats` → 36/36, including explicit `CONTROL:` cases proving each assertion can fail (not vacuously true).
- [x] `python3 scripts/checks/check_checks_are_wired.py` → `check_deploy_drift.sh` shows `bats,workflow` — actually invoked, not just present (this repo has a check specifically for "check written and wired to nothing", from #688/#689).
- [x] Ran the full surrounding vault/traefik/deploy bats suites to check for regressions from restructuring 5 workflow files: `deploy.bats`, `host-invariants.bats`, `vault.bats`, `traefik-config.bats`, `root-revoke-fails-closed-control.bats`, `silent-success-sweep-control.bats`, `unseal-contracts-control.bats`, `vault-revoke-order-control.bats` — 188/188 pass.
- [x] `shellcheck` on both modified/new scripts — no new findings (one pre-existing SC2001 style note, unrelated to this diff).
- [x] All 5 touched workflow YAML files + the new one parse clean (`yaml.safe_load`).

## Caution confirmed before touching anything

`deploy.yml`'s `on.push.paths` filter (read directly, not assumed): `platform/auth/keycloak/**`, `platform/data/postgres/**`, `platform/observability/**`, four `deploy/compose/prod/docker-compose.*.yml` files, and `scripts/minio.sh`. None of the files this PR touches match any of those. The other four workflows this PR edits (`deploy-infra.yml`, `vault-init.yml`, `vault-reinitialize.yml`, `vault-regain-root.yml`) are `workflow_dispatch`-only with no push trigger at all. **Merging this does not deploy production.**

## Scope, stated so it isn't inferred wider than it is

- Defect 3's alarm is **checkout-only**. It does not compare what a running *container* was built from — hill90-app's own alarm didn't either until its #158, several PRs after the first cut. Porting that is separate future work if this repo hits the same "checkout current, container stale" gap.
- No production access was used or needed for any of this — `check_deploy_drift.sh` runs entirely against git history in the tests; the real workflow only reads one `git rev-parse HEAD` over ssh, and it wasn't run against the live host as part of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)