### PR TITLE
fix(checks): wire check_realm_tenant_clients.py into ci.yml (h#758 3/8)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,19 @@ jobs:
       - name: Assert every referenced OIDC client is created on the deploy path
         run: python3 scripts/checks/check_oidc_clients_reconciled.py
 
+      # h#758 (found by h#736's fix): wired only to its own bats/pytest
+      # control since it was written. Fully hermetic — parses
+      # platform/auth/keycloak/platform-realm.json statically, no live
+      # Keycloak needed, no design question about WHERE it can run. Pins
+      # the tenant's authorization shape against exactly the regression
+      # class that produced hill90-app#306/#704: hill90-ui losing its
+      # `basic` client scope (no `sub` claim, every login refused) or its
+      # `roles` scope (every permission check silently empty), or gaining a
+      # realm-roles mapper it must never have (a client-admin inheriting
+      # infrastructure-admin).
+      - name: Assert the realm's tenant clients match the shape production runs
+        run: python3 scripts/checks/check_realm_tenant_clients.py
+
       # h#727: static mode (no --live) is explicitly documented in the
       # script's own module docstring as "static, CI" — this wires that
       # documented, secrets-free half in. It cannot see holders (needs the

--- a/scripts/checks/check_checks_are_wired.py
+++ b/scripts/checks/check_checks_are_wired.py
@@ -100,7 +100,6 @@ TEST_SOURCES = ("bats", "pytest")
 # an acknowledgment of a known gap, not a decision that it is acceptable
 # forever.
 ALLOWLIST: dict[str, str] = {
-    "check_realm_tenant_clients.py": "test-only, found by h#736 — tracked in h#758",
     "check_role_mappings_repointed.py": "test-only, found by h#736 — tracked in h#758",
     "check_silent_success.py": "test-only, found by h#736 — tracked in h#758",
     "check_vault_covers_compose.py": "test-only, found by h#736 — tracked in h#758",

--- a/tests/checks/test_realm_tenant_clients.py
+++ b/tests/checks/test_realm_tenant_clients.py
@@ -161,3 +161,16 @@ def test_fails_when_vaults_realm_roles_mapper_is_lost(realm):
     r = run(realm)
     assert r.returncode == 1
     assert "realm_roles" in r.stderr
+
+
+# ---- wiring, not logic (h#736/h#758) ----------------------------------------
+#
+# Every test above proves the check's LOGIC is correct. None of them prove
+# anything ever RUNS it — before this fix, this check's only caller anywhere
+# was this pytest file and its own bats mention, exactly the TEST-ONLY
+# outcome h#736 taught check_checks_are_wired.py to catch. Fully hermetic (no
+# live Keycloak — see the check's own docstring), so unlike h#738 there was
+# no design question about WHERE it could run: ci.yml, on every PR.
+def test_h758_ci_yml_genuinely_invokes_this_check():
+    ci_yml = (ROOT / ".github/workflows/ci.yml").read_text()
+    assert "run: python3 scripts/checks/check_realm_tenant_clients.py" in ci_yml


### PR DESCRIPTION
## h#758, check 3 of 8: `check_realm_tenant_clients.py`

Part of h#758 — the 8 checks h#736's fix found wired only to their own bats/pytest control (proven correct under test, never once run against real state). Each check gets its own investigation and its own PR.

**What it asserts.** `platform-realm.json`'s tenant clients keep the exact authorization shape production runs on:
- `hill90-ui` keeps `roles` and `basic` (added h#704 — without `basic` the issued token carries no `sub`) in `defaultClientScopes`
- `hill90-ui` carries NO realm-roles mapper — the platform grants Grafana Admin/OpenBao off the realm role `platform-admin`; the app deliberately reads only client roles so an app-admin can't inherit infrastructure-admin
- `hill90-api`'s audience mapper survives, and it stays `bearerOnly`
- `hill90-vault`'s own `realm_roles` mapper isn't clobbered by any of the above (do-not-clobber check)

**Is it true right now?** Yes — ran the check directly against the real committed realm file before touching anything else:
```
Tenant clients pinned: hill90-ui (confidential, roles scope, audience mapper,
no realm-roles mapper), hill90-api (bearer-only), client roles user+admin,
hill90-vault intact.
```

**Where it can run.** Fully hermetic — parses `platform/auth/keycloak/platform-realm.json` statically, no live Keycloak needed. Unlike h#738 there was no design question about placement, just a check that had never been asked to run. Wired into `ci.yml`, same as `check_alert_counts_documented.py` (h#758 1/8, #760) and `check_declared_paths_are_seeded.py` (h#758 2/8, #761).

**Positive control, both directions.** Saved the `ci.yml` diff, reverted it, reran the new wiring-proof pytest test alone — it failed on exactly the predicted assertion (invocation line absent from `ci.yml`). Reapplied the diff, reran — it passed.

**`check_silent_success.py`.** Clean, no new finding (A=1, B=5, both the existing tracked baseline — the new step carries no `if:` condition).

**Full suites, both green:**
```
bats tests/scripts/     589 passed, 0 failed
pytest tests/checks/     81 passed in 146.06s
```

**Bookkeeping.** Removes `check_realm_tenant_clients.py`'s own now-stale entry from `check_checks_are_wired.py`'s `ALLOWLIST`, leaving the other 5 not-yet-fixed entries alone (verified current `origin/main` state before editing).

## Test plan
- [x] Check asserts something true about the estate right now (ran directly, confirmed pass)
- [x] Confirmed fully hermetic — no design question about where it runs
- [x] Wired into `ci.yml`
- [x] Positive control: revert → new test fails for the predicted reason → restore → new test passes
- [x] `check_silent_success.py` shows no new finding
- [x] Full `bats tests/scripts/` — 589 passed, 0 failed
- [x] Full `pytest tests/checks/` — 81 passed
- [x] Stale `ALLOWLIST` entry removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)