### PR TITLE
diag: throwaway read-only IPv6 probe for #542 (delete after one dispatch)

### DIFF
--- a/.github/workflows/diag-ipv6-readonly.yml
+++ b/.github/workflows/diag-ipv6-readonly.yml
@@ -1,0 +1,103 @@
+name: Diagnostic — IPv6 reachability read-only (throwaway, #542)
+
+# THROWAWAY. Exists only to answer #542's question by reading the host, not by
+# reasoning from compose files: is anything listening on IPv6, is Traefik bound
+# to it, and could an inbound client reach anything over v6 if a AAAA record
+# existed. Read-only: no file is written, no service is restarted, no DNS is
+# touched. This workflow is not meant to be kept — delete the branch after the
+# one dispatch that answers the question.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  probe:
+    name: read-only IPv6 probe
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Tailscale
+        uses: tailscale/github-action@v2
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:github-actions
+
+      - name: Setup SSH key
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.VPS_SSH_PRIVATE_KEY }}" > ~/.ssh/vps_key
+          chmod 600 ~/.ssh/vps_key
+
+      - name: Setup SOPS/age
+        env:
+          SOPS_VERSION: '3.9.4'
+        run: |
+          SOPS_URL="https://github.com/getsops/sops/releases/download/v${SOPS_VERSION}/sops-v${SOPS_VERSION}.linux.amd64"
+          curl -fsSL -o /tmp/sops "$SOPS_URL"
+          if file /tmp/sops | grep -q "HTML"; then
+            echo "::error::SOPS download returned HTML instead of binary — check URL: $SOPS_URL"
+            exit 1
+          fi
+          chmod +x /tmp/sops
+          sudo mv /tmp/sops /usr/local/bin/sops
+          mkdir -p ~/.config/sops/age
+          echo "${{ secrets.SOPS_AGE_KEY }}" > ~/.config/sops/age/keys.txt
+          chmod 600 ~/.config/sops/age/keys.txt
+
+      - name: Get Tailscale IP from secrets
+        id: get-ip
+        run: |
+          TAILSCALE_IP=$(sops -d --extract '["TAILSCALE_IP"]' infra/secrets/prod.enc.env)
+          if [ -z "$TAILSCALE_IP" ]; then
+            echo "::error::TAILSCALE_IP is empty or absent in infra/secrets/prod.enc.env"
+            exit 1
+          fi
+          echo "::add-mask::$TAILSCALE_IP"
+          echo "tailscale_ip=$TAILSCALE_IP" >> $GITHUB_OUTPUT
+
+      - name: Read the host — IPv6 interface, listeners, firewall, container binds
+        run: |
+          ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no -o ConnectTimeout=15 \
+            deploy@${{ steps.get-ip.outputs.tailscale_ip }} '
+              echo "=== ip -6 addr (public IPv6 actually configured on an interface?) ==="
+              ip -6 addr show scope global || echo "(command failed or nothing global-scope)"
+
+              echo ""
+              echo "=== ss -tlnp — every TCP listener, host network namespace ==="
+              sudo ss -tlnp
+
+              echo ""
+              echo "=== of those, ones bound to :: or ::1 (IPv6-capable) ==="
+              sudo ss -tlnp | grep -E "\[::\]|\[::1\]" || echo "(none)"
+
+              echo ""
+              echo "=== docker ps — running containers ==="
+              docker ps --format "table {{.Names}}\t{{.Ports}}"
+
+              echo ""
+              echo "=== traefik container port bindings ==="
+              docker port traefik 2>&1 || echo "(no container named traefik, or docker port failed)"
+
+              echo ""
+              echo "=== docker-proxy processes (per app#(prior finding): binds [::]:80/443 even on an IPv4-only network) ==="
+              ps aux | grep -i "docker-proxy" | grep -v grep || echo "(none running)"
+
+              echo ""
+              echo "=== firewalld: public zone rich rules and services (would inbound v6 even be let through?) ==="
+              sudo firewall-cmd --zone=public --list-all 2>&1 || echo "(firewall-cmd not available or failed)"
+
+              echo ""
+              echo "=== ip6tables INPUT chain, if firewalld manages one ==="
+              sudo ip6tables -L INPUT -n -v 2>&1 || echo "(ip6tables not available or failed)"
+
+              echo ""
+              echo "=== docker network inspect hill90_edge — IPv6 enabled on the bridge? ==="
+              docker network inspect hill90_edge --format "EnableIPv6: {{.EnableIPv6}}" 2>&1 || echo "(network not found)"
+            '


### PR DESCRIPTION
Read-only diagnostic to answer #542 directly from the host rather than by reasoning from compose files: is anything listening on IPv6, is Traefik bound to it, and could an inbound client reach anything over v6 if a AAAA record existed.

No file written, no service touched, no DNS changed. Reuses the exact SSH/Tailscale connection pattern already trusted in `deploy-drift.yml` and `scheduled-checks-watchdog.yml` — same secrets, same access, nothing new granted.

Requesting merge + a `workflow_dispatch` run, then this branch and workflow file should be deleted — not meant to be kept.