### PR TITLE
feat(ci): schedule the hill90-ui secret-agreement audit, and fail on disagreement

### DIFF
--- a/.github/workflows/audit-hill90-ui-client.yml
+++ b/.github/workflows/audit-hill90-ui-client.yml
@@ -1,35 +1,60 @@
-name: Audit hill90-ui Client (Read-Only)
+name: Audit hill90-ui Client Secret Agreement
 
-# One-off, read-only verification for #707: did the auth-stack restart that
-# PR's merge triggered (platform/auth/keycloak/** matches deploy.yml's push
-# filter) change anything about the LIVE hill90-ui client?
+# Does the LIVE Keycloak hill90-ui client still agree with the LIVE app-ui
+# container about their shared secret?
 #
-# `start --import-realm` is documented as IGNORE_EXISTING once a realm
-# exists — see platform/auth/keycloak/README.md — but that is a claim about
-# behaviour, not an observation. This asks the running Keycloak directly.
+# Originated as a one-off read for #707: did the auth-stack restart that PR's
+# merge triggered (platform/auth/keycloak/** matches deploy.yml's push
+# filter) change anything about the running client? `start --import-realm` is
+# documented as IGNORE_EXISTING once a realm exists — see
+# platform/auth/keycloak/README.md — but that is a claim about behaviour, not
+# an observation, so this asks the running Keycloak directly.
 #
-# NEVER prints the client secret. Only its length and a sha256 hash, so a
-# before/after comparison is possible without the value ever appearing in an
-# Actions log. Uses the HOST's own already-present age key
-# (/opt/hill90/secrets/keys/keys.txt, the same one scripts/deploy.sh uses
-# remotely) rather than threading Keycloak admin credentials through the
-# runner.
+# NOW SCHEDULED, because a one-off dispatched by hand is written and wired to
+# nothing the moment nobody remembers to run it — the same defect
+# scripts/checks/check_checks_are_wired.py exists to catch, pointed at a
+# workflow instead of a script.
 #
-# THE SECOND ASSERTION, AND WHY IT IS THE RIGHT SHAPE. The first version of
-# this workflow could only report the live secret's hash in isolation, with
-# no earlier reading to diff it against — a hash with nothing to compare
-# against looks like evidence and is not. The property that actually matters
-# is not "is this the same secret as this morning", it is "do the two sides
-# that must agree still agree": the Keycloak client's secret and the
-# AUTH_KEYCLOAK_SECRET the running app-ui container was started with. A
-# coordinated rotation of both changes the hash on both sides and breaks
-# nothing — this check stays quiet. The two drifting apart — one side
-# restarted with an old value, one side's secret regenerated without the
-# other being updated — is the actual outage case, and THAT is what makes
-# this fail loudly. Comparing to history answers a question nobody needs
-# answered; comparing the two sides answers the one that matters.
+# WHY ITS OWN SCHEDULE, NOT deploy-drift.yml's. deploy-drift's 4-hour cadence
+# is tuned to ITS risk: code merged and not yet deployed, which is bounded by
+# how often a human chooses to run a deploy. That reasoning does not transfer
+# here. The two secrets this checks can drift with NO deploy at all — a
+# manual rotation in the Keycloak admin console, or a SOPS-stored secret
+# edited and app-ui restarted, either one independent of any push or merge.
+# Riding deploy-drift's timer would make detection latency track an unrelated
+# event instead of the actual risk window, which is convenient, not correct.
+#
+# Every 30 minutes: agreement is a binary, always-expected state with no
+# "normal" drift to filter out (unlike deploy-drift, there is no grace
+# window here — a disagreement is never tolerable, only ever a bug), so
+# there is no reason to wait longer than the check itself is cheap to run.
+# A disagreement is also loud to any user attempting to log in, but the
+# platform's own health checks answer from container status and would not
+# catch it — the same blind spot class deploy-drift's own motivating
+# incident was about — so this closes it with a bound on how long that gap
+# can persist before something other than a user complaint notices it.
+#
+# NEVER prints either secret. Only sha256 hashes, computed inside the process
+# that already holds each plaintext (the python reading the kcadm response;
+# the container holding AUTH_KEYCLOAK_SECRET as an env var) — only the two
+# hex digests ever cross a process boundary. Uses the HOST's own
+# already-present age key (/opt/hill90/secrets/keys/keys.txt, the same one
+# scripts/deploy.sh uses remotely) rather than threading Keycloak admin
+# credentials through the runner.
+#
+# THE DECISION HAPPENS ON THE RUNNER, in
+# scripts/checks/check_hill90_ui_secret_agreement.sh — not inside the SSH
+# session — for the same reason check_deploy_drift.sh's comparison runs on
+# the runner rather than the host: the thing deciding must not also be able
+# to be the thing drifting. That script is bats-controlled
+# (tests/scripts/hill90-ui-secret-agreement-control.bats) with a fabricated
+# mismatched pair proving it fails red, independent of and never touching
+# production — a comparison that has only ever seen agreement has not been
+# shown to notice disagreement.
 
 on:
