### PR TITLE
fix(ci): drop the never-set TENANT_BASELINE_TOKEN checkout token

### DIFF
--- a/.github/workflows/tenant-baseline-agreement.yml
+++ b/.github/workflows/tenant-baseline-agreement.yml
@@ -8,11 +8,18 @@ name: Tenant Baseline Agreement
 # on a developer's machine against a sibling clone, or anywhere else. Nothing in
 # this repo depends on a particular directory existing.
 #
-# hill90-app is PRIVATE and this repo is PUBLIC, so the checkout needs a token
-# with read access to it: TENANT_BASELINE_TOKEN. Until that secret exists the
-# checkout fails and this job is RED — deliberately. A missing credential is a
-# reason this check cannot see, and a check that cannot see must not report
-# agreement.
+# hill90-app was PRIVATE when this was written, so the checkout used an
+# explicit token: TENANT_BASELINE_TOKEN. That secret was never created, and
+# every run since (six of six, 2026-08-03/04) failed identically at this
+# step with "Input required and not supplied: token" — an EXPLICIT empty
+# secret reference is rejected outright by actions/checkout, unlike an
+# OMITTED token, which falls back to the default github.token. hill90-app
+# is now PUBLIC (verified via the GitHub API), so no credential is needed
+# at all: dropping the token key lets that default fall-through do the
+# read. (hill90-app#177 tracks this workflow — the issue and the code
+# live in different repos, which is exactly how a workflow can go six
+# runs deep into failure before anyone reads the log instead of the
+# conclusion field.)
 #
 # NOT a pull_request trigger. Secrets are not available to fork pull requests,
 # so a PR gate would fail for a reason unrelated to its change. Catching drift
@@ -44,7 +51,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: jonhill90/hill90-app
-          token: ${{ secrets.TENANT_BASELINE_TOKEN }}
           path: tenant
           sparse-checkout: |
             scripts/checks/hill90-platform-baseline.txt


### PR DESCRIPTION
## Summary

Tracked at **hill90-app#177**, not an issue in this repo — the issue and the workflow it's about live in different repositories, which is exactly the kind of split that let this go six runs deep into 100% failure before anyone read a log instead of a conclusion field. Noting that explicitly since it's part of why this sat broken.

`tenant-baseline-agreement.yml` has never had a successful run. `gh run list --workflow=tenant-baseline-agreement.yml`: 6 runs, 6 failures (one `push` on 2026-08-03, one `schedule`, four `workflow_dispatch` retries on 2026-08-04). Every one fails at the same step with the same message, read from the log directly, not inferred:

```
Checkout the tenant, for its baseline copy only
##[error]Input required and not supplied: token
```

`gh secret list` confirms `TENANT_BASELINE_TOKEN` was never created. The workflow's own comment predicted this by name in advance, on the premise that hill90-app was private and needed a credentialed cross-repo checkout. That premise is now false — checked directly (`gh api repos/jonhill90/hill90-app --jq '.visibility'` → `public`). `actions/checkout@v4`'s `token` input falls back to the default `github.token` when omitted, which is sufficient to read any public repo; an *explicit* reference to an unset secret evaluates to an empty string, which `actions/checkout` rejects outright before making any request — that's the specific reason "secret never configured" and "token omitted" are not the same failure. Dropping the `token:` line is the fix.

## What this does NOT prove

Deleting line 47 only gets past the step that has failed six times. The step after it — `Compare the two lists`, which runs `check_tenant_baseline_agrees.py` against the freshly-checked-out tenant file — **has never executed once, in any run, ever.** I ran that comparison locally against both repos' current `main` (Hill90's compose files and hill90-app's `hill90-platform-baseline.txt`) and got exit 0, "16 containers, both lists identical" — but that's my local reproduction, not this workflow's CI environment, and the sparse-checkout mechanics (non-cone-mode, `path: tenant`) that step depends on have equally never been exercised for real. I am not claiming this workflow works. I'm claiming the one *known, observed* cause of failure is removed. Whether step two behaves the same way in CI as it does locally is genuinely unproven, and the honest thing to do is run it and read the result rather than assume the fix is complete because the diff is small.

**Do not merge and assume green.** After merge, trigger `workflow_dispatch` and read the actual run — if it fails at step two, that's real information about a step that's been sitting untested since the workflow was written, not a sign this PR was wrong.

## Why repair over retire

`hill90-app#332` (merged today) already built a working, **credential-free** equivalent from the other direction — `platform-baseline-freshness.yml`, comparing the same two lists by fetching Hill90's public compose files over an unauthenticated tarball download, currently passing (16/16 agree). That means this specific workflow's coverage is not load-bearing today; hill90-app's side already closes the gap #176/#177 originally asked about.

But that's an argument for redundancy, not for retiring this one. The two checks fail independently: hill90-app's freshness check depends on GitHub's API and a tarball fetch succeeding on *hill90-app's* runners on *its* schedule; this one, once repaired, depends on nothing but this repo's own checkout succeeding on *this* repo's runners on *its* schedule. Two independently-failing checks of the same fact catch more than either alone, and the marginal cost of keeping this one is now a single deleted line — no secret to provision, nothing to rotate, no new design surface. That's a smaller bill than the redundancy is worth, which is the case for repairing rather than retiring.

## Test plan
- [x] YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] No remaining `secrets.*` reference in the workflow
- [x] Local reproduction of the comparison step: `check_tenant_baseline_agrees.py` against current `hill90-app` main → exit 0, 16/16 agree (evidence the DATA agrees, not evidence the CI STEP works)
- [ ] **Not done, and not claimed**: an actual successful run of this workflow. Left for `workflow_dispatch` after merge, per instruction — the only honest way to know is to run it and read the result.

Not merging this myself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)