### PR TITLE
fix(deploy): make a manual deploy target the service that was asked for

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,12 @@ jobs:
       - name: Assert CLAUDE.md's alert counts match the rules that ship
         run: python3 scripts/checks/check_alert_counts_documented.py
 
+      # `-f service=auth` deployed all five services, because on a
+      # workflow_dispatch paths-filter falls back to a parentless last commit
+      # and reports the whole repo as changed. Hermetic — reads deploy.yml.
+      - name: Assert a manual deploy targets one service
+        run: python3 scripts/checks/check_dispatch_targets_one_service.py
+
       - name: Install bats
         run: |
           sudo apt-get update

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,8 +40,22 @@ jobs:
       observability: ${{ steps.filter.outputs.observability }}
     steps:
       - uses: actions/checkout@v4
+      # Change detection is for `push` only. On a workflow_dispatch the event
+      # payload carries no `before`, so paths-filter falls back to "changes in
+      # the last commit" — and actions/checkout's default `fetch-depth: 1`
+      # leaves that commit parentless, so `git log --name-status -n 1` lists
+      # the ENTIRE repository as added. Run 31040415190 detected "272 changed
+      # files" and set all five filters true, which is why `-f service=auth`
+      # deployed all five services and restarted Keycloak underneath the
+      # observability job's login check.
+      #
+      # Skipping the step leaves every output empty, so the `== 'true'` arms
+      # below are all false and only the explicit `inputs.service` arms decide.
+      # Deepening the checkout would NOT fix this: the fallback is triggered by
+      # the missing `before` field, not by the clone depth.
       - uses: dorny/paths-filter@v3
         id: filter
+        if: github.event_name != 'workflow_dispatch'
         with:
           filters: |
             db:

