### PR TITLE
fix(local): cmd_health had no MinIO check at all

### DIFF
--- a/scripts/local.sh
+++ b/scripts/local.sh
@@ -666,6 +666,32 @@ cmd_health() {
     check_http "Keycloak platform realm (OIDC discovery)" \
         "$(base_url "$(env_get AUTH_HOST auth)")/realms/${KC_PLATFORM_REALM:-platform}/.well-known/openid-configuration" 200 || failed=1
 
+    # h#758-sibling-drift sweep: this had NO MinIO check anywhere — not here,
+    # not in the routed-surfaces list above (Traefik/Portainer/Grafana/
+    # Prometheus only), not in the generic container-health-wait loop (which
+    # only watches EDGE_PROJECT/OBS_PROJECT labels, neither of which cover
+    # MinIO). `local.sh up && local.sh health` could print "All local checks
+    # passed" with MinIO broken or its credentials wrong. deploy.sh already
+    # checks this in production via `minio.sh status`
+    # (MINIO_READY_TIMEOUT=5 MINIO_READY_INTERVAL=1, in cmd_verify) — this
+    # runs the SAME script with the SAME env-override pattern cmd_up already
+    # uses for `minio.sh apply` a few lines above, so it is a rehearsal of the
+    # real command, not a simulation of one.
+    if docker inspect "${cp}minio" >/dev/null 2>&1; then
+        if MINIO_CONTAINER="${cp}minio" \
+           MINIO_SECRETS_FILE="$LOCAL_VAULT_DIR/local.enc.env" \
+           SOPS_AGE_KEY_FILE="$LOCAL_VAULT_DIR/age.key" \
+           MINIO_ROOT_USER="$(env_get MINIO_ROOT_USER "")" \
+           MINIO_ROOT_PASSWORD="$(env_get MINIO_ROOT_PASSWORD "")" \
+           MINIO_READY_TIMEOUT=5 MINIO_READY_INTERVAL=1 \
+               bash "$SCRIPT_DIR/minio.sh" status >/dev/null 2>&1; then
+            echo "  ${GREEN}✓${NC} MinIO responding, admin credentials valid"
+        else
+            echo "  ${RED}✗${NC} MinIO not responding or admin credentials invalid — 'bash scripts/minio.sh status' for detail"
+            failed=1
+        fi
+    fi
+
     echo ""
     if [ "$failed" -eq 0 ]; then
         success "All local checks passed."


### PR DESCRIPTION
## Sibling-drift sweep: scripts/deploy.sh vs scripts/local.sh

`deploy.sh` checks MinIO in production via `minio.sh status` (`MINIO_READY_TIMEOUT=5 MINIO_READY_INTERVAL=1`, in `cmd_verify`, run after every minio deploy). `local.sh`'s `cmd_health` had no equivalent anywhere — absent from the routed-surfaces probe list, the observability-internals block, the platform-services block, and the generic container-health-wait loop (which only watches `EDGE_PROJECT`/`OBS_PROJECT` labels, neither of which cover MinIO). `local.sh up && local.sh health` could print *"All local checks passed"* while MinIO was broken or its admin credentials wrong.

**Fix.** Added a MinIO check to `cmd_health` running the *same* script (`minio.sh status`) with the *same* env-override pattern `cmd_up` already uses a few lines above for `minio.sh apply` — `MINIO_CONTAINER`, `MINIO_SECRETS_FILE`, `SOPS_AGE_KEY_FILE` pointed at local's own vault directory, `MINIO_ROOT_USER`/`PASSWORD` from `.env.local`. A rehearsal of the real command, not a new one invented for this.

**Verified against a real running local stack** (`hill90dev-` prefix, already up), not mocked:
```
✓ MinIO responding, admin credentials valid
✓ All local checks passed.
```

**Positive-controlled both directions**: `docker stop hill90dev-minio` turned the same command red —
```
✗ MinIO not responding or admin credentials invalid — 'bash scripts/minio.sh status' for detail
! Some checks failed. 'bash scripts/local.sh logs' for detail.
```
`docker start hill90dev-minio` restored it to green.

No bats test added — `cmd_health` is inherently a live-stack integration command with no existing test harness (confirmed: no bats file references it), and direct verification against the real stack is stronger evidence than a mock would be here.

`shellcheck --severity=error`: clean. Full bats suite: 596 passed, 0 failed (unrelated to this change, confirms no regression).

**Local-only** — does not touch `deploy.sh` or anything that ships to production.

## Test plan
- [x] Verified against a real running local stack, both directions (stop → red, start → green)
- [x] `shellcheck --severity=error` clean
- [x] Full `bats tests/scripts/` — 596 passed, 0 failed
- [x] No production/deploy behavior touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)