### PR TITLE
fix(vault): sync workflow authenticates via AppRole, not a periodic token (#711)

### DIFF
--- a/.github/workflows/vault-sync-to-sops.yml
+++ b/.github/workflows/vault-sync-to-sops.yml
@@ -78,16 +78,31 @@ jobs:
           ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no -o ConnectTimeout=10 \
             deploy@${{ steps.get-ip.outputs.tailscale_ip }} 'echo "SSH connection successful"'
 
-      - name: Read sync token from SOPS
-        id: sync-token
+      # h#711: replaces the old "Read sync token from SOPS" step.
+      # VAULT_SYNC_TOKEN was a periodic token that had to be RENEWED weekly —
+      # and renewal silently capped at OpenBao's config.hcl max_lease_ttl=24h
+      # instead of the token's own -period=768h, because periodic-token
+      # renewal only exceeds the system ceiling when the renewing identity
+      # holds `sudo` on auth/token/renew-self, which policy-sync never
+      # granted. The token was dead most weeks; see #711.
+      #
+      # VAULT_SYNC_ROLE_ID/VAULT_SYNC_SECRET_ID replace it. They are AppRole
+      # credentials, not a token — this step only reads them; the next step
+      # logs in fresh every run instead of renewing anything.
+      - name: Read sync AppRole credentials from SOPS
+        id: sync-creds
         run: |
-          VAULT_SYNC_TOKEN=$(sops -d infra/secrets/prod.enc.env | grep '^VAULT_SYNC_TOKEN=' | cut -d= -f2-)
-          if [ -z "$VAULT_SYNC_TOKEN" ]; then
-            echo "::error::VAULT_SYNC_TOKEN not found in SOPS. Run 'vault.sh setup-sync-token' first."
+          PLAIN=$(sops -d infra/secrets/prod.enc.env)
+          ROLE_ID=$(printf '%s\n' "$PLAIN" | grep '^VAULT_SYNC_ROLE_ID=' | cut -d= -f2-)
+          SECRET_ID=$(printf '%s\n' "$PLAIN" | grep '^VAULT_SYNC_SECRET_ID=' | cut -d= -f2-)
+          if [ -z "$ROLE_ID" ] || [ -z "$SECRET_ID" ]; then
+            echo "::error::VAULT_SYNC_ROLE_ID/VAULT_SYNC_SECRET_ID not found in SOPS. Run 'vault.sh setup-sync-approle' first (h#711) — this is expected to fail on the first scheduled run after that migration lands, until the one-time credential mint has happened and been pushed."
             exit 1
           fi
-          echo "::add-mask::$VAULT_SYNC_TOKEN"
-          echo "token=$VAULT_SYNC_TOKEN" >> $GITHUB_OUTPUT
+          echo "::add-mask::$ROLE_ID"
+          echo "::add-mask::$SECRET_ID"
+          echo "role_id=$ROLE_ID" >> $GITHUB_OUTPUT
+          echo "secret_id=$SECRET_ID" >> $GITHUB_OUTPUT
 
       - name: Check script drift
         run: |
@@ -107,30 +122,46 @@ jobs:
             'export SOPS_AGE_KEY_FILE=/opt/hill90/secrets/keys/keys.txt && sops -d /opt/hill90/app/infra/secrets/prod.enc.env | sha256sum | cut -d" " -f1')
           echo "hash=$BEFORE_HASH" >> $GITHUB_OUTPUT
 
-      - name: Renew sync token
+      # h#711: replaces "Renew sync token". There is nothing to renew — a
+      # fresh AppRole login every run mints a token bounded by
+      # token_ttl=1h/token_max_ttl=4h (scripts/vault.sh's AppRole loop),
+      # comfortably inside config.hcl's max_lease_ttl=24h. That bound is the
+      # whole point: this can never need the sudo exemption periodic-token
+      # renewal required and never had, so this step either succeeds with a
+      # working token or fails here, loudly, every single run — there is no
+      # multi-week gap between cause and symptom left for this class of bug
+      # to hide in.
+      - name: AppRole login — mint a fresh token for this run
+        id: approle-login
         env:
