### PR TITLE
fix(checks): stop check_retired_roles_ungranted.py's --live mode from turning an unreachable host into a PASS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,29 @@ jobs:
       - name: Assert every referenced OIDC client is created on the deploy path
         run: python3 scripts/checks/check_oidc_clients_reconciled.py
 
+      # h#727: static mode (no --live) is explicitly documented in the
+      # script's own module docstring as "static, CI" — this wires that
+      # documented, secrets-free half in. It cannot see holders (needs the
+      # live realm), so it cannot replace --live; it catches the config-file
+      # half of the same property on every PR: a retired role must not be
+      # (re)created in keycloak.sh, or named in MinIO's policy list,
+      # Grafana's role_attribute_path, or OpenBao's bound_claims.
+      #
+      # --live is NOT wired here, or anywhere yet, and that is a deliberate
+      # stop rather than an oversight: it hardcodes `ssh vps <cmd>` — an SSH
+      # config alias literal — and no workflow in this repo defines a "vps"
+      # host alias; every other workflow reaches the VPS via
+      # `ssh -i ~/.ssh/vps_key ... deploy@$TAILSCALE_IP` directly, with no
+      # alias at all. Wiring --live needs either a new alias-setup step here
+      # (a real design decision, not obviously the right one — it duplicates
+      # what every other workflow already does differently) or refactoring
+      # the script to accept an explicit SSH target instead of a hardcoded
+      # alias, and validating either path end-to-end needs a real run against
+      # production Keycloak/MinIO with decrypted secrets, out of scope for
+      # this change. See h#738 for what's left.
+      - name: Assert no retired role is granted anything (static)
+        run: python3 scripts/checks/check_retired_roles_ungranted.py
+
       - name: Assert no path revokes root before OIDC is enabled
         run: python3 scripts/checks/check_vault_revoke_order.py
 

--- a/scripts/checks/check_retired_roles_ungranted.py
+++ b/scripts/checks/check_retired_roles_ungranted.py
@@ -4,6 +4,13 @@
     python3 scripts/checks/check_retired_roles_ungranted.py           # static, CI
     python3 scripts/checks/check_retired_roles_ungranted.py --live    # + live estate
 
+Exit 0 = no retired role is granted anything (measured, clean). Exit 1 = a
+retired role IS granted something (measured, real problem). Exit 2 = --live
+could not measure at all — SSH/the remote command chain failed, or its output
+could not be parsed. 2 is not 0: an unreachable host must never read as "no
+retired role is granted", which is the null result that happens to agree with
+what everyone hopes is true. See h#727.
+
 WHY. Deleting the four zero-holder realm roles is only safe while nothing grants
 them anything. The danger is the reverse of the usual one: a grant attached to a
 role with no holders costs nothing today and everything the moment someone is
@@ -98,12 +105,33 @@ def static_checks(retired: set[str]) -> list[str]:
     return problems
 
 
+class LiveCheckUnreachable(Exception):
+    """The live estate could not be measured at all.
+
+    Must never be folded into `problems` and reported through the same exit
+    code as a genuine PASS or FAIL. An SSH failure (VPS unreachable, tailscale
+    down, the remote command chain itself failing) is the dangerous null
+    here: it agrees with what everyone hopes is true ("no retired role is
+    granted"), which is exactly backwards from a check whose entire job is to
+    notice a silent grant. See h#727 — `ssh(cmd) or "[]"` used to turn "the
+    connection failed and stdout is empty" into "valid JSON for an empty
+    list", so the surrounding except never fired and this printed a PASS
+    having measured nothing.
+    """
+
+
 def live_checks(retired: set[str]) -> list[str]:
-    """Measure holders and read the live estate. Needs the VPS."""
+    """Measure holders and read the live estate. Needs the VPS.
+
+    Returns a normal problems list (possibly empty — clean) on a genuine
+    measurement. Raises LiveCheckUnreachable if the estate could not be
+    reached or a remote command failed, so a caller can never mistake
+    "could not measure" for "measured and clean".
+    """
     problems: list[str] = []
 
