### PR TITLE
fix(checks): a test-only caller is now distinct from a real one (h#736); wire check_retired_roles_ungranted.py --live (h#738)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,3 +211,12 @@ jobs:
 
       - name: Run check script tests
         run: pip install pytest pyyaml && pytest tests/checks/ -v
+
+      # Hill90#736: this checker's own bats control
+      # (tests/scripts/checks-are-wired-control.bats) used to be its only
+      # caller — which, after that fix, is exactly the TEST-ONLY outcome
+      # this file exists to catch. A bats control proves the checker's
+      # LOGIC works against a fabricated fixture; it does not prove
+      # anything runs the checker for real. This step is that real caller.
+      - name: Every check must be invoked by something real
+        run: python3 scripts/checks/check_checks_are_wired.py

--- a/.github/workflows/reusable-deploy-service.yml
+++ b/.github/workflows/reusable-deploy-service.yml
@@ -160,6 +160,44 @@ jobs:
             deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
             'cd /opt/hill90/app && export SOPS_AGE_KEY_FILE=/opt/hill90/secrets/keys/keys.txt && bash scripts/checks/minio-policy-names-test.sh'
 
+      # PROVE NO RETIRED ROLE IS GRANTED ANYTHING, ON THE LIVE ESTATE.
+      #
+      # ci.yml already runs this check statically on every PR (no --live) — that
+      # half catches a retired role named in keycloak.sh, MinIO's policy list,
+      # Grafana's role_attribute_path, or OpenBao's bound_claims. It cannot see
+      # HOLDERS: a role removed from keycloak.sh but never actually deleted from
+      # the live realm, or a MinIO policy created out-of-band with `mc`. Only
+      # --live measures those, and --live had no caller anywhere (h#738) —
+      # `live_checks()` shelled out via `ssh vps <cmd>`, a literal SSH CONFIG
+      # ALIAS that only resolves on a workstation with `Host vps` in its own
+      # ~/.ssh/config. No workflow in this repo ever establishes that alias,
+      # which is the actual reason nothing could wire it in: not a missing
+      # step, a transport this repo's workflows do not use.
+      #
+      # --local (h#738) is the fix: it runs the same measurement directly, no
+      # extra SSH hop, once this step has already SSH'd onto the VPS — the
+      # exact shape the MinIO check immediately above already relies on.
+      #
+      # GATED ON auth OR minio, not every deploy: those are the two services
+      # that can move a role's grants (Keycloak realm roles themselves, and the
+      # MinIO policies a role's claim can now collide with). observability and
+      # db deploys cannot change either.
+      #
+      # exit 2 (CANNOT DETERMINE) fails this step same as exit 1 — `run:` fails
+      # on any non-zero exit — which is deliberate: an unreachable host must
+      # never be read as "no retired role is granted", the null result that
+      # agrees with what everyone hopes is true. See h#727.
+      #
+      # success(), same reasoning as the MinIO check above it: verifying a
+      # deploy that did not happen proves nothing. Cleanup needs always();
+      # verification needs success().
+      - name: Prove no retired role is granted anything, on the live estate
+        if: success() && (inputs.service == 'auth' || inputs.service == 'minio')
+        run: |
+          ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
+            deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
+            'cd /opt/hill90/app && export SOPS_AGE_KEY_FILE=/opt/hill90/secrets/keys/keys.txt && python3 scripts/checks/check_retired_roles_ungranted.py --live --local'
+
       # PROVE EVERY ALERT RULE CAN ACTUALLY MATCH A SERIES.
       #
       # A rule can be health=ok and still never fire, if its selector names a

--- a/scripts/checks/check_checks_are_wired.py
+++ b/scripts/checks/check_checks_are_wired.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Every check in scripts/checks must be invoked by something.
+"""Every check in scripts/checks must be invoked by something REAL.
 
     python3 scripts/checks/check_checks_are_wired.py
 
@@ -13,24 +13,53 @@ The inventory that found them was an ad-hoc script run by hand. This makes the
 result an invariant instead: a new check that nobody wires fails the pull request
 that adds it.
 
-WHAT COUNTS AS INVOKED
-======================
-A bats control, a pytest test, a workflow, the Makefile, or another script.
+REAL vs TEST-ONLY (Hill90#736), the distinction this file exists to draw and
+for four attempts did not:
+======================================================================
+A bats control or a pytest test PROVES a check behaves correctly when it is
+run, against a fixture built for the purpose. It does NOT prove anything ever
+runs that check in CI or in a deploy path — a check whose only caller, in the
+entire repository, is its own test harness has never once been evaluated
+against real state. That is the exact blind spot this file exists to catch,
+one level up: "wired" must mean a workflow step, the Makefile, or another
+script actually invokes the check — not merely that a test proves the check
+would behave if something did.
 
-HOW THE CLASSIFIER IS WRITTEN, and why each rule is there. Getting this right
-took four attempts and the first three were confidently wrong:
+So there are three outcomes per check, not two:
+  REAL       — invoked by a workflow step, the Makefile, or another script.
+  TEST-ONLY  — invoked ONLY by a bats control and/or a pytest test. The
+               check's logic is proven correct; nothing runs it for real.
+  ORPHAN     — invoked by nothing at all, not even a test.
+Only REAL passes. TEST-ONLY and ORPHAN both fail, reported separately, because
+a check nobody runs for real is exactly as decorative as a check nobody runs
+at all — the difference is only in how convincing the illusion of coverage is.
+
+HOW THE CLASSIFIER IS WRITTEN, and why each rule is there. Getting the mention
+vs. invocation distinction right took four attempts and the first three were
+confidently wrong:
 
   * MENTION IS NOT INVOCATION. `minio.sh` prints "Verify with: …
     minio-policy-names-test.sh" and `ci.yml` echoes "python3 …
     check_alert_series.py (run on the VPS)". Both name a check they never run,
     and a plain `grep -rl` counted them as wired. So lines that are comments, or
-    that run through echo/printf, do not count.
+    that run through echo/printf, do not count. This still applies to REAL
+    sources (workflow, Makefile, script) — it is orthogonal to the REAL vs
+    TEST-ONLY split above, which is about WHICH source hit, not HOW it hit.
 
-  * BATS IS DIFFERENT, AND MUST BE. A control copies the check into a temp tree
-    and runs it through a variable — `python3 "$CHECK"` — so the check's name
-    never appears on the invocation line. Requiring an invocation pattern there
-    reported every bats-gated check as an orphan. For .bats files a mention IS
-    the evidence, because that is how the pattern works.
+  * BATS IS DIFFERENT, AND MUST BE, FOR HOW IT MATCHES. A control copies the
+    check into a temp tree and runs it through a variable — `python3 "$CHECK"`
+    — so the check's name never appears on the invocation line. Requiring an
+    invocation pattern there reported every bats-gated check as an orphan. For
+    .bats files a mention IS the evidence that a control exists — it is just
+    evidence of a TEST now, not of real wiring.
+
+  * PYTEST HAS THE SAME BLIND SPOT AS BATS, for the same reason. Every check's
+    pytest file in this repo uses the identical shape — `subprocess.run([...,
+    str(SCRIPT)])` — to invoke the check as a CLI under a fabricated fixture.
+    That is a control, not a production caller, even though `pytest tests/checks/`
+    itself genuinely runs in CI (ci.yml). The check being invoked by a test
+    suite that CI runs is still not the check being invoked for real; only
+    proof that the test suite's own assertions about the check keep passing.
 
   * A CI LOG PROVES PRESENCE, NOT ABSENCE. Searching a run's log for each check's
     banner looked authoritative and is one-directional: bats suppresses the
@@ -43,7 +72,7 @@ the check can fail, or whether it asserts anything worthwhile. `check_silent_suc
 covers the second. Nothing covers the first or third, and this green should not
 be read as covering them either.
 
-Exit 0 if every check is invoked by something.
+Exit 0 if every check has a REAL caller.
 """
 from __future__ import annotations
 
@@ -54,9 +83,32 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 CHECKS = ROOT / "scripts/checks"
 
-# Checks deliberately not invoked, with the reason. An entry is a decision;
-# silence is a failure. Empty is the goal state and currently the real one.
-ALLOWLIST: dict[str, str] = {}
+# Categories that prove a check is invoked FOR REAL — a workflow step, the
+# Makefile, or another script. A hit in any of these is enough to pass.
+REAL_SOURCES = ("workflow", "Makefile", "script")
+
+# Categories that only prove a TEST exists for the check — a bats control or
+# a pytest test invoking it as a CLI under a fabricated fixture. Necessary,
+# not sufficient: see the module docstring's REAL vs TEST-ONLY section.
+TEST_SOURCES = ("bats", "pytest")
+
+# Checks deliberately not invoked FOR REAL, with the reason. An entry is a
+# decision; silence is a failure. Empty is the goal state, not the current
+# one: h#736's fix found 8 checks wired only to their own bats/pytest
+# control — proven correct under test, never once run against real state.
+# Tracked in h#758, NOT declared fine to stay this way — each entry below is
+# an acknowledgment of a known gap, not a decision that it is acceptable
+# forever.
+ALLOWLIST: dict[str, str] = {
+    "check_alert_counts_documented.py": "test-only, found by h#736 — tracked in h#758",
+    "check_declared_paths_are_seeded.py": "test-only, found by h#736 — tracked in h#758",
+    "check_realm_tenant_clients.py": "test-only, found by h#736 — tracked in h#758",
+    "check_role_mappings_repointed.py": "test-only, found by h#736 — tracked in h#758",
+    "check_silent_success.py": "test-only, found by h#736 — tracked in h#758",
+    "check_vault_covers_compose.py": "test-only, found by h#736 — tracked in h#758",
+    "realm-tenant-serves-test.sh": "test-only, found by h#736 — tracked in h#758",
+    "tenant-login-local-test.sh": "test-only, found by h#736 — tracked in h#758",
+}
 
 
 def sources() -> dict[str, list[Path]]:
@@ -94,9 +146,10 @@ def main() -> int:
         return 1
 
     src = sources()
-    rows: list[tuple[str, list[str]]] = []
+    rows: list[tuple[str, list[str], list[str]]] = []
     for name in names:
-        where: list[str] = []
+        real: list[str] = []
+        test: list[str] = []
         for cat, files in src.items():
             for f in files:
                 if f.name == name:
@@ -107,27 +160,52 @@ def main() -> int:
                     continue
                 hit = (name in text) if cat == "bats" else invokes(text, name)
                 if hit:
-                    where.append(cat)
+                    (real if cat in REAL_SOURCES else test).append(cat)
                     break
-        rows.append((name, where))
+        rows.append((name, real, test))
 
-    orphans = [n for n, w in rows if not w and n not in ALLOWLIST]
-    allowed = [n for n, w in rows if not w and n in ALLOWLIST]
+    test_only = [n for n, r, t in rows if not r and t and n not in ALLOWLIST]
+    orphans = [n for n, r, t in rows if not r and not t and n not in ALLOWLIST]
+    allowed = [n for n, r, t in rows if not r and n in ALLOWLIST]
+    wired = len(rows) - len(test_only) - len(orphans) - len(allowed)
 
-    print("Every check must be invoked by something")
-    print("========================================")
-    for name, where in rows:
-        mark = "ok  " if where else ("note" if name in ALLOWLIST else "MISS")
-        print(f"  {mark}  {name:<42} {','.join(where) or '(nothing)'}")
+    print("Every check must be invoked by something REAL")
+    print("===============================================")
+    for name, real, test in rows:
+        if real:
+            mark = "ok  "
+        elif name in ALLOWLIST:
+            mark = "note"
+        elif test:
+            mark = "TEST"
+        else:
+            mark = "MISS"
+        where = ",".join(real) if real else (",".join(test) if test else "(nothing)")
+        print(f"  {mark}  {name:<42} {where}")
 
-    print(f"\n  {len(rows)} checks, {len(rows) - len(orphans) - len(allowed)} invoked, "
-          f"{len(allowed)} allowlisted, {len(orphans)} orphaned")
+    print(f"\n  {len(rows)} checks, {wired} invoked for real, "
+          f"{len(test_only)} test-only, {len(allowed)} allowlisted, "
+          f"{len(orphans)} orphaned")
 
     for n in allowed:
         print(f"  allowlisted: {n} — {ALLOWLIST[n]}")
 
+    if test_only:
+        print(f"\nFAIL — {len(test_only)} check(s) proven correct by a test but never run for real:\n")
+        for n in test_only:
+            print(f"  {n}")
+        print(
+            "\nA bats control or a pytest test proves the check behaves correctly\n"
+            "when invoked against a fabricated fixture. It does not prove anything\n"
+            "in CI or a deploy path ever runs it against real state — which is the\n"
+            "exact blind spot this file exists to catch, one level up. Wire it into\n"
+            "a workflow step, the Makefile, or another real script — or retire it\n"
+            "(#694), or allowlist it here with the reason it is deliberately\n"
+            "test-only forever."
+        )
+
     if orphans:
-        print(f"\nFAIL — {len(orphans)} check(s) invoked by nothing:\n")
+        print(f"\nFAIL — {len(orphans)} check(s) invoked by nothing, not even a test:\n")
         for n in orphans:
             print(f"  {n}")
         print(
@@ -137,9 +215,11 @@ def main() -> int:
             "#694 for the property-by-property gate a retirement should satisfy).\n"
             "If it is deliberately manual, add it to ALLOWLIST here with the reason."
         )
+
+    if test_only or orphans:
         return 1
 
-    print("\nPASS — no check is invoked by nothing")
+    print("\nPASS — every check has a real caller")
     print("  (this says nothing about whether the invocation is in a useful place,")
     print("   or whether the check can fail — see the module docstring)")
     return 0

--- a/scripts/checks/check_retired_roles_ungranted.py
+++ b/scripts/checks/check_retired_roles_ungranted.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 """A retired (zero-holder) role must not be granted a policy anywhere.
 
-    python3 scripts/checks/check_retired_roles_ungranted.py           # static, CI
-    python3 scripts/checks/check_retired_roles_ungranted.py --live    # + live estate
+    python3 scripts/checks/check_retired_roles_ungranted.py                  # static, CI
+    python3 scripts/checks/check_retired_roles_ungranted.py --live           # + live estate, from a workstation with `Host vps` in ~/.ssh/config
+    python3 scripts/checks/check_retired_roles_ungranted.py --live --local   # + live estate, run directly ON the target host
 
 Exit 0 = no retired role is granted anything (measured, clean). Exit 1 = a
 retired role IS granted something (measured, real problem). Exit 2 = --live
@@ -10,6 +11,22 @@ could not measure at all — SSH/the remote command chain failed, or its output
 could not be parsed. 2 is not 0: an unreachable host must never read as "no
 retired role is granted", which is the null result that happens to agree with
 what everyone hopes is true. See h#727.
+
+--local (h#738): --live's `docker exec` commands were always wrapped in
+`ssh vps <cmd>` — a literal SSH CONFIG ALIAS that only resolves on a
+workstation whose personal ~/.ssh/config defines `Host vps`. No workflow in
+this repo ever establishes that alias; every other live-estate check
+(minio-policy-names-test.sh, check_alert_series.py) instead runs its
+docker-exec commands DIRECTLY, relying on the CALLING workflow to have
+already SSH'd onto the VPS via the same `deploy@$TAILSCALE_IP` a
+gated post-deploy step in reusable-deploy-service.yml already resolves. That
+was the actual reason --live had no caller: not a missing workflow step, a
+transport the established pattern does not use. --local makes this check fit
+that same shape — the exact same measurement, run without the extra SSH hop,
+for when this process is already executing on the host being measured. The
+default (no --local) is UNCHANGED: still `ssh vps <cmd>`, still positive
+controlled the way h#727 verified it, for the workstation use case that
+already relies on it.
 
 WHY. Deleting the four zero-holder realm roles is only safe while nothing grants
 them anything. The danger is the reverse of the usual one: a grant attached to a
@@ -120,17 +137,26 @@ class LiveCheckUnreachable(Exception):
     """
 
 
-def live_checks(retired: set[str]) -> list[str]:
+def live_checks(retired: set[str], local: bool = False) -> list[str]:
     """Measure holders and read the live estate. Needs the VPS.
 
     Returns a normal problems list (possibly empty — clean) on a genuine
     measurement. Raises LiveCheckUnreachable if the estate could not be
     reached or a remote command failed, so a caller can never mistake
     "could not measure" for "measured and clean".
+
+    `local=True` (h#738) runs each remote command directly via `bash -c`
+    instead of `ssh vps <cmd>` — for when this process is already executing
+    on the host being measured, the same assumption minio-policy-names-test.sh
+    and check_alert_series.py already make. `local=False` (the default)
+    keeps the original `ssh vps <cmd>` behavior byte-for-byte, unchanged from
+    h#727, for the workstation use case that already relies on it.
     """
     problems: list[str] = []
 
     def ssh(cmd: str) -> subprocess.CompletedProcess:
+        if local:
+            return subprocess.run(["bash", "-c", cmd], capture_output=True, text=True)
         return subprocess.run(["ssh", "vps", cmd], capture_output=True, text=True)
 
     kc = (
@@ -198,6 +224,12 @@ def live_checks(retired: set[str]) -> list[str]:
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--live", action="store_true", help="also query the live estate")
+    ap.add_argument(
+        "--local", action="store_true",
+        help="with --live, run remote commands directly (bash -c) instead of "
+             "`ssh vps <cmd>` — for when this process already runs on the "
+             "host being measured (h#738). Ignored without --live.",
+    )
     args = ap.parse_args()
 
     retired = set(shell_list(KEYCLOAK, "REALM_ROLES_REMOVED"))
@@ -214,7 +246,7 @@ def main() -> int:
     if args.live:
         print()
         try:
-            problems += live_checks(retired)
+            problems += live_checks(retired, local=args.local)
         except LiveCheckUnreachable as e:
             print(f"CANNOT DETERMINE — {e}")
             print(

--- a/scripts/checks/check_silent_success.py
+++ b/scripts/checks/check_silent_success.py
@@ -82,6 +82,12 @@ ALLOWLIST_B = {
         "the FIRST step of the job — nothing can have failed before it, so the "
         "implicit success() is unreachable. Matched on the word 'Refuse'."
     ),
+    ("reusable-deploy-service.yml", "Prove no retired role is granted anything, on the live estate"): (
+        "a VERIFICATION, not a cleanup — same reasoning as the MinIO and "
+        "Grafana entries above (h#738). success() is correct: verifying a "
+        "deploy that did not happen proves nothing. Matched on the word "
+        "'Prove'."
+    ),
 }
 
 CLEANUP_WORDS = re.compile(

--- a/tests/scripts/checks-are-wired-control.bats
+++ b/tests/scripts/checks-are-wired-control.bats
@@ -47,10 +47,10 @@ setup() {
   CHECK="$CTL/scripts/checks/check_checks_are_wired.py"
 }
 
-@test "CONTROL: passes on the real tree — every check is invoked" {
+@test "CONTROL: passes on the real tree — every check has a real caller" {
   run python3 "$CHECK"
   [ "$status" -eq 0 ]
-  [[ "$output" == *"no check is invoked by nothing"* ]]
+  [[ "$output" == *"every check has a real caller"* ]]
 }
 
 @test "CONTROL: it examines a real number of checks, not zero" {
@@ -58,7 +58,7 @@ setup() {
   [ "$status" -eq 0 ]
   # A run over an empty set would pass while measuring nothing.
   [[ "$output" != *"0 checks,"* ]]
-  [[ "$output" == *"invoked,"* ]]
+  [[ "$output" == *"invoked for real,"* ]]
 }
 
 @test "a new check that nobody wires is caught" {
@@ -107,10 +107,21 @@ SH
   [ "$status" -eq 0 ]
 }
 
-# BATS IS DIFFERENT — a control copies the check and runs it through a variable,
-# so the name never appears on the invocation line. Requiring an invocation
-# pattern here reported every bats-gated check as an orphan.
-@test "a check exercised only by a bats control counts as wired" {
+# BATS IS DIFFERENT, FOR HOW IT MATCHES — a control copies the check and runs
+# it through a variable, so the name never appears on the invocation line.
+# Requiring an invocation pattern there reported every bats-gated check as an
+# orphan. A mention in a .bats file IS the evidence a control exists.
+#
+# BUT A CONTROL IS NOT REAL WIRING (h#736). A bats control proves the check
+# behaves correctly when invoked against a fabricated fixture. It does not
+# prove anything in CI or a deploy path ever runs it against real state —
+# which is the exact blind spot this classifier exists to catch, one level
+# up. Before h#736, a check exercised ONLY by its own bats control was
+# reported "ok" — indistinguishable from a check with a genuine caller. This
+# is the two-directions positive control that fix requires: the SAME
+# scenario must now go red (below), and a check with a genuine caller must
+# stay green (the test after it).
+@test "a check exercised ONLY by a bats control is TEST-ONLY, not wired — and FAILS" {
   cat > "$CTL/scripts/checks/check_bats_gated_only.py" <<'PY'
 #!/usr/bin/env python3
 import sys
@@ -126,7 +137,62 @@ setup() { CHECK="$BATS_TEST_DIRNAME/../../scripts/checks/check_bats_gated_only.p
 BATS
 
   run python3 "$CHECK"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"check_bats_gated_only.py"* ]]
+  [[ "$output" == *"proven correct by a test but never run for real"* ]]
+}
+
+# THE OTHER DIRECTION. A check with a genuine caller — a workflow step here,
+# but the Makefile or another script prove identically, since REAL_SOURCES
+# treats the three the same — must stay green. Without this test, a
+# classifier that marked EVERYTHING test-only (over-correcting h#736 the
+# other way) would also pass the test above.
+@test "the SAME check, ALSO invoked by a real workflow step, is wired — stays green" {
+  cat > "$CTL/scripts/checks/check_bats_gated_only.py" <<'PY'
+#!/usr/bin/env python3
+import sys
+sys.exit(0)
+PY
+  cat > "$CTL/tests/scripts/bats-gated-only-control.bats" <<'BATS'
+#!/usr/bin/env bats
+setup() { CHECK="$BATS_TEST_DIRNAME/../../scripts/checks/check_bats_gated_only.py"; }
+BATS
+  cat > "$CTL/.github/workflows/pretend-ci.yml" <<'YML'
+name: pretend
+on: push
+jobs:
+  test:
+    steps:
+      - run: python3 scripts/checks/check_bats_gated_only.py
+YML
+
+  run python3 "$CHECK"
   [ "$status" -eq 0 ]
+  [[ "$output" == *"PASS"* ]]
+}
+
+# PYTEST HAS THE SAME BLIND SPOT AS BATS, for the same reason: every check's
+# pytest file in this repo subprocess-invokes the check as a CLI under a
+# fabricated fixture — a control, not a production caller. Proven separately
+# from the bats case above, since TEST_SOURCES is a tuple of two categories
+# and either one alone must produce the same TEST-ONLY outcome.
+@test "a check exercised ONLY by a pytest test is ALSO test-only, not wired" {
+  cat > "$CTL/scripts/checks/check_pytest_gated_only.py" <<'PY'
+#!/usr/bin/env python3
+import sys
+sys.exit(0)
+PY
+  cat > "$CTL/tests/checks/test_pytest_gated_only.py" <<'PY'
+import subprocess
+SCRIPT = "scripts/checks/check_pytest_gated_only.py"
+def test_it():
+    subprocess.run(["python3", SCRIPT])
+PY
+
+  run python3 "$CHECK"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"check_pytest_gated_only.py"* ]]
+  [[ "$output" == *"proven correct by a test but never run for real"* ]]
 }
 
 @test "an empty checks directory fails rather than reporting success" {

--- a/tests/scripts/retired-roles-ungranted-control.bats
+++ b/tests/scripts/retired-roles-ungranted-control.bats
@@ -176,3 +176,45 @@ STUB
   [ "$found_status" -eq 1 ]
   [ "$unreachable_status" -eq 2 ]
 }
+
+# --------------------------------------------------------------- --local ----
+#
+# h#738: --live had no caller anywhere. `ssh vps <cmd>` is a literal SSH
+# CONFIG ALIAS that only resolves on a workstation whose personal
+# ~/.ssh/config defines `Host vps` — no workflow in this repo ever
+# establishes it, which is the actual reason --live was unwireable, not a
+# missing workflow step. --local runs the same commands directly instead,
+# matching the shape minio-policy-names-test.sh and check_alert_series.py
+# already use once a workflow has SSH'd onto the VPS.
+#
+# THE ASSERTION THAT MATTERS, proven without any stub: this sandbox has no
+# /opt/hill90/app, so the remote command's own `cd /opt/hill90/app` fails
+# immediately if run as a literal local command. That failure message is
+# categorically different from what an accidental `ssh vps <cmd>` call would
+# produce (a hostname-resolution or connection failure, not a `cd` error) —
+# so which message appears proves which transport actually ran, without
+# needing to stub ssh, docker, or anything else.
+
+@test "--live --local runs the command directly (bash -c), not via ssh vps" {
+  run python3 "$CHECK" --live --local
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"CANNOT DETERMINE"* ]]
+  # Proves bash -c actually ran the command string locally: a `cd` failure,
+  # not an ssh/hostname-resolution failure.
+  [[ "$output" == *"No such file or directory"* ]]
+  [[ "$output" != *"Could not resolve hostname"* ]]
+}
+
+@test "--local is a no-op without --live — static mode is unaffected" {
+  run python3 "$CHECK" --local
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"PASS"* ]]
+  [[ "$output" != *"CANNOT DETERMINE"* ]]
+}
+
+@test "default --live (no --local) still goes through ssh vps, unchanged from h#727" {
+  setup_ssh_stub clean
+  run env PATH="$STUB_DIR:$PATH" python3 "$CHECK" --live
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"PASS"* ]]
+}