-          SYNC_TOKEN: ${{ steps.sync-token.outputs.token }}
+          ROLE_ID: ${{ steps.sync-creds.outputs.role_id }}
+          SECRET_ID: ${{ steps.sync-creds.outputs.secret_id }}
         run: |
-          # The token goes over STDIN, never into a command line.
-          #
-          # Interpolating it into the ssh command string put it in argv of the
-          # remote shell AND of `docker exec` on the VPS, where `ps -Ao args`
-          # shows it to any local user. It is masked in the Actions log, which is
-          # what made this easy to miss: the leak is on the host, not here.
-          printf '%s' "$SYNC_TOKEN" | ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
+          # Both credentials and the minted token travel over stdin/env,
+          # never argv — same discipline the old renew step used, for the
+          # same reason: interpolated into the ssh/docker-exec command line,
+          # they'd sit in `ps -Ao args` on the VPS, visible to any local
+          # user there, regardless of Actions log masking.
+          TOKEN=$(printf '%s\n%s' "$ROLE_ID" "$SECRET_ID" | ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
             deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
-            'read -r BAO_TOKEN; export BAO_TOKEN; \
-             docker exec -e BAO_ADDR=http://127.0.0.1:8200 -e BAO_TOKEN \
-               openbao bao token renew' || {
-            echo "::error::Token renewal failed — token may be expired or revoked. Re-run 'vault.sh setup-sync-token'."
+            'read -r ROLE_ID; read -r SECRET_ID; export ROLE_ID SECRET_ID; \
+             docker exec -e BAO_ADDR=http://127.0.0.1:8200 -e ROLE_ID -e SECRET_ID openbao \
+               sh -c '"'"'bao write -field=token auth/approle/login role_id="$ROLE_ID" secret_id="$SECRET_ID"'"'"'') || {
+            echo "::error::AppRole login failed — role_id/secret_id may be stale, or the sync role may not exist yet. Run 'vault.sh setup-sync-approle' to (re)mint (h#711)."
             exit 1
           }
+          if [ -z "$TOKEN" ]; then
+            echo "::error::AppRole login reported success but returned no token — treating as a failure rather than proceeding with nothing to authenticate the sync step."
+            exit 1
+          fi
+          echo "::add-mask::$TOKEN"
+          echo "token=$TOKEN" >> $GITHUB_OUTPUT
 
       - name: Run sync on VPS
         env:
-          SYNC_TOKEN: ${{ steps.sync-token.outputs.token }}
+          SYNC_TOKEN: ${{ steps.approle-login.outputs.token }}
         run: |
-          # Same reasoning as the renew step: stdin, not argv.
+          # Same reasoning as the login step: stdin, not argv.
           printf '%s' "$SYNC_TOKEN" | ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
             deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
             'read -r BAO_TOKEN; export BAO_TOKEN; \

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -249,6 +249,15 @@ vault_paths_for_service() {
         auth)          echo "secret/shared/database secret/auth/config" ;;
         infra)         echo "secret/infra/traefik" ;;
         observability) echo "secret/observability/grafana" ;;
+        # h#711: "sync" is not a deployable stack — vault_load_secrets is
+        # never called with it (deploy.sh only ever passes an actual compose
+        # stack name), so this entry exists purely so
+        # vault-approle-real-read-test.sh exercises a genuine read for the
+        # sync AppRole too, instead of silently reporting "declares no vault
+        # paths — nothing to read" for the one role this issue is about.
+        # secret/shared/database is not sync-specific; it's simply a real,
+        # already-seeded path policy-sync's read-all-of-secret/* grant covers.
+        sync)          echo "secret/shared/database" ;;
         *)             echo "" ;;
     esac
 }

--- a/scripts/checks/vault-approle-login-test.sh
+++ b/scripts/checks/vault-approle-login-test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Do the four platform AppRoles still authenticate against OpenBao?
+# Do the platform AppRoles still authenticate against OpenBao?
 #
 # WHY THIS IS A SEPARATE CHECK
 # ============================