--- a/scripts/checks/check_dispatch_targets_one_service.py
+++ b/scripts/checks/check_dispatch_targets_one_service.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""A manual deploy must deploy the service that was asked for, and no other.
+
+THE DEFECT (run 31040415190, 2026-08-05). `deploy.yml` decides what to deploy
+from two independent sources OR'd together: dorny/paths-filter output, and the
+`service` workflow_dispatch input. On a dispatch the first source is not merely
+unhelpful, it is actively wrong — the event payload has no `before` field, so
+paths-filter falls back to "changes in the last commit", and actions/checkout's
+default `fetch-depth: 1` leaves that commit with no parent. `git log
+--name-status -n 1` against a parentless commit reports the whole repository as
+added: "Detected 272 changed files", all five filters true.
+
+The visible consequence was not a red job. `-f service=auth` deployed all five
+services, and the Keycloak restart it caused landed underneath the concurrently
+running observability job's Grafana login check, which failed on a login form
+Keycloak was momentarily not serving. An operator asking for one service got the
+estate, and the report blamed the wrong service.
+
+WHAT THIS ASSERTS, and deliberately not more: that the change-detection step is
+gated so it cannot run on a workflow_dispatch. It does not simulate a dispatch —
+that needs GitHub — so the runtime proof is a real dispatch of one service with
+only that service's job running — recorded on the PR that added this check.
+
+Hermetic: reads the workflow file, no network, no host. Runs in ci.yml.
+
+Exit 0 PASS, 1 FAIL, 2 CANNOT DETERMINE — the last so that a rename of the step
+reports blindness rather than a clean run over nothing found.
+"""
+import re
+import sys
+from pathlib import Path
+
+WORKFLOW = Path(__file__).resolve().parents[2] / ".github" / "workflows" / "deploy.yml"
+
+
+def main() -> int:
+    if not WORKFLOW.exists():
+        print(f"CANNOT DETERMINE — {WORKFLOW} does not exist")
+        return 2
+
+    text = WORKFLOW.read_text()
+
+    # Find the paths-filter step and take the block up to the next step marker.
+    start = text.find("- uses: dorny/paths-filter")
+    if start == -1:
+        print(
+            "CANNOT DETERMINE — no dorny/paths-filter step in deploy.yml. Either "
+            "change detection was replaced (in which case re-point this check at "
+            "whatever replaced it) or it was removed. Not asserting a pass over a "
+            "step that is not there."
+        )
+        return 2
+
+    rest = text[start + 1 :]
+    end = rest.find("\n      - ")
+    block = rest[: end if end != -1 else len(rest)]
+
+    if "workflow_dispatch" not in block or not re.search(r"\n\s+if:", block):
+        print("FAIL — the change-detection step is not gated against workflow_dispatch.")
+        print()
+        print("  On a dispatch it reports every file in the repository as changed,")
+        print("  so every per-service filter is true and every service deploys —")
+        print("  whatever the `service` input said. The step needs:")
+        print()
+        print("      if: github.event_name != 'workflow_dispatch'")
+        print()
+        print("  Deepening the checkout does not fix it: the fallback is triggered")
+        print("  by the missing `before` field in the payload, not by clone depth.")
+        print()
+        print("  The step as it stands:")
+        for line in block.strip().splitlines()[:6]:
+            print(f"      {line}")
+        return 1
+
+    # A gate that permits dispatch through is worse than none, because it reads
+    # as fixed. Require the sense of the comparison, not just the two words.
+    if not re.search(r"if:\s*github\.event_name\s*!=\s*'workflow_dispatch'", block):
+        print("FAIL — the step has a workflow_dispatch gate, but not one that excludes it.")
+        print()
+        print("  Expected `if: github.event_name != 'workflow_dispatch'`. Found:")
+        for line in block.strip().splitlines()[:6]:
+            print(f"      {line}")
+        return 1
+
+    print("PASS — change detection is gated to non-dispatch events, so a manual")
+    print("       deploy is decided by the `service` input alone.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scripts/dispatch-targets-one-service-control.bats
+++ b/tests/scripts/dispatch-targets-one-service-control.bats
@@ -1,0 +1,103 @@
+#!/usr/bin/env bats
+
+# POSITIVE CONTROL for scripts/checks/check_dispatch_targets_one_service.py.
+#
+# The check reads one file and looks for one line, which is exactly the shape
+# that passes forever once the line is deleted. Every test below moves the
+# workflow and REQUIRES red — including the pre-fix text verbatim, so the
+# control is anchored to the defect that actually happened rather than to a
+# rule someone wrote down afterwards.
+
+setup() {
+  ROOT="$BATS_TEST_DIRNAME/../.."
+  CTL="$BATS_TEST_TMPDIR/ctl"
+  mkdir -p "$CTL/scripts/checks" "$CTL/.github/workflows"
+  cp "$ROOT/scripts/checks/check_dispatch_targets_one_service.py" "$CTL/scripts/checks/"
+  cp "$ROOT/.github/workflows/deploy.yml" "$CTL/.github/workflows/"
+  CHECK="$CTL/scripts/checks/check_dispatch_targets_one_service.py"
+  WF="$CTL/.github/workflows/deploy.yml"
+}
+
+@test "CONTROL: passes on the real tree" {
+  run python3 "$CHECK"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"PASS"* ]]
+}
+
+# THE ACTUAL DEFECT, replayed: the step as it stood before this fix, with no
+# `if` at all. Run 31040415190 deployed all five services from `-f service=auth`.
+@test "the pre-fix step — no gate at all — is caught" {
+  python3 - "$WF" <<'PY'
+import re, sys
+p = sys.argv[1]
+t = open(p).read()
+t2 = re.sub(r"(- uses: dorny/paths-filter@v3\n        id: filter\n)        if: [^\n]*\n",
+            r"\1", t, count=1)
+assert t2 != t, "mutation did not apply"
+open(p, "w").write(t2)
+PY
+
+  run python3 "$CHECK"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"not gated against workflow_dispatch"* ]]
+}
+
+# A gate with the comparison the wrong way round runs change detection on
+# dispatch and NOTHING else — worse than the defect, and it reads as fixed.
+@test "an inverted gate is caught, not accepted as 'mentions workflow_dispatch'" {
+  python3 - "$WF" <<'PY'
+import sys
+p = sys.argv[1]
+t = open(p).read()
+t2 = t.replace("if: github.event_name != 'workflow_dispatch'",
+               "if: github.event_name == 'workflow_dispatch'", 1)
+assert t2 != t, "mutation did not apply"
+open(p, "w").write(t2)
+PY
+
+  run python3 "$CHECK"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"not one that excludes it"* ]]
+}
+
+# Gating on the wrong event satisfies a naive "contains workflow_dispatch" test
+# while leaving dispatch fully exposed.
+@test "a gate on some other event is caught" {
+  python3 - "$WF" <<'PY'
+import sys
+p = sys.argv[1]
+t = open(p).read()
+t2 = t.replace("if: github.event_name != 'workflow_dispatch'",
+               "if: github.event_name != 'schedule'", 1)
+assert t2 != t, "mutation did not apply"
+open(p, "w").write(t2)
+PY
+
+  run python3 "$CHECK"
+  [ "$status" -eq 1 ]
+}
+
+# Blindness must not read as health. If the step is renamed away, the check has
+# nothing to measure and has to say so — the 0-inputs-scanned trap.
+@test "a missing paths-filter step is CANNOT DETERMINE, not a pass" {
+  python3 - "$WF" <<'PY'
+import sys
+p = sys.argv[1]
+t = open(p).read()
+t2 = t.replace("dorny/paths-filter", "some-other/change-detector")
+assert t2 != t, "mutation did not apply"
+open(p, "w").write(t2)
+PY
+
+  run python3 "$CHECK"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"CANNOT DETERMINE"* ]]
+}
+
+# WIRING, not logic (h#736/h#758): every test above proves the check's logic.
+# None of them prove anything ever runs it.
+@test "ci.yml genuinely invokes this check, not just mentions it" {
+  run grep -n "run: python3 scripts/checks/check_dispatch_targets_one_service.py" \
+    "$ROOT/.github/workflows/ci.yml"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Plan

`gh workflow run deploy.yml -f service=auth` deployed **all five** services. The `service` input has never selected anything.

`deploy.yml` OR-s two sources per job: `needs.changes.outputs.<svc> == 'true'`, and `github.event.inputs.service`. On a `workflow_dispatch` the first source is not merely unhelpful, it is actively wrong:

- the dispatch payload has no `before` field, so `dorny/paths-filter` warns and falls back to *"changes will be detected from last commit"*;
- `actions/checkout` defaults to `fetch-depth: 1`, so that commit has no parent;
- `git log --format= --no-renames --name-status -z -n 1` against a parentless commit lists the **entire repository** as `[added]`.

From run `31040415190`'s own log:

```
##[warning]'before' field is missing in event payload - changes will be detected from last commit
Detected 272 changed files
##[group]Filter db = true
  deploy/compose/prod/docker-compose.db.yml [added]
##[group]Filter auth = true
  deploy/compose/prod/docker-compose.auth.yml [added]
...
```

**Deepening the checkout does not fix this.** The fallback is triggered by the missing payload field, not by clone depth — `fetch-depth: 0` would still take the last-commit path.

The fix gates change detection to non-dispatch events. A skipped step leaves its outputs empty, so every `== 'true'` arm is false and only the explicit `inputs.service` arms decide. **Push behaviour is byte-for-byte unchanged.**

## Why this surfaced now, and what it cost

Not as a red job in the service anyone was looking at.

h#774 merged and its deploy failed on a git race between concurrent jobs (#778), leaving `db.yml` and `auth.yml` undeployed while `observability.yml` went live — a partial deploy reported as one failed job. Recovering it service by service is what exposed this: `-f service=auth` fanned out to all five, and the Keycloak restart landed underneath the concurrently running observability job's Grafana login check, which failed with `no Keycloak login form in the response`.

That failure was **transient, and verified so rather than assumed** — the same authorize URL serves the form now, fetched by hand rather than by re-running the check:

```
$ curl -o /dev/null -w '%{redirect_url}' https://grafana.hill90.com/login/generic_oauth
https://auth.hill90.com/realms/platform/protocol/openid-connect/auth?...
$ curl "$that" | python3 -c '...re.search(r"<form[^>]*id=\"kc-form-login\"")...'
LOGIN FORM PRESENT
```

So the report named the wrong service, and the operator who asked for one service got the estate. Both of today's deploy failures reduce to *too many jobs touching production at once*; #778 is the other half and is **not** fixed here.

## Risks

- **Genuinely narrow.** One `if:` on one step, plus a check and its control. No job's logic changes; on `push` the filter runs exactly as before.
- **The real risk is the reverse of the defect**: if the gate were inverted or pointed at the wrong event, a dispatch would deploy *nothing* and say nothing. The control requires red on both of those specific mutations, not merely on the absence of a gate.
- This does not touch #778. Until that is fixed, a **push** touching several filtered paths still fans out concurrently and can still race on `/opt/hill90/app`.

## Rollback

Revert the commit. Behaviour returns to "any dispatch deploys everything" — noisy and over-broad, never silent.

## Validation Evidence

Positive control, every arm requiring red, run locally:

```
$ bats tests/scripts/dispatch-targets-one-service-control.bats
1..6
ok 1 CONTROL: passes on the real tree
ok 2 the pre-fix step — no gate at all — is caught
ok 3 an inverted gate is caught, not accepted as 'mentions workflow_dispatch'
ok 4 a gate on some other event is caught
ok 5 a missing paths-filter step is CANNOT DETERMINE, not a pass
ok 6 ci.yml genuinely invokes this check, not just mentions it
```

Test 2 replays the pre-fix step **verbatim** — strips the `if:`, requires exit 1 — so the control is anchored to the defect that actually happened rather than to a rule written afterwards. Test 5 is the 0-inputs-scanned guard: renaming the step away must report blindness, not a clean run over nothing found. Test 6 is the h#736/h#758 wiring assertion.

Check on the real tree, and both workflows still parse:

```
$ python3 scripts/checks/check_dispatch_targets_one_service.py
PASS — change detection is gated to non-dispatch events, so a manual
       deploy is decided by the `service` input alone.

$ python3 -c "import yaml; d=yaml.safe_load(open('.github/workflows/deploy.yml')); print(', '.join(d['jobs']))"
changes, deploy-db, deploy-auth, deploy-minio, deploy-vault, deploy-observability
```

**What this evidence does NOT cover, stated rather than left implied.** The check is static — it reads `deploy.yml`. It cannot simulate a dispatch, because that needs GitHub. The runtime proof is a real single-service dispatch after merge, showing only that service's job running. I will run one and post the job list here. Until that comment exists, treat the runtime behaviour as unproven.

## Estate state throughout

Checked after each of today's deploys; degraded at no point:

```
missing: none  unhealthy:0  restarting:0  tenant:7
  hill90.com 200
  auth.hill90.com/realms/platform 200
```

All five services are now deployed at h#774's HEAD (`a25974e`), which the partial deploy had left half-applied.
