### PR TITLE
fix: hill90-ui's platform-realm.json is missing the basic scope, so a rebuild would import a client that authenticates nobody (#704)

### DIFF
--- a/platform/auth/keycloak/platform-realm.json
+++ b/platform/auth/keycloak/platform-realm.json
@@ -129,6 +129,7 @@
         "web-origins",
         "acr",
         "roles",
+        "basic",
         "profile",
         "email"
       ],

--- a/scripts/checks/check_realm_tenant_clients.py
+++ b/scripts/checks/check_realm_tenant_clients.py
@@ -28,16 +28,25 @@ So four things are asserted here, and each one has a specific way of going wrong
    (it was built by kcadm, which inherited it); this file did not, and until
    now nothing compared the two.
    #
-   hill90-app#306 makes the api REFUSE a token with no `sub`, which is what
-   turns this into a total outage — but #306 is NOT deployed as of 2026-08-04
-   (deployed checkout 114b9e5, main 55 commits ahead, #306 among them). So the
-   failure this check exists to prevent runs BACKWARDS right now: a rebuild
-   today would produce subject-less tokens, and the currently-deployed api
-   would keep accepting them and silently scope ownership by `undefined` at
-   all 158 call sites — quietly wrong rather than loudly down. Deploying #306
-   makes this WORSE, not better, until this scope fix ships too. Do not
-   describe #306 as deployed without re-checking; that direction of the
-   claim is the one that overstates urgency rather than understates it.
+   hill90-app#306 makes the api REFUSE a token with no `sub`, and as of
+   2026-08-04 ~15:20 UTC it IS deployed — verified: api, ai, knowledge, mcp
+   and ui are all on 22a6b44, all three pending migrations applied. The live
+   `hill90-ui` client keeps working right now ONLY because `kcadm` gave it
+   `basic` when it was created; this file's own list still does not. So
+   importing this file AS COMMITTED, right now, would take every user out —
+   loudly and immediately, every login refused at once, not a slow leak.
+   #
+   THIS IS A CHANGE FROM EARLIER THE SAME DAY, and both states are kept here
+   deliberately because a comment in a realm-guard file gets read for months.
+   Before ~15:20 UTC (deployed checkout 114b9e5, #306 still 55 commits
+   undeployed), the api accepted a subject-less token and silently scoped
+   ownership by `undefined` at all 158 call sites instead of refusing it — a
+   quiet mis-owned-data bug, not an outage. Deploying #306 made this SPECIFIC
+   gap worse, not better: the same missing scope in this file went from a
+   silent-corruption hazard to a total-lockout hazard the moment #306 shipped,
+   which inverts the usual assumption that deploying a security fix makes
+   things safer. Re-check the deployed SHA before repeating either claim; do
+   not assume this comment's date still describes the live state.
 
 2. `hill90-ui` has NO realm-roles mapper. This is the inversion worth
    understanding, because the obvious instinct is backwards:
@@ -123,22 +132,22 @@ def check(realm: dict) -> list[str]:
             )
         # ---- 1b. the basic scope is pinned too ---------------------------
         # basic is what emits `sub`. hill90-app reads user.sub at 158 call
