### PR TITLE
docs(checks): file tenant-login-local-test.sh as unreachable, not wired (h#758 8/8)

### DIFF
--- a/scripts/checks/check_checks_are_wired.py
+++ b/scripts/checks/check_checks_are_wired.py
@@ -100,7 +100,57 @@ TEST_SOURCES = ("bats", "pytest")
 # an acknowledgment of a known gap, not a decision that it is acceptable
 # forever.
 ALLOWLIST: dict[str, str] = {
-    "tenant-login-local-test.sh": "test-only, found by h#736 — tracked in h#758",
+    # h#758 8/8, closed as FILED rather than wired — the only one of the eight
+    # that did not end in a real caller. It needs a RUNNING LOCAL PLATFORM
+    # STACK (docker inspect on a Keycloak container named from
+    # $CONTAINER_PREFIX, plus .env.local for host/port/secret config) — its
+    # own pytest wrapper's docstring already said so before this entry was
+    # written: "the only check in the suite that needs a RUNNING local
+    # platform stack, so it skips rather than fails when there isn't one —
+    # including in CI... Run it locally after `bash scripts/local.sh up`."
+    # Verified directly: the property IS true right now, run against a real
+    # local stack (all 9 assertions passed) — this is not a stale check, just
+    # one CI structurally cannot reach.
+    #
+    # Checked against all three places h#758 asks a check to run before
+    # calling it unreachable:
+    #   CI (ci.yml)      — no local platform stack exists on a GitHub-hosted
+    #                       runner, and none of the other 7 checks in this
+    #                       series needed one; realm-tenant-serves-test.sh
+    #                       (h#758 7/8) proves Keycloak emits the same claim
+    #                       without needing this stack, by building its own
+    #                       throwaway Keycloak instead of a full local.sh
+    #                       stack.
+    #   VPS deploy step   — reusable-deploy-service.yml deploys PRODUCTION;
+    #                       this script tests the LOCAL platform, a different
+    #                       Keycloak instance with different container names,
+    #                       hosts and a separate local secrets store
+    #                       (scripts/local.sh's own $LOCAL_VAULT_DIR, kept
+    #                       deliberately isolated from
+    #                       infra/secrets/prod.enc.env — see cmd_sso's
+    #                       comment on that isolation). There is no VPS
+    #                       concept this maps to.
+    #   scheduled workflow — none of the four existing scheduled workflows
+    #                       (audit-hill90-ui-client, deploy-drift,
+    #                       tenant-baseline-agreement, vault-sync-to-sops)
+    #                       stand up an ephemeral local dev stack; all four
+    #                       check the live production estate directly.
+    #                       Building one from scratch — full docker compose
+    #                       orchestration matching compose/local.yml plus
+    #                       overrides, hostname/DNS resolution for
+    #                       $AUTH_HOST.$BASE_DOMAIN, generating a fresh local
+    #                       age key and secrets — is new infrastructure this
+    #                       change does not add, and a decision for Jon, not
+    #                       an agent improvising inside "wire the check."
+    #
+    # If that infrastructure is ever built for another reason, this check
+    # should be the first thing pointed at it.
+    "tenant-login-local-test.sh": (
+        "genuinely cannot run in CI, a VPS deploy step, or any existing "
+        "scheduled workflow — needs a full local platform stack with no "
+        "current home in this pipeline. See the block comment above this "
+        "entry. Filed, not wired: h#758 8/8."
+    ),
 }
 
 


### PR DESCRIPTION
## h#758, check 8 of 8: `tenant-login-local-test.sh` — FILED, not wired

Part of h#758 — the last of the 8 checks h#736's fix found wired only to their own bats/pytest control. This one does not end in a real caller, and that is the honest conclusion rather than a gap.

**What it asserts.** A completed authorization-code login against the LOCAL platform Keycloak, with a refusal control (a role-less user must be denied). Verified true right now — ran it directly against a locally running stack:
```
All 9 assertions passed against the local platform Keycloak.
```

**Where it can run — nowhere in this pipeline, and that is the answer.** Its own pytest wrapper's docstring already said so before this change: *"the only check in the suite that needs a RUNNING local platform stack, so it skips rather than fails when there isn't one — including in CI... Run it locally after `bash scripts/local.sh up`."* A step that skips reports green — wiring it into `ci.yml` would do exactly that on every PR, which is worse than leaving it unwired.

Checked against all three places this series asks a check to run before calling it unreachable:
- **CI** — no local platform stack exists on a GitHub-hosted runner. None of the other 7 checks needed one; `realm-tenant-serves-test.sh` (h#758 7/8, #767) proves the equivalent claim by building its own throwaway Keycloak instead of a full `local.sh` stack.
- **VPS deploy step** — `reusable-deploy-service.yml` deploys PRODUCTION; this script tests the LOCAL platform, a different Keycloak instance with different container names, hosts, and a separate local secrets store (`scripts/local.sh`'s own `$LOCAL_VAULT_DIR`, deliberately isolated from `infra/secrets/prod.enc.env`). There's no VPS concept this maps to.
- **Scheduled workflow** — none of the four existing ones (`audit-hill90-ui-client`, `deploy-drift`, `tenant-baseline-agreement`, `vault-sync-to-sops`) stand up an ephemeral local dev stack; all four check live production directly. Building one from scratch — full compose orchestration matching `compose/local.yml` plus overrides, hostname/DNS resolution, generating a fresh local age key and secrets — is new infrastructure this change does not add, and a decision for Jon to make deliberately, not one to improvise inside "wire the check."

**What this PR does.** Updates the `ALLOWLIST` reason in `check_checks_are_wired.py` from the placeholder `"tracked in h#758"` to a permanent, decided one, with the full reasoning above kept as a block comment so the next reader doesn't have to re-derive it. If that local-stack-in-CI infrastructure is ever built for another reason, this is the first check that should be pointed at it.

**Full suites, both green:**
```
bats tests/scripts/     593 passed, 0 failed
pytest tests/checks/     82 passed
```

**`check_silent_success.py`.** Clean, no new finding — no workflow file touched.

**h#758 is now fully worked**: 7 of 8 checks wired for real (#760, #761, #762, #764, #765, #766, #767), 1 of 8 filed as genuinely unreachable rather than half-wired somewhere it would silently skip.

## Test plan
- [x] Check asserts something true about the estate right now (verified against a real local stack)
- [x] Established there is no place in this pipeline it can genuinely run — all three categories checked and ruled out
- [x] `ALLOWLIST` entry updated with the permanent decision, not the stale "tracked in h#758" placeholder
- [x] Full `bats tests/scripts/` — 593 passed, 0 failed
- [x] Full `pytest tests/checks/` — 82 passed
- [x] `check_silent_success.py` unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)