-    def ssh(cmd: str) -> str:
-        return subprocess.run(["ssh", "vps", cmd], capture_output=True, text=True).stdout
+    def ssh(cmd: str) -> subprocess.CompletedProcess:
+        return subprocess.run(["ssh", "vps", cmd], capture_output=True, text=True)
 
     kc = (
         "cd /opt/hill90/app && export SOPS_AGE_KEY_FILE=/opt/hill90/secrets/keys/keys.txt && "
@@ -114,11 +142,22 @@ def live_checks(retired: set[str]) -> list[str]:
         "--realm master --user \"$U\" >/dev/null 2>&1; "
         "docker exec keycloak /opt/keycloak/bin/kcadm.sh get roles -r platform --fields name 2>/dev/null"
     )
+    kc_result = ssh(kc)
+    # The remote command is a `;`-chained sequence ending in the kcadm read, so
+    # its exit code — whether the failure is ssh itself refusing to connect,
+    # or the docker exec/kcadm call inside failing — is the last command's,
+    # which is the one we actually need to have succeeded.
+    if kc_result.returncode != 0:
+        raise LiveCheckUnreachable(
+            f"could not read live realm roles — ssh/remote command exited "
+            f"{kc_result.returncode}: {kc_result.stderr.strip() or '(no stderr)'}"
+        )
     try:
-        live_roles = {x["name"] for x in json.loads(ssh(kc) or "[]")}
+        live_roles = {x["name"] for x in json.loads(kc_result.stdout)}
     except Exception as e:  # noqa: BLE001
-        problems.append(f"could not read live realm roles, so holders are UNMEASURED: {e}")
-        return problems
+        raise LiveCheckUnreachable(
+            f"ssh succeeded but the realm-roles output could not be parsed as JSON: {e}"
+        ) from e
 
     still = sorted(retired & live_roles)
     print(f"  {'MISS' if still else 'ok  '}  live realm roles: retired ones still present = {', '.join(still) or 'none'}")
@@ -129,8 +168,25 @@ def live_checks(retired: set[str]) -> list[str]:
         "cd /opt/hill90/app && export SOPS_AGE_KEY_FILE=/opt/hill90/secrets/keys/keys.txt && "
         "bash scripts/checks/minio-policy-names-test.sh 2>/dev/null | grep 'MinIO policies:'"
     )
-    line = ssh(pol_cmd)
-    live_pol = set(line.split(":", 1)[1].split()) if ":" in line else set()
+    pol_result = ssh(pol_cmd)
+    # minio-policy-names-test.sh never prints "MinIO policies:" on a failure
+    # (it exits 1 with a distinct stderr message instead — see its own
+    # `[ -n "$POLICIES" ] || { echo "Could not list MinIO policies" >&2; exit
+    # 1; }`), so grep finding nothing to match propagates as this ssh
+    # command's own non-zero exit — no pipefail needed for that half. A
+    # connection failure that never reaches the remote script at all behaves
+    # identically: grep sees no input, matches nothing, exits 1.
+    if pol_result.returncode != 0:
+        raise LiveCheckUnreachable(
+            f"could not read live MinIO policies — ssh/remote command exited "
+            f"{pol_result.returncode}: {pol_result.stderr.strip() or '(no stderr)'}"
+        )
+    line = pol_result.stdout
+    if ":" not in line:
+        raise LiveCheckUnreachable(
+            f"ssh succeeded but the MinIO policy line could not be parsed: {line!r}"
+        )
+    live_pol = set(line.split(":", 1)[1].split())
     bad = sorted(retired & live_pol)
     print(f"  {'MISS' if bad else 'ok  '}  live MinIO policies: retired ones still present = {', '.join(bad) or 'none'}")
     for r in bad:
@@ -157,7 +213,18 @@ def main() -> int:
     problems = static_checks(retired)
     if args.live:
         print()
-        problems += live_checks(retired)
+        try:
+            problems += live_checks(retired)
+        except LiveCheckUnreachable as e:
+            print(f"CANNOT DETERMINE — {e}")
+            print(
+                "\nThis is NOT a pass. An unreachable host must never be read as "
+                "'no retired role is granted' — that is the answer that agrees "
+                "with what everyone hopes, which is exactly the wrong direction "
+                "for this check to fail in. Fix connectivity to the VPS and "
+                "re-run, or check the failure above by hand."
+            )
+            return 2
 
     print()
     if problems:

--- a/tests/scripts/retired-roles-ungranted-control.bats
+++ b/tests/scripts/retired-roles-ungranted-control.bats
@@ -80,3 +80,99 @@ setup() {
   [ "$status" -eq 1 ]
   [[ "$output" == *"created and deleted every run"* ]]
 }