@@ -16,8 +16,16 @@
 # outcome and the policies attached; no role_id, secret_id or token value ever
 # reaches stdout, a log, or argv.
 #
+# h#711: the role list used to be a literal default here, duplicating
+# scripts/vault.sh's own VAULT_SERVICES — two lists that could silently
+# drift apart, the exact shape vault-approle-real-read-test.sh was already
+# written to avoid for the same reason. Now reads the canonical list out of
+# vault.sh instead, the same way that script does, so a role added there
+# (like "sync") is covered here automatically rather than needing a second
+# edit someone can forget.
+#
 # Usage: bash scripts/checks/vault-approle-login-test.sh
-# Exit:  0 all four authenticate | 1 any failure
+# Exit:  0 every role authenticates | 1 any failure
 
 set -uo pipefail
 
@@ -26,7 +34,13 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
 CONTAINER="${VAULT_CONTAINER:-openbao}"
 SECRETS_FILE="${VAULT_SECRETS_FILE:-${PROJECT_ROOT}/infra/secrets/prod.enc.env}"
-SERVICES="${VAULT_SERVICES:-db auth infra observability}"
+
+if [ -n "${VAULT_SERVICES:-}" ]; then
+    SERVICES="$VAULT_SERVICES"
+else
+    SERVICES="$(grep -m1 '^VAULT_SERVICES=' "$PROJECT_ROOT/scripts/vault.sh" | cut -d'"' -f2)"
+    [ -n "$SERVICES" ] || { echo "could not read VAULT_SERVICES from scripts/vault.sh" >&2; exit 1; }
+fi
 
 command -v sops >/dev/null 2>&1 || { echo "sops is required" >&2; exit 1; }
 [ -f "$SECRETS_FILE" ] || { echo "Secrets file not found: $SECRETS_FILE" >&2; exit 1; }
