### PR TITLE
fix(backup): stop backup_volume/restore_volume reporting success on a real failure

### DIFF
--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -169,10 +169,35 @@ backup_volume() {
     fi
 
     echo "  Backing up volume $volume..."
-    docker run --rm \
+    # The `docker run`/tar result was never checked — `echo` was the next
+    # unconditional statement, and echo never fails, so this function's own
+    # exit status reflected only the echo, never whether the tar actually
+    # happened. Under `set -e` that would still abort a direct single-service
+    # backup, but every multi-volume caller wraps this in `|| true`, and
+    # cmd_backup_all wraps the whole call chain in `if ( cmd_backup "$svc" )`
+    # — a subshell used as an if-condition, which suppresses errexit
+    # transitively underneath it. So under `backup-all`, a failed tar for ANY
+    # of six targets (including prod_minio-data, "the ONLY entry here holding
+    # state that git and SOPS cannot rebuild" per this file's own comment
+    # above) silently reported "✓ Saved", updated the Prometheus success
+    # metric, and the run printed "Full Backup Complete!" with zero trace.
+    if ! docker run --rm \
         -v "${volume}:/data:ro" \
         -v "$(dirname "$dest_file"):/backup" \
-        alpine tar czf "/backup/$(basename "$dest_file")" -C /data .
+        alpine tar czf "/backup/$(basename "$dest_file")" -C /data .; then
+        warn "  ✗ FAILED to back up volume $volume — the tar operation did not complete"
+        return 1
+    fi
+
+    # Belt and suspenders: `docker run` can exit 0 having still produced
+    # nothing or nothing useful (a mount race, alpine writing an empty
+    # archive). This is the same non-empty check verify_artifacts already
+    # applies to the SQL dumps — applied here too, at the source, rather than
+    # relying solely on callers remembering to verify afterward.
+    if [ ! -s "$dest_file" ]; then
+        warn "  ✗ FAILED to back up volume $volume — $dest_file is missing or empty"
+        return 1
+    fi
 
     echo "  ✓ Saved to $dest_file"
 }
@@ -187,10 +212,19 @@ restore_volume() {
     fi
 
     echo "  Restoring volume $volume from $src_file..."
-    docker run --rm \
+    # Same shape as backup_volume's own bug, on the side where it matters
+    # more: an unconditional "✓ Restored" after an unchecked docker run/tar
+    # extraction. Not currently reachable under set -e (no caller wraps
+    # restore in `|| true` or a subshell-if today), but it is the same
+    # one-line class of bug sitting immediately next to the exploitable one,
+    # and any future change here (a retry wrapper, a restore-all) would
+    # silently reintroduce it on the side with no second chance.
+    if ! docker run --rm \
         -v "${volume}:/data" \
         -v "$(dirname "$src_file"):/backup:ro" \
-        alpine sh -c "rm -rf /data/* && tar xzf /backup/$(basename "$src_file") -C /data"
+        alpine sh -c "rm -rf /data/* && tar xzf /backup/$(basename "$src_file") -C /data"; then
+        die "FAILED to restore volume $volume from $src_file — the extraction did not complete. The volume may now be partially emptied; do not assume it is usable."
+    fi
 
     echo "  ✓ Restored $volume"
 }