+
+# ---------------------------------------------------------------- --live ----
+#
+# h#727: `ssh(cmd) or "[]"` turned "the ssh call failed and stdout is empty"
+# into valid JSON for an empty list, so the surrounding except never fired and
+# an unreachable host printed a PASS having measured nothing. The danger is
+# inverted from the usual check-writing instinct: the null result here
+# AGREES with what everyone hopes ("no retired role is granted"), which is
+# exactly the wrong direction for a security check to fail in.
+#
+# These stub the literal `ssh vps <cmd>` invocation the script makes — a real
+# throwaway SSH server (linuxserver/openssh-server, alias temporarily
+# resolved to it) was used to positive-control this fix directly against a
+# genuine network round-trip during development; these bats tests are the
+# permanent, fast, CI-safe regression form of that same verification, driven
+# by a PATH-shadowing `ssh` stub rather than a live container.
+
+setup_ssh_stub() {
+  local scenario="$1"
+  STUB_DIR="$BATS_TEST_TMPDIR/stub-bin"
+  mkdir -p "$STUB_DIR"
+  cat > "$STUB_DIR/ssh" <<STUB
+#!/bin/bash
+# argv: vps '<remote command string>'
+cmd="\$2"
+case "\$cmd" in
+  *"kcadm.sh get roles"*)
+    case "$scenario" in
+      clean)          echo '[{"name":"platform-admin"},{"name":"platform-editor"},{"name":"platform-viewer"}]'; exit 0 ;;
+      retired-found)  echo '[{"name":"platform-admin"},{"name":"admin"}]'; exit 0 ;;
+      kc-cmd-fails)   echo "remote: keycloak container is restarting" >&2; exit 1 ;;
+      kc-unreachable) echo "ssh: connect to host 100.88.29.112 port 22: Connection refused" >&2; exit 255 ;;
+    esac
+    ;;
+  *"minio-policy-names-test.sh"*)
+    case "$scenario" in
+      clean|kc-cmd-fails|kc-unreachable) echo "  MinIO policies: platform-admin platform-viewer"; exit 0 ;;
+      retired-found)                     echo "  MinIO policies: platform-admin admin"; exit 0 ;;
+    esac
+    ;;
+esac
+exit 0
+STUB
+  chmod +x "$STUB_DIR/ssh"
+}
+
+@test "--live CONTROL: a clean live estate passes" {
+  setup_ssh_stub clean
+  run env PATH="$STUB_DIR:$PATH" python3 "$CHECK" --live
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"PASS"* ]]
+  [[ "$output" == *"live realm roles: retired ones still present = none"* ]]
+}
+
+@test "--live: a retired role genuinely present on the live realm turns it red (exit 1, not 2)" {
+  setup_ssh_stub retired-found
+  run env PATH="$STUB_DIR:$PATH" python3 "$CHECK" --live
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"realm role admin is still present on the live realm"* ]]
+  [[ "$output" == *"MinIO policy admin still exists"* ]]
+}
+
+@test "THE ASSERTION THAT MATTERS: a remote command failure refuses to answer (exit 2), never a silent PASS" {
+  setup_ssh_stub kc-cmd-fails
+  run env PATH="$STUB_DIR:$PATH" python3 "$CHECK" --live
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"CANNOT DETERMINE"* ]]
+  [[ "$output" != *"PASS"* ]]
+}
+
+@test "THE ASSERTION THAT MATTERS: an unreachable host refuses to answer (exit 2), never a silent PASS" {
+  setup_ssh_stub kc-unreachable
+  run env PATH="$STUB_DIR:$PATH" python3 "$CHECK" --live
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"CANNOT DETERMINE"* ]]
+  [[ "$output" == *"Connection refused"* ]]
+  [[ "$output" != *"PASS"* ]]
+}
+
+@test "exit codes for clean / real-violation / cannot-determine are three genuinely different states" {
+  setup_ssh_stub clean
+  run env PATH="$STUB_DIR:$PATH" python3 "$CHECK" --live
+  clean_status="$status"
+
+  setup_ssh_stub retired-found
+  run env PATH="$STUB_DIR:$PATH" python3 "$CHECK" --live
+  found_status="$status"
+
+  setup_ssh_stub kc-unreachable
+  run env PATH="$STUB_DIR:$PATH" python3 "$CHECK" --live
+  unreachable_status="$status"
+
+  [ "$clean_status" -eq 0 ]
+  [ "$found_status" -eq 1 ]
+  [ "$unreachable_status" -eq 2 ]
+}


