### PR TITLE
fix(checks): wire realm-tenant-serves-test.sh into ci.yml (h#758 7/8)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,6 +253,26 @@ jobs:
       - name: MinIO readiness regression test
         run: bash scripts/checks/minio-readiness-test.sh
 
+      # h#758 (found by h#736's fix): this script's only caller was
+      # tests/checks/test_realm_tenant_serves.py, a pytest wrapper — and
+      # `pytest tests/checks/` running in CI is still not this SCRIPT being
+      # invoked for real, only the wrapper's own assertions about it (see
+      # check_checks_are_wired.py's docstring on why TEST_SOURCES never
+      # counts). No design question about placement, unlike
+      # check_vault_covers_compose.py (h#758 6/8): this builds and destroys
+      # its OWN throwaway Keycloak container — it never touches a running
+      # stack, the VPS, or any live secret. The only credentials involved are
+      # literal throwaways the script defines itself (see its own argv-ok
+      # comments). It needs only Docker, already used elsewhere in this same
+      # job (promtool above, minio-readiness-test.sh right above this step).
+      # Proves what check_realm_tenant_clients.py (h#758 3/8) cannot: that
+      # file shows platform-realm.json is SHAPED correctly, this shows
+      # Keycloak actually EMITS the claim the app reads —
+      # resource_access.hill90-ui.roles — which depends on built-in client
+      # scopes this repo does not define, so only a real Keycloak can answer.
+      - name: Prove the platform realm actually serves the tenant
+        run: bash scripts/checks/realm-tenant-serves-test.sh
+
       - name: Setup Python
         uses: actions/setup-python@v5
         with:

--- a/scripts/checks/check_checks_are_wired.py
+++ b/scripts/checks/check_checks_are_wired.py
@@ -100,7 +100,6 @@ TEST_SOURCES = ("bats", "pytest")
 # an acknowledgment of a known gap, not a decision that it is acceptable
 # forever.
 ALLOWLIST: dict[str, str] = {
-    "realm-tenant-serves-test.sh": "test-only, found by h#736 — tracked in h#758",
     "tenant-login-local-test.sh": "test-only, found by h#736 — tracked in h#758",
 }
 

--- a/tests/checks/test_realm_tenant_serves.py
+++ b/tests/checks/test_realm_tenant_serves.py
@@ -63,3 +63,19 @@ def test_the_realm_serves_the_tenant(capsys):
         "the platform realm does not serve the tenant correctly:\n"
         f"{result.stdout}\n{result.stderr}"
     )
+
+
+# WIRING, not logic (h#736/h#758): the test above proves the SCRIPT's logic is
+# correct when invoked. It does not prove anything outside this pytest file
+# ever runs it — `pytest tests/checks/` running in CI is still not this
+# script being invoked for real, only this wrapper's own assertions about it
+# (see check_checks_are_wired.py's docstring on why a pytest caller is
+# TEST-ONLY, not REAL). Fully self-contained (builds and destroys its own
+# throwaway Keycloak, no live secret, no VPS), so unlike
+# check_vault_covers_compose.py (h#758 6/8) there was no design question
+# about WHERE it could run: ci.yml, directly, next to
+# minio-readiness-test.sh which needs the same thing (a reachable Docker
+# daemon) and already runs there the same way.
+def test_h758_ci_yml_genuinely_invokes_this_script_directly():
+    ci_yml = (ROOT / ".github/workflows/ci.yml").read_text()
+    assert "run: bash scripts/checks/realm-tenant-serves-test.sh" in ci_yml


### PR DESCRIPTION
## h#758, check 7 of 8: `realm-tenant-serves-test.sh`

Part of h#758 — the 8 checks h#736's fix found wired only to their own bats/pytest control. Cut fresh from main after #766 (6/8) merged.

**What it asserts.** `platform-realm.json` actually SERVES the tenant, not just that the file is shaped correctly. It imports the real realm into a throwaway Keycloak container, assigns a client role, and reads the resulting access token — proving Keycloak actually emits `resource_access.hill90-ui.roles`, which depends on built-in client scopes this repo does not define. `check_realm_tenant_clients.py` (h#758 3/8, #762) shows the FILE is right; only a real Keycloak can show the CLAIM is right.

**Is it true right now?** Yes:
```
All 21 assertions passed against a real Keycloak.
  image   cached, no pull
  start   1s
  ready   25s  (8/60 attempts of a 120s cap)
  asserts 23s  (21 assertions, each one or more docker exec calls)
  total   49s accounted for
```

**Where it can run.** No design question, unlike `check_vault_covers_compose.py` (h#758 6/8, #766). This script builds and destroys its own throwaway Keycloak — it never touches a running stack, the VPS, or any live secret; the only credentials involved are literal throwaways it defines itself (see its own `argv-ok` comments). It needs only Docker, already used elsewhere in the same `ci.yml` job (promtool, `minio-readiness-test.sh` right above this step). Wired directly into `ci.yml` next to `minio-readiness-test.sh`.

Its only prior caller was `tests/checks/test_realm_tenant_serves.py`, a pytest wrapper — `pytest tests/checks/` running in CI is still not this SCRIPT being invoked for real, only the wrapper's own assertions about it, the same TEST-ONLY distinction as every other check in this series.

**Positive control, both directions.** Reverted `ci.yml`, the new wiring-proof pytest test failed on exactly the predicted assertion (invocation line absent), the other 2 tests in the file were unaffected. Reapplied, it passed.

**`check_silent_success.py`.** Clean, no new finding. Unlike #766, this step carries no `if:` condition at all, so shape B's scan doesn't even consider it — no `ALLOWLIST_B` entry needed.

**Full suites, both green:**
```
bats tests/scripts/     593 passed, 0 failed
pytest tests/checks/     82 passed
```

**Bookkeeping, same PR as the wiring.** Removes `realm-tenant-serves-test.sh`'s own now-stale `ALLOWLIST` entry. Only `tenant-login-local-test.sh` (h#758 8/8) remains.

## Test plan
- [x] Check asserts something true about the estate right now
- [x] Established WHERE it can genuinely run — no design question this time, unlike 6/8
- [x] Wired directly into `ci.yml`
- [x] Positive control: revert → new test fails for the predicted reason → restore → passes
- [x] `check_silent_success.py` shows no new finding (no `if:` on the new step)
- [x] Full `bats tests/scripts/` — 593 passed, 0 failed
- [x] Full `pytest tests/checks/` — 82 passed
- [x] Stale `ALLOWLIST` entry removed in the same commit as the wiring

🤖 Generated with [Claude Code](https://claude.com/claude-code)