### PR TITLE
fix(checks): refuse a vacuous pass when declared_paths() finds no arms (h#730)

### DIFF
--- a/scripts/checks/check_declared_paths_are_seeded.py
+++ b/scripts/checks/check_declared_paths_are_seeded.py
@@ -89,6 +89,19 @@ def seeded_keys(path: str) -> set[str]:
 
 def main() -> int:
     declared = declared_paths()
+
+    # h#730: declared_paths() returning empty is indistinguishable from every
+    # case arm in vault_paths_for_service() having rotted out of the regex,
+    # and would pass vacuously — "every declared path is seeded" having
+    # checked zero of them. Refuse instead, matching the sibling check this
+    # one is modelled on: check_oidc_clients_reconciled.py's identical guard
+    # on `refs` a few lines into its own main().
+    if not declared:
+        print("FAIL — no declared paths found at all. The pattern no longer matches "
+              "anything in vault_paths_for_service(), which is a broken check, not a "
+              "clean estate.", file=sys.stderr)
+        return 1
+
     seeded = seeded_paths()
     required = required_keys()
 

--- a/tests/scripts/declared-paths-seeded-control.bats
+++ b/tests/scripts/declared-paths-seeded-control.bats
@@ -110,6 +110,39 @@ PY
   [[ "$output" == *"empty string"* ]]
 }
 
+# h#730: unlike its sibling check_oidc_clients_reconciled.py (which refuses a
+# zero-reference result as indistinguishable from every pattern having
+# rotted), this check had no guard for declared_paths() returning empty — a
+# regex-vs-source-shape drift that stops every case arm from matching, while
+# the outer function-body regex still matches fine, would have printed "PASS
+# — every declared path is seeded" having examined zero of them. Simulated
+# the drift the sibling's own docstring names as the trigger: a refactor away
+# from the shape the regex expects — here, `echo "..."` becoming `printf`.
+@test "THE ASSERTION THAT MATTERS: every case arm losing its echo shape refuses rather than passing vacuously" {
+  python3 - "$CTL/scripts/_common.sh" <<'PY'
+import re, sys
+p = sys.argv[1]
+t = open(p).read()
+m = re.search(r"vault_paths_for_service\(\)\s*\{(.*?)\n\}", t, re.S)
+assert m, "fixture setup broken: could not find the function to mutate"
+body = m.group(1)
+# Every arm goes from `echo "..."` to `printf '%s' "..."` — the regex this
+# check parses arms with requires the literal `echo`, so this drops every
+# arm from the parse while the outer function-body regex still matches.
+mutated_body = re.sub(r'echo\s+"', 'printf \'%s\' "', body)
+assert mutated_body != body, "mutation did not apply"
+t2 = t[:m.start(1)] + mutated_body + t[m.end(1):]
+open(p, "w").write(t2)
+PY
+
+  run python3 "$CHECK"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"FAIL"* ]]
+  [[ "$output" == *"no declared paths found at all"* ]]
+  # Must not be silently indistinguishable from a genuine clean pass.
+  [[ "$output" != *"PASS"* ]]
+}
+
 # PROSE IS NOT AN ACTION — the same trap that made an earlier check read an
 # echoed command as a real one. A path named only in a comment is not seeded.
 @test "a path mentioned only in a comment does not count as seeded" {


### PR DESCRIPTION
Closes #730 — steals the guard from its sibling `check_oidc_clients_reconciled.py` rather than inventing a new shape, per the instruction.

## The bug

`declared_paths()` parses the case arms of `vault_paths_for_service()` with a regex requiring the literal shape `arm)  echo "..."`. If that function is ever refactored away from `echo` — a case arm rewritten to `printf`, for instance — the outer "could not find `vault_paths_for_service()`" guard still matches (the function body itself is still found), but the per-arm regex silently matches zero arms. The check printed "PASS — every declared path is seeded" having examined none of them.

## The fix

`check_oidc_clients_reconciled.py` already has the identical guard for the identical shape:

```python
if not refs:
    print("FAIL — no client references found at all. The patterns no longer match "
          "anything, which is a broken check, not a clean estate.", file=sys.stderr)
    return 1
```

Copied it — same wording, same exit behavior — rather than writing something new:

```python
if not declared:
    print("FAIL — no declared paths found at all. The pattern no longer matches "
          "anything in vault_paths_for_service(), which is a broken check, not a "
          "clean estate.", file=sys.stderr)
    return 1
```

## Positive-controlled directly

Ran the **old** script against a real copy of `scripts/_common.sh` with every arm's `echo "..."` mechanically rewritten to `printf '%s' "..."` — the exact drift the fix targets:

```
$ python3 check_declared_paths_are_seeded.py   # old code, mutated real source
Declared vault paths must be seeded
===================================

  note: seeded but declared by no service: secret/auth/config, secret/infra/traefik, secret/infra/vps, secret/observability/grafana, secret/shared/database

PASS — every declared path is seeded, and every seeded key is guarded
exit=0
```

Zero of the six real declared paths were examined — visible only as "seeded but declared by no service" *orphans*, never as a single `ok`/`MISS` line, and still a clean PASS. The **new** code, same mutation:

```
FAIL — no declared paths found at all. The pattern no longer matches
anything in vault_paths_for_service(), which is a broken check, not a
clean estate.
exit=1
```

The real, unmutated `scripts/_common.sh` is unaffected — still `PASS`, all six paths examined as before.

## Test plan

- [x] `tests/scripts/declared-paths-seeded-control.bats` gained a permanent regression test for this exact mutation — 8/8 pass; the new assertion fails against the pre-fix script (stashed and re-run).
- [x] Full pytest suite: 75/75 pass.
- [x] Full `bats tests/scripts/`: 543/543 pass.
- [x] `shellcheck --severity=error scripts/*.sh`: clean.

Not infra/secrets/sops/credential work. No deploy run from a workstation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)