### PR TITLE
fix(ci): wire check_root_revoke_fails_closed.py into CI (h#726)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,19 @@ jobs:
       - name: Assert no path revokes root before OIDC is enabled
         run: python3 scripts/checks/check_vault_revoke_order.py
 
+      # h#726: written to catch the exact regression in run 30791332461 (a
+      # revoke step's `if:` ANDed with success() skipped it on failure and
+      # left a live root token on production), then never invoked — the
+      # detection logic was proven only against synthetic bats fixtures,
+      # never against this repo's real workflow files. Static and read-only:
+      # parses .github/workflows/*.yml from the checkout, no vault, no SSH,
+      # no secret. Verified before wiring, against a mutated copy of the
+      # real vault-regain-root.yml with the exact historical condition
+      # reintroduced: goes red, correctly, on both the revoke-step and the
+      # confirm-step half of the property.
+      - name: Assert a root-minting workflow revokes and confirms on failure
+        run: python3 scripts/checks/check_root_revoke_fails_closed.py
+
       - name: Validate secrets schema consistency
         env:
           SECRETS_SCHEMA_STRICT: "0"


### PR DESCRIPTION
Closes #726 — the highest-consequence finding from #735's sweep: a root-token safety net wired to nothing.

## What I established before writing anything, per the ask

**What the check actually asserts:** every workflow step that mints a root token (`vault.sh regain-root` or `vault.sh init`) must be followed by a revoke step and a confirmation step, both surviving a failure anywhere in between — i.e. both `if:` conditions must name `always()`, `failure()`, or `cancelled()`. A workflow can opt out with a declared `ROOT-TOKEN-DISPOSAL: deliberate` marker and a stated reason.

**Whether that property is true of the estate today:** read `vault-init.yml` and `vault-regain-root.yml` in full, independently of the checker. Both correctly gate their revoke and confirm steps with `always() && inputs.revoke_root[_at_end]` — this was the actual fix for run 30791332461, and it's still in place. `vault-reinitialize.yml` mints but deliberately hands the token to a human ("Deliberately not automated"); confirmed it carries the `ROOT-TOKEN-DISPOSAL` marker and its only mention of `revoke-root` is inside `echo` lines. **The property genuinely holds today.**

**The real root-minting paths:** grepped for `bao operator generate-root` (the underlying primitive) across the whole repo. Three call sites: `vault.sh regain-root`, `vault.sh init`, and `vault.sh bootstrap-approles` — the third isn't covered by the checker's `MINT` patterns, but it's also not invoked from any GitHub Actions workflow (only run by hand), so it's outside what a workflow-YAML-only checker can audit. Noted, not treated as a gap in this fix.

**Whether the checker's own logic is trustworthy** — did not assume it, because per the task's instruction a check that was never run has never been proven to work: copied the real `vault-regain-root.yml`, reverted its revoke step's condition to the exact historical `if: ${{ inputs.revoke_root_at_end }}` (no `always()`), ran the checker against that mutated real file — **FAIL**, correct step numbers, correct message. Restored the real condition — **PASS**. Repeated independently for the confirm step's condition. Both directions, both halves of the property, shown below.

```
$ # mutated: revoke step's if: reverted to the exact 30791332461 bug
FAIL — 1 problem(s):
  vault-regain-root.yml:regain step 13 ('Regain root from the unseal key') fails ->
  step 25 ('Revoke the recovered root token') is SKIPPED, leaving a live root
  token. Its condition is '${{ inputs.revoke_root_at_end }}'; it needs always().

$ # restored: real, current condition
PASS — every root-minting workflow revokes and verifies on failure

$ # mutated: confirm step's if: reverted the same way
FAIL — 1 problem(s):
  vault-regain-root.yml:regain step 26 ('ASSERT the root token is dead') confirms
  the token is gone but is skipped on failure — the confirmation disappears
  exactly when it matters. Its condition is '${{ inputs.revoke_root_at_end }}'.
```

This is a stronger verification than the existing bats suite gives — it exercises the checker against production-shaped YAML, not a fixture built to match the checker's own expectations.

## The fix

One step in `ci.yml`, next to its sibling `check_vault_revoke_order.py`. Static and read-only — parses `.github/workflows/*.yml` from the checkout; no vault, no SSH, no secret.

## A related discovery, filed separately as #736

`check_checks_are_wired.py` — the meta-check whose whole job is "is this check invoked by anything" — counts a bats **control** test alone as "invoked" (confirmed: `checks-are-wired-control.bats:16` passes today, by design). `root-revoke-fails-closed-control.bats` only ever exercised synthetic fixtures, never the real workflow files. So the meta-check that exists specifically to catch "a check nobody calls" reported this exact check as wired the whole time it wasn't actually running against anything real. That's very likely the mechanism by which #726 slipped through in the first place. Not fixed here — it's a real design question about what "invoked" should mean, not a one-line bug — filed as #736.

## Test plan

- [x] `check_root_revoke_fails_closed.py` run directly against the real repo: PASS (property holds).
- [x] Mutated-real-file verification, both directions, both halves — shown above.
- [x] `check_checks_are_wired.py` now reports `check_root_revoke_fails_closed.py` as `bats,workflow` (genuinely invoked, not bats-only).
- [x] `tests/scripts/root-revoke-fails-closed-control.bats` (10 tests), `checks-are-wired-control.bats` (7), `vault-revoke-order-control.bats` (8) — all pass.
- [x] Full `bats tests/scripts/` suite: 530 tests, all green.
- [x] `shellcheck --severity=error scripts/*.sh`: clean.
- [x] YAML validated (`yaml.safe_load`).

Not infra/secrets/sops/credential work. No token minted, rotated, or written. No deploy run from a workstation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)