### PR TITLE
fix(checks): stop vault-sops-name-parity.sh reporting a live path ABSENT on a transient docker-exec failure (h#731)

### DIFF
--- a/scripts/checks/vault-sops-name-parity.sh
+++ b/scripts/checks/vault-sops-name-parity.sh
@@ -58,10 +58,37 @@ except Exception:
 done
 echo
 
-vault_keys() {  # path -> key NAMES, one per line. Values never leave the pipe.
-    BAO_TOKEN="$BAO_TOKEN" docker exec -e BAO_ADDR=http://127.0.0.1:8200 -e BAO_TOKEN \
-        "$CONTAINER" bao read -format=json "secret/data/${1#secret/}" 2>/dev/null \
-      | python3 -c 'import sys,json
+# h#731: a docker-exec/connection failure used to read identically to a
+# genuinely absent path — `2>/dev/null` discarded the difference, and empty
+# stdout from EITHER cause printed the same "ABSENT" line. Verified against
+# a real ghcr.io/openbao/openbao:2.6.1 container (the pinned production
+# version) that a genuinely missing path and a real connection refusal
+# (the "openbao mid-restart" scenario this issue names) return the SAME
+# exit code, 2, from `bao` itself — only the stderr TEXT differs
+# ("No value found at ..." vs "dial tcp ... connection refused"), so text is
+# what this now checks, not the exit code. A docker exec failing outright
+# (container not running) is a third real case, distinguishable the same
+# way: empty stdout, a docker-daemon error on stderr containing neither.
+VAULT_KEYS_ERR="$(mktemp)"
+trap 'rm -f "$VAULT_KEYS_ERR"' EXIT
+
+vault_keys() {  # path -> key NAMES on stdout, one per line. Values never leave the pipe.
+    # Return: 0 = success (keys on stdout). 1 = GENUINELY ABSENT (bao's own
+    # distinct "No value found at" message). 2 = CANNOT DETERMINE — anything
+    # else (docker exec failing outright, a connection refusal, or any other
+    # error) — must not be reported the same as absent.
+    local raw
+    : > "$VAULT_KEYS_ERR"
+    raw="$(BAO_TOKEN="$BAO_TOKEN" docker exec -e BAO_ADDR=http://127.0.0.1:8200 -e BAO_TOKEN \
+        "$CONTAINER" bao read -format=json "secret/data/${1#secret/}" 2>"$VAULT_KEYS_ERR")"
+    if [ -z "$raw" ]; then
+        if grep -q "No value found at" "$VAULT_KEYS_ERR"; then
+            return 1
+        fi
+        return 2
+    fi
+    printf '%s' "$raw" | python3 -c '
+import sys,json
 try:
     print("\n".join(sorted(json.load(sys.stdin)["data"]["data"])))
 except Exception:
@@ -82,10 +109,20 @@ echo
 
 fail=0
 missing_paths=()
+undetermined_paths=()
 echo "${BOLD}Per-path key parity (names only)${OFF}"
 for p in $PATHS; do
     keys="$(vault_keys "$p")"
-    if [ -z "$keys" ]; then
+    rc=$?
+    if [ "$rc" -eq 2 ]; then
+        # CANNOT DETERMINE, not ABSENT — see vault_keys()'s own comment.
+        # Printed distinctly and counted separately so it can never be read
+        # as "checked and clean" OR silently folded into a real absence.
+        err="$(cat "$VAULT_KEYS_ERR" 2>/dev/null)"
+        printf '  %sCANNOT DETERMINE%s %-25s %s\n' "$YEL" "$OFF" "$p" "${err:-(no error output captured)}"
+        undetermined_paths+=("$p"); continue
+    fi
+    if [ "$rc" -eq 1 ] || [ -z "$keys" ]; then
         printf '  %sABSENT%s  %-34s not present on the vault\n' "$RED" "$OFF" "$p"
         missing_paths+=("$p"); fail=$((fail+1)); continue
     fi
@@ -105,8 +142,21 @@ if [ "${#missing_paths[@]}" -gt 0 ]; then
     printf '%s%d canonical path(s) absent from the vault:%s %s\n' \
         "$RED" "${#missing_paths[@]}" "$OFF" "${missing_paths[*]}"
 fi
+if [ "${#undetermined_paths[@]}" -gt 0 ]; then
+    printf '%s%d canonical path(s) could not be read at all:%s %s\n' \
+        "$YEL" "${#undetermined_paths[@]}" "$OFF" "${undetermined_paths[*]}"
+fi
 if [ "$fail" -gt 0 ]; then
     printf '%s%d parity problem(s).%s\n' "$RED" "$fail" "$OFF"
     exit 1
+fi
+if [ "${#undetermined_paths[@]}" -gt 0 ]; then
+    # NOT a pass. Some paths were never actually read — "every canonical
+    # path exists" would be a claim this run did not establish, exactly the
+    # h#731 hazard in the other direction: a transient failure must not
+    # silently disappear into a clean-looking result either.
+    printf '%sCANNOT DETERMINE: %d path(s) could not be read — this run does NOT confirm parity for them.%s\n' \
+        "$YEL" "${#undetermined_paths[@]}" "$OFF"
+    exit 2
 fi
 printf '%severy canonical path exists and every vault key name is backed by SOPS%s\n' "$GREEN" "$OFF"

--- a/tests/scripts/vault-sops-name-parity-control.bats
+++ b/tests/scripts/vault-sops-name-parity-control.bats
@@ -1,0 +1,160 @@
+#!/usr/bin/env bats
+#
+# POSITIVE CONTROL for scripts/checks/vault-sops-name-parity.sh.
+#
+# h#731: vault_keys() used to discard `docker exec`'s stderr entirely
+# (`2>/dev/null`), so a docker-exec failure or a connection refusal (the
+# "openbao mid-restart" scenario this issue names) produced empty stdout —
+# indistinguishable from a genuinely absent KV v2 path, which ALSO produces
+# empty stdout on that code path. Both printed the same "ABSENT" line.
+#
+# Verified directly against a real ghcr.io/openbao/openbao:2.6.1 container
+# (the pinned production version) during development: a genuinely-absent
+# path and a real connection refusal BOTH return exit code 2 from `bao`
+# itself — only the stderr TEXT differs ("No value found at ..." vs
+# "dial tcp ... connection refused"). With the container simply stopped, the
+# OLD code reported a real, seeded, GENUINELY PRESENT path as "ABSENT". That
+# is the decisive before/after this file's tests are the permanent form of —
+# fast, CI-safe, no Docker/network dependency at test time, via a
+# PATH-shadowing `docker` stub.
+
+setup() {
+    ROOT="$BATS_TEST_DIRNAME/../.."
+    SCRIPT="$ROOT/scripts/checks/vault-sops-name-parity.sh"
+
+    # vault_keys() is the whole surface of the bug — extract and source it
+    # alone rather than running the full script, which needs a real SOPS
+    # store this task must not touch.
+    FUNC_FILE="$BATS_TEST_TMPDIR/vault_keys.sh"
+    sed -n '/^VAULT_KEYS_ERR=/,/^}/p' "$SCRIPT" > "$FUNC_FILE"
+    [ -s "$FUNC_FILE" ]
+
+    STUB_DIR="$BATS_TEST_TMPDIR/stub-bin"
+    mkdir -p "$STUB_DIR"
+    export CONTAINER=fake-openbao
+    export BAO_TOKEN=fake-token
+}
+
+stub_docker_exec() {
+    # $1: scenario — present | absent | connection-refused | exec-fails.
+    # One stub file is written per test, with the scenario baked in
+    # directly, rather than dispatching on the real invocation's argv (which
+    # is `docker exec -e ... -e ... "$CONTAINER" bao read ...` regardless of
+    # scenario, so there is nothing scenario-specific to dispatch on).
+    local scenario="$1"
+    case "$scenario" in
+        present)
+            cat > "$STUB_DIR/docker" <<'STUB'
+#!/bin/bash
+echo '{"data":{"data":{"DB_NAME":"x","DB_USER":"y"}}}'
+exit 0
+STUB
+            ;;
+        absent)
+            cat > "$STUB_DIR/docker" <<'STUB'
+#!/bin/bash
+echo "No value found at secret/data/does-not-exist" >&2
+exit 2
+STUB
+            ;;
+        connection-refused)
+            cat > "$STUB_DIR/docker" <<'STUB'
+#!/bin/bash
+echo 'Error reading secret/data/x: Get "http://127.0.0.1:8200/v1/secret/data/x": dial tcp 127.0.0.1:8200: connect: connection refused' >&2
+exit 2
+STUB
+            ;;
+        exec-fails)
+            cat > "$STUB_DIR/docker" <<'STUB'
+#!/bin/bash
+echo "Error response from daemon: container fake-openbao is not running" >&2
+exit 1
+STUB
+            ;;
+    esac
+    chmod +x "$STUB_DIR/docker"
+}
+
+run_vault_keys() {
+    env PATH="$STUB_DIR:$PATH" bash -c "
+        set -uo pipefail
+        source '$FUNC_FILE'
+        keys=\"\$(vault_keys secret/whatever)\"
+        rc=\$?
+        echo \"RC=\$rc\"
+        echo \"KEYS=\$keys\"
+        echo \"ERR=\$(cat \"\$VAULT_KEYS_ERR\")\"
+    "
+}
+
+@test "CONTROL: a genuinely present path returns success and the real keys" {
+    stub_docker_exec present
+    run run_vault_keys
+    [[ "$output" == *"RC=0"* ]]
+    [[ "$output" == *"DB_NAME"* ]]
+}
+
+@test "CONTROL: a genuinely absent path returns rc=1, not rc=2" {
+    stub_docker_exec absent
+    run run_vault_keys
+    [[ "$output" == *"RC=1"* ]]
+}
+
+@test "THE ASSERTION THAT MATTERS: a connection refusal returns rc=2 (CANNOT DETERMINE), never rc=1 (ABSENT)" {
+    stub_docker_exec connection-refused
+    run run_vault_keys
+    [[ "$output" == *"RC=2"* ]]
+    [[ "$output" != *"RC=1"* ]]
+    [[ "$output" == *"connection refused"* ]]
+}
+
+@test "THE ASSERTION THAT MATTERS: docker exec failing outright returns rc=2 (CANNOT DETERMINE), never rc=1 (ABSENT)" {
+    stub_docker_exec exec-fails
+    run run_vault_keys
+    [[ "$output" == *"RC=2"* ]]
+    [[ "$output" != *"RC=1"* ]]
+    [[ "$output" == *"is not running"* ]]
+}
+
+@test "exit codes for present / absent / cannot-determine are three genuinely distinct outcomes" {
+    stub_docker_exec present
+    run run_vault_keys
+    present_rc="$(printf '%s' "$output" | grep -o 'RC=[0-9]*' | head -1)"
+
+    stub_docker_exec absent
+    run run_vault_keys
+    absent_rc="$(printf '%s' "$output" | grep -o 'RC=[0-9]*' | head -1)"
+
+    stub_docker_exec connection-refused
+    run run_vault_keys
+    undetermined_rc="$(printf '%s' "$output" | grep -o 'RC=[0-9]*' | head -1)"
+
+    [ "$present_rc" = "RC=0" ]
+    [ "$absent_rc" = "RC=1" ]
+    [ "$undetermined_rc" = "RC=2" ]
+}
+
+@test "CONTROL: the OLD (2>/dev/null, no classification) shape could not distinguish these (regression guard)" {
+    # Not a test of the new function — a permanent record that the bug was
+    # real. If this ever starts failing, the old shape has been
+    # reintroduced elsewhere and this comment is the only thing that will
+    # say why it matters.
+    OLD_FUNC="$BATS_TEST_TMPDIR/vault_keys_old.sh"
+    cat > "$OLD_FUNC" <<'OLD'
+vault_keys_old() {
+    BAO_TOKEN="$BAO_TOKEN" docker exec -e BAO_ADDR=http://127.0.0.1:8200 -e BAO_TOKEN \
+        "$CONTAINER" bao read -format=json "secret/data/${1#secret/}" 2>/dev/null \
+      | python3 -c 'import sys,json
+try:
+    print("\n".join(sorted(json.load(sys.stdin)["data"]["data"])))
+except Exception:
+    pass'
+}
+OLD
+    stub_docker_exec exec-fails
+    run env PATH="$STUB_DIR:$PATH" bash -c "source '$OLD_FUNC'; vault_keys_old secret/whatever"
+    [ -z "$output" ]
+    # Empty output here is EXACTLY what the caller in the old script read as
+    # "ABSENT" — indistinguishable from a genuinely missing path, and from
+    # a genuinely PRESENT one the docker-exec failure merely hid.
+}