+  schedule:
+    - cron: '*/30 * * * *'
   workflow_dispatch:
 
 permissions:
@@ -37,7 +62,7 @@ permissions:
 
 jobs:
   audit:
-    name: read hill90-ui client shape
+    name: hill90-ui secret agreement
     runs-on: ubuntu-latest
     environment: production
     env:
@@ -87,9 +112,13 @@ jobs:
           echo "::add-mask::$TAILSCALE_IP"
           echo "tailscale_ip=$TAILSCALE_IP" >> $GITHUB_OUTPUT
 
-      - name: Read hill90-ui client shape, and confirm it agrees with app-ui (read-only, no writes)
+      # Read-only, no writes. Reports the client's shape for context and
+      # emits ONLY the two sha256 hashes as step outputs — the decision is
+      # made by the next step, on the runner, not here.
+      - name: Read the two secret hashes from the host
+        id: read
         run: |
-          ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no -o ConnectTimeout=15 \
+          out=$(ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no -o ConnectTimeout=15 \
             deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
             "cd ${VPS_APP_PATH} && bash -s" <<'REMOTE'
           set -euo pipefail
@@ -127,27 +156,24 @@ jobs:
           print("secret length:", len(secret))
           print("secret sha256:", hashlib.sha256(secret.encode()).hexdigest())
           ')
-          echo "$fields"
+          echo "$fields" >&2
 
-          # The property that matters is AGREEMENT, not sameness-over-time — see
-          # the header comment. Neither side's plaintext ever leaves its own
-          # process: the Keycloak secret was hashed above, inside the python
-          # that already held it in memory; app-ui's is hashed inside the
-          # container that holds it as an env var. Only the two hex digests are
-          # ever assigned to a shell variable.
           kc_hash=$(printf '%s\n' "$fields" | awk -F': ' '/^secret sha256:/{print $2}')
           ui_hash=$(docker exec app-ui sh -c 'printf "%s" "$AUTH_KEYCLOAK_SECRET" | sha256sum' 2>/dev/null | cut -d' ' -f1)
 
-          echo "keycloak client secret sha256: ${kc_hash:-<empty>}"
-          echo "app-ui AUTH_KEYCLOAK_SECRET sha256: ${ui_hash:-<empty>}"
-
-          if [ -z "$kc_hash" ] || [ -z "$ui_hash" ]; then
-            echo "::error::could not read one or both secrets to compare — CANNOT DETERMINE agreement, not a pass"
-            exit 2
-          elif [ "$kc_hash" = "$ui_hash" ]; then
-            echo "AGREE: the Keycloak client and app-ui hold the same secret."
-          else
-            echo "::error::DISAGREE: the Keycloak client and app-ui secrets do NOT match. This is the outage case — every login will fail token exchange."
-            exit 1
-          fi
+          echo "kc_hash=${kc_hash}"
+          echo "ui_hash=${ui_hash}"
           REMOTE
+          )
+          echo "$out" | grep '^kc_hash=' >> "$GITHUB_OUTPUT"
+          echo "$out" | grep '^ui_hash=' >> "$GITHUB_OUTPUT"
+
+      # THE DECISION. Runs on the runner, against the checkout's own tested
+      # script, against nothing but the two hashes read above — never
+      # re-contacts Keycloak or app-ui, never sees a plaintext secret. A
+      # nonzero exit here fails this step, and with it the job: a scheduled
+      # run that finds disagreement goes red, it does not print and pass.
+      - name: Assert the two sides agree
+        run: |
+          bash scripts/checks/check_hill90_ui_secret_agreement.sh \
+            "${{ steps.read.outputs.kc_hash }}" "${{ steps.read.outputs.ui_hash }}"

