### PR TITLE
docs: the estate is no longer empty — correct the zero-rows claim

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -220,12 +220,36 @@ bookkeeping; no agents, no chats, no user records. Nothing to preserve — every
 is created by a migration and every `created_at` falls inside the 960 ms window of
 the migration run — but say "nothing worth preserving", not "empty".
 
-**Still true today, on the LIVE (post-cutover) database, re-read directly rather
-than assumed forward from the paragraph above.** `Verified 2026-08-04`: `agents`,
-`chat_threads` and `provider_connections` are all **zero** rows on the live
-`hill90_api`. The estate still has no agents, no chats and no provider
-connections. Several claims elsewhere in this file and in hill90-app's are sized
-on that fact — re-check it before trusting anything that assumes activity.
+**This said all three tables were empty, and that stopped being true the same
+day.** It read: *"`Verified 2026-08-04`: `agents`, `chat_threads` and
+`provider_connections` are all **zero** rows on the live `hill90_api`. The estate
+still has no agents, no chats and no provider connections."* True when written;
+false a few hours later.
+
+`Verified 2026-08-05 01:05 UTC`, read from the live database:
+
+- **`agents` — 1 row.** `platform-guide` / "Platform Guide", `status=stopped`,
+  on the `default` model policy and the `standard` container profile, owned by
+  `jon`. Seeded for QA, **not created through `POST /agents`** — direct access
+  grants are off on every client in the realm and I was not going to enable
+  password grant on the client fronting hill90.com to insert a demo row. The
+  INSERT mirrors the route's own statement column for column, so the row is
+  shaped like a real one; the **create path itself remains unexercised**, and a
+  human clicking "Create Agent" is what would prove it.
+- **`provider_connections` — 1 row.** "Platform OpenAI", `created_by IS NULL`
+  so it is platform-wide rather than anyone's BYOK. It holds the OpenAI key the
+  estate already gives LiteLLM, encrypted with the api's own
+  `encryptProviderKey`. The stored value was decrypted and compared back to the
+  input in the same script — the create route validates nothing against the
+  provider, so an unreadable blob would have stored as happily as a good key.
+- **`chat_threads` — still 0.** No chat has happened.
+
+Knowledge is no longer near-empty either: **3 collections, 7 sources, 7 chunks**
+in `hill90_akm`, all owned by `jon`, six of them seeded through the knowledge
+service's real ingestion path rather than by SQL.
+
+Claims elsewhere in this file and in hill90-app's that are sized on "no
+activity" should be re-checked against these numbers rather than the old ones.
 
 ## Still not done — do not let these read as finished
 


### PR DESCRIPTION
## Plan

`CLAUDE.md` said `agents`, `chat_threads` and `provider_connections` were all zero rows, `Verified 2026-08-04`. I invalidated two of those three a few hours later by seeding QA data at Jon's request, so the file was carrying a claim I had personally made false.

Replaces the paragraph with the live numbers and leaves the superseded text quoted, per the convention already used throughout this file.

## What changed on the host

`Verified 2026-08-05 01:05 UTC`:

| table | was | now |
|---|---|---|
| `agents` | 0 | 1 — `platform-guide`, stopped, owned by `jon` |
| `provider_connections` | 0 | 1 — "Platform OpenAI", platform-wide |
| `chat_threads` | 0 | 0 |

Knowledge in `hill90_akm`: 1 collection / 1 source / 1 chunk → **3 / 7 / 7**, all owned by `jon`.

## The two boundaries the numbers would otherwise hide

Both are written into the file rather than left implied:

- The agent row was **seeded by SQL that mirrors the route's own INSERT**, not created through `POST /agents`. Direct access grants are disabled on every client in the realm, and enabling password grant on the client fronting hill90.com to insert a demo row is not a trade worth making. So the row is shaped correctly but **the create path is unproven** — a human clicking "Create Agent" is what proves it.
- The provider connection holds the OpenAI key the estate already gives LiteLLM, encrypted with the api's own `encryptProviderKey`. That route **validates nothing against the provider**, so an unreadable blob would store exactly as happily as a good key. The seed decrypts what it wrote and compares it to the input: `roundtrip_matches_input: true`.

## Risks

Documentation only. `docs/**` and `CLAUDE.md` are not in `deploy.yml`'s path filter, so merging this deploys nothing.

## Rollback

`git revert`.

## Validation Evidence

Live reads behind every number above:

```
=== agents ===
    agent_id    |      name      | status  | policy  | profile
 platform-guide | Platform Guide | stopped | default | standard

=== connections ===
      name       | provider | platform_wide
 Platform OpenAI | openai   | t

=== knowledge (hill90_akm) ===
 3 collections | 7 sources | 7 chunks   (all 7 sources status=active, all owned by jon)

=== baseline unaffected ===
missing: none unhealthy 0 apphealthy:7
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)