-        # sites — a REALM IMPORT (a VPS rebuild) that used this file without
-        # 'basic' would issue tokens with no subject. hill90-app#306 makes the
-        # api refuse such a token outright, but #306 is NOT deployed as of
-        # 2026-08-04 — until it ships, a subject-less token is instead
-        # accepted and silently scopes ownership by `undefined` at all 158
-        # sites. See #704.
+        # sites, and hill90-app#306 IS deployed as of 2026-08-04 ~15:20 UTC
+        # (verified: api/ai/knowledge/mcp/ui all on 22a6b44) — the api now
+        # refuses a token with no `sub`. A REALM IMPORT that used this file
+        # without 'basic', right now, authenticates nobody: every login
+        # refused, immediately. Earlier the same day, before #306 shipped,
+        # the same missing scope would have been silent instead — undefined
+        # ownership at all 158 sites rather than a locked-out login. See
+        # #704, and re-check the deployed SHA before repeating either claim.
         if "basic" not in scopes:
             fail(
                 problems,
                 "hill90-ui's defaultClientScopes does not include 'basic', so "
-                "issued tokens carry no 'sub' claim. hill90-app#306 (not yet "
-                "deployed as of 2026-08-04) will make the api refuse such a "
-                "token outright; until it ships, the deployed api accepts it "
-                "and silently scopes ownership by 'undefined'. A realm import "
-                "from this file authenticates nobody once #306 is live, and "
-                "quietly mis-owns everything until then. See #704.",
+                "issued tokens carry no 'sub' claim. hill90-app#306 is DEPLOYED "
+                "(as of 2026-08-04) and makes the api refuse such a token "
+                "outright — a realm import from this file authenticates nobody, "
+                "right now, not eventually. See #704.",
             )
 
     # ---- 2. no realm-roles mapper on the tenant client ------------------

--- a/scripts/checks/check_realm_tenant_clients.py
+++ b/scripts/checks/check_realm_tenant_clients.py
@@ -24,11 +24,20 @@ So four things are asserted here, and each one has a specific way of going wrong
    tenant-clients, before this fix) or through the realm's own default scopes
    gets `basic` automatically; this FILE did not list it explicitly, so a
    REALM IMPORT — the path a VPS rebuild takes — would produce a `hill90-ui`
-   that issues tokens with no `sub`. hill90-app#306, already deployed, makes
-   the api refuse such a token outright, so the failure is a total outage on
-   every request from every user, not a quiet bug. The live realm has always
-   had `basic` (it was built by kcadm, which inherited it); this file did not,
-   and until now nothing compared the two.
+   that issues tokens with no `sub`. The live realm has always had `basic`
+   (it was built by kcadm, which inherited it); this file did not, and until
+   now nothing compared the two.
+   #
+   hill90-app#306 makes the api REFUSE a token with no `sub`, which is what
+   turns this into a total outage — but #306 is NOT deployed as of 2026-08-04
+   (deployed checkout 114b9e5, main 55 commits ahead, #306 among them). So the
+   failure this check exists to prevent runs BACKWARDS right now: a rebuild
+   today would produce subject-less tokens, and the currently-deployed api
+   would keep accepting them and silently scope ownership by `undefined` at
+   all 158 call sites — quietly wrong rather than loudly down. Deploying #306
+   makes this WORSE, not better, until this scope fix ships too. Do not
+   describe #306 as deployed without re-checking; that direction of the
+   claim is the one that overstates urgency rather than understates it.
 
 2. `hill90-ui` has NO realm-roles mapper. This is the inversion worth
    understanding, because the obvious instinct is backwards:
@@ -114,16 +123,22 @@ def check(realm: dict) -> list[str]:
             )
         # ---- 1b. the basic scope is pinned too ---------------------------
         # basic is what emits `sub`. hill90-app reads user.sub at 158 call
-        # sites, and hill90-app#306 makes the api refuse a token that has
-        # none — so a REALM IMPORT (a VPS rebuild) that used this file
-        # without 'basic' would authenticate nobody. See #704.
+        # sites — a REALM IMPORT (a VPS rebuild) that used this file without
+        # 'basic' would issue tokens with no subject. hill90-app#306 makes the
+        # api refuse such a token outright, but #306 is NOT deployed as of
+        # 2026-08-04 — until it ships, a subject-less token is instead
+        # accepted and silently scopes ownership by `undefined` at all 158
+        # sites. See #704.
         if "basic" not in scopes:
             fail(
                 problems,
                 "hill90-ui's defaultClientScopes does not include 'basic', so "
-                "issued tokens carry no 'sub' claim. hill90-app#306 makes the api "
-                "refuse such a token outright — a realm import from this file "
-                "would authenticate nobody. See #704.",
+                "issued tokens carry no 'sub' claim. hill90-app#306 (not yet "
+                "deployed as of 2026-08-04) will make the api refuse such a "
+                "token outright; until it ships, the deployed api accepts it "
+                "and silently scopes ownership by 'undefined'. A realm import "
+                "from this file authenticates nobody once #306 is live, and "
+                "quietly mis-owns everything until then. See #704.",
             )
 
     # ---- 2. no realm-roles mapper on the tenant client ------------------