@@ -38,8 +52,8 @@ PLAIN="$(sops -d "$SECRETS_FILE" 2>/dev/null)" || { echo "Could not decrypt $SEC
 
 field() { printf '%s\n' "$PLAIN" | grep "^${1}=" | cut -d= -f2- | head -1; }
 
-echo "OpenBao AppRole login — the four platform roles"
-echo "==============================================="
+echo "OpenBao AppRole login — the platform roles (${SERVICES})"
+echo "==========================================================="
 
 FAIL=0
 for svc in $SERVICES; do

--- a/scripts/vault.sh
+++ b/scripts/vault.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Vault CLI — OpenBao secrets management lifecycle
-# Usage: vault.sh {init|unseal|auto-unseal|status|setup|seed|policy-apply|backup|export|sync-to-sops|setup-sync-token|bootstrap-approles|help}
+# Usage: vault.sh {init|unseal|auto-unseal|status|setup|seed|policy-apply|backup|export|sync-to-sops|setup-sync-token|setup-sync-approle|bootstrap-approles|help}
 
 set -e
 
@@ -17,7 +17,18 @@ SECRETS_FILE="${VAULT_SECRETS_FILE:-${PROJECT_ROOT}/infra/secrets/prod.enc.env}"
 POLICY_DIR="${PROJECT_ROOT}/platform/vault/policies"
 
 # Services that get their own AppRole
-VAULT_SERVICES="db auth infra observability"
+#
+# h#711 added "sync": the vault-to-SOPS sync workflow used to authenticate
+# with a periodic token (`setup-sync-token`, below) that had to be renewed
+# weekly. Renewal silently capped at config.hcl's max_lease_ttl=24h instead
+# of the token's own -period=768h, because periodic-token renewal only
+# honours its own period when the renewing identity holds `sudo` on
+# auth/token/renew-self — which policy-sync never granted, and which this
+# estate has never granted anywhere outside policy-admin's break-glass
+# capability. AppRole sidesteps the whole mismatch: each run logs in fresh
+# (see cmd_setup_sync_approle) for a token bounded by token_ttl/token_max_ttl
+# below, comfortably inside the 24h ceiling, needing no exemption ever.
+VAULT_SERVICES="db auth infra observability sync"
 
 # ---------------------------------------------------------------------------
 # Usage
@@ -45,7 +56,10 @@ Commands:
   auto-unseal         Wait for container + unseal (for systemd/deploy hooks)
   assert-unsealed     Exit non-zero if OpenBao is sealed OR not deployed (an assertion)
   sync-to-sops        Sync vault secrets back to SOPS backup (requires BAO_TOKEN)
-  setup-sync-token    Create a read-only sync token and store in SOPS (requires BAO_TOKEN)
+  setup-sync-token    SUPERSEDED for the sync workflow by setup-sync-approle (h#711).
+                      Left for vault-init.yml/vault-reinitialize.yml, which still call it.
+  setup-sync-approle  Create the sync AppRole and store role_id/secret_id in SOPS
+                      (requires BAO_TOKEN) — what the sync workflow actually uses now
   bootstrap-approles  Generate AppRole credentials for all services and store in SOPS
   help                Show this help message
 
@@ -543,6 +557,14 @@ cmd_setup() {
     cmd_policy_apply
 
     # Create AppRoles for each service
+    #
+    # token_max_ttl=4h, well inside config.hcl's max_lease_ttl=24h — every
+    # AppRole login mints a token that fits inside the system ceiling on
+    # its own, with no exemption of any kind. That is the property h#711's
+    # fix relies on for the "sync" member of this list: a periodic token
+    # needed `sudo` on auth/token/renew-self to renew past this ceiling and
+    # never had it, which is what left it dead for five months. A token
+    # this short never asks the ceiling to bend at all.
     echo ""
     echo "Creating AppRoles for each service..."
     for svc in $VAULT_SERVICES; do
@@ -949,6 +971,16 @@ for k, v in sorted(data.items()):
     echo "Backup saved: $backup_file"
 }
 
+# SUPERSEDED for vault-sync-to-sops.yml by cmd_setup_sync_approle (h#711) —
+# the workflow now authenticates via AppRole, not this periodic token.
+#
+# Left in place, unmodified, rather than removed: vault-init.yml and
+# vault-reinitialize.yml still call this as part of full-vault-bootstrap
+# automation, and retiring VAULT_SYNC_TOKEN from those workflows (plus the
+# several docs that still describe it) is a separate, larger change than
+# h#711 asked for. A periodic sync token that nothing renews it against is
+# inert, not dangerous — it simply goes unused once the workflow stops
+# reading VAULT_SYNC_TOKEN.
 cmd_setup_sync_token() {
     require_running
 
@@ -1005,6 +1037,85 @@ cmd_setup_sync_token() {
     echo "  git add infra/secrets/prod.enc.env"
     echo "  git commit -m 'chore: store vault sync token in SOPS'"
     echo "  git push"
+    echo ""
+}
+
+# h#711: the sync workflow's actual credential setup, replacing
+# cmd_setup_sync_token above. Scoped to the "sync" AppRole only — deliberately
+# NOT cmd_bootstrap_approles, which mints a fresh secret_id for EVERY service
+# in VAULT_SERVICES on every run (harmless — old secret_ids stay valid,
+# secret_id_ttl=0 — but noisy: it would touch db/auth/infra/observability's
+# credentials too for no reason connected to this fix).
+#
+# cmd_setup is safe to call unconditionally here: it is idempotent (the
+# AppRole loop is a `write` with the same arguments every time) and it is
+# what actually creates auth/approle/role/sync in the first place, now that
+# "sync" is a VAULT_SERVICES member. Running it is what makes this command
+# work on a vault that has never seen "sync" at all, not just one that
+# already has stale sync credentials.
+cmd_setup_sync_approle() {
+    require_running
+
+    echo "================================"
+    echo "Setup Vault Sync AppRole"
+    echo "================================"
+    echo ""
+
+    require_file "$SECRETS_FILE" "Secrets file"
+    ensure_age_key prod
+
+    echo "Running setup (idempotent) — creates/updates every VAULT_SERVICES role, including sync..."
+    cmd_setup
+
+    echo ""
+    echo "Minting a secret_id for sync only..."
+    local role_id
+    role_id=$(bao_exec_env read -format=json "auth/approle/role/sync/role-id" 2>/dev/null | \
+        python3 -c "import sys,json; print(json.load(sys.stdin)['data']['role_id'])")
+    if [ -z "$role_id" ]; then
+        die "Failed to read role_id for sync — did cmd_setup run against a reachable, unsealed vault?"
+    fi
+
+    local secret_id
+    secret_id=$(bao_exec_env write -f -format=json "auth/approle/role/sync/secret-id" 2>/dev/null | \
+        python3 -c "import sys,json; print(json.load(sys.stdin)['data']['secret_id'])")
+    if [ -z "$secret_id" ]; then
+        die "Failed to generate secret_id for sync"
+    fi
+
+    echo "Storing VAULT_SYNC_ROLE_ID / VAULT_SYNC_SECRET_ID in SOPS..."
+    local escaped_role_id escaped_secret_id
+    escaped_role_id=$(printf '%s' "$role_id" | jq -Rs .)
+    escaped_secret_id=$(printf '%s' "$secret_id" | jq -Rs .)
+
+    if ! sops --set "[\"VAULT_SYNC_ROLE_ID\"] ${escaped_role_id}" "$SECRETS_FILE"; then
+        die "Failed to store VAULT_SYNC_ROLE_ID in SOPS"
+    fi
+    if ! sops --set "[\"VAULT_SYNC_SECRET_ID\"] ${escaped_secret_id}" "$SECRETS_FILE"; then
+        die "Failed to store VAULT_SYNC_SECRET_ID in SOPS"
+    fi
+
+    unset role_id secret_id escaped_role_id escaped_secret_id
+
+    echo ""
+    success "Sync AppRole credentials created and stored in SOPS!"
+    echo ""
+    # Deliberately NOT printed — same reasoning as cmd_setup_sync_token: this
+    # runs in CI, and a printed secret_id would be a durable copy in the log.
+    echo "The old VAULT_SYNC_TOKEN key is left in SOPS, unused by the workflow"
+    echo "from this point on. Removing it is a separate, deliberate cleanup,"
+    echo "not automatic here."
+    echo ""
+    echo "IMPORTANT: Commit and push the updated SOPS file so GitHub Actions can read it:"
+    echo "  git add infra/secrets/prod.enc.env"
+    echo "  git commit -m 'chore: store vault sync AppRole credentials in SOPS (h#711)'"
+    echo "  git push"
+    echo ""
+    echo "The next scheduled vault-sync-to-sops run after this merges will be"
+    echo "the first to use these credentials. Until this command has been run"
+    echo "and its commit pushed, that run is EXPECTED to fail — no role_id/"
+    echo "secret_id in SOPS yet is the same shape as no VAULT_SYNC_TOKEN was"
+    echo "before it, and the workflow says so explicitly rather than guessing."
     echo ""
 }
 
@@ -1310,6 +1421,7 @@ main() {
         assert-unsealed)    cmd_assert_unsealed "$@" ;;
         sync-to-sops)       cmd_sync_to_sops "$@" ;;
         setup-sync-token)   cmd_setup_sync_token "$@" ;;
+        setup-sync-approle) cmd_setup_sync_approle "$@" ;;
         bootstrap-approles) cmd_bootstrap_approles "$@" ;;
         help|--help|-h) usage ;;
         *)

