### PR TITLE
fix(checks): wire check_declared_paths_are_seeded.py into ci.yml (h#758, 2/8)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,19 @@ jobs:
       - name: Assert no path revokes root before OIDC is enabled
         run: python3 scripts/checks/check_vault_revoke_order.py
 
+      # h#758 (found by h#736's fix): wired only to its own bats control
+      # since it was written. Fully hermetic — parses scripts/_common.sh and
+      # scripts/vault.sh statically, no vault, no host. Same shape as
+      # check_alert_counts_documented.py above: no design question about
+      # WHERE this can run, just a check that had never been asked to.
+      # Ties vault_paths_for_service() (what deploy time reads secrets from)
+      # to cmd_seed() (what actually writes them) — the drift underneath the
+      # 2026-08-03 auth outage (#495 removed a seed block, #531 restored the
+      # declaration but not the seed, and nothing compared the two for
+      # months).
+      - name: Assert every declared vault path is seeded
+        run: python3 scripts/checks/check_declared_paths_are_seeded.py
+
       # h#726: written to catch the exact regression in run 30791332461 (a
       # revoke step's `if:` ANDed with success() skipped it on failure and
       # left a live root token on production), then never invoked — the

--- a/scripts/checks/check_checks_are_wired.py
+++ b/scripts/checks/check_checks_are_wired.py
@@ -101,7 +101,6 @@ TEST_SOURCES = ("bats", "pytest")
 # forever.
 ALLOWLIST: dict[str, str] = {
     "check_alert_counts_documented.py": "test-only, found by h#736 — tracked in h#758",
-    "check_declared_paths_are_seeded.py": "test-only, found by h#736 — tracked in h#758",
     "check_realm_tenant_clients.py": "test-only, found by h#736 — tracked in h#758",
     "check_role_mappings_repointed.py": "test-only, found by h#736 — tracked in h#758",
     "check_silent_success.py": "test-only, found by h#736 — tracked in h#758",

--- a/tests/scripts/declared-paths-seeded-control.bats
+++ b/tests/scripts/declared-paths-seeded-control.bats
@@ -143,6 +143,19 @@ PY
   [[ "$output" != *"PASS"* ]]
 }
 
+# WIRING, not logic (h#736/h#758): every test above proves the check's LOGIC
+# is correct. None of them prove anything ever RUNS it — before this fix,
+# this check's only caller anywhere was this bats file, exactly the
+# TEST-ONLY outcome h#736 taught check_checks_are_wired.py to catch. Fully
+# hermetic (no vault, no host — see its own docstring's design), so unlike
+# h#738 there was no design question about WHERE it could run: ci.yml, on
+# every PR.
+@test "h#758: ci.yml genuinely invokes this check, not just mentions it" {
+  run grep -n "run: python3 scripts/checks/check_declared_paths_are_seeded.py" \
+    "$ROOT/.github/workflows/ci.yml"
+  [ "$status" -eq 0 ]
+}
+
 # PROSE IS NOT AN ACTION — the same trap that made an earlier check read an
 # echoed command as a real one. A path named only in a comment is not seeded.
 @test "a path mentioned only in a comment does not count as seeded" {


### PR DESCRIPTION
## Investigation

**What it asserts.** Every vault path a service declares in `scripts/_common.sh`'s `vault_paths_for_service()` is one `cmd_seed()` in `scripts/vault.sh` actually writes. This is the exact drift underneath the 2026-08-03 auth outage: #495 removed a seed block, #531 restored the declaration but not the seed, and nothing compared the two for months — a 404 that a coincident 403 (#660) masked, so every diagnosis stopped at the permission error and the missing data was never reached.

**Is it true right now?** Yes — verified: all six declared paths across four services are seeded (one seeded-but-undeclared note, non-fatal by design).

**Where can it run?** Fully hermetic — parses two shell scripts statically, no vault, no host. No design question like h#738. Wired into `ci.yml` next to the other vault-config-consistency checks.

Also removes its now-stale entry from `check_checks_are_wired.py`'s `ALLOWLIST` (h#759 has since merged) — leaving it would be exactly the "dead scaffolding" `check_silent_success.py`'s own baseline convention warns against.

## Positive control, both directions
- New bats test asserts `ci.yml` genuinely contains the invocation line.
- Reverted and reran: fails for that exact reason before the fix, confirming the original gap. Restored.

## Test plan
- [x] Full bats suite: 579/579 pass
- [x] Full pytest suite: 80/80 pass
- [x] `check_silent_success.py` re-run: clean
- [x] `check_checks_are_wired.py`: check drops out of the allowlist correctly

No infra/secrets/sops/credential work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)