### PR DESCRIPTION
Closes #727.

## The bug

`live_checks()` reached the VPS via `ssh(cmd) or "[]"` — when the ssh call itself failed, `.stdout` was empty, `"" or "[]"` became a valid empty JSON list, and the `except` around `json.loads` never fired. An unreachable host silently reported **PASS**, having measured nothing. The same shape recurred for the MinIO policy read.

The instruction for this fix named the exact hazard: an unreachable host must not read as "no retired role is granted" — that's the answer that agrees with what everyone hopes, which is precisely the wrong direction for a security check to fail in.

## The fix

Both `ssh()` calls now capture the full `CompletedProcess`, check `returncode` explicitly, and raise a new `LiveCheckUnreachable` — distinct from both PASS and FAIL — on failure. `main()` catches it and returns **exit 2** (CANNOT DETERMINE), matching the sibling convention already used by `check_deploy_drift.sh` and `check_tenant_baseline_agrees.py`. Three genuinely different exit codes now: 0 (clean), 1 (real violation), 2 (could not measure).

## Positive-controlled both directions, against something real

Not mocked — a throwaway `linuxserver/openssh-server` container, with the script's literal hardcoded `ssh vps` alias temporarily pointed at it via a `Host vps` block placed ahead of the real one in `~/.ssh/config` (restored afterward — diffed clean against a backup taken first; the container and its key material lived only in `/tmp` for the test's duration).

| Scenario | Result |
|---|---|
| Clean live estate | **PASS**, exit 0 |
| A retired role genuinely present, live, in both Keycloak and MinIO | **FAIL**, exit 1, names both |
| Remote command chain fails (stand-in `docker exec` returns real non-zero) | **CANNOT DETERMINE**, exit 2 |
| Host genuinely unreachable (container stopped, real "Connection refused") | **CANNOT DETERMINE**, exit 2 |

**The decisive comparison** — same real stopped container, only the code differed:
```
$ # pre-fix code, real unreachable host
PASS — no retired role is granted anything
OLD CODE exit=0

$ # fixed code, same real unreachable host
CANNOT DETERMINE — could not read live realm roles — ssh/remote command exited 255: ssh: connect to host localhost port 12222: Connection refused
exit=2
```

`tests/scripts/retired-roles-ungranted-control.bats` gained a permanent, CI-safe regression form of the same four scenarios via a PATH-shadowing `ssh` stub (no Docker/network dependency at test time) — the real-container run is what established the fix is correct; the stub tests are what keep it that way. Failing-test-first confirmed: 3 of the 5 new assertions fail against the pre-fix script.

## Also wired: static mode

`python3 scripts/checks/check_retired_roles_ungranted.py` (no `--live`) is explicitly documented in the script's own docstring as the CI-safe half ("static, CI") — needs no secrets, now runs in `ci.yml`. It cannot see live holders, so it does not replace `--live`.

## Stopped at a real boundary: `--live` itself is not wired anywhere yet

Filed as **#738**. `--live` hardcodes `ssh vps <cmd>` — an SSH config alias literal that nothing in this repo's CI establishes; every workflow reaches the VPS via `ssh -i ~/.ssh/vps_key ... deploy@$TAILSCALE_IP` directly, no alias. Wiring it needs a real decision (add an alias-setup step that duplicates what every other workflow does differently, or refactor the script to take an explicit SSH target) and validating either path needs a live run against production Keycloak/MinIO with decrypted secrets — explicitly out of scope for this task.

## Test plan

- [x] Real-container positive control, both directions, shown above.
- [x] `tests/scripts/retired-roles-ungranted-control.bats`: 12/12 pass; 3/12 fail against pre-fix code (stashed and re-run).
- [x] `check_checks_are_wired.py` now reports `check_retired_roles_ungranted.py` as `bats,workflow`.
- [x] Full `bats tests/scripts/` suite: 535 tests, all green.
- [x] `shellcheck --severity=error scripts/*.sh`: clean.
- [x] YAML validated.

Not infra/secrets/sops/credential work. No token/credential minted, rotated, or written. No deploy run from a workstation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)