### PR TITLE
fix(checks): wire check_role_mappings_repointed.py into ci.yml (h#758 4/8)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,19 @@ jobs:
       - name: Assert no retired role is granted anything (static)
         run: python3 scripts/checks/check_retired_roles_ungranted.py
 
+      # h#758 (found by h#736's fix): wired only to its own bats control
+      # since it was written. Fully hermetic — parses
+      # docker-compose.observability.yml and scripts/vault.sh statically for
+      # role-mapping expressions, no live Keycloak needed, no design question
+      # about WHERE it can run. Guards the exact half-repoint shape from
+      # #637/#666: Grafana's role_attribute_path had its admin arm repointed
+      # from the zero-holder legacy role to platform-admin, but its editor arm
+      # was left naming another zero-holder role — and because
+      # role_attribute_strict defaults to false, that arm fails silently, with
+      # no log line and no failed login to notice it by.
+      - name: Assert no consumer role mapping still names a legacy realm role
+        run: python3 scripts/checks/check_role_mappings_repointed.py
+
       - name: Assert no path revokes root before OIDC is enabled
         run: python3 scripts/checks/check_vault_revoke_order.py
 

--- a/scripts/checks/check_checks_are_wired.py
+++ b/scripts/checks/check_checks_are_wired.py
@@ -100,7 +100,6 @@ TEST_SOURCES = ("bats", "pytest")
 # an acknowledgment of a known gap, not a decision that it is acceptable
 # forever.
 ALLOWLIST: dict[str, str] = {
-    "check_role_mappings_repointed.py": "test-only, found by h#736 — tracked in h#758",
     "check_silent_success.py": "test-only, found by h#736 — tracked in h#758",
     "check_vault_covers_compose.py": "test-only, found by h#736 — tracked in h#758",
     "realm-tenant-serves-test.sh": "test-only, found by h#736 — tracked in h#758",

--- a/tests/scripts/role-mappings-repointed-control.bats
+++ b/tests/scripts/role-mappings-repointed-control.bats
@@ -104,3 +104,15 @@ setup() {
   [ "$status" -eq 1 ]
   [[ "$output" == *"gone blind"* ]]
 }
+
+# WIRING, not logic (h#736/h#758): every test above proves the check's LOGIC
+# is correct. None of them prove anything ever RUNS it — before this fix, this
+# check's only caller anywhere was this bats file, exactly the TEST-ONLY
+# outcome h#736 taught check_checks_are_wired.py to catch. Fully hermetic (no
+# live Keycloak — see the check's own docstring), so unlike h#738 there was no
+# design question about WHERE it could run: ci.yml, on every PR.
+@test "h#758: ci.yml genuinely invokes this check, not just mentions it" {
+  run grep -n "run: python3 scripts/checks/check_role_mappings_repointed.py" \
+    "$ROOT/.github/workflows/ci.yml"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## h#758, check 4 of 8: `check_role_mappings_repointed.py`

Part of h#758 — the 8 checks h#736's fix found wired only to their own bats/pytest control. Each check gets its own investigation and its own PR.

**What it asserts.** No consumer's role-mapping configuration (Grafana's `role_attribute_path`, OpenBao's admin-sso `bound_claims`) names a legacy realm role — `admin`, `user`, `editor`, `viewer`. Those four are being removed because they have zero holders, so a mapping that still names one authorises nobody. Because Grafana's `role_attribute_strict` defaults to `false`, a half-repointed arm fails silently: no log line, no failed login. That is the exact shape #637/#666 produced — Stage 2a repointed Grafana's admin arm to `platform-admin` and left the editor arm naming a zero-holder role, and the config read as though the work was finished.

**Is it true right now?** Yes:
```
  ok    Grafana role_attribute_path: platform-admin, platform-editor
  ok    OpenBao admin-sso bound_claims: platform-admin

PASS — 2 mapping(s) checked, none names a legacy realm role
```

**Where it can run.** Fully hermetic — parses `docker-compose.observability.yml` and `scripts/vault.sh` statically, no live Keycloak needed. Same shape as checks 1-3/8 (#760, #761, #762): no design question about placement, just a check that had never been asked to run. Wired into `ci.yml` right after `check_retired_roles_ungranted.py`, its thematic sibling on role-scheme hygiene.

**Positive control, both directions.** Saved the `ci.yml` diff, reverted it, reran this check's full bats file — the new wiring-proof test failed on exactly the predicted assertion (invocation line absent from `ci.yml`), the 8 pre-existing logic tests stayed green. Reapplied the diff, reran — all 9 passed.

**`check_silent_success.py`.** Clean, no new finding (A=1, B=5, both the existing tracked baseline).

**Full suites, both green:**
```
bats tests/scripts/     591 passed, 0 failed
pytest tests/checks/     80 passed in 144.92s
```

**Bookkeeping.** Removes `check_role_mappings_repointed.py`'s own now-stale `ALLOWLIST` entry.

## Test plan
- [x] Check asserts something true about the estate right now
- [x] Confirmed fully hermetic — no design question about where it runs
- [x] Wired into `ci.yml`
- [x] Positive control: revert → new test fails for the predicted reason → restore → passes
- [x] `check_silent_success.py` shows no new finding
- [x] Full `bats tests/scripts/` — 591 passed, 0 failed
- [x] Full `pytest tests/checks/` — 80 passed
- [x] Stale `ALLOWLIST` entry removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)