### PR TITLE
fix(checks): wire check_vault_covers_compose.py into deploy (h#758 6/8)

### DIFF
--- a/.github/workflows/reusable-deploy-service.yml
+++ b/.github/workflows/reusable-deploy-service.yml
@@ -108,6 +108,46 @@ jobs:
             deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
             "cd /opt/hill90/app && bash scripts/deploy.sh verify ${{ inputs.service }}"
 
+      # PROVE VAULT ACTUALLY CARRIES EVERY SECRET THE COMPOSE FILE NEEDS.
+      #
+      # h#758 (found by h#736's fix): wired only to its own bats/pytest control
+      # since it was written. Genuinely NOT hermetic, unlike checks 1-5/8 in
+      # this same series — it calls `sops -d` on the real encrypted store to
+      # read SOPS key NAMES (never values), which is the same distinction the
+      # rest of this series draws between "no design question" and "needed a
+      # real one" (h#727/h#738). ci.yml has no age key anywhere (confirmed: no
+      # `sops`/`SOPS_AGE_KEY` reference exists in it at all), and the check's
+      # own bats control (tests/scripts/vault-covers-compose-control.bats)
+      # already SKIPS rather than fails when no key is present — proof this
+      # cannot run there. It CAN run here: /opt/hill90/secrets/keys/keys.txt
+      # already exists on the VPS for every deploy, and is the check's own
+      # second candidate key path (see sops_key_names() in the check itself) —
+      # no new secret, no new access, the exact shape --live --local took in
+      # h#738.
+      #
+      # AFTER the deploy, not before, so the checkout this reads from is the
+      # one `git reset --hard origin/main` just made current — same reason
+      # "Checkout preflight" above stopped running the host's stale copy.
+      # Placing it earlier would mean checking the PREVIOUS deploy's files.
+      # This means it detects the #665 outage class immediately after a bad
+      # deploy rather than preventing it outright; blocking it beforehand
+      # would mean rewriting the single SSH command in "Deploy
+      # ${{ inputs.service }}" above, which is deploy-mechanics work, not
+      # wiring a check, and is out of scope here.
+      #
+      # UNGATED BY inputs.service, unlike the checks below: this one examines
+      # every prod compose file in one pass regardless of which service
+      # triggered the run, so it runs on every deploy.
+      #
+      # success(), same reasoning as every "Prove ..." step below: verifying a
+      # deploy that did not happen proves nothing.
+      - name: Prove vault carries every secret the compose files need
+        if: success()
+        run: |
+          ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
+            deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
+            'cd /opt/hill90/app && export SOPS_AGE_KEY_FILE=/opt/hill90/secrets/keys/keys.txt && python3 scripts/checks/check_vault_covers_compose.py'
+
       # PROVE SSO STILL WORKS, not just that the container is healthy.
       #
       # On 2026-08-03 an observability deploy started Grafana with an empty

--- a/scripts/checks/check_checks_are_wired.py
+++ b/scripts/checks/check_checks_are_wired.py
@@ -100,7 +100,6 @@ TEST_SOURCES = ("bats", "pytest")
 # an acknowledgment of a known gap, not a decision that it is acceptable
 # forever.
 ALLOWLIST: dict[str, str] = {
-    "check_vault_covers_compose.py": "test-only, found by h#736 — tracked in h#758",
     "realm-tenant-serves-test.sh": "test-only, found by h#736 — tracked in h#758",
     "tenant-login-local-test.sh": "test-only, found by h#736 — tracked in h#758",
 }

--- a/scripts/checks/check_silent_success.py
+++ b/scripts/checks/check_silent_success.py
@@ -88,6 +88,12 @@ ALLOWLIST_B = {
         "deploy that did not happen proves nothing. Matched on the word "
         "'Prove'."
     ),
+    ("reusable-deploy-service.yml", "Prove vault carries every secret the compose files need"): (
+        "a VERIFICATION, not a cleanup — same reasoning as the other four "
+        "'Prove ...' entries above (h#758 6/8). success() is correct: "
+        "verifying a deploy that did not happen proves nothing. Matched on "
+        "the word 'Prove'."
+    ),
 }
 
 CLEANUP_WORDS = re.compile(

--- a/tests/scripts/vault-covers-compose-control.bats
+++ b/tests/scripts/vault-covers-compose-control.bats
@@ -101,3 +101,20 @@ PY
   run bash -c "python3 '$CHECK' | grep -c 'pre-up hook'"
   [ "$output" -eq 1 ]
 }
