### PR TITLE
fix(checks): remove check_alert_counts_documented.py's stale ALLOWLIST entry

### DIFF
--- a/scripts/checks/check_checks_are_wired.py
+++ b/scripts/checks/check_checks_are_wired.py
@@ -100,7 +100,6 @@ TEST_SOURCES = ("bats", "pytest")
 # an acknowledgment of a known gap, not a decision that it is acceptable
 # forever.
 ALLOWLIST: dict[str, str] = {
-    "check_alert_counts_documented.py": "test-only, found by h#736 — tracked in h#758",
     "check_realm_tenant_clients.py": "test-only, found by h#736 — tracked in h#758",
     "check_role_mappings_repointed.py": "test-only, found by h#736 — tracked in h#758",
     "check_silent_success.py": "test-only, found by h#736 — tracked in h#758",


### PR DESCRIPTION
## Small bookkeeping fix, found while starting h#758 check 4/8

PR #760 (h#758 1/8) wired `check_alert_counts_documented.py` into `ci.yml` but never removed its own `ALLOWLIST` entry in `check_checks_are_wired.py`. Found while diffing PR #760 to confirm current `ALLOWLIST` state before starting the next check's investigation — the diff touches only `ci.yml` and the check's own bats control, never `check_checks_are_wired.py`.

**Not a functional bug.** `check_checks_are_wired.py` reports a check "ok" the moment it has a real caller, regardless of an `ALLOWLIST` entry — so this cost nothing operationally; the entry was inert.

**But it is stale, false documentation.** The entry claims "test-only, found by h#736 — tracked in h#758" for a check that has had a real `ci.yml` caller since #760 merged. The file's own docstring is explicit that an entry is "an acknowledgment of a known gap, not a decision that it is acceptable forever" — this one had already stopped being either.

Verified: `check_checks_are_wired.py` now reports exactly 6 allowlisted entries, matching the 6 of 8 h#758 checks not yet fixed (`check_realm_tenant_clients.py`'s own cleanup ships separately in #762, not yet merged).

## Test plan
- [x] `python3 scripts/checks/check_checks_are_wired.py` — 35 checks, 29 real, 0 test-only, 6 allowlisted, 0 orphaned

🤖 Generated with [Claude Code](https://claude.com/claude-code)