### PR DESCRIPTION
## h#736 — the number, before anything else

**With the fix applied, 9 of 35 checks in `scripts/checks/` turn out to be wired only to their own control** — a bats control and/or a pytest test, no real caller (workflow step, Makefile, or another script) anywhere. Breakdown: 6 bats-only, 3 bats+pytest (both test types, still zero real callers). That is the number h#736 exists to surface: this fraction of the estate's safety net was decorative — proven correct under test, never once run against real state.

One of the 9 was `check_checks_are_wired.py` itself — its own bats control was its only caller, which is the most direct possible illustration of the exact defect it exists to catch. Fixed directly in this PR (a real `ci.yml` step). **The remaining 8 are filed as #758** and allowlisted in `check_checks_are_wired.py` with a reason pointing at that issue — an acknowledged, tracked gap, not a decision that staying test-only is fine forever. Fixing each of those 8 for real is its own investigation (same depth h#738's fix below required) and would have turned this into two different PRs bundled as one.

### The fix
`check_checks_are_wired.py` now has three outcomes, not two: **REAL** (a workflow step, the Makefile, or another script actually invokes the check), **TEST-ONLY** (only a bats control and/or pytest test), **ORPHAN** (nothing at all). Only REAL passes; TEST-ONLY and ORPHAN both fail, reported separately.