@@ -357,8 +391,17 @@ backup_infra() {
     mkdir -p "$backup_dir"
 
     echo "Backing up infrastructure volumes..."
-    backup_volume "prod_traefik-certs" "$backup_dir/traefik-certs.tar.gz" || true
-    backup_volume "prod_portainer-data" "$backup_dir/portainer-data.tar.gz" || true
+    # `|| true` here used to discard a real backup_volume failure entirely —
+    # now that backup_volume genuinely returns non-zero on failure, `|| true`
+    # would still swallow it. Accumulate instead: try both volumes (traefik
+    # failing must not skip the portainer attempt), but the function's own
+    # return value must reflect whether EITHER one actually failed, so
+    # cmd_backup_all's `if ( cmd_backup "$svc" )` can see it.
+    local failed=0
+    backup_volume "prod_traefik-certs" "$backup_dir/traefik-certs.tar.gz" || failed=1
+    backup_volume "prod_portainer-data" "$backup_dir/portainer-data.tar.gz" || failed=1
+    verify_artifacts "$backup_dir" "traefik-certs.tar.gz"
+    [ "$failed" -eq 0 ]
 }
 
 backup_observability() {
@@ -366,8 +409,11 @@ backup_observability() {
     mkdir -p "$backup_dir"
 
     echo "Backing up observability volumes..."
-    backup_volume "grafana-data" "$backup_dir/grafana-data.tar.gz" || true
-    backup_volume "prometheus-data" "$backup_dir/prometheus-data.tar.gz" || true
+    local failed=0
+    backup_volume "grafana-data" "$backup_dir/grafana-data.tar.gz" || failed=1
+    backup_volume "prometheus-data" "$backup_dir/prometheus-data.tar.gz" || failed=1
+    verify_artifacts "$backup_dir" "grafana-data.tar.gz" "prometheus-data.tar.gz"
+    [ "$failed" -eq 0 ]
 }
 
 backup_minio() {
@@ -377,7 +423,12 @@ backup_minio() {
     echo "Backing up MinIO object store..."
     # Volume tar only. `mc mirror` would need working credentials and somewhere
     # to mirror TO; the volume is the whole store and is what a restore needs.
-    backup_volume "prod_minio-data" "$backup_dir/minio-data.tar.gz" || true
+    #
+    # No `|| true` — this is the one entry in this file holding state git and
+    # SOPS cannot rebuild (see the caveat above backup_volume), so its own
+    # exit status must reach the caller directly, not be discarded.
+    backup_volume "prod_minio-data" "$backup_dir/minio-data.tar.gz"
+    verify_artifacts "$backup_dir" "minio-data.tar.gz"
 }
 
 backup_vault() {
@@ -386,6 +437,7 @@ backup_vault() {
 
     echo "Backing up OpenBao..."
     backup_volume "openbao-data" "$backup_dir/openbao-data.tar.gz"
+    verify_artifacts "$backup_dir" "openbao-data.tar.gz"
 }
 
 # ---------------------------------------------------------------------------
@@ -591,12 +643,21 @@ cmd_restore() {
             echo "  Then unseal: bash scripts/vault.sh unseal"
             ;;
         observability)
+            local restored=0
             if [ -f "$backup_dir/grafana-data.tar.gz" ]; then
                 restore_volume "grafana-data" "$backup_dir/grafana-data.tar.gz"
+                restored=1
             fi
             if [ -f "$backup_dir/prometheus-data.tar.gz" ]; then
                 restore_volume "prometheus-data" "$backup_dir/prometheus-data.tar.gz"
+                restored=1
             fi
+            # Both are individually optional (a targeted restore of just one
+            # component is legitimate), but AT LEAST one archive existing is
+            # not optional — without this, pointing this command at a
+            # directory with neither file present restored nothing at all
+            # and still fell through to "✓ Restore complete" below.
+            [ "$restored" -eq 1 ] || die "Neither grafana-data.tar.gz nor prometheus-data.tar.gz found in $backup_dir — nothing to restore"
             echo "  Restart services: docker restart grafana prometheus"
             ;;
         *)

--- a/tests/scripts/backup.bats
+++ b/tests/scripts/backup.bats
@@ -394,12 +394,30 @@ teardown_real_volume() {
   setup_real_volume
   FUNCS="$BATS_TEST_TMPDIR/funcs.sh"
   BACKUP_VOLUME_FUNCS "$PWD/scripts/backup.sh" > "$FUNCS"
+  # NOT chmod 555 on the parent — that denies a normal user, but
+  # backup_volume writes via `docker run` as root inside the container, and
+  # root ignores directory permission bits. Verified directly (not assumed):
+  # a container writing into a bind-mounted, chmod-555 host directory
+  # succeeds when run as root on real Linux (GitHub Actions' own runner —
+  # macOS Docker Desktop's bind-mount layer masked this locally, which is
+  # exactly how this got past local testing). CI caught this: the test
+  # passed 555 as "unwritable," root wrote through it anyway, and the
+  # assertion that the write must fail was the thing that was wrong.
+  #
+  # A destination that is ALREADY A DIRECTORY denies the write regardless of
+  # uid — `tar czf` on an existing directory fails EISDIR for root exactly
+  # as it does for anyone else. Verified against the real alpine image this
+  # function uses, as root: `tar: can't open '...': Is a directory`, exit 1.
   ro_dir="$BATS_TEST_TMPDIR/readonly"
   mkdir -p "$ro_dir"
-  chmod 555 "$ro_dir"
   dest="$ro_dir/vol.tar.gz"
+  mkdir -p "$dest"
+  # Evidence, not assumption: what uid actually performs the write, on
+  # THIS run, in THIS environment. Printed unconditionally so it's in every
+  # CI log next to the assertion it explains, not just asserted about here.
+  echo "# outer shell uid: $(id -u)" >&3
+  echo "# container write uid: $(docker run --rm alpine id -u)" >&3
   run bash -c "warn() { echo \"WARN: \$*\" >&2; }; source '$FUNCS'; backup_volume '$TEST_VOL' '$dest'"
-  chmod 755 "$ro_dir"
   teardown_real_volume
   [ "$status" -ne 0 ]
   [[ "$output" != *"✓ Saved"* ]]
@@ -409,12 +427,17 @@ teardown_real_volume() {
 @test "CONTROL: the OLD backup_volume shape would have reported success on the same real failure (regression guard)" {
   # Not a test of the new function — a permanent record that the bug was
   # real, using the exact real failure the fixed version now catches.
+  #
+  # Same fix as the assertion test above, same reason: chmod 555 does not
+  # stop root, and this container writes as root. A pre-existing directory
+  # at the destination path denies the write for root just as it does for
+  # anyone else.
   command -v docker >/dev/null || skip "docker not available"
   setup_real_volume
   ro_dir="$BATS_TEST_TMPDIR/readonly-old"
   mkdir -p "$ro_dir"
-  chmod 555 "$ro_dir"
   dest="$ro_dir/vol.tar.gz"
+  mkdir -p "$dest"
   OLD_FUNC="$BATS_TEST_TMPDIR/old_backup_volume.sh"
   cat > "$OLD_FUNC" <<'OLD'
 backup_volume_old() {
@@ -425,11 +448,10 @@ backup_volume_old() {
 }
 OLD
   run bash -c "source '$OLD_FUNC'; backup_volume_old '$TEST_VOL' '$dest'"
-  chmod 755 "$ro_dir"
   teardown_real_volume
   [ "$status" -eq 0 ]
   [[ "$output" == *"✓ Saved"* ]]
-  # The tar genuinely failed (readonly destination) — this is the false pass.
+  # The tar genuinely failed (EISDIR) — this is the false pass.
 }
 
 @test "REAL DOCKER: restore_volume FAILS loud (not '✓ Restored') on a genuinely corrupt archive" {

--- a/tests/scripts/backup.bats
+++ b/tests/scripts/backup.bats
@@ -341,3 +341,115 @@ EOF
       bash scripts/backup.sh backup app-db
   [ "$status" -ne 0 ]
 }
+
+# ---------------------------------------------------------------------------
+# backup_volume() / restore_volume() used to report success unconditionally,
+# regardless of whether the underlying `docker run`/tar actually succeeded —
+# `echo` was the next unconditional statement after each, and echo never
+# fails. Under `backup-all` specifically this was live, not dormant: every
+# multi-volume caller wraps the call in `|| true`, and cmd_backup_all wraps
+# the whole chain in `if ( cmd_backup "$svc" )`, a subshell-as-if-condition
+# that suppresses errexit transitively underneath it — so a failed tar for
+# ANY of six targets (including prod_minio-data, the one volume this file's
+# own comments call irreplaceable) silently reported "✓ Saved" and never
+# turned the run red.
+#
+# These use REAL docker volumes rather than the stub above: the stub's bare
+# `*run*) exit 0 ;;` never actually writes a file, which is realistic for
+# testing the SQL-dump paths (those write via redirected stdout, not through
+# the container) but cannot exercise backup_volume's own real success/failure
+# path, which depends on whether `docker run ... tar czf ...` genuinely wrote
+# something. A small, real, throwaway volume is fast and faithful.
+# ---------------------------------------------------------------------------
+
+BACKUP_VOLUME_FUNCS() {
+  sed -n '/^backup_volume() {/,/^}/p; /^# Restore a named Docker volume/,/^}/p' "$1"
+}
+
+setup_real_volume() {
+  TEST_VOL="bats-backup-vol-$$"
+  docker volume create "$TEST_VOL" >/dev/null
+  docker run --rm -v "${TEST_VOL}:/data" alpine sh -c "echo real > /data/f.txt" >/dev/null
+}
+
+teardown_real_volume() {
+  docker volume rm "$TEST_VOL" >/dev/null 2>&1 || true
+}
+
+@test "REAL DOCKER: backup_volume succeeds and creates a real, non-empty archive" {
+  command -v docker >/dev/null || skip "docker not available"
+  setup_real_volume
+  FUNCS="$BATS_TEST_TMPDIR/funcs.sh"
+  BACKUP_VOLUME_FUNCS "$PWD/scripts/backup.sh" > "$FUNCS"
+  dest="$BATS_TEST_TMPDIR/vol.tar.gz"
+  run bash -c "warn() { echo \"WARN: \$*\" >&2; }; source '$FUNCS'; backup_volume '$TEST_VOL' '$dest'"
+  teardown_real_volume
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"✓ Saved"* ]]
+  [ -s "$dest" ]
+}
+
+@test "THE ASSERTION THAT MATTERS: backup_volume FAILS (not '✓ Saved') when the tar genuinely cannot write" {
+  command -v docker >/dev/null || skip "docker not available"
+  setup_real_volume
+  FUNCS="$BATS_TEST_TMPDIR/funcs.sh"
+  BACKUP_VOLUME_FUNCS "$PWD/scripts/backup.sh" > "$FUNCS"
+  ro_dir="$BATS_TEST_TMPDIR/readonly"
+  mkdir -p "$ro_dir"
+  chmod 555 "$ro_dir"
+  dest="$ro_dir/vol.tar.gz"
+  run bash -c "warn() { echo \"WARN: \$*\" >&2; }; source '$FUNCS'; backup_volume '$TEST_VOL' '$dest'"
+  chmod 755 "$ro_dir"
+  teardown_real_volume
+  [ "$status" -ne 0 ]
+  [[ "$output" != *"✓ Saved"* ]]
+  [[ "$output" == *"FAILED"* ]]
+}
+
+@test "CONTROL: the OLD backup_volume shape would have reported success on the same real failure (regression guard)" {
+  # Not a test of the new function — a permanent record that the bug was
+  # real, using the exact real failure the fixed version now catches.
+  command -v docker >/dev/null || skip "docker not available"
+  setup_real_volume
+  ro_dir="$BATS_TEST_TMPDIR/readonly-old"
+  mkdir -p "$ro_dir"
+  chmod 555 "$ro_dir"
+  dest="$ro_dir/vol.tar.gz"
+  OLD_FUNC="$BATS_TEST_TMPDIR/old_backup_volume.sh"
+  cat > "$OLD_FUNC" <<'OLD'
+backup_volume_old() {
+    local volume="$1"; local dest_file="$2"
+    docker run --rm -v "${volume}:/data:ro" -v "$(dirname "$dest_file"):/backup" \
+        alpine tar czf "/backup/$(basename "$dest_file")" -C /data .
+    echo "  ✓ Saved to $dest_file"
+}
+OLD
+  run bash -c "source '$OLD_FUNC'; backup_volume_old '$TEST_VOL' '$dest'"
+  chmod 755 "$ro_dir"
+  teardown_real_volume
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"✓ Saved"* ]]
+  # The tar genuinely failed (readonly destination) — this is the false pass.
+}
+
+@test "REAL DOCKER: restore_volume FAILS loud (not '✓ Restored') on a genuinely corrupt archive" {
+  command -v docker >/dev/null || skip "docker not available"
+  setup_real_volume
+  FUNCS="$BATS_TEST_TMPDIR/funcs.sh"
+  BACKUP_VOLUME_FUNCS "$PWD/scripts/backup.sh" > "$FUNCS"
+  bad="$BATS_TEST_TMPDIR/corrupt.tar.gz"
+  echo "not a valid tar" > "$bad"
+  run bash -c "die() { echo \"ERROR: \$*\" >&2; exit 1; }; source '$FUNCS'; restore_volume '$TEST_VOL' '$bad'"
+  teardown_real_volume
+  [ "$status" -ne 0 ]
+  [[ "$output" != *"✓ Restored"* ]]
+  [[ "$output" == *"FAILED to restore"* ]]
+}
+
+@test "observability restore refuses when neither archive is present, rather than reporting complete" {
+  mkdir -p "$BATS_TEST_TMPDIR/empty-dir"
+  run env BACKUP_DIR="$BATS_TEST_TMPDIR/backups" \
+      bash scripts/backup.sh restore observability "$BATS_TEST_TMPDIR/empty-dir"
+  [ "$status" -ne 0 ]
+  [[ "$output" != *"Restore complete"* ]]
+}


### PR DESCRIPTION
Platform-side mirror of today's checks sweep, applied to `scripts/` itself: "operations that report success while having done nothing or only partial work." `backup.sh` ranked highest going in — a backup that reports success and is unusable is the failure mode with no recovery path — and it's where this landed.

## The bug

`backup_volume()`'s `docker run`/tar result was never checked — `echo "  ✓ Saved to $dest_file"` was the next unconditional statement, and echo never fails. Under plain `set -e` this would still abort a direct single-service backup — but it wasn't dormant: **7 of 8 call sites wrap the call in `|| true`**, and `cmd_backup_all` wraps the whole chain in `if ( cmd_backup "$svc" )` — a subshell-as-if-condition, which suppresses errexit transitively underneath it, exposing even the one call site (vault) with no `|| true` of its own.

Under `backup-all` — the real, scheduled, production invocation — a failed tar for **any of six targets, including `prod_minio-data`** ("the ONLY entry here holding state that git and SOPS cannot rebuild" per this file's own comment) silently reported success, updated the Prometheus success metric, and printed "Full Backup Complete!" with zero trace. `verify_artifacts()` — the correct existing model, added after two backup directories were found completely empty and still counted as successful — was only ever called for the two SQL dumps; every volume tar had zero verification.

`restore_volume()` had the identical shape on the side where it matters more (`rm -rf /data/* && tar xzf ...` → unconditional "✓ Restored"). Not currently reachable, but the same one-line class of bug sitting right next to the exploitable one. `cmd_restore`'s observability branch could restore zero volumes and still report complete.

## The fix

`backup_volume`/`restore_volume` now check the real exit status (and, for backup, that the destination is non-empty). The multi-volume callers accumulate failure instead of discarding it, and now call `verify_artifacts` too — extended to the volume tars for the first time. `backup_minio`'s `|| true` is removed outright. `cmd_restore`'s observability branch now requires at least one archive to have existed.

## Positive-controlled, both directions, against real Docker volumes and real tar operations

**The decisive one**, at the actual `cmd_backup_all` call shape:
```
NEW: same real unwritable-destination failure for both volumes → reports FAILURE
OLD: same real failure → "✓ Saved to a.tar.gz" / "✓ Saved to b.tar.gz", RESULT: reported SUCCESS
```

A real corrupt archive: NEW fails loud ("do not assume it is usable", exit 1); OLD — after `rm -rf /data/*` had already emptied the real volume — printed "✓ Restored", exit 0, leaving the volume in a **worse** state than before while claiming success.

## Test plan

- [x] `tests/scripts/backup.bats` gained 5 tests using real, throwaway Docker volumes (the existing docker-stub pattern never actually writes files, so it can't exercise this path faithfully) plus a regression-guard test. 3 fail against pre-fix code (stashed and re-run), all pass against the fix.
- [x] Full existing suite (33 tests): unaffected.
- [x] Full `bats tests/scripts/`: 583/583 pass.
- [x] `shellcheck --severity=error`: clean.

Not infra/secrets/sops/credential work — tested against throwaway local Docker volumes only. No deploy run from a workstation, no backup.sh/deploy.sh run against production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)