--- a/tests/scripts/vault.bats
+++ b/tests/scripts/vault.bats
@@ -325,9 +325,58 @@
   [ "$status" -eq 0 ]
 }
 
-@test "vault-sync-to-sops workflow reads VAULT_SYNC_TOKEN from SOPS" {
-  run grep "VAULT_SYNC_TOKEN" .github/workflows/vault-sync-to-sops.yml
+# h#711: VAULT_SYNC_TOKEN (a periodic token that had to be renewed weekly,
+# and silently could not — see the file's own comment) was replaced by
+# VAULT_SYNC_ROLE_ID/VAULT_SYNC_SECRET_ID, an AppRole login done fresh every
+# run. Asserting on the `=` makes this check on the FUNCTIONAL read, not
+# just the bare name — the bare string "VAULT_SYNC_TOKEN" still legitimately
+# appears in this file's own explanatory comments, and a check that can't
+# tell those apart would have kept passing throughout this exact migration
+# for the wrong reason, which is precisely what happened before this test
+# was corrected: it passed against the new file on a stale assumption.
+@test "vault-sync-to-sops workflow reads the sync AppRole credentials from SOPS, not VAULT_SYNC_TOKEN" {
+  run grep "VAULT_SYNC_ROLE_ID=" .github/workflows/vault-sync-to-sops.yml
   [ "$status" -eq 0 ]
+  run grep "VAULT_SYNC_SECRET_ID=" .github/workflows/vault-sync-to-sops.yml
+  [ "$status" -eq 0 ]
+  # The old FUNCTIONAL read is gone — `=` excludes the comment mentioning
+  # the old name by history, which is expected to remain.
+  run grep "VAULT_SYNC_TOKEN=" .github/workflows/vault-sync-to-sops.yml
+  [ "$status" -ne 0 ]
+}
+
+@test "vault-sync-to-sops workflow logs in via AppRole rather than renewing a token" {
+  run grep "auth/approle/login" .github/workflows/vault-sync-to-sops.yml
+  [ "$status" -eq 0 ]
+  run grep "bao token renew" .github/workflows/vault-sync-to-sops.yml
+  [ "$status" -ne 0 ]
+}
+
+# app-h#711's whole argument for AppRole over the alternatives: it never
+# needs `sudo` on anything. Pin it so a future edit can't quietly add the
+# one thing this design was chosen specifically to avoid.
+@test "the sync AppRole never needs sudo — policy-sync.hcl grants none" {
+  run grep -i "sudo" platform/vault/policies/policy-sync.hcl
+  [ "$status" -ne 0 ]
+}
+
+# "sync" is deliberately NOT a hand-written role definition — it goes
+# through the same VAULT_SERVICES loop as db/auth/infra/observability,
+# which is what gives it the same token_ttl=1h/token_max_ttl=4h bound
+# (well inside config.hcl's max_lease_ttl=24h) with no new code to keep
+# correct. This pins that it's on the list, not a special case.
+@test "sync is a VAULT_SERVICES member, not a hand-written AppRole" {
+  run grep '^VAULT_SERVICES=' scripts/vault.sh
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"sync"* ]]
+}
+
+@test "the AppRole token bound (token_max_ttl) is inside OpenBao's max_lease_ttl" {
+  max_lease=$(grep 'max_lease_ttl' platform/vault/config.hcl | grep -oE '[0-9]+h' | head -1)
+  token_max=$(grep 'token_max_ttl=' scripts/vault.sh | grep -oE '[0-9]+h' | head -1)
+  [ -n "$max_lease" ]
+  [ -n "$token_max" ]
+  [ "${token_max%h}" -lt "${max_lease%h}" ]
 }
 
 # ---------------------------------------------------------------------------