--- a/scripts/checks/check_realm_tenant_clients.py
+++ b/scripts/checks/check_realm_tenant_clients.py
@@ -11,11 +11,24 @@ it stops being emitted — the token still validates, the login still succeeds, 
 every permission check silently returns empty. A user sees an app with no
 permissions and no error.
 
-So three things are asserted here, and each one has a specific way of going wrong:
+So four things are asserted here, and each one has a specific way of going wrong:
 
 1. `hill90-ui` keeps `roles` in its `defaultClientScopes`. Left implicit, the
    claim depends on the realm's default-client-scope list, which is edited
    elsewhere and for other reasons.
+
+1b. `hill90-ui` also keeps `basic` — added for #704 (2026-08-04). Keycloak 24+
+   emits the `sub` claim into the access token via the `basic` client scope,
+   and hill90-app reads `user.sub` at 158 call sites to answer "is this
+   yours?". A client CREATED through `kcadm` (scripts/keycloak.sh
+   tenant-clients, before this fix) or through the realm's own default scopes
+   gets `basic` automatically; this FILE did not list it explicitly, so a
+   REALM IMPORT — the path a VPS rebuild takes — would produce a `hill90-ui`
+   that issues tokens with no `sub`. hill90-app#306, already deployed, makes
+   the api refuse such a token outright, so the failure is a total outage on
+   every request from every user, not a quiet bug. The live realm has always
+   had `basic` (it was built by kcadm, which inherited it); this file did not,
+   and until now nothing compared the two.
 
 2. `hill90-ui` has NO realm-roles mapper. This is the inversion worth
    understanding, because the obvious instinct is backwards:
@@ -91,13 +104,27 @@ def check(realm: dict) -> list[str]:
             "hill90-ui has no explicit defaultClientScopes. "
             f"{TENANT_ROLES_CLAIM} then depends on the realm's default list; pin it.",
         )
-    elif "roles" not in scopes:
-        fail(
-            problems,
-            "hill90-ui's defaultClientScopes does not include 'roles', so "
-            f"{TENANT_ROLES_CLAIM} is never emitted and every permission check "
-            "silently returns empty.",
-        )
+    else:
+        if "roles" not in scopes:
+            fail(
+                problems,
+                "hill90-ui's defaultClientScopes does not include 'roles', so "
+                f"{TENANT_ROLES_CLAIM} is never emitted and every permission check "
+                "silently returns empty.",
+            )
+        # ---- 1b. the basic scope is pinned too ---------------------------
+        # basic is what emits `sub`. hill90-app reads user.sub at 158 call
+        # sites, and hill90-app#306 makes the api refuse a token that has
+        # none — so a REALM IMPORT (a VPS rebuild) that used this file
+        # without 'basic' would authenticate nobody. See #704.
+        if "basic" not in scopes:
+            fail(
+                problems,
+                "hill90-ui's defaultClientScopes does not include 'basic', so "
+                "issued tokens carry no 'sub' claim. hill90-app#306 makes the api "
+                "refuse such a token outright — a realm import from this file "
+                "would authenticate nobody. See #704.",
+            )
 
     # ---- 2. no realm-roles mapper on the tenant client ------------------
     for m in ui.get("protocolMappers", []) or []:

