### PR TITLE
fix(scripts): docker network create's exit status, explicitly checked

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -277,12 +277,24 @@ cmd_infra() {
 
     # Create internal networks if not present (edge compose creates hill90_edge;
     # internal networks are needed by app services but not by edge services)
+    #
+    # Sibling-drift sweep: this repo's own set -e already aborts the script if
+    # docker network create fails here — verified directly, not assumed: a
+    # forced failure never reaches the echo below and preserves docker's own
+    # exit code. So this was never a silent-success bug in practice, but it
+    # relied on that entirely on an implicit bash abort with docker's own raw
+    # error text, rather than a legible message naming what failed — and the
+    # identical code in local.sh has no such backstop (see that fix). Made
+    # explicit here too, for the same reason a check should not depend on an
+    # interpreter flag staying set three refactors from now.
     if ! docker network inspect hill90_internal >/dev/null 2>&1; then
-        docker network create --driver bridge --internal hill90_internal
+        docker network create --driver bridge --internal hill90_internal \
+            || die "Failed to create hill90_internal network"
         echo "✓ Created hill90_internal network for app services"
     fi
     if ! docker network inspect hill90_agent_internal >/dev/null 2>&1; then
-        docker network create --driver bridge --internal hill90_agent_internal
+        docker network create --driver bridge --internal hill90_agent_internal \
+            || die "Failed to create hill90_agent_internal network"
         echo "✓ Created hill90_agent_internal network for agent containers"
     fi
 

--- a/scripts/local.sh
+++ b/scripts/local.sh
@@ -284,7 +284,17 @@ cmd_up() {
     local netpfx; netpfx=$(env_get NETWORK_PREFIX hill90dev)
     for net in internal agent_internal; do
         if ! docker network inspect "${netpfx}_${net}" >/dev/null 2>&1; then
-            docker network create --driver bridge --internal "${netpfx}_${net}" >/dev/null
+            # Sibling-drift sweep: deploy.sh's identical block is protected
+            # by that script's own set -e (verified directly: a forced
+            # failure there never reaches its echo). This script has no
+            # set -e — only set -uo pipefail — so the same bare command here
+            # genuinely reported success unconditionally on a failed create.
+            # Explicit die() closes it without retrofitting set -e onto the
+            # whole 800-line script, which risks changing behavior on some
+            # other line that currently relies on continuing past a soft
+            # failure (see the held decision on set -e).
+            docker network create --driver bridge --internal "${netpfx}_${net}" >/dev/null \
+                || die "Failed to create ${netpfx}_${net} network"
             success "Created ${netpfx}_${net}"
         fi
     done


### PR DESCRIPTION
## Sibling-drift sweep: scripts/deploy.sh vs scripts/local.sh

Both scripts ran \`docker network create\` as a bare statement with no exit-status check, printing a hardcoded success line unconditionally afterward.

**Corrected from the initial sweep report for \`deploy.sh\` specifically**, after verifying rather than assuming: this script has \`set -e\` at the top, and a forced-failure test confirms it already aborts the script the instant \`docker network create\` fails — the echo never runs, docker's own exit code propagates. So this was **not** a live silent-success bug in \`deploy.sh\`; it relied entirely on that interpreter flag staying set, with docker's own raw error text standing in for a legible message. Made explicit anyway (\`|| die \"...\"\`), so it doesn't depend on an interpreter flag surviving three future refactors, and to match \`local.sh\`'s fix with the same shape rather than leaving one silent and one explicit for the identical operation.

\`local.sh\` has **no** \`set -e\` (only \`set -uo pipefail\`), and this loop's bare \`docker network create\` genuinely printed \`"Created \${netpfx}_\${net}"\` unconditionally regardless of whether the create succeeded. Fixed with the same explicit \`|| die\` \`local.sh\`'s own \`cmd_sso\`/\`cmd_vault\` already use for every other risky call in this script.

**Positive-controlled**: a forced-failure harness (\`docker()\` stubbed to fail on \`network create\`) confirms both fixed scripts now stop with a clear \"Failed to create ... network\" message and non-zero exit, and confirms the **unfixed** \`local.sh\` code reaches its end with exit 0 having silently reported success on the identical simulated failure.

Not retrofitting \`set -e\` onto all of \`local.sh\` here — that's a separate, larger decision, and this fix doesn't depend on it.

**Full suites, both green:**
\`\`\`
bats tests/scripts/    596 passed, 0 failed
pytest tests/checks/    82 passed
\`\`\`

\`shellcheck --severity=error\`: clean on both files.

## Test plan
- [x] Verified empirically whether \`set -e\` already caught this in \`deploy.sh\` — it does; framing corrected accordingly rather than reporting a false positive
- [x] Positive control: forced-failure harness confirms both fixes stop cleanly; confirms pre-fix \`local.sh\` silently "succeeds"
- [x] Full \`bats tests/scripts/\` — 596 passed, 0 failed
- [x] Full \`pytest tests/checks/\` — 82 passed
- [x] \`shellcheck --severity=error\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)