### PR TITLE
fix(ci): flip check_secrets_schema.py to strict mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,9 +106,25 @@ jobs:
       - name: Assert a root-minting workflow revokes and confirms on failure
         run: python3 scripts/checks/check_root_revoke_fails_closed.py
 
+      # h#728: this ran advisory-only (STRICT=0) since it was added — real
+      # warnings were printed but never failed the build. Flipped to strict
+      # after establishing, not assuming, that it costs nothing today: ran
+      # in strict mode against the real repo (zero findings, and confirmed
+      # that's a genuine clean by checking the comparison counts — 43
+      # compose refs, 38 SOPS keys, 22+4+2+5 schema entries — not an
+      # empty-input vacuous pass), confirmed strict and non-strict report
+      # IDENTICAL warning content and differ ONLY in the trailing "Strict
+      # mode: failing" line and exit code (diffed both against a real
+      # injected violation), and positive-controlled the flip itself against
+      # a real compose-file mutation: an undeclared ${VAR} added to
+      # docker-compose.infra.yml turned this red, reverting it turned this
+      # green. See h#728's PR and issue comment for the full inventory. Does
+      # NOT cover drift between infra/secrets/prod.enc.env and its own
+      # .example template — this check reads only the checked-in example,
+      # never the encrypted store.
       - name: Validate secrets schema consistency
         env:
-          SECRETS_SCHEMA_STRICT: "0"
+          SECRETS_SCHEMA_STRICT: "1"
         run: python3 scripts/checks/check_secrets_schema.py
 
       - name: Assert no destructive volume commands


### PR DESCRIPTION
Closes #728 (see the issue comment for the original zero-findings inventory this decision rests on).

## The decision, and why it was free to make

- Ran in strict mode against the real repo: **zero findings**.
- Confirmed that's a genuine clean, not a vacuous 0==0: 43 compose refs, 38 SOPS keys, 22+4+2+5 schema entries across categories — real, substantial sets on both sides. Checked the 31-entry `excluded_vars` list too — hostnames/ports/prefixes/feature flags, not credentials, so it isn't quietly absorbing real drift.
- Confirmed the checker can actually detect drift (not silently broken some other way): injected an undeclared `${VAR}` via its own test-override hooks, strict mode correctly failed.

## What this PR adds on top: proof the flip does something

**1. Strict and non-strict report identically, differing only in exit code.** Diffed stdout for both the clean repo (byte-identical) and a real injected violation (identical warning content, only the trailing "Strict mode: failing" line differs). This means the zero-findings measurement taken in advisory mode transfers directly to strict mode — nothing new comes into view just because the flag flipped.

**2. Positive-controlled the flip against a real file mutation, not the override hooks.** Appended an undeclared `${GENUINELY_UNDECLARED_SECRET_PROBE}` directly to `deploy/compose/prod/docker-compose.infra.yml`, ran the exact command CI now runs:

```
$ SECRETS_SCHEMA_STRICT=1 python3 scripts/checks/check_secrets_schema.py
Secrets schema validation: 1 warning(s)
  [WARN] Compose ref ${GENUINELY_UNDECLARED_SECRET_PROBE} (in docker-compose.infra.yml) not found in schema

Strict mode: failing due to warnings above
RED exit=1
```

Reverted with `git checkout --`:

```
$ SECRETS_SCHEMA_STRICT=1 python3 scripts/checks/check_secrets_schema.py
Secrets schema validation: all checks passed
GREEN exit=0
```

## What this does not cover

Drift between the real `infra/secrets/prod.enc.env` and its own `.example` template — this check reads only the checked-in example, never the encrypted store. Noted in the new `ci.yml` comment so the boundary isn't lost later.

## Test plan

- [x] Strict vs non-strict diff, clean repo: identical.
- [x] Strict vs non-strict diff, real injected violation: identical except the trailing line.
- [x] Real compose-file mutation positive control, both directions, shown above.
- [x] `tests/checks/test_secrets_schema.py`: 11/11 pass (script itself unchanged).
- [x] Full pytest suite: 75/75 pass.
- [x] Full `bats tests/scripts/`: 543/543 pass.
- [x] `shellcheck --severity=error scripts/*.sh`: clean.
- [x] YAML validated.

Not infra/secrets/sops/credential work — the script only reads plaintext checked-in files. No deploy run from a workstation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)