--- a/scripts/keycloak.sh
+++ b/scripts/keycloak.sh
@@ -724,14 +724,20 @@ print(json.dumps({
     # Both branches below pin defaultClientScopes explicitly, and both must
     # include 'basic' — added for #704. Keycloak 24+ emits the `sub` claim via
     # 'basic', and hill90-app reads user.sub at 158 call sites. hill90-app#306
-    # will make the api refuse a token with none, but is NOT deployed as of
-    # 2026-08-04 — until it ships, a subject-less token is silently accepted
-    # and scopes ownership by `undefined` instead. Do not describe #306 as
-    # deployed without re-checking; that direction of the claim overstates
-    # today's severity, not understates it. This is not just a rebuild-time
-    # concern: the RECONCILE branch (the `else` below) runs `kcadm update`
-    # against a client that may already be correct, so a scope list here that
-    # omitted 'basic' would have STRIPPED it from a working production client
+    # IS deployed as of 2026-08-04 ~15:20 UTC (verified: api/ai/knowledge/mcp/
+    # ui all on 22a6b44) and the api now refuses a token with no `sub` — a
+    # client created without 'basic', right now, authenticates nobody at all.
+    # Earlier the same day, before #306 shipped, the identical gap would have
+    # been silent instead: a subject-less token accepted and ownership scoped
+    # by `undefined`. Both states are worth keeping in this comment, because
+    # this is the one that got WORSE the moment the security fix deployed —
+    # re-check the deployed SHA before repeating either claim; do not assume
+    # this comment's date still describes the live state.
+    #
+    # This is not just a rebuild-time concern: the RECONCILE branch (the
+    # `else` below) runs `kcadm update` against a client that may already be
+    # correct, so a scope list here that omitted 'basic' would have STRIPPED
+    # it from a working production client
     # the next time this command ran — actively regressing a client that had
     # it, not merely failing to grant it to a new one. platform-realm.json
     # carries the same list for the same reason; the two must move together.

--- a/scripts/keycloak.sh
+++ b/scripts/keycloak.sh
@@ -723,8 +723,12 @@ print(json.dumps({
     #
     # Both branches below pin defaultClientScopes explicitly, and both must
     # include 'basic' — added for #704. Keycloak 24+ emits the `sub` claim via
-    # 'basic', hill90-app reads user.sub at 158 call sites, and hill90-app#306
-    # makes the api refuse a token with none. This is not just a rebuild-time
+    # 'basic', and hill90-app reads user.sub at 158 call sites. hill90-app#306
+    # will make the api refuse a token with none, but is NOT deployed as of
+    # 2026-08-04 — until it ships, a subject-less token is silently accepted
+    # and scopes ownership by `undefined` instead. Do not describe #306 as
+    # deployed without re-checking; that direction of the claim overstates
+    # today's severity, not understates it. This is not just a rebuild-time
     # concern: the RECONCILE branch (the `else` below) runs `kcadm update`
     # against a client that may already be correct, so a scope list here that
     # omitted 'basic' would have STRIPPED it from a working production client

--- a/scripts/keycloak.sh
+++ b/scripts/keycloak.sh
@@ -720,6 +720,17 @@ print(json.dumps({
     fi
 
     # --- hill90-ui --------------------------------------------------------
+    #
+    # Both branches below pin defaultClientScopes explicitly, and both must
+    # include 'basic' — added for #704. Keycloak 24+ emits the `sub` claim via
+    # 'basic', hill90-app reads user.sub at 158 call sites, and hill90-app#306
+    # makes the api refuse a token with none. This is not just a rebuild-time
+    # concern: the RECONCILE branch (the `else` below) runs `kcadm update`
+    # against a client that may already be correct, so a scope list here that
+    # omitted 'basic' would have STRIPPED it from a working production client
+    # the next time this command ran — actively regressing a client that had
+    # it, not merely failing to grant it to a new one. platform-realm.json
+    # carries the same list for the same reason; the two must move together.
     local ui_uuid; ui_uuid=$(client_uuid "hill90-ui")
     if [ -z "$ui_uuid" ]; then
         [ -n "$ui_secret" ] || die "hill90-ui does not exist and HILL90_UI_CLIENT_SECRET is empty — refusing to create a login client with no secret"
@@ -731,7 +742,7 @@ print(json.dumps({
     "standardFlowEnabled": True, "directAccessGrantsEnabled": False,
     "serviceAccountsEnabled": False, "fullScopeAllowed": True,
     "redirectUris": sys.argv[2].split(","), "webOrigins": sys.argv[3].split(","),
-    "defaultClientScopes": ["web-origins", "acr", "roles", "profile", "email"],
+    "defaultClientScopes": ["web-origins", "acr", "roles", "basic", "profile", "email"],
 }))' "$ui_secret" "$ui_redirects" "$ui_origins" \
           | docker exec -i "$KC_CONTAINER" /opt/keycloak/bin/kcadm.sh \
                 create clients -r "$KC_REALM" -f - >/dev/null 2>&1
@@ -746,7 +757,7 @@ print(json.dumps({
     "standardFlowEnabled": True, "directAccessGrantsEnabled": False,
     "publicClient": False, "bearerOnly": False, "fullScopeAllowed": True,
     "redirectUris": sys.argv[1].split(","), "webOrigins": sys.argv[2].split(","),
-    "defaultClientScopes": ["web-origins", "acr", "roles", "profile", "email"],
+    "defaultClientScopes": ["web-origins", "acr", "roles", "basic", "profile", "email"],
 }))' "$ui_redirects" "$ui_origins" \
           | docker exec -i "$KC_CONTAINER" /opt/keycloak/bin/kcadm.sh \
                 update "clients/${ui_uuid}" -r "$KC_REALM" -f - >/dev/null 2>&1

--- a/tests/checks/test_realm_tenant_clients.py
+++ b/tests/checks/test_realm_tenant_clients.py
@@ -60,13 +60,15 @@ def test_fails_when_the_roles_scope_is_dropped(realm):
 
 def test_fails_when_the_basic_scope_is_dropped(realm):
     # #704: without 'basic' the issued token carries no 'sub'. hill90-app#306
-    # will make the api refuse such a token, but is NOT deployed as of
-    # 2026-08-04 — until it ships, the deployed api accepts it silently and
-    # scopes ownership by `undefined` instead, which is the worse failure to
-    # have live right now. Reproduces the exact defect this file had before
-    # the fix: 'basic' absent from hill90-ui's defaultClientScopes while
-    # 'roles' is present, so this must fail on its own and not be caught
-    # incidentally by the roles assertion above.
+    # IS deployed as of 2026-08-04 ~15:20 UTC (verified: api/ai/knowledge/mcp/
+    # ui all on 22a6b44), and the api now refuses such a token outright — a
+    # client created without 'basic', right now, authenticates nobody at all.
+    # Earlier the same day, before #306 shipped, the identical gap would have
+    # been silent instead: an accepted token scoping ownership by `undefined`.
+    # Reproduces the exact defect this file had before the fix: 'basic'
+    # absent from hill90-ui's defaultClientScopes while 'roles' is present,
+    # so this must fail on its own and not be caught incidentally by the
+    # roles assertion above.
     ui = client(realm, "hill90-ui")
     assert "roles" in ui["defaultClientScopes"]
     ui["defaultClientScopes"] = [s for s in ui["defaultClientScopes"] if s != "basic"]

--- a/tests/checks/test_realm_tenant_clients.py
+++ b/tests/checks/test_realm_tenant_clients.py
@@ -58,6 +58,21 @@ def test_fails_when_the_roles_scope_is_dropped(realm):
     assert "roles" in r.stderr and "silently" in r.stderr
 
 
+def test_fails_when_the_basic_scope_is_dropped(realm):
+    # #704: without 'basic' the issued token carries no 'sub', and
+    # hill90-app#306 makes the api refuse it outright — a realm import from
+    # this file would authenticate nobody. Reproduces the exact defect this
+    # file had before the fix: 'basic' absent from hill90-ui's
+    # defaultClientScopes while 'roles' is present, so this must fail on its
+    # own and not be caught incidentally by the roles assertion above.
+    ui = client(realm, "hill90-ui")
+    assert "roles" in ui["defaultClientScopes"]
+    ui["defaultClientScopes"] = [s for s in ui["defaultClientScopes"] if s != "basic"]
+    r = run(realm)
+    assert r.returncode == 1
+    assert "basic" in r.stderr and "sub" in r.stderr
+
+
 def test_fails_when_default_client_scopes_are_left_implicit(realm):
     del client(realm, "hill90-ui")["defaultClientScopes"]
     r = run(realm)

--- a/tests/checks/test_realm_tenant_clients.py
+++ b/tests/checks/test_realm_tenant_clients.py
@@ -59,12 +59,14 @@ def test_fails_when_the_roles_scope_is_dropped(realm):
 
 
 def test_fails_when_the_basic_scope_is_dropped(realm):
-    # #704: without 'basic' the issued token carries no 'sub', and
-    # hill90-app#306 makes the api refuse it outright — a realm import from
-    # this file would authenticate nobody. Reproduces the exact defect this
-    # file had before the fix: 'basic' absent from hill90-ui's
-    # defaultClientScopes while 'roles' is present, so this must fail on its
-    # own and not be caught incidentally by the roles assertion above.
+    # #704: without 'basic' the issued token carries no 'sub'. hill90-app#306
+    # will make the api refuse such a token, but is NOT deployed as of
+    # 2026-08-04 — until it ships, the deployed api accepts it silently and
+    # scopes ownership by `undefined` instead, which is the worse failure to
+    # have live right now. Reproduces the exact defect this file had before
+    # the fix: 'basic' absent from hill90-ui's defaultClientScopes while
+    # 'roles' is present, so this must fail on its own and not be caught
+    # incidentally by the roles assertion above.
     ui = client(realm, "hill90-ui")
     assert "roles" in ui["defaultClientScopes"]
     ui["defaultClientScopes"] = [s for s in ui["defaultClientScopes"] if s != "basic"]

--- a/tests/scripts/platform-services.bats
+++ b/tests/scripts/platform-services.bats
@@ -116,6 +116,24 @@ assert not bad, f'realm-role mapper on a tenant client: {bad}'
   [ "$status" -eq 0 ]
 }
 
+@test "scripts/keycloak.sh's hardcoded hill90-ui scope lists include 'basic', both of them" {
+  # #704: platform-realm.json's hill90-ui was missing 'basic', so a realm
+  # IMPORT (a VPS rebuild) would produce a client that issues tokens with no
+  # 'sub' — hill90-app reads user.sub at 158 call sites and hill90-app#306
+  # refuses a token without one.
+  #
+  # scripts/keycloak.sh tenant_clients has the SAME list twice, hardcoded in a
+  # python payload: once when CREATING hill90-ui, once when RECONCILING it.
+  # The reconcile branch runs `kcadm update` against a client that may
+  # already be correct — so if this list omitted 'basic', running this
+  # command would have STRIPPED it from a working production client, not
+  # merely failed to grant it to a new one. Both occurrences must carry it,
+  # and both must move with platform-realm.json's own list or the two paths
+  # that can create hill90-ui (import vs kcadm) disagree again.
+  count=$(grep -c '"defaultClientScopes": \[.*"basic".*\]' scripts/keycloak.sh)
+  [ "$count" -eq 2 ]
+}
+
 @test "the platform realm requires TLS, so production is not relaxed by default" {
   # local.sh relaxes this on the RUNNING realm for plain-HTTP local dev. If the
   # shipped file ever says NONE, production silently accepts unencrypted auth.

--- a/tests/scripts/platform-services.bats
+++ b/tests/scripts/platform-services.bats
@@ -119,12 +119,13 @@ assert not bad, f'realm-role mapper on a tenant client: {bad}'
 @test "scripts/keycloak.sh's hardcoded hill90-ui scope lists include 'basic', both of them" {
   # #704: platform-realm.json's hill90-ui was missing 'basic', so a realm
   # IMPORT (a VPS rebuild) would produce a client that issues tokens with no
-  # 'sub' — hill90-app reads user.sub at 158 call sites. hill90-app#306 will
-  # refuse a token without one, but is NOT deployed as of 2026-08-04; until it
-  # ships, the deployed api accepts such a token and silently scopes
-  # ownership by `undefined` instead, which is the more urgent failure to
-  # have live right now, not the total outage #306 will eventually turn it
-  # into.
+  # 'sub' — hill90-app reads user.sub at 158 call sites. hill90-app#306 IS
+  # deployed as of 2026-08-04 ~15:20 UTC (verified: api/ai/knowledge/mcp/ui
+  # all on 22a6b44), and the api now refuses such a token outright — a client
+  # created without 'basic', right now, authenticates nobody at all. Earlier
+  # the same day, before #306 shipped, the identical gap would have been
+  # silent instead: an accepted token scoping ownership by `undefined`. The
+  # hazard got WORSE the moment #306 deployed, not better.
   #
   # scripts/keycloak.sh tenant_clients has the SAME list twice, hardcoded in a
   # python payload: once when CREATING hill90-ui, once when RECONCILING it.

--- a/tests/scripts/platform-services.bats
+++ b/tests/scripts/platform-services.bats
@@ -119,8 +119,12 @@ assert not bad, f'realm-role mapper on a tenant client: {bad}'
 @test "scripts/keycloak.sh's hardcoded hill90-ui scope lists include 'basic', both of them" {
   # #704: platform-realm.json's hill90-ui was missing 'basic', so a realm
   # IMPORT (a VPS rebuild) would produce a client that issues tokens with no
-  # 'sub' — hill90-app reads user.sub at 158 call sites and hill90-app#306
-  # refuses a token without one.
+  # 'sub' — hill90-app reads user.sub at 158 call sites. hill90-app#306 will
+  # refuse a token without one, but is NOT deployed as of 2026-08-04; until it
+  # ships, the deployed api accepts such a token and silently scopes
+  # ownership by `undefined` instead, which is the more urgent failure to
+  # have live right now, not the total outage #306 will eventually turn it
+  # into.
   #
   # scripts/keycloak.sh tenant_clients has the SAME list twice, hardcoded in a
   # python payload: once when CREATING hill90-ui, once when RECONCILING it.


### PR DESCRIPTION
## Summary

Closes #704. `hill90-ui`'s `defaultClientScopes` in `platform-realm.json` is `web-origins, acr, roles, profile, email` — missing `basic`. Confirmed still true against current `main` before touching anything.

**This is a rebuild-path fix, not a live-production fix.** The running Keycloak client has always had `basic` — it was created through `kcadm`, which inherits the realm's default client scopes. The committed JSON's own explicit list simply never included it. Two different creation paths, quietly disagreeing, with nothing comparing them until now.

**Why it matters anyway: this file is what a VPS rebuild imports.** Keycloak 24+ emits the `sub` claim via the `basic` client scope, and hill90-app reads `user.sub` at 158 call sites to answer "is this yours?".

**Second correction, because the world moved under the first one: hill90-app#306 (refuse a token with no `sub`) IS deployed as of 2026-08-04 ~15:20 UTC.** Jon authorised the deploy and it ran while this PR was open. Verified against the deploy workflow's own run history, not assumed: `api`, `ai`, `knowledge`, `mcp` and `ui` are all on `22a6b44`, all three pending migrations applied, and `f10fb00` (#306) is an ancestor of that SHA.

**So the api now refuses a subject-less token outright.** The live `hill90-ui` client keeps working only because `kcadm` gave it `basic` when it was created — this file's own list still does not. **Importing `platform-realm.json` as committed, right now, would take every user out at once: every login refused, immediately, not a slow leak.**

Both states are kept here deliberately, dated, because this description and the matching code comments get read long after today. Before ~15:20 UTC the same day (deployed checkout `114b9e5`, #306 still 55 commits undeployed), the identical missing scope would have been silent instead — a subject-less token accepted and ownership scoped by `undefined` at all 158 call sites, not a refused login. Deploying the security fix made this specific gap WORSE, not better, until this scope fix is live too — the opposite of the usual assumption that deploying a fix makes things safer, and worth keeping on record for exactly that reason.

## The second thing this PR fixes, and why it had to move with the first

Checked for a conflicting guard before writing anything, per the concern that a guard certifying the broken state is worse than no guard. Found one — not a check, but `scripts/keycloak.sh`'s `tenant_clients` command, which hardcodes the **identical** scope list, missing `basic`, **twice**: once when creating `hill90-ui`, once when reconciling it.

The reconcile occurrence is not a rebuild-time risk, it's a **live** one: that branch runs `kcadm update` against a client that may already be correct. With `basic` absent from that list, the next run of `keycloak.sh tenant-clients` against production would have **stripped `basic` from a working client**, not merely failed to grant it to a new one. Both occurrences are fixed here, with a comment explaining why they must move together with `platform-realm.json`'s own list — leaving one fixed and the other not would have meant this PR and that script actively disagreeing about what's correct.

## Verified as a guard, not just a value change

**`check_realm_tenant_clients.py` itself was the guard that asserted the scope list without ever checking for `basic`** — it already pinned `roles` there, so a missing-`basic` regression would have sailed through the one check whose whole job is reviewing this file's separation properties. Extended it in this same PR rather than leaving it behind: the check and `platform-realm.json` now move together, because a check that certifies a file as correct while missing the exact defect that file has is worse than no check at all — it would have been evidence for the wrong conclusion.
- Extended `check_realm_tenant_clients.py` with the same assertion pattern it already uses for `roles` (which client, which claim, which downstream consequence).
- Added `test_fails_when_the_basic_scope_is_dropped`, mirroring the existing `roles` test.
- Added a bats test asserting both of `keycloak.sh`'s hardcoded scope lists carry `basic`.
- **Confirmed both new tests fail against the pre-fix files**: reverted `platform-realm.json` and `keycloak.sh` to their pre-fix content (`git show HEAD:... > file`, restored after), ran the new tests, watched them fail with the exact message the fix is meant to prevent, then restored and confirmed green.
- No other file in the repo pins `hill90-ui`'s scope list — searched for any exact-list guard before writing this; the only other place it appeared was the two `keycloak.sh` occurrences, fixed in this same PR.

Full test run: `python3 -m pytest tests/checks/test_realm_tenant_clients.py` → 15/15. `bats tests/scripts/platform-services.bats` → 43/43. `shellcheck scripts/keycloak.sh` → no new findings (pre-existing SC1091/SC2016/SC2086/SC2015 notes elsewhere in the file, none touching this diff). JSON, Python and bash syntax all verified clean.

## Deploy consequence of merging — read, not assumed

`platform-realm.json` matches `deploy.yml`'s push-path filter (`platform/auth/keycloak/**`), unlike #706. **Merging this WILL trigger a real deploy of the `auth` stack** — the Keycloak container restarts. But `deploy/compose/prod/docker-compose.auth.yml` runs `start --import-realm` with strategy `IGNORE_EXISTING` (confirmed in `platform/auth/keycloak/README.md`), and the `platform` realm already exists in production Postgres — so the realm re-import on that deploy is a no-op. The live client's scopes are unaffected by this specific deploy; the fix reaches the live realm only via `keycloak.sh tenant-clients` (also fixed here) or a future full rebuild. Flagging this because it's the opposite of #706, where nothing in that PR matched the filter at all — this one does, and whoever merges should know a container restart is coming, even though the realm content itself won't move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

