### PR TITLE
chore(ci): one-off read-only audit of the live hill90-ui client, for #707

### DIFF
--- a/.github/workflows/audit-hill90-ui-client.yml
+++ b/.github/workflows/audit-hill90-ui-client.yml
@@ -1,0 +1,112 @@
+name: Audit hill90-ui Client (Read-Only)
+
+# One-off, read-only verification for #707: did the auth-stack restart that
+# PR's merge triggered (platform/auth/keycloak/** matches deploy.yml's push
+# filter) change anything about the LIVE hill90-ui client?
+#
+# `start --import-realm` is documented as IGNORE_EXISTING once a realm
+# exists — see platform/auth/keycloak/README.md — but that is a claim about
+# behaviour, not an observation. This asks the running Keycloak directly.
+#
+# NEVER prints the client secret. Only its length and a sha256 hash, so a
+# before/after comparison is possible without the value ever appearing in an
+# Actions log. Uses the HOST's own already-present age key
+# (/opt/hill90/secrets/keys/keys.txt, the same one scripts/deploy.sh uses
+# remotely) rather than threading Keycloak admin credentials through the
+# runner.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    name: read hill90-ui client shape
+    runs-on: ubuntu-latest
+    environment: production
+    env:
+      VPS_APP_PATH: /opt/hill90/app
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Tailscale
+        uses: tailscale/github-action@v2
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:github-actions
+
+      - name: Setup SSH key
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.VPS_SSH_PRIVATE_KEY }}" > ~/.ssh/vps_key
+          chmod 600 ~/.ssh/vps_key
+
+      - name: Setup SOPS/age
+        env:
+          SOPS_VERSION: '3.9.4'
+        run: |
+          SOPS_URL="https://github.com/getsops/sops/releases/download/v${SOPS_VERSION}/sops-v${SOPS_VERSION}.linux.amd64"
+          curl -fsSL -o /tmp/sops "$SOPS_URL"
+          if file /tmp/sops | grep -q "HTML"; then
+            echo "::error::SOPS download returned HTML instead of binary — check URL: $SOPS_URL"
+            exit 1
+          fi
+          chmod +x /tmp/sops
+          sudo mv /tmp/sops /usr/local/bin/sops
+          mkdir -p ~/.config/sops/age
+          echo "${{ secrets.SOPS_AGE_KEY }}" > ~/.config/sops/age/keys.txt
+          chmod 600 ~/.config/sops/age/keys.txt
+
+      - name: Get Tailscale IP from secrets
+        id: get-ip
+        run: |
+          TAILSCALE_IP=$(sops -d --extract '["TAILSCALE_IP"]' infra/secrets/prod.enc.env)
+          if [ -z "$TAILSCALE_IP" ]; then
+            echo "::error::TAILSCALE_IP is empty or absent in infra/secrets/prod.enc.env"
+            exit 1
+          fi
+          echo "::add-mask::$TAILSCALE_IP"
+          echo "tailscale_ip=$TAILSCALE_IP" >> $GITHUB_OUTPUT
+
+      - name: Read hill90-ui client shape (read-only, no writes)
+        run: |
+          ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no -o ConnectTimeout=15 \
+            deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
+            "cd ${VPS_APP_PATH} && bash -s" <<'REMOTE'
+          set -euo pipefail
+          export SOPS_AGE_KEY_FILE=/opt/hill90/secrets/keys/keys.txt
+
+          user=$(sops -d infra/secrets/prod.enc.env 2>/dev/null | grep '^KC_ADMIN_USERNAME=' | cut -d= -f2-)
+          pass=$(sops -d infra/secrets/prod.enc.env 2>/dev/null | grep '^KC_ADMIN_PASSWORD=' | cut -d= -f2-)
+          [ -n "$user" ] && [ -n "$pass" ] || { echo "::error::could not read KC admin credentials"; exit 1; }
+
+          docker exec -e KC_CLI_PASSWORD="$pass" keycloak /opt/keycloak/bin/kcadm.sh \
+            config credentials --server http://127.0.0.1:8080 --realm master --user "$user" >/dev/null
+
+          uuid=$(docker exec keycloak /opt/keycloak/bin/kcadm.sh get clients -r platform \
+            -q clientId=hill90-ui --fields id --format csv --noquotes 2>/dev/null | tr -d '\r')
+          [ -n "$uuid" ] || { echo "::error::hill90-ui client not found in realm platform"; exit 1; }
+
+          docker exec keycloak /opt/keycloak/bin/kcadm.sh get "clients/${uuid}" -r platform 2>/dev/null \
+            | python3 -c '
+          import json, sys, hashlib
+          c = json.load(sys.stdin)
+          secret = c.get("secret") or ""
+          print("clientId:", c.get("clientId"))
+          print("enabled:", c.get("enabled"))
+          print("publicClient:", c.get("publicClient"))
+          print("bearerOnly:", c.get("bearerOnly"))
+          print("standardFlowEnabled:", c.get("standardFlowEnabled"))
+          print("directAccessGrantsEnabled:", c.get("directAccessGrantsEnabled"))
+          print("defaultClientScopes:", c.get("defaultClientScopes"))
+          print("redirectUris:", c.get("redirectUris"))
+          print("webOrigins:", c.get("webOrigins"))
+          print("secret length:", len(secret))
+          print("secret sha256:", hashlib.sha256(secret.encode()).hexdigest())
+          '
+          REMOTE


### PR DESCRIPTION
Read-only verification requested after #707's merge triggered the auth-stack deploy (platform-realm.json matches deploy.yml's push filter, as flagged in that PR). Checks the live hill90-ui client's defaultClientScopes, redirectUris, webOrigins, and the client secret's length + sha256 (never the plaintext) so the restart's effect can be observed rather than assumed from IGNORE_EXISTING's documented behaviour. workflow_dispatch only, no writes.