### PR TITLE
fix(checks): close the remaining 0==0-family findings from h#735's sweep (h#729, h#732, h#734)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,13 +71,44 @@ jobs:
       - name: Lint scripts
         run: shellcheck --severity=error scripts/*.sh
 
+      # h#732 found the dormant 0==0 trap on the second check below (if
+      # deploy.sh's invocation style is ever renamed, the grep for "docker
+      # compose" matches zero lines and the check finds nothing to complain
+      # about — an unchecked invariant, not an upheld one). Fixing it
+      # surfaced something more severe in the SAME lines: GitHub Actions
+      # runs `run:` blocks under `bash -eo pipefail`, and bash's `set -e`
+      # explicitly EXEMPTS a `!`-negated command from triggering abort, even
+      # when the negated result is failure. `! (pipeline)` never aborted
+      # this step on a real violation — it just fell through to the next
+      # line, and the step always ended on the final `echo`'s exit 0.
+      # Verified directly, not by reasoning about bash semantics alone:
+      # injected a real `docker compose ... ` call with no -p flag into a
+      # copy of deploy.sh and ran this exact step, byte for byte, under
+      # `bash -eo pipefail` — it printed "All safety checks passed." and
+      # exited 0. Both checks are rewritten with an explicit if/exit so a
+      # real violation actually fails the step, which the `!`-negated form
+      # could not do regardless of the 0==0 trap.
       - name: Assert deploy safety invariants
         run: |
           echo "Checking: no --remove-orphans..."
-          ! (grep -- "--remove-orphans" scripts/deploy.sh | grep -v "^#" | grep -v "^[[:space:]]*#")
+          if grep -- "--remove-orphans" scripts/deploy.sh | grep -v "^#" | grep -v "^[[:space:]]*#" | grep -q .; then
+            echo "::error::scripts/deploy.sh contains --remove-orphans"
+            grep -n -- "--remove-orphans" scripts/deploy.sh | grep -v "^#"
+            exit 1
+          fi
 
           echo "Checking: all docker compose calls use -p..."
-          ! (grep "docker compose" scripts/deploy.sh | grep -v "^#" | grep -v "^[[:space:]]*#" | grep -v -- "-p ")
+          DC_LINES=$(grep "docker compose" scripts/deploy.sh | grep -v "^#" | grep -v "^[[:space:]]*#" || true)
+          if [ -z "$DC_LINES" ]; then
+            echo "::error::CANNOT DETERMINE — zero 'docker compose' invocations found in scripts/deploy.sh. Either the invocation pattern changed (renamed, wrapped, hyphenated) and this check is no longer looking at anything real, or deploy.sh itself changed shape. Fix this check before trusting a green run here."
+            exit 1
+          fi
+          if printf '%s\n' "$DC_LINES" | grep -v -- "-p " > /dev/null; then
+            echo "::error::a docker compose invocation in scripts/deploy.sh is missing -p"
+            printf '%s\n' "$DC_LINES" | grep -v -- "-p "
+            exit 1
+          fi
+          echo "  ok — $(printf '%s\n' "$DC_LINES" | grep -c .) docker compose invocation(s), all use -p"
 
           echo "All safety checks passed."
 

--- a/scripts/checks/check_md_links.py
+++ b/scripts/checks/check_md_links.py
@@ -49,7 +49,21 @@ def resolve_target(source: Path, link: str) -> Path:
 def main() -> int:
     missing: list[tuple[Path, int, str]] = []
 
-    for md_file in iter_md_files():
+    md_files = iter_md_files()
+    # h#734: the same 0==0 trap check_destructive_commands.sh had — if every
+    # entry in SCAN_ROOTS stops existing (a directory renamed or moved),
+    # iter_md_files() returns [], `missing` stays empty, and this printed
+    # "no missing local links found" having scanned nothing. Same fix shape:
+    # count what was actually examined, and refuse to call zero of them a
+    # clean pass.
+    if not md_files:
+        print(
+            f"CANNOT DETERMINE: none of {', '.join(str(r) for r in SCAN_ROOTS)} "
+            "exist — nothing was scanned. Run this from the repository root."
+        )
+        return 2
+
+    for md_file in md_files:
         text = md_file.read_text(encoding="utf-8", errors="ignore")
         for line_no, line in enumerate(text.splitlines(), start=1):
             for match in LINK_RE.finditer(line):
@@ -73,7 +87,7 @@ def main() -> int:
         print(f"\nTotal missing links: {len(missing)}")
         return 1
 
-    print("Markdown link check passed: no missing local links found.")
+    print(f"Markdown link check passed: no missing local links found ({len(md_files)} files scanned).")
     return 0
 
 

--- a/scripts/checks/check_role_mappings_repointed.py
+++ b/scripts/checks/check_role_mappings_repointed.py
@@ -71,6 +71,36 @@ def main() -> int:
             for rm in role_re.finditer(m.group(0)):
                 roles += [r.strip().strip('"\'') for r in rm.group(1).split(",") if r.strip()]
             if not roles:
+                # h#729: the outer regex matched a real mapping expression,
+                # but the inner one extracted zero role names from it — e.g.
+                # the expression's format drifted from what role_re expects.
+                # This used to `continue` silently: not counted toward
+                # `checked`, not printed as a MISS, and invisible to the
+                # `found_any` guard below (which only catches line_re
+                # matching NOTHING, not line_re matching something role_re
+                # then can't parse).
+                #
+                # A PER-SITE problem, not a whole-run CANNOT DETERMINE: this
+                # site's line WAS found and read — the failure is narrower
+                # (role_re couldn't parse it), and this repo's own sibling
+                # for the identical "regex over a checked-in file found
+                # nothing" shape (check_declared_paths_are_seeded.py, h#730)
+                # reports it as FAIL/exit 1 rather than a separate
+                # CANNOT-DETERMINE exit code, because the input WAS read
+                # successfully — unlike check_retired_roles_ungranted.py's
+                # --live mode (h#727) or check_destructive_commands.sh
+                # (h#735), where the defect is that NOTHING was read or
+                # examined at all. Reporting per-site also preserves more
+                # information than a whole-run refusal would: if only ONE
+                # of several sites goes blind, naming exactly which one and
+                # why is more actionable than declaring the whole run
+                # unmeasurable when the OTHER sites are genuinely fine.
+                problems.append(
+                    f"{rel}: {label} matched a mapping expression but no role "
+                    f"names could be extracted from it — the expression's format "
+                    f"may have drifted from what this check expects. "
+                    f"Matched text: {m.group(0)!r}"
+                )
                 continue
             checked += 1
             bad = sorted(set(roles) & LEGACY)

--- a/tests/checks/test_md_links.py
+++ b/tests/checks/test_md_links.py
@@ -1,0 +1,102 @@
+"""Tests for scripts/checks/check_md_links.py
+
+h#734: SCAN_ROOTS is resolved from the script's own file location
+(Path(__file__).resolve().parents[2]), not from cwd, so reproducing the
+"nothing to scan" case needs a copy of the script placed under an isolated
+tree that genuinely lacks README.md / CONTRIBUTING.md / docs / .github —
+not just a different working directory.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "checks" / "check_md_links.py"
+
+
+def _run_in(tree: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["python3", str(tree / "scripts" / "checks" / "check_md_links.py")],
+        cwd=tree,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _isolated_tree(tmp_path: Path) -> Path:
+    """A tree shaped like the repo root, with the real script copied in."""
+    (tmp_path / "scripts" / "checks").mkdir(parents=True)
+    shutil.copy(SCRIPT, tmp_path / "scripts" / "checks" / "check_md_links.py")
+    return tmp_path
+
+
+def test_real_repo_passes():
+    """CONTROL: the real repo has no missing local links today."""
+    result = subprocess.run(
+        ["python3", str(SCRIPT)], capture_output=True, text=True
+    )
+    assert result.returncode == 0
+    assert "passed" in result.stdout
+    # Not vacuous: the real repo has real docs to scan.
+    assert "files scanned" in result.stdout
+
+
+def test_none_of_the_scan_roots_existing_refuses_rather_than_passing(tmp_path):
+    """THE ASSERTION THAT MATTERS: no scan roots present -> CANNOT DETERMINE, not PASS."""
+    tree = _isolated_tree(tmp_path)
+    result = _run_in(tree)
+    assert result.returncode == 2
+    assert "CANNOT DETERMINE" in result.stdout
+    assert "passed" not in result.stdout
+
+
+def test_a_real_broken_link_is_still_caught(tmp_path):
+    """CONTROL: detection itself is unaffected by the guard."""
+    tree = _isolated_tree(tmp_path)
+    docs = tree / "docs"
+    docs.mkdir()
+    (docs / "test.md").write_text("[broken](./does-not-exist.md)\n", encoding="utf-8")
+
+    result = _run_in(tree)
+    assert result.returncode == 1
+    assert "does-not-exist.md" in result.stdout
+
+
+def test_a_real_working_link_passes_and_reports_a_nonzero_scan_count(tmp_path):
+    """CONTROL: a genuinely clean, non-empty scan is unaffected — still PASS."""
+    tree = _isolated_tree(tmp_path)
+    docs = tree / "docs"
+    docs.mkdir()
+    (docs / "a.md").write_text("[ok](./b.md)\n", encoding="utf-8")
+    (docs / "b.md").write_text("nothing here\n", encoding="utf-8")
+
+    result = _run_in(tree)
+    assert result.returncode == 0
+    assert "2 files scanned" in result.stdout
+
+
+def test_exit_codes_for_nothing_to_scan_vs_clean_vs_broken_are_three_distinct_states(
+    tmp_path,
+):
+    empty_tree = _isolated_tree(tmp_path / "empty")
+    empty_status = _run_in(empty_tree).returncode
+
+    clean_tree = _isolated_tree(tmp_path / "clean")
+    (clean_tree / "docs").mkdir()
+    (clean_tree / "docs" / "a.md").write_text("nothing here\n", encoding="utf-8")
+    clean_status = _run_in(clean_tree).returncode
+
+    broken_tree = _isolated_tree(tmp_path / "broken")
+    (broken_tree / "docs").mkdir()
+    (broken_tree / "docs" / "a.md").write_text(
+        "[broken](./nope.md)\n", encoding="utf-8"
+    )
+    broken_status = _run_in(broken_tree).returncode
+
+    assert empty_status == 2
+    assert clean_status == 0
+    assert broken_status == 1

--- a/tests/scripts/ci-deploy-safety-invariants.bats
+++ b/tests/scripts/ci-deploy-safety-invariants.bats
@@ -1,0 +1,138 @@
+#!/usr/bin/env bats
+#
+# POSITIVE CONTROL for the "Assert deploy safety invariants" step in
+# .github/workflows/ci.yml.
+#
+# Two defects, found together (h#732). The one that was FILED: the second
+# check's `grep "docker compose" scripts/deploy.sh | ... | grep -v -- "-p "`
+# is the 0==0 trap — if deploy.sh's invocation style is ever renamed, the
+# first grep matches zero lines and the pipeline reports "nothing to
+# complain about" without having examined a single real invocation.
+#
+# The one FOUND WHILE FIXING IT, more severe: GitHub Actions runs `run:`
+# blocks under `bash -eo pipefail`, and bash's `set -e` explicitly EXEMPTS a
+# `!`-negated command from triggering abort, even when the negated result is
+# failure. `! (pipeline)` in the ORIGINAL step never aborted on a real
+# violation — it fell through to the next line, and the step always ended
+# on the final `echo`'s exit 0. Verified directly against real deploy.sh
+# mutations under the exact bash flags GitHub Actions uses, not by reasoning
+# about bash semantics alone.
+#
+# This extracts the step's exact `run:` body from the real workflow YAML —
+# so a future edit to the step is re-tested against these fixtures rather
+# than re-verified by hand — and runs it against fixture copies of
+# deploy.sh, under the same `bash -eo pipefail` GitHub Actions uses.
+
+setup() {
+    ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    WORKFLOW="$ROOT/.github/workflows/ci.yml"
+    SCRIPT="$BATS_TEST_TMPDIR/step.sh"
+
+    python3 - "$WORKFLOW" "$SCRIPT" <<'PY'
+import sys, yaml
+workflow_path, out_path = sys.argv[1], sys.argv[2]
+d = yaml.safe_load(open(workflow_path))
+run_body = None
+for s in d["jobs"]["test"]["steps"]:
+    if s.get("name") == "Assert deploy safety invariants":
+        run_body = s["run"]
+        break
+assert run_body, "could not find the 'Assert deploy safety invariants' step — did its name change?"
+open(out_path, "w").write(run_body)
+PY
+
+    FIXTURE="$BATS_TEST_TMPDIR/fixture"
+    mkdir -p "$FIXTURE/scripts"
+}
+
+run_step() {
+    (cd "$FIXTURE" && bash -eo pipefail "$SCRIPT")
+}
+
+@test "extraction sanity: the step body was found and is non-trivial" {
+    [ -s "$SCRIPT" ]
+    grep -q "remove-orphans" "$SCRIPT"
+}
+
+@test "CONTROL: a clean deploy.sh (no violations, real invocations present) passes" {
+    cp "$ROOT/scripts/deploy.sh" "$FIXTURE/scripts/deploy.sh"
+    run run_step
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"All safety checks passed."* ]]
+}
+
+@test "THE ASSERTION THAT MATTERS: a real --remove-orphans violation fails the step" {
+    cp "$ROOT/scripts/deploy.sh" "$FIXTURE/scripts/deploy.sh"
+    echo '  docker compose down --remove-orphans' >> "$FIXTURE/scripts/deploy.sh"
+    run run_step
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"::error::"* ]]
+    [[ "$output" != *"All safety checks passed."* ]]
+}
+
+@test "THE ASSERTION THAT MATTERS: a real docker-compose-missing--p violation fails the step" {
+    cp "$ROOT/scripts/deploy.sh" "$FIXTURE/scripts/deploy.sh"
+    echo '  docker compose -f "$f" up -d' >> "$FIXTURE/scripts/deploy.sh"
+    run run_step
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"::error::"* ]]
+    [[ "$output" == *"missing -p"* ]]
+    [[ "$output" != *"All safety checks passed."* ]]
+}
+
+@test "THE ASSERTION THAT MATTERS: zero docker-compose invocations refuses rather than passing" {
+    printf '#!/bin/bash\necho "totally different tool now"\n' > "$FIXTURE/scripts/deploy.sh"
+    run run_step
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"CANNOT DETERMINE"* ]]
+    [[ "$output" != *"All safety checks passed."* ]]
+}
+
+@test "CONTROL: the OLD (!)-negated logic could not fail on the same real violations (regression guard)" {
+    # Not a test of the new step — a permanent record that the bug was
+    # real. If this ever starts failing, the old shape has been
+    # reintroduced elsewhere and this comment is the only thing that will
+    # say why it matters.
+    OLD_SCRIPT="$BATS_TEST_TMPDIR/old_step.sh"
+    cat > "$OLD_SCRIPT" <<'OLD'
+echo "Checking: no --remove-orphans..."
+! (grep -- "--remove-orphans" scripts/deploy.sh | grep -v "^#" | grep -v "^[[:space:]]*#")
+
+echo "Checking: all docker compose calls use -p..."
+! (grep "docker compose" scripts/deploy.sh | grep -v "^#" | grep -v "^[[:space:]]*#" | grep -v -- "-p ")
+
+echo "All safety checks passed."
+OLD
+
+    cp "$ROOT/scripts/deploy.sh" "$FIXTURE/scripts/deploy.sh"
+    echo '  docker compose down --remove-orphans' >> "$FIXTURE/scripts/deploy.sh"
+
+    run bash -c "cd '$FIXTURE' && bash -eo pipefail '$OLD_SCRIPT'"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"All safety checks passed."* ]]
+}
+
+@test "exit codes for clean / violation / cannot-determine are correctly distinguishable by message" {
+    cp "$ROOT/scripts/deploy.sh" "$FIXTURE/scripts/deploy.sh"
+    run run_step
+    clean_status="$status"
+    clean_output="$output"
+
+    VIOLATION_FIXTURE="$BATS_TEST_TMPDIR/fixture-violation"
+    mkdir -p "$VIOLATION_FIXTURE/scripts"
+    cp "$ROOT/scripts/deploy.sh" "$VIOLATION_FIXTURE/scripts/deploy.sh"
+    echo '  docker compose down --remove-orphans' >> "$VIOLATION_FIXTURE/scripts/deploy.sh"
+    FIXTURE="$VIOLATION_FIXTURE" run run_step
+    violation_status="$status"
+
+    EMPTY_FIXTURE="$BATS_TEST_TMPDIR/fixture-empty"
+    mkdir -p "$EMPTY_FIXTURE/scripts"
+    printf '#!/bin/bash\necho "nothing here"\n' > "$EMPTY_FIXTURE/scripts/deploy.sh"
+    FIXTURE="$EMPTY_FIXTURE" run run_step
+    empty_output="$output"
+
+    [ "$clean_status" -eq 0 ]
+    [ "$violation_status" -eq 1 ]
+    [[ "$clean_output" == *"passed"* ]]
+    [[ "$empty_output" == *"CANNOT DETERMINE"* ]]
+}

--- a/tests/scripts/role-mappings-repointed-control.bats
+++ b/tests/scripts/role-mappings-repointed-control.bats
@@ -61,6 +61,38 @@ setup() {
   [[ "$output" == *"OpenBao admin-sso bound_claims"* ]]
 }
 
+# h#729: a NARROWER version of the same silent-pass class. The site's line IS
+# found (line_re matches), but the inner role_re can't extract any role names
+# from it — e.g. single quotes rewritten to double quotes. That used to
+# `continue` silently: not a MISS, not caught by the "gone blind" guard above
+# (which only fires when line_re matches nothing at all), invisible.
+@test "THE ASSERTION THAT MATTERS: a site whose role names become unparseable turns it red, not silently dropped" {
+  sed -i.bak "s/'platform-admin'/\"platform-admin\"/; s/'platform-editor'/\"platform-editor\"/" \
+    "$CTL/deploy/compose/prod/docker-compose.observability.yml"
+  rm -f "$CTL/deploy/compose/prod/docker-compose.observability.yml.bak"
+
+  run python3 "$CHECK"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"FAIL"* ]]
+  [[ "$output" == *"no role names could be extracted"* ]]
+  # Must not be silently indistinguishable from a genuine clean pass: the
+  # OTHER site (OpenBao) is still fine, so the run must not read as PASS.
+  [[ "$output" != *"PASS"* ]]
+}
+
+@test "CONTROL: an unparseable site does not block a genuinely legacy-named OTHER site from also being reported" {
+  sed -i.bak "s/'platform-admin'/\"platform-admin\"/; s/'platform-editor'/\"platform-editor\"/" \
+    "$CTL/deploy/compose/prod/docker-compose.observability.yml"
+  rm -f "$CTL/deploy/compose/prod/docker-compose.observability.yml.bak"
+  sed -i.bak 's/"realm_roles": \["platform-admin"\]/"realm_roles": ["admin"]/' "$CTL/scripts/vault.sh"
+  rm -f "$CTL/scripts/vault.sh.bak"
+
+  run python3 "$CHECK"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"no role names could be extracted"* ]]
+  [[ "$output" == *"OpenBao admin-sso bound_claims"* ]]
+}
+
 # A check that stops finding its target is a check that stopped checking, and it
 # would go green. That is the same silent-pass class as the defect itself.
 @test "a mapping site that disappears turns it red rather than green" {


### PR DESCRIPTION
Closes #729, #732, #734.

Same family as #726/#727/#730/#735's `check_destructive_commands.sh` fix: "examined nothing" silently reading as "examined everything and found nothing." Bundled into one PR since all three are genuinely that shape — reused the two conventions this repo already established rather than inventing per-site variants:

- **Shape A** — zero inputs matched at all → **CANNOT DETERMINE**, distinct from a clean pass (precedent: `check_destructive_commands.sh`).
- **Shape B** — input was read, a match was found, but parsing *within* that match yielded nothing → a **per-finding FAIL**, not a separate exit code (precedent: `check_declared_paths_are_seeded.py`, `check_oidc_clients_reconciled.py`).

## #734 (shape A) — `check_md_links.py`

If every `SCAN_ROOTS` entry stops existing, the script scanned zero files and still printed "no missing local links found." Now counts files scanned; zero is `CANNOT DETERMINE` (exit 2) — the exact fix the issue asked for, matching `check_destructive_commands.sh`.

Positive-controlled: an isolated tree with none of the four scan roots → refuses (exit 2). Same tree + one real broken link → still fails (exit 1). A genuinely clean non-empty scan → still passes, now reports its scan count.

## #732 (shape A — **plus a more severe defect found while fixing it**) — `ci.yml`

The filed defect: the `-p`-invariant grep matches zero lines if `deploy.sh`'s invocation style is ever renamed, and the pipeline finds nothing to complain about.

**Found while fixing it, more severe:** GitHub Actions runs `run:` blocks under `bash -eo pipefail`, and bash's `set -e` explicitly *exempts* a `!`-negated command from triggering abort — even when the negated result is failure. `! (pipeline)` never aborted this step on a **real** violation; it fell through to the final `echo` and always exited 0. This wasn't dormant — the step could not fail today for any real violation of either invariant, full stop. Verified under the exact bash flags GitHub Actions uses, not by reasoning about semantics:

```
$ # old step, real deploy.sh + a genuine docker-compose call with no -p
Checking: all docker compose calls use -p...
  docker compose down --remove-orphans
All safety checks passed.
exit=0
```

Rewrote both checks with explicit `if`/`exit` (fixes the `!`-under-`set -e` defect for both, independent of the 0==0 trap) and added the zero-matches `CANNOT DETERMINE` guard to the `-p` check. Positive-controlled all four states against real `deploy.sh` mutations: clean passes; a real `--remove-orphans` violation fails; a real missing-`-p` violation fails; zero `docker compose` invocations refuses. The old step's inability to fail on real violations is kept as a permanent bats regression-guard test.

## #729 (shape B — decided deliberately, as asked) — `check_role_mappings_repointed.py`

If the outer regex matches a mapping expression but the inner one extracts zero role names (e.g. single quotes → double quotes), the loop silently `continue`d — not counted, not printed, not caught by the existing "gone blind" guard (which only fires when the *outer* regex matches nothing).

**The decision, and why:** per-site **FAIL**, not a whole-run `CANNOT DETERMINE`.
1. The input *was* read and a real match *was* found — narrower than "nothing examined," closer to `check_declared_paths_are_seeded.py`'s shape (which uses FAIL/exit 1) than to `check_retired_roles_ungranted.py --live` or `check_destructive_commands.sh`, where nothing was read at all.
2. This file already has a per-site convention at exactly this granularity — the existing "gone blind" guard is per-site, not whole-run.
3. Per-site reporting preserves more information: if one of two sites goes blind while the other is genuinely clean, naming exactly which site and why beats declaring the whole run unmeasurable — and the whole-run "examined nothing" case is still correctly caught as a consequence, since every site failing to extract now contributes its own FAIL entry.

Positive-controlled against a real mutation of the real `docker-compose.observability.yml` (single→double quotes in Grafana's `role_attribute_path`, the exact drift class the issue names):

```
$ # OLD code, real mutation
PASS — 1 mapping(s) checked, none names a legacy realm role
exit=0   # Grafana silently dropped entirely, zero trace

$ # NEW code, same real mutation
FAIL — 1 problem(s):
  ...Grafana role_attribute_path matched a mapping expression but no role
  names could be extracted from it...
exit=1
```

Also confirmed a genuinely legacy-named *other* site is still independently reported even when one site is unparseable, and that real legacy-role detection is unaffected.

## Test plan

- [x] All three positive-controlled failing-test-first: stashed each fix, reran its new tests against pre-fix code — 4/7, 4/7, 2/8 fail as expected; all pass against the fix.
- [x] Full pytest suite: 80/80 pass.
- [x] Full `bats tests/scripts/`: 556/556 pass.
- [x] `shellcheck --severity=error scripts/*.sh`: clean.
- [x] YAML validated.

## What's still open from h#735's ranked list

#731 (false-RED on a transient docker-exec failure) and #733 (fixed sleeps instead of polling) — deliberately left, per the sweep's own ranking and this task's scope.

Not infra/secrets/sops/credential work. No deploy run from a workstation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)