### PR TITLE
fix(checks): close two vacuous-pass gaps found by the sibling-drift sweep

### DIFF
--- a/scripts/checks/check_root_revoke_fails_closed.py
+++ b/scripts/checks/check_root_revoke_fails_closed.py
@@ -212,6 +212,26 @@ def main() -> int:
     print(f"  workflows that mint a root token: {', '.join(minting) or 'none'}")
     print()
 
+    # `minting` ending up empty is indistinguishable from MINT's invocation
+    # strings no longer matching anything real — vault.sh's regain-root/init
+    # subcommands being renamed or reshaped — and would pass vacuously:
+    # nothing to audit, so `problems` stays empty and this prints PASS having
+    # verified zero workflows. vault-regain-root.yml and vault-init.yml are
+    # known, current root-minting workflows, so a genuinely empty list here
+    # means this check went blind, not that root minting stopped happening.
+    # Same shape as check_vault_covers_compose.py's declared()/required_vars()
+    # guards and check_declared_paths_are_seeded.py's h#730 fix.
+    if not minting:
+        print(
+            "FAIL — no root-minting workflow found at all. Either root minting has "
+            "genuinely been removed from every workflow (update MINT's comment and "
+            "this message if so, deliberately), or MINT no longer matches — a "
+            "renamed or reshaped vault.sh subcommand — which is a broken check, not "
+            "a clean estate.",
+            file=sys.stderr,
+        )
+        return 1
+
     if problems:
         print(f"FAIL — {len(problems)} problem(s):\n")
         for p in problems:

--- a/scripts/checks/check_vault_covers_compose.py
+++ b/scripts/checks/check_vault_covers_compose.py
@@ -98,6 +98,8 @@ def required_vars() -> dict[str, set[str]]:
 def declared() -> dict[str, list[str]]:
     body = COMMON.read_text()
     m = re.search(r"vault_paths_for_service\(\)\s*\{(.*?)\n\}", body, re.S)
+    if not m:
+        sys.exit("could not find vault_paths_for_service() in scripts/_common.sh")
     out: dict[str, list[str]] = {}
     for arm in re.finditer(r"^\s*([a-z0-9_|]+)\)\s*echo\s+\"([^\"]*)\"", m.group(1), re.M):
         service, paths = arm.group(1), arm.group(2).split()
@@ -150,6 +152,26 @@ def main() -> int:
     decl = declared()
     seeded = seeded_keys_by_path()
     required = required_vars()
+
+    # declared()/required_vars() returning empty is indistinguishable from
+    # every case arm in vault_paths_for_service()/vault_required_vars_for_
+    # service() having rotted out of the regex, and would pass vacuously —
+    # every real service reads as "declares no vault paths -> SOPS path,
+    # which has all keys" and gets skipped before ever being compared,
+    # printing PASS having checked nothing. Same guard as the sibling this
+    # check shares its regex with, check_declared_paths_are_seeded.py (h#730),
+    # which was hardened after this exact drift happened for real once.
+    if not decl:
+        print("FAIL — no declared vault paths found at all. The pattern no longer "
+              "matches anything in vault_paths_for_service(), which is a broken "
+              "check, not a clean estate.", file=sys.stderr)
+        return 1
+    if not required:
+        print("FAIL — no required-vars entries found at all. The pattern no longer "
+              "matches anything in vault_required_vars_for_service(), which is a "
+              "broken check, not a clean estate.", file=sys.stderr)
+        return 1
+
     problems: list[str] = []
 
     print("Vault must carry every secret the compose file needs")

--- a/tests/scripts/root-revoke-fails-closed-control.bats
+++ b/tests/scripts/root-revoke-fails-closed-control.bats
@@ -177,3 +177,25 @@ PY
   [ "$status" -eq 0 ]
   [[ "$output" == *"PASS"* ]]
 }