### PR DESCRIPTION
Closes #731. Same conflation as #726/#727, opposite direction — a false-RED instead of a false-GREEN — and the task asked for the same three-outcome treatment.

## The bug

`vault_keys()` discarded `docker exec`'s stderr entirely (`2>/dev/null`), so a transient failure and a genuinely absent path both produced empty stdout and were reported identically: `ABSENT ... not present on the vault`.

## What I established before fixing it

Against a real `ghcr.io/openbao/openbao:2.6.1` container (the pinned production version): a genuinely missing KV v2 path and a real connection refusal (the "openbao mid-restart" scenario the issue names) **both return exit code 2** from `bao` itself — the exit code alone can't distinguish them. Only the stderr **text** differs: `"No value found at ..."` vs `"dial tcp ... connection refused"`. A docker exec failing outright (container not running) is a third case, distinguishable the same way — empty stdout, a docker-daemon error containing neither.

## The fix

`vault_keys()` now captures stderr and returns three distinct outcomes: `0` = success, `1` = genuinely absent (bao's own "No value found at" message), `2` = CANNOT DETERMINE (anything else). The caller reports CANNOT DETERMINE as its own line, counted separately from ABSENT, and the final summary refuses to claim "every canonical path exists" if anything was undetermined — exiting `2`, matching this file's own existing use of exit 2 (the missing-`BAO_TOKEN` guard at the top).

## Positive-controlled, both directions, against the real container

```
$ # genuinely present path
rc=0, real keys returned

$ # genuinely absent path
rc=1, "No value found at ..." captured

$ # connection refused (wrong port, simulating not-yet-listening)
rc=2, the exact real dial-tcp error captured — not misreported as absent
```

**The decisive one** — container genuinely stopped, tested against a real seeded path:

```
OLD CODE, container STOPPED, against the genuinely PRESENT path secret/shared/database:
  -> would print: ABSENT  secret/shared/database  not present on the vault
  (WRONG — this path genuinely exists and has real data)
```

New code: `rc=2` for **both** a present and an absent path when the container is down — because with `docker exec` itself failing, which one it is genuinely cannot be told, and it correctly refuses to guess for either.

## Test plan

- [x] `tests/scripts/vault-sops-name-parity-control.bats`: 6 tests via a PATH-shadowing `docker` stub covering all three outcomes plus a regression-guard test — all fail against pre-fix code (the new function shape doesn't exist there), pass against the fix.
- [x] Full `bats tests/scripts/`: 560/560 pass.
- [x] `shellcheck --severity=error`: clean.

Not infra/secrets/sops/credential work — tested against a throwaway, locally-run OpenBao dev-mode container, never the real vault or SOPS store. No deploy run from a workstation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)