**Positive-controlled both directions**, per your instruction:
- A check with ONLY a bats control now goes red (`checks-are-wired-control.bats`, "a check exercised ONLY by a bats control is TEST-ONLY, not wired — and FAILS").
- The identical check, ALSO invoked by a real workflow step, stays green ("the SAME check, ALSO invoked by a real workflow step, is wired — stays green").
- A pytest-only caller is shown to have the identical blind spot as bats (separate test, since `TEST_SOURCES` is two categories and either alone must produce the same outcome).

## h#738 — where `--live` can actually run, stated plainly

**Not `ci.yml`.** GitHub-hosted PR runners have no route to the VPS. Wiring `--live` there would make the step silently skip or fail on every single PR — and a check that skips is a check that does not exist. I did not do that.

**Root cause, not a missing step:** `live_checks()` shelled out via `ssh vps <cmd>` — a literal SSH **config alias**, only resolvable on a workstation whose personal `~/.ssh/config` defines `Host vps`. No workflow in this repo ever establishes that alias. Nothing could have called `--live` as it was written, regardless of where you tried to wire it.

**Where it genuinely can run:** `reusable-deploy-service.yml` — the deploy pipeline already SSHes to the VPS via `deploy@$TAILSCALE_IP` with the existing `~/.ssh/vps_key`, the same mechanism `minio-policy-names-test.sh` and `check_alert_series.py` already use as live-estate verifications in that exact file. Added `--local` to the script: runs the same remote commands directly (`bash -c`, no ssh hop) for when the process is already executing on the host being measured — matching the shape those two established checks use. Wired as a new step gated `if: success() && (inputs.service == 'auth' || inputs.service == 'minio')`, matching the two "Prove ..." verification steps already there (auth/minio are the only deploys that can move a role's grant; observability/db cannot).

Default `--live` (no `--local`) is **unchanged** — still `ssh vps <cmd>`, still exactly the h#727-positive-controlled behavior, for the workstation use case that already depends on it.

**Not validated against the real production VPS** — explicitly out of scope (no infra/secrets/credential work), the same limitation h#738's own filer named. Positive-controlled instead: the existing 12-test SSH-alias-stub suite is unchanged and still green, proving the exit-0/1/2 semantics untouched; 3 new tests prove `--local` genuinely takes the `bash -c` path (a real `cd` failure in this sandbox — categorically different from an ssh/hostname-resolution failure), is a no-op without `--live`, and that default `--live` is unaffected.

## A real finding along the way

Adding the new `reusable-deploy-service.yml` step surfaced a genuine hit from `check_silent_success.py`'s own sweep: the new step's `success() && (...)` condition reads as a verification that legitimately skips on failure — exactly the shape its two sibling "Prove ..." steps already have, and already have an `ALLOWLIST_B` entry for. Added the matching entry rather than suppressing or ignoring the finding.

## Test plan
- [x] Full bats suite: **574/574 pass** (`bats tests/scripts/`)
- [x] Full pytest suite: **80/80 pass** (`python3 -m pytest tests/checks/ -q`)
- [x] `check_checks_are_wired.py`: PASS (27 real, 0 test-only, 8 allowlisted+tracked, 0 orphaned)
- [x] `check_silent_success.py`: PASS (no new finding beyond the tracked-empty baseline)
- [x] Positive control, h#736: reverted the classifier, reran the two-direction tests, confirmed both failed for the exact predicted reason, restored
- [x] Positive control, h#738: reverted the `--local` change, reran the 3 new tests, confirmed all failed for the exact predicted reason, restored
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` on both touched workflow files

Deploys through the pipeline only. No infra/secrets/sops/credential work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)