### PR TITLE
fix(workflows): scheduled-workflow guard drift — ConnectTimeout + preflight secrets

### DIFF
--- a/.github/workflows/audit-hill90-ui-client.yml
+++ b/.github/workflows/audit-hill90-ui-client.yml
@@ -72,6 +72,30 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      # Same guard as deploy-drift.yml's — added by the sibling-drift sweep
+      # that found this workflow, tenant-baseline-agreement.yml and
+      # vault-sync-to-sops.yml using the identical four secrets for the
+      # identical purpose without it. Without this, a missing/blank secret
+      # surfaces later as a confusing Tailscale or SSH auth failure instead of
+      # a clear "cannot run" — the same CANNOT-DETERMINE-vs-clean-failure
+      # distinction this repo's own scripts/checks/*.py already take care
+      # over. Pure early-exit: never touches the VPS.
+      - name: Preflight — required secrets are present
+        env:
+          TS_OAUTH_CLIENT_ID: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          TS_OAUTH_SECRET: ${{ secrets.TS_OAUTH_SECRET }}
+          VPS_SSH_PRIVATE_KEY: ${{ secrets.VPS_SSH_PRIVATE_KEY }}
+          SOPS_AGE_KEY: ${{ secrets.SOPS_AGE_KEY }}
+        run: |
+          missing=()
+          for name in TS_OAUTH_CLIENT_ID TS_OAUTH_SECRET VPS_SSH_PRIVATE_KEY SOPS_AGE_KEY; do
+            [ -n "${!name}" ] || missing+=("$name")
+          done
+          if [ ${#missing[@]} -ne 0 ]; then
+            echo "::error::hill90-ui secret agreement audit cannot run: missing secret(s) ${missing[*]}. This is not a pass — nothing was compared."
+            exit 1
+          fi
+
       - name: Setup Tailscale
         uses: tailscale/github-action@v2
         with:

--- a/.github/workflows/tenant-baseline-agreement.yml
+++ b/.github/workflows/tenant-baseline-agreement.yml
@@ -80,6 +80,35 @@ jobs:
       # workflows extending existing VPS access, one gaining it from
       # scratch — was checked file-by-file before building this, not
       # assumed uniform across all four.
+      # Added by the sibling-drift sweep, which found the other three
+      # scheduled workflows guarding these same four secrets before use and
+      # this one not. Placed HERE, not before "Compare the two lists" like
+      # its siblings' guards precede their primary check: this job's actual
+      # comparison needs none of these four secrets at all — only the
+      # heartbeat below does, per the comment at the top of this job — so an
+      # unconditional preflight up front would block a check that does not
+      # need it. `if: always()`, matching every other step in this VPS-access
+      # block, so a missing secret is still caught (and fails the job
+      # loudly, distinct from a real baseline disagreement, which already
+      # failed the earlier step) even when the comparison itself has already
+      # succeeded or failed on its own terms.
+      - name: Preflight — required secrets are present, for the heartbeat below
+        if: always()
+        env:
+          TS_OAUTH_CLIENT_ID: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          TS_OAUTH_SECRET: ${{ secrets.TS_OAUTH_SECRET }}
+          VPS_SSH_PRIVATE_KEY: ${{ secrets.VPS_SSH_PRIVATE_KEY }}
+          SOPS_AGE_KEY: ${{ secrets.SOPS_AGE_KEY }}
+        run: |
+          missing=()
+          for name in TS_OAUTH_CLIENT_ID TS_OAUTH_SECRET VPS_SSH_PRIVATE_KEY SOPS_AGE_KEY; do
+            [ -n "${!name}" ] || missing+=("$name")
+          done
+          if [ ${#missing[@]} -ne 0 ]; then
+            echo "::error::Scheduled-workflow heartbeat cannot run: missing secret(s) ${missing[*]}. The baseline comparison above is unaffected; this is the dead-man's-switch metric failing to record, not the comparison."
+            exit 1
+          fi
+
       - name: Setup Tailscale
         if: always()
         uses: tailscale/github-action@v2

--- a/.github/workflows/vault-sync-to-sops.yml
+++ b/.github/workflows/vault-sync-to-sops.yml
@@ -35,6 +35,28 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      # Same guard as deploy-drift.yml's — added by the sibling-drift sweep
+      # that found this workflow, audit-hill90-ui-client.yml and
+      # tenant-baseline-agreement.yml using the identical four secrets
+      # without it. Unlike tenant-baseline-agreement.yml, this job's entire
+      # purpose depends on VPS/vault access from the start, so this belongs
+      # up front like its other two siblings, not scoped to a later step.
+      - name: Preflight — required secrets are present
+        env:
+          TS_OAUTH_CLIENT_ID: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          TS_OAUTH_SECRET: ${{ secrets.TS_OAUTH_SECRET }}
+          VPS_SSH_PRIVATE_KEY: ${{ secrets.VPS_SSH_PRIVATE_KEY }}
+          SOPS_AGE_KEY: ${{ secrets.SOPS_AGE_KEY }}
+        run: |
+          missing=()
+          for name in TS_OAUTH_CLIENT_ID TS_OAUTH_SECRET VPS_SSH_PRIVATE_KEY SOPS_AGE_KEY; do
+            [ -n "${!name}" ] || missing+=("$name")
+          done
+          if [ ${#missing[@]} -ne 0 ]; then
+            echo "::error::Vault-to-SOPS sync cannot run: missing secret(s) ${missing[*]}. This is not a pass — nothing was synced."
+            exit 1
+          fi
+
       - name: Setup Tailscale
         uses: tailscale/github-action@v2
         with:
@@ -75,7 +97,7 @@ jobs:
 
       - name: Verify SSH connectivity
         run: |
-          ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no -o ConnectTimeout=10 \
+          ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no -o ConnectTimeout=15 \
             deploy@${{ steps.get-ip.outputs.tailscale_ip }} 'echo "SSH connection successful"'
 
       # h#711: replaces the old "Read sync token from SOPS" step.
@@ -107,7 +129,7 @@ jobs:
       - name: Check script drift
         run: |
           LOCAL_HASH=$(sha256sum scripts/vault.sh | cut -d' ' -f1)
-          REMOTE_HASH=$(ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
+          REMOTE_HASH=$(ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no -o ConnectTimeout=15 \
             deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
             'sha256sum /opt/hill90/app/scripts/vault.sh | cut -d" " -f1')
           if [ "$LOCAL_HASH" != "$REMOTE_HASH" ]; then
@@ -117,7 +139,7 @@ jobs:
       - name: Hash SOPS before sync
         id: before
         run: |
-          BEFORE_HASH=$(ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
+          BEFORE_HASH=$(ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no -o ConnectTimeout=15 \
             deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
             'export SOPS_AGE_KEY_FILE=/opt/hill90/secrets/keys/keys.txt && sops -d /opt/hill90/app/infra/secrets/prod.enc.env | sha256sum | cut -d" " -f1')
           echo "hash=$BEFORE_HASH" >> $GITHUB_OUTPUT
@@ -142,7 +164,7 @@ jobs:
           # same reason: interpolated into the ssh/docker-exec command line,
           # they'd sit in `ps -Ao args` on the VPS, visible to any local
           # user there, regardless of Actions log masking.
-          TOKEN=$(printf '%s\n%s' "$ROLE_ID" "$SECRET_ID" | ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
+          TOKEN=$(printf '%s\n%s' "$ROLE_ID" "$SECRET_ID" | ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no -o ConnectTimeout=15 \
             deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
             'read -r ROLE_ID; read -r SECRET_ID; export ROLE_ID SECRET_ID; \
              docker exec -e BAO_ADDR=http://127.0.0.1:8200 -e ROLE_ID -e SECRET_ID openbao \
@@ -162,7 +184,7 @@ jobs:
           SYNC_TOKEN: ${{ steps.approle-login.outputs.token }}
         run: |
           # Same reasoning as the login step: stdin, not argv.
-          printf '%s' "$SYNC_TOKEN" | ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
+          printf '%s' "$SYNC_TOKEN" | ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no -o ConnectTimeout=15 \
             deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
             'read -r BAO_TOKEN; export BAO_TOKEN; \
              export SOPS_AGE_KEY_FILE=/opt/hill90/secrets/keys/keys.txt; \
@@ -171,7 +193,7 @@ jobs:
       - name: Hash SOPS after sync
         id: after
         run: |
-          AFTER_HASH=$(ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
+          AFTER_HASH=$(ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no -o ConnectTimeout=15 \
             deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
             'export SOPS_AGE_KEY_FILE=/opt/hill90/secrets/keys/keys.txt && sops -d /opt/hill90/app/infra/secrets/prod.enc.env | sha256sum | cut -d" " -f1')
           echo "hash=$AFTER_HASH" >> $GITHUB_OUTPUT
@@ -190,14 +212,14 @@ jobs:
       - name: Copy updated SOPS from VPS
         if: steps.compare.outputs.changed == 'true'
         run: |
-          scp -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
+          scp -i ~/.ssh/vps_key -o StrictHostKeyChecking=no -o ConnectTimeout=15 \
             deploy@${{ steps.get-ip.outputs.tailscale_ip }}:/opt/hill90/app/infra/secrets/prod.enc.env \
             infra/secrets/prod.enc.env
 
       - name: Cleanup VPS
         if: always()
         run: |
-          ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no \
+          ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no -o ConnectTimeout=15 \
             deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
             "cd /opt/hill90/app && \
              git checkout -- infra/secrets/prod.enc.env && \


### PR DESCRIPTION
## Sibling-drift sweep: the four scheduled workflows

Companion to hill90-app's silent-success sweep — compared the four scheduled GitHub Actions workflows against each other (structurally similar jobs, natural place for one to have a guard its siblings lack).

**ConnectTimeout.** 7 of `vault-sync-to-sops.yml`'s 9 SSH/SCP calls had no timeout at all, and the 8th used `ConnectTimeout=10` while every other call across all four scheduled workflows uses `15`. Doesn't change what a successful run does — only how long a genuinely unreachable VPS takes to fail loudly instead of hanging on OS-default TCP timeouts, which run far longer, especially for a silently-dropping-packets failure mode. Normalized all 9 calls to `15`.

**Preflight secrets guard.** `deploy-drift.yml` already refuses to run with a clear `::error::` when any of `TS_OAUTH_CLIENT_ID`/`TS_OAUTH_SECRET`/`VPS_SSH_PRIVATE_KEY`/`SOPS_AGE_KEY` is missing, rather than failing confusingly deep inside Tailscale/SSH auth. The other three used the identical four secrets for the identical purpose without it.

- `audit-hill90-ui-client.yml` and `vault-sync-to-sops.yml`: guard added up front, right after checkout — same placement as `deploy-drift.yml`, since both jobs' entire purpose depends on VPS/vault access from the start.
- `tenant-baseline-agreement.yml` is **not** symmetric with its three siblings, and the guard is placed differently on purpose: its actual comparison (`check_tenant_baseline_agrees.py`) needs none of the four secrets at all — only the heartbeat dead-man's-switch metric after it does, per that job's own existing comment. An unconditional preflight before the comparison would have blocked a check that doesn't need these secrets. Placed instead right before the heartbeat's `Setup Tailscale` step, gated `if: always()` to match every other step in that block, so a missing secret still fails loudly (distinct from a real baseline disagreement, which already failed the earlier step) without gating the comparison this job actually exists to run.

Pure early-exit in all three cases — never touches the VPS, so success paths are unaffected.

**`check_silent_success.py`**: clean, no new finding — none of the new step names match `CLEANUP_WORDS`.

**Full suites, both green:**
```
bats tests/scripts/    593 passed, 0 failed
pytest tests/checks/    82 passed
```

## Test plan
- [x] All three files' YAML validated
- [x] `check_silent_success.py` shows no new finding
- [x] Full `bats tests/scripts/` — 593 passed, 0 failed
- [x] Full `pytest tests/checks/` — 82 passed
- [x] No production/deploy behavior touched — pure reporting/timeout additions

🤖 Generated with [Claude Code](https://claude.com/claude-code)