--- a/scripts/checks/check_hill90_ui_secret_agreement.sh
+++ b/scripts/checks/check_hill90_ui_secret_agreement.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+#
+# Does the Keycloak hill90-ui client's secret still agree with the secret
+# app-ui was started with?
+#
+# NEITHER side ever appears here. This takes two sha256 hex digests, computed
+# by the caller from wherever each secret actually lives, and compares them.
+# The plaintext never reaches this script, never reaches a shell variable
+# outside the process that read it, and never appears in a log.
+#
+# WHY AGREEMENT, NOT SAMENESS-OVER-TIME. A hash of the live secret with
+# nothing to compare it to looks like evidence and is not — that was the gap
+# in the first version of this check, closed after Jon compared the two sides
+# by hand on the host and found they agreed (2026-08-04). The property that
+# actually matters is not "is this the same secret as an earlier reading", it
+# is "do the two sides that must agree still agree": a coordinated rotation
+# of both changes the hash on both sides and breaks nothing — this stays
+# quiet. The two drifting apart — one side restarted with an old value, one
+# side's secret regenerated without the other being updated — is the actual
+# outage case (every login fails token exchange), and that is what this
+# fails loudly on.
+#
+# THIS RUNS ON THE RUNNER, against two values the caller already read. It does
+# not itself touch Keycloak or app-ui, for the same reason
+# check_deploy_drift.sh does its comparison on the runner rather than the
+# host: the decision belongs somewhere that cannot also be the thing drifting.
+#
+# Usage:
+#   check_hill90_ui_secret_agreement.sh <keycloak-secret-sha256> <app-ui-secret-sha256>
+#
+# Exit codes, following check_deploy_drift.sh's contract:
+#   0  AGREE              (both hashes present and equal)
+#   1  DISAGREE            (both hashes present, not equal — the outage case)
+#   2  CANNOT DETERMINE    (either hash missing/empty — never silent, never green)
+
+set -uo pipefail
+
+KC_HASH="${1:-}"
+UI_HASH="${2:-}"
+
+say()  { printf '%s\n' "$*"; }
+fail() { printf '::error::%s\n' "$*" >&2; }
+
+say "hill90-ui secret agreement"
+say "=============================================="
+
+if [ -z "$KC_HASH" ] || [ -z "$UI_HASH" ]; then
+    fail "CANNOT DETERMINE: one or both secret hashes were not supplied. This is NOT a pass — nothing was compared. keycloak='${KC_HASH:-<empty>}' app-ui='${UI_HASH:-<empty>}'"
+    exit 2
+fi
+
+say "  keycloak client secret sha256: ${KC_HASH}"
+say "  app-ui AUTH_KEYCLOAK_SECRET sha256: ${UI_HASH}"
+
+if [ "$KC_HASH" = "$UI_HASH" ]; then
+    say "  AGREE: the Keycloak client and app-ui hold the same secret."
+    exit 0
+fi
+
+fail "DISAGREE: the Keycloak client secret and app-ui's AUTH_KEYCLOAK_SECRET do NOT match. This is the outage case — every login will fail token exchange until they are reconciled."
+exit 1