+
+# THE ASSERTION THAT MATTERS: MINT's invocation strings going blind (a renamed
+# or reshaped vault.sh subcommand) must refuse rather than reporting PASS
+# having audited zero workflows. vault-regain-root.yml and vault-init.yml are
+# known, current root-minting workflows — a run that finds none is a check
+# that stopped looking, not an estate that stopped minting root tokens. Same
+# shape as check_vault_covers_compose.py's declared()/required_vars() guards.
+@test "THE ASSERTION THAT MATTERS: no root-minting workflow found at all refuses rather than passing vacuously" {
+  for f in "$CTL"/.github/workflows/*.yml; do
+    sed -i.bak \
+      -e 's/vault\.sh regain-root/vault.sh reclaim-root/g' \
+      -e 's/vault\.sh init/vault.sh bootstrap-root/g' \
+      "$f"
+    rm -f "$f.bak"
+  done
+
+  run python3 "$CHECK"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"FAIL"* ]]
+  [[ "$output" == *"no root-minting workflow found at all"* ]]
+  [[ "$output" != *"PASS"* ]]
+}

--- a/tests/scripts/vault-covers-compose-control.bats
+++ b/tests/scripts/vault-covers-compose-control.bats
@@ -118,3 +118,63 @@ PY
     "$ROOT/.github/workflows/reusable-deploy-service.yml"
   [ "$status" -eq 0 ]
 }
+
+# THE ASSERTION THAT MATTERS: declared() parses the SAME vault_paths_for_
+# service() function, with the identical regex, as check_declared_paths_are_
+# seeded.py's declared_paths() — which was hardened after exactly this drift
+# happened for real (h#730): `echo "..."` becoming `printf '%s' "..."` drops
+# every case arm from the parse while the outer function-body regex still
+# matches, and every real service then reads as "declares no vault paths ->
+# SOPS path, which has all keys" and is skipped before ever being compared —
+# a run that checked zero services printing PASS. This check shared the exact
+# same unguarded regex until this fix; the sibling's own control
+# (declared-paths-seeded-control.bats) exercises the identical mutation.
+@test "THE ASSERTION THAT MATTERS: every case arm losing its echo shape refuses rather than passing vacuously" {
+  python3 - "$CTL/scripts/_common.sh" <<'PY'
+import re, sys
+p = sys.argv[1]
+t = open(p).read()
+m = re.search(r"vault_paths_for_service\(\)\s*\{(.*?)\n\}", t, re.S)
+assert m, "fixture setup broken: could not find the function to mutate"
+body = m.group(1)
+mutated_body = re.sub(r'echo\s+"', 'printf \'%s\' "', body)
+assert mutated_body != body, "mutation did not apply"
+t2 = t[:m.start(1)] + mutated_body + t[m.end(1):]
+open(p, "w").write(t2)
+PY
+
+  run python3 "$CHECK"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"FAIL"* ]]
+  [[ "$output" == *"no declared vault paths found at all"* ]]
+  # Must not be silently indistinguishable from a genuine clean pass, and must
+  # not read as every service legitimately declaring nothing.
+  [[ "$output" != *"PASS"* ]]
+  [[ "$output" != *"declares no vault paths"* ]]
+}
+
+# The other function sharing this shape: vault_required_vars_for_service()
+# going blind must also refuse rather than silently reporting every compose
+# variable as missing from the runtime guard's manifest (a noisy false
+# positive) OR, worse, silently reporting nothing wrong if the under-coverage
+# check happens to short-circuit first.
+@test "vault_required_vars_for_service() losing its echo shape also refuses rather than passing vacuously" {
+  python3 - "$CTL/scripts/_common.sh" <<'PY'
+import re, sys
+p = sys.argv[1]
+t = open(p).read()
+m = re.search(r"vault_required_vars_for_service\(\)\s*\{(.*?)\n\}", t, re.S)
+assert m, "fixture setup broken: could not find the function to mutate"
+body = m.group(1)
+mutated_body = re.sub(r'echo\s+"', 'printf \'%s\' "', body)
+assert mutated_body != body, "mutation did not apply"
+t2 = t[:m.start(1)] + mutated_body + t[m.end(1):]
+open(p, "w").write(t2)
+PY
+
+  run python3 "$CHECK"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"FAIL"* ]]
+  [[ "$output" == *"no required-vars entries found at all"* ]]
+  [[ "$output" != *"PASS"* ]]
+}


### PR DESCRIPTION
## Sibling-drift sweep: scripts/checks pairs

Companion to hill90-app's SSE/CLI silent-success sweep — same family, this repo's own `scripts/checks/` compared sibling-to-sibling instead of symptom-to-symptom.

**`check_vault_covers_compose.py`'s `declared()`** parses the exact same `vault_paths_for_service()` function, with the identical regex, as `check_declared_paths_are_seeded.py`'s `declared_paths()` — which was hardened after this exact drift happened for real once (h#730): `echo "..."` becoming `printf '%s' "..."` drops every case arm from the parse while the outer function-body regex still matches, so every real service reads as *"declares no vault paths -> SOPS path, which has all keys"* and is skipped before ever being compared. A run that checked zero services printed PASS. This check shared the exact same unguarded regex until now; `required_vars()` (`vault_required_vars_for_service()`) had the missing-function guard but not the empty-result one either.

**`check_root_revoke_fails_closed.py`** had the same shape one level up: `if not files: return 1` covers zero workflow *files*, but a `minting` list ending up empty (`MINT`'s invocation strings no longer matching anything real — a renamed or reshaped `vault.sh` subcommand) skipped the whole audit loop and printed *"PASS — every root-minting workflow revokes and verifies on failure"* having verified zero workflows. `vault-regain-root.yml` and `vault-init.yml` are known, current root-minting workflows, so an empty list means the check went blind, not that root minting stopped.

**Neither gap is currently live** — both checks report correctly against the real estate right now, verified directly before and after this fix. This closes the *resilience* gap: what happens the next time either regex-parsed function's shape drifts, the same way it already has once.

**Positive-controlled, both directions, both checks**: reused the exact h#730 mutation (echo → printf, dropping every case arm) for `check_vault_covers_compose.py`'s two functions, and a renamed-subcommand mutation for `check_root_revoke_fails_closed.py`'s `MINT` strings. Reverted each source fix, confirmed the new bats test fails for exactly the predicted reason, reapplied, confirmed green.

**Full suites, both green:**
```
bats tests/scripts/    596 passed, 0 failed
pytest tests/checks/    82 passed in 154.86s
```

**Reporting-only**: neither fix changes what any deploy or workflow *does* — only what these two static checks report when their own parsing assumptions eventually drift.

## Test plan
- [x] Both checks still pass correctly against the real estate right now
- [x] Positive control: revert → new test fails for the predicted reason → restore → passes (both checks)
- [x] Full `bats tests/scripts/` — 596 passed, 0 failed
- [x] Full `pytest tests/checks/` — 82 passed
- [x] No production/deploy behavior touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)