+
+# WIRING, not logic (h#736/h#758): every test above proves the check's LOGIC
+# is correct. None of them prove anything ever RUNS it — before this fix, this
+# check's only caller anywhere was this bats file, exactly the TEST-ONLY
+# outcome h#736 taught check_checks_are_wired.py to catch. UNLIKE checks 1-5/8
+# in this series, this one is genuinely NOT hermetic — it needs `sops -d` on
+# the real store, which ci.yml never sets up and this file's own setup()
+# above SKIPS without. It runs on the VPS during a deploy instead, where
+# /opt/hill90/secrets/keys/keys.txt already exists — the same h#738 shape.
+# This test does NOT require the age key itself; it only greps the workflow
+# file, which is always present in the checkout regardless of setup()'s skip.
+@test "h#758: reusable-deploy-service.yml genuinely invokes this check, not just mentions it" {
+  ROOT="$BATS_TEST_DIRNAME/../.."
+  run grep -n "python3 scripts/checks/check_vault_covers_compose.py" \
+    "$ROOT/.github/workflows/reusable-deploy-service.yml"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## h#758, check 6 of 8: `check_vault_covers_compose.py`

Part of h#758 — the 8 checks h#736's fix found wired only to their own bats/pytest control. Cut fresh from main after #762 (3/8), #764 (4/8) and #765 (5/8) merged.

**What it asserts.** Every SOPS-backed `${VAR}` a prod compose file (or its pre-up hook) interpolates is actually written by `cmd_seed` into a vault path the service declares. This is the check that would have caught the exact 2026-08-03 outage: `secret/observability/grafana` held one key, `deploy.sh`'s vault-first path exports only what vault returns with no SOPS merge underneath, so `GRAFANA_OIDC_CLIENT_SECRET` resolved to the empty string — and the deploy printed `"loaded 1 variables for observability, none empty"`, true and worthless, since "none empty" describes what vault *returned*, not what the service *needed*.

**Is it true right now?** Yes:
```
  ok    auth           needs 5, vault carries 5
  ok    db             needs 2, vault carries 2
  ok    infra          needs 2, vault carries 2
  skip  minio          declares no vault paths -> SOPS path, which has all keys
  ....  observability  pre-up hook render-alertmanager-config.sh reads SMTP_PASSWORD
  ok    observability  needs 3, vault carries 3

PASS — every SOPS-backed compose variable is carried by a declared vault path
```

**Where it can run — a genuine design question this time, unlike checks 1-5/8.** This one is NOT hermetic: it calls `sops -d` on the real encrypted store to read SOPS key NAMES (never values). `ci.yml` has no age key anywhere at all — confirmed, no `sops`/`SOPS_AGE_KEY` reference exists in it — and the check's own bats control (`vault-covers-compose-control.bats`) already **SKIPs** rather than fails without a key, which is itself proof it cannot run in CI. It **can** run on the VPS: `/opt/hill90/secrets/keys/keys.txt` already exists there for every deploy, and is the check's own second candidate key path (`sops_key_names()`) — no new secret, no new access, the same shape h#738 used for `--live --local`.

**Placement.** Wired into `reusable-deploy-service.yml` as "Prove vault carries every secret the compose files need", placed **after** `Deploy ${{ inputs.service }}`, not before — the checkout it reads from is the one `git reset --hard origin/main` just made current, the same reason "Checkout preflight" earlier in this file stopped running the host's stale copy. Blocking the deploy outright would mean rewriting the deploy step's single SSH command, which is deploy-mechanics work and out of scope here; this detects the outage class immediately after a bad deploy rather than preventing it. Ungated by `inputs.service`, unlike its siblings, since it examines every prod compose file in one pass regardless of which service triggered the run. `success()`, same reasoning as the four existing "Prove ..." steps: verifying a deploy that did not happen proves nothing.

**`check_silent_success.py`.** The new step's name matches `CLEANUP_WORDS` ("Prove"), so it needed its own `ALLOWLIST_B` entry — same reasoning as the four existing "Prove ..." entries (h#738's own precedent). Confirmed clean: B=6 now (was 5), no new PASS-blocking finding.

**Positive control, both directions.** Saved the workflow diff, reverted it, reran this check's full bats file — the new wiring-proof test failed on exactly the predicted assertion (invocation line absent), the 7 pre-existing logic tests stayed green (I have the local age key, so `setup()` did not skip). Reapplied, all 8 passed.

**Full suites, both green:**
```
bats tests/scripts/     593 passed, 0 failed
pytest tests/checks/     81 passed
```

**Bookkeeping, same PR as the wiring.** Removes `check_vault_covers_compose.py`'s own now-stale `ALLOWLIST` entry.

## Test plan
- [x] Check asserts something true about the estate right now
- [x] Established WHERE it can genuinely run (VPS during deploy, not CI — a real design question, documented)
- [x] Wired into `reusable-deploy-service.yml`
- [x] Positive control: revert → new test fails for the predicted reason → restore → passes
- [x] `check_silent_success.py` allowlisted correctly, no new PASS-blocking finding
- [x] Full `bats tests/scripts/` — 593 passed, 0 failed
- [x] Full `pytest tests/checks/` — 81 passed
- [x] Stale `ALLOWLIST` entry removed in the same commit as the wiring

🤖 Generated with [Claude Code](https://claude.com/claude-code)