--- a/tests/scripts/hill90-ui-secret-agreement-control.bats
+++ b/tests/scripts/hill90-ui-secret-agreement-control.bats
@@ -1,0 +1,90 @@
+#!/usr/bin/env bats
+#
+# POSITIVE CONTROL for scripts/checks/check_hill90_ui_secret_agreement.sh.
+#
+# A comparison that has only ever seen agreement has not been shown to notice
+# disagreement. This is the scratch-copy proof: fabricated hashes, never
+# production, one deliberately flipped per FAIL case — so this file is red
+# on the exact defect the script exists to catch before the script is ever
+# trusted to run unattended on a schedule.
+
+CHECK=""
+
+setup() {
+    CHECK="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)/scripts/checks/check_hill90_ui_secret_agreement.sh"
+}
+
+@test "AGREE: identical hashes exit 0" {
+    run bash "$CHECK" "abc123def456" "abc123def456"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"AGREE"* ]]
+}
+
+@test "AGREE: a real-shaped sha256 pair still agrees" {
+    h=$(printf 'the-same-secret' | sha256sum | cut -d' ' -f1)
+    run bash "$CHECK" "$h" "$h"
+    [ "$status" -eq 0 ]
+}
+
+@test "FAILS RED: one side flipped — this is the outage case" {
+    # The scratch-copy proof: two hashes that would have come from a real
+    # rotation of only one side. Nothing here touches Keycloak or app-ui.
+    kc=$(printf 'keycloak-secret-v1' | sha256sum | cut -d' ' -f1)
+    ui=$(printf 'app-ui-secret-v1-but-rotated' | sha256sum | cut -d' ' -f1)
+    run bash "$CHECK" "$kc" "$ui"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"DISAGREE"* ]]
+    [[ "$output" == *"outage"* ]]
+}
+
+@test "FAILS RED: a single differing character is still a disagreement" {
+    run bash "$CHECK" "0081deadbeef" "0081deadbeee"
+    [ "$status" -eq 1 ]
+}
+
+@test "CANNOT DETERMINE: the keycloak side missing exits 2, not 0 or 1" {
+    run bash "$CHECK" "" "abc123"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"CANNOT DETERMINE"* ]]
+    [[ "$output" == *"NOT a pass"* ]]
+}
+
+@test "CANNOT DETERMINE: the app-ui side missing exits 2, not 0 or 1" {
+    run bash "$CHECK" "abc123" ""
+    [ "$status" -eq 2 ]
+}
+
+@test "CANNOT DETERMINE: both missing exits 2" {
+    run bash "$CHECK" "" ""
+    [ "$status" -eq 2 ]
+}
+
+@test "CANNOT DETERMINE: no arguments at all exits 2" {
+    run bash "$CHECK"
+    [ "$status" -eq 2 ]
+}
+
+@test "the failing message names the consequence, not just the fact" {
+    run bash "$CHECK" "aaa" "bbb"
+    [[ "$output" == *"every login will fail token exchange"* ]]
+}
+
+@test "CONTROL: exit codes are genuinely different states, not one collapsed into another" {
+    run bash "$CHECK" "same" "same"
+    agree_status="$status"
+    run bash "$CHECK" "one" "two"
+    disagree_status="$status"
+    run bash "$CHECK" "" ""
+    unknown_status="$status"
+
+    [ "$agree_status" -ne "$disagree_status" ]
+    [ "$agree_status" -ne "$unknown_status" ]
+    [ "$disagree_status" -ne "$unknown_status" ]
+}
+
+@test "CONTROL: neither plaintext secret nor a script-internal value leaks into the output" {
+    # The script only ever receives hashes, so this also guards against a
+    # future edit accidentally threading a plaintext argument through.
+    run bash "$CHECK" "abc123" "abc123"
+    [[ "$output" != *"AUTH_KEYCLOAK_SECRET="* ]]
+}


### PR DESCRIPTION
## Summary

Wires the read-only audit added for #707/#709 to an actual schedule, and moves the pass/fail decision into a bats-tested script so a scheduled run that finds disagreement fails the job instead of printing to a log nobody reads.

**Own schedule, not deploy-drift.yml's** — justified in the workflow header: deploy-drift's 4h cadence is tuned to its own risk (code merged and not yet deployed, bounded by how often someone runs a deploy). The two secrets this checks can drift with **no deploy at all** — a manual Keycloak console rotation, or a SOPS-stored secret edited and app-ui restarted. Riding deploy-drift's timer would make detection latency track an unrelated event. Every 30 minutes because agreement is binary and always expected — there's no grace window to wait out the way deploy-drift waits out normal, expected drift.

**The decision moved to `scripts/checks/check_hill90_ui_secret_agreement.sh`**, run on the *runner* against two hashes the host already produced — mirrors why `check_deploy_drift.sh`'s comparison also runs on the runner: the thing deciding must not be able to also be the thing drifting. The workflow's read step now only emits `kc_hash`/`ui_hash` as step outputs; a new "Assert the two sides agree" step runs the script and its exit code fails the step (and the job) directly.

## Proven red, without touching production

`tests/scripts/hill90-ui-secret-agreement-control.bats` fabricates a deliberately mismatched hash pair and asserts `exit 1` with the outage-framed message, plus `CANNOT DETERMINE` (missing input) and exit-code-distinctness controls in the same style `check_deploy_drift.sh` already established. **11/11 pass.**

```
ok 3 FAILS RED: one side flipped — this is the outage case
ok 4 FAILS RED: a single differing character is still a disagreement
```

`check_checks_are_wired.py` confirms the new script is actually invoked (`bats,workflow`), not merely present: **34/34 checks wired, 0 orphaned.**

## Verified end-to-end against production before this PR

The previous PR (#709) added the comparison and I dispatched it live after merging — it printed `AGREE`, matching Jon's manual host check exactly (`008156b6...d923b` on both sides). This PR restructures *how* that decision is made and reported, not the read itself; the underlying kcadm/docker-exec logic is unchanged from that verified run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)