### PR TITLE
fix(checks): wire check_silent_success.py into ci.yml (h#758 5/8)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,6 +261,21 @@ jobs:
       - name: Run check script tests
         run: pip install pytest pyyaml && pytest tests/checks/ -v
 
+      # h#758 (found by h#736's fix): wired only to its own bats control
+      # since it was written. Fully hermetic — parses scripts/*.sh and
+      # .github/workflows/*.yml statically for the two machine-detectable
+      # silent-success shapes (a fallback subshell swallowing a failed call;
+      # a cleanup/assertion step's `if:` skipping on failure), no live host
+      # needed. Placed after the pyyaml install above because it imports
+      # `yaml` to parse workflow files. No design question about WHERE it
+      # can run — just a check that had never been asked to. This is the
+      # same script used throughout h#758's own investigation as the
+      # regression detector for new `if:` conditions on other steps; wiring
+      # its own execution here is a separate question from using it as a
+      # tool, and was open until now.
+      - name: Sweep for operations that fail and report success
+        run: python3 scripts/checks/check_silent_success.py
+
       # Hill90#736: this checker's own bats control
       # (tests/scripts/checks-are-wired-control.bats) used to be its only
       # caller — which, after that fix, is exactly the TEST-ONLY outcome

--- a/scripts/checks/check_checks_are_wired.py
+++ b/scripts/checks/check_checks_are_wired.py
@@ -100,7 +100,6 @@ TEST_SOURCES = ("bats", "pytest")
 # an acknowledgment of a known gap, not a decision that it is acceptable
 # forever.
 ALLOWLIST: dict[str, str] = {
-    "check_silent_success.py": "test-only, found by h#736 — tracked in h#758",
     "check_vault_covers_compose.py": "test-only, found by h#736 — tracked in h#758",
     "realm-tenant-serves-test.sh": "test-only, found by h#736 — tracked in h#758",
     "tenant-login-local-test.sh": "test-only, found by h#736 — tracked in h#758",

--- a/tests/scripts/silent-success-sweep-control.bats
+++ b/tests/scripts/silent-success-sweep-control.bats
@@ -96,3 +96,18 @@ PY
   # implicit success() is unreachable. It must not appear as a finding.
   [[ "$output" != *"Refuse without the typed confirmation' reads as cleanup"* ]]
 }
+
+# WIRING, not logic (h#736/h#758): every test above proves the check's LOGIC
+# is correct. None of them prove anything ever RUNS it — before this fix, this
+# check's only caller anywhere was this bats file, exactly the TEST-ONLY
+# outcome h#736 taught check_checks_are_wired.py to catch. Fully hermetic (no
+# live host — see the check's own docstring), so unlike h#738 there was no
+# design question about WHERE it could run: ci.yml, on every PR. Note this is
+# a separate question from the check being USED throughout h#758's own
+# investigation as a regression detector for `if:` conditions on other new
+# steps — using it as a tool never proved anything ran it in CI.
+@test "h#758: ci.yml genuinely invokes this check, not just mentions it" {
+  run grep -n "run: python3 scripts/checks/check_silent_success.py" \
+    "$ROOT/.github/workflows/ci.yml"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## h#758, check 5 of 8: `check_silent_success.py`

Part of h#758 — the 8 checks h#736's fix found wired only to their own bats/pytest control. Cut fresh from main after #762 (3/8) and #764 (4/8) merged, per the structural fix to avoid paying a rebase for wiring already landed.

**What it asserts.** No shell script or GitHub Actions workflow contains either of the two machine-detectable silent-success shapes:
- **A.** a call swallowed inside a fallback subshell with no `|| exit 1`
- **B.** a cleanup/assertion step whose `if:` is ANDed with implicit `success()`, so it skips on the exact failure it exists to catch

Five members of this family were closed reactively on 2026-08-03, after two of them caused a 43-minute auth outage and a Grafana SSO breakage. This sweep looks for the sixth before it causes one.

**Is it true right now?** Yes, re-verified against current main after #762/#764 landed:
```
  A. swallowed inside a fallback subshell: 0
  B. cleanup/assertion skipped on failure: 0

PASS — no NEW instance beyond the tracked baseline
```

**Where it can run.** Fully hermetic — parses `scripts/*.sh` and `.github/workflows/*.yml` statically, no live host needed. No design question about placement, same as checks 1-4/8. Wired after the `pip install pytest pyyaml` step since it imports `yaml`.

Worth calling out explicitly: this is the same script I've used throughout h#758's own investigation as a regression detector for new `if:` conditions on other steps in this series. Using it as a tool never proved anything ran it for real in CI — that's the separate question this PR answers.

**Positive control, both directions.** Reverted `ci.yml`, the new wiring-proof bats test failed on exactly the predicted assertion (invocation line absent), the other 6 logic tests stayed green. Reapplied, all 7 passed.

**Self-check.** Running `check_silent_success.py` against the *modified* `ci.yml` itself reports no new finding — the new step carries no `if:` condition and its name doesn't match `CLEANUP_WORDS`.

**Full suites, both green:**
```
bats tests/scripts/     592 passed, 0 failed
pytest tests/checks/     81 passed
```

**Bookkeeping, same PR as the wiring** (per the #760/#763 lesson): removes `check_silent_success.py`'s own now-stale `ALLOWLIST` entry.

## Test plan
- [x] Check asserts something true about the estate right now (re-verified post #762/#764)
- [x] Confirmed fully hermetic — no design question about where it runs
- [x] Wired into `ci.yml`
- [x] Positive control: revert → new test fails for the predicted reason → restore → passes
- [x] Self-check: the check finds no new finding in the diff that wires it
- [x] Full `bats tests/scripts/` — 592 passed, 0 failed
- [x] Full `pytest tests/checks/` — 81 passed
- [x] Stale `ALLOWLIST` entry removed in the same commit as the wiring

🤖 Generated with [Claude Code](https://claude.com/claude-code)