@@ -497,6 +546,41 @@
 @test "vault.sh usage lists bootstrap-approles command" {
   run bash scripts/vault.sh help
   [[ "$output" == *"bootstrap-approles"* ]]
+}
+
+@test "vault.sh has cmd_setup_sync_approle function (h#711)" {
+  run grep "^cmd_setup_sync_approle()" scripts/vault.sh
+  [ "$status" -eq 0 ]
+}
+
+@test "vault.sh setup-sync-approle is in the dispatcher" {
+  run grep "setup-sync-approle)" scripts/vault.sh
+  [ "$status" -eq 0 ]
+}
+
+@test "vault.sh usage lists setup-sync-approle command" {
+  run bash scripts/vault.sh help
+  [[ "$output" == *"setup-sync-approle"* ]]
+}
+
+@test "cmd_setup_sync_approle stores VAULT_SYNC_ROLE_ID and VAULT_SYNC_SECRET_ID, not a token" {
+  run sed -n '/^cmd_setup_sync_approle()/,/^}/p' scripts/vault.sh
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"VAULT_SYNC_ROLE_ID"* ]]
+  [[ "$output" == *"VAULT_SYNC_SECRET_ID"* ]]
+  [[ "$output" != *"token create"* ]]
+  [[ "$output" != *"-period="* ]]
+}
+
+# The old cmd_setup_sync_token is left in place (vault-init.yml and
+# vault-reinitialize.yml still call it) but must no longer be what the sync
+# workflow actually depends on for its own credentials — that's
+# cmd_setup_sync_approle now.
+@test "cmd_setup_sync_token still exists, unmodified in shape, for the other workflows that call it" {
+  run grep "^cmd_setup_sync_token()" scripts/vault.sh
+  [ "$status" -eq 0 ]
+  run grep "setup-sync-token)" scripts/vault.sh
+  [ "$status" -eq 0 ]
 }
 
 @test "cmd_bootstrap_approles generates root token and revokes it" {


### PR DESCRIPTION
## Summary

Closes the root cause #711 diagnosed: the weekly `vault-sync-to-sops` workflow held a periodic token (`period=768h`) that renewed itself via `bao token renew` each run. Renewal silently capped at OpenBao's `config.hcl` `max_lease_ttl=24h` instead of the token's own period, because periodic-token renewal only exceeds the system ceiling when the renewing identity holds `sudo` on `auth/token/renew-self` — which `policy-sync` never granted. The token was dead most weeks.

**Recommendation and decision are recorded on #711's comment thread** — four options plus a fifth from the issue's own diagnosis were argued there before any code was written, per instruction. Summary: AppRole removes the renewal/ceiling mismatch as a category (a fresh login every run either succeeds inside the 24h ceiling or fails immediately — no multi-week gap for this bug class to hide in again), and it avoids granting `sudo` anywhere, which appears in exactly one policy in this estate today (`policy-admin`, break-glass) and would otherwise become the first non-break-glass `sudo` grant on an automated, CI-triggered credential.

## Precondition checked before writing this, not assumed

Per instruction, ran `scripts/checks/vault-approle-login-test.sh` **on the VPS**, not this workstation — a workstation attempt correctly reported "Container openbao is not running" (no such container locally), which is the exact blindness trap the estate has written down before. On the VPS: the four maintained AppRoles (`db`, `auth`, `infra`, `observability`) pass both a real login and a real read of their declared paths. Full output and the discovery of five separate, already-dead orphaned AppRole pairs (`ai`/`api`/`mcp`/`minio`/`ui`) are on #711's thread; that cleanup is filed separately as **#721**, out of scope here.

## What changed

- **`scripts/vault.sh`**: `"sync"` added to `VAULT_SERVICES` — it gets the same AppRole shape as the other four via the existing `cmd_setup` loop: `token_ttl=1h`/`token_max_ttl=4h`, comfortably inside the 24h ceiling. New `cmd_setup_sync_approle` mints and stores just the `sync` credential (`VAULT_SYNC_ROLE_ID`/`VAULT_SYNC_SECRET_ID`), deliberately **not** `cmd_bootstrap_approles`, which would also mint fresh (harmless but noisy) secret-ids for the other four services. `cmd_setup_sync_token` is left in place, unmodified — `vault-init.yml` and `vault-reinitialize.yml` still call it as part of full-vault-bootstrap automation; retiring it there is a separate, larger change than this issue asked for.
- **`.github/workflows/vault-sync-to-sops.yml`**: "Renew sync token" is gone — there's nothing to renew. Replaced by an AppRole login step that mints a fresh token every run. Credentials and the resulting token travel over stdin/env, never argv, matching this file's existing security discipline (documented in the step's own comment, not just here).
- **`scripts/checks/vault-approle-login-test.sh`**: now derives its role list from `scripts/vault.sh`'s own `VAULT_SERVICES` instead of a separately hardcoded default — fixes a real two-lists-that-can-drift gap this issue's own precondition check surfaced (this script silently only checked "the four platform roles" while `vault-approle-real-read-test.sh` already read the canonical list to avoid exactly that).
- **`scripts/_common.sh`**: `vault_paths_for_service` gets a `sync` case (reusing the already-seeded `secret/shared/database`) so the real-read test exercises a genuine read for the new role too, not just a login.
- **`tests/scripts/vault.bats`**: new tests, plus one existing test fixed for real — `"vault-sync-to-sops workflow reads VAULT_SYNC_TOKEN from SOPS"` was asserting the bare string appears anywhere in the file, which kept passing against the new version purely because of this PR's own explanatory comments mentioning the old name by history. Rewritten to assert on the functional `VAULT_SYNC_TOKEN=` read specifically (now absent) and the new `VAULT_SYNC_ROLE_ID=`/`VAULT_SYNC_SECRET_ID=` reads (now present) — the same distinction the whole rest of this exercise has been about.

## The one-time manual step — unavoidable under any option, stated exactly

A human must run `vault.sh setup-sync-approle` (with `BAO_TOKEN` set) on a host that can reach OpenBao, then commit and push the resulting SOPS change, **before** the schedule can recover on its own. No config change resurrects the already-dead `VAULT_SYNC_TOKEN` — a token past its own TTL doesn't come back under any of the options that were on the table.

**The first scheduled run after this merges, and before that step runs, is EXPECTED to fail.** The workflow's own error message says exactly that (`"Run 'vault.sh setup-sync-approle' first (h#711) — this is expected to fail on the first scheduled run after that migration lands, until the one-time credential mint has happened and been pushed."`) rather than reading like a regression to whoever's on call that week.

## Positive control — captured live, real output

Read-only against the running OpenBao on the VPS (a failed auth attempt mutates nothing):

```
$ ROLE_ID="00000000-0000-0000-0000-000000000000" SECRET_ID="00000000-0000-0000-0000-000000000000" \
  docker exec -e BAO_ADDR=http://127.0.0.1:8200 -e ROLE_ID -e SECRET_ID openbao \
  sh -c 'bao write -field=token auth/approle/login role_id="$ROLE_ID" secret_id="$SECRET_ID"'; echo "EXIT:$?"

Error writing data to auth/approle/login: Error making API request.
URL: PUT http://127.0.0.1:8200/v1/auth/approle/login
Code: 400. Errors:
* invalid role or secret ID
EXIT:2
```

Same shape #721's five already-dead orphaned credentials produce independently — a wrong or stale credential fails loudly and immediately, every time, through the exact chain the workflow now uses. Verified the success path too, through the identical mechanism, with a real working credential (`db`) returning a real token (not reproduced here).

## Test plan

- [x] `bash -n` on every modified script: clean.
- [x] `shellcheck -S warning`: 0 new warnings on `scripts/vault.sh` or `scripts/_common.sh` (diffed against the pre-change versions to confirm — 0 before, 0 after, both files).
- [x] `python3 scripts/checks/check_declared_paths_are_seeded.py`: passes, `sync` → `secret/shared/database` recognized as already-seeded.
- [x] `bats tests/scripts/vault.bats tests/scripts/vault-required-vars-control.bats tests/scripts/vault-empty-guard.bats tests/scripts/vault-covers-compose-control.bats tests/scripts/vault-revoke-order-control.bats`: 129/129 pass, including 10 new/rewritten tests specific to this change (sudo absence pinned, token bound checked against `max_lease_ttl`, the AppRole-login-not-token-renew shape, `cmd_setup_sync_approle` structural checks).
- [x] YAML parses (`yaml.safe_load`) and every `run:` block passes `bash -n`, extracted and checked individually.
- [x] Positive control shown above, captured for real, both failure and success paths, against the live OpenBao.
- [x] `policy-sync.hcl`: untouched, `grep -c sudo` still 0 — pinned by a new bats test so a future edit can't quietly add it.
- [ ] Not deployed. No token minted. No OpenBao config touched. PR only, per instruction — the one-time `setup-sync-approle` step and the merge itself are yours to sequence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)