### PR TITLE
fix(deploy): serialise the deploy jobs — two at once broke twice in an hour

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,12 @@ jobs:
       - name: Assert a manual deploy targets one service
         run: python3 scripts/checks/check_dispatch_targets_one_service.py
 
+      # #778: deploy-db and deploy-observability started at the same second and
+      # raced on /opt/hill90/app; an hour later deploy-auth restarted Keycloak
+      # underneath observability's login check. Hermetic — reads deploy.yml.
+      - name: Assert no two deploy jobs can run at once
+        run: python3 scripts/checks/check_deploy_jobs_serialized.py
+
       - name: Install bats
         run: |
           sudo apt-get update

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -104,17 +104,31 @@ jobs:
       service: minio
     secrets: inherit
 
+  # SERIALISED, and this is load-bearing rather than tidiness. Every deploy
+  # job SSHes to the same VPS, works in the same checkout (/opt/hill90/app)
+  # and deploys onto the same running estate. On 2026-08-05 two jobs in
+  # parallel broke twice in an hour: run 31039334078 raced on the git
+  # checkout ("incorrect old value provided") and left a PARTIAL deploy
+  # reported as a single failed job; run 31040415190 restarted Keycloak
+  # underneath the observability job's Grafana login check, which then
+  # blamed the wrong service. See #778.
+  #
+  # deploy-observability is deliberately LAST: its post-deploy checks assert
+  # against the other services, so it must not start until they have settled.
+  #
+  # The cost is real and accepted — a five-service deploy is now serial, not
+  # parallel. scripts/checks/check_deploy_jobs_serialized.py holds the line.
   deploy-vault:
-    needs: [changes]
-    if: needs.changes.outputs.vault == 'true' || github.event.inputs.service == 'all' || github.event.inputs.service == 'vault'
+    needs: [changes, deploy-minio]
+    if: always() && (needs.changes.outputs.vault == 'true' || github.event.inputs.service == 'all' || github.event.inputs.service == 'vault') && !failure() && !cancelled()
     uses: ./.github/workflows/reusable-deploy-service.yml
     with:
       service: vault
     secrets: inherit
 
   deploy-observability:
-    needs: [changes]
-    if: needs.changes.outputs.observability == 'true' || github.event.inputs.service == 'all' || github.event.inputs.service == 'observability'
+    needs: [changes, deploy-vault]
+    if: always() && (needs.changes.outputs.observability == 'true' || github.event.inputs.service == 'all' || github.event.inputs.service == 'observability') && !failure() && !cancelled()
     uses: ./.github/workflows/reusable-deploy-service.yml
     with:
       service: observability

--- a/scripts/checks/check_deploy_jobs_serialized.py
+++ b/scripts/checks/check_deploy_jobs_serialized.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""No two deploy jobs may be able to run at the same time.
+
+THE DEFECT, twice in one hour on 2026-08-05.
+
+Every deploy job SSHes to the same VPS and operates on the same checkout,
+`/opt/hill90/app`, against the same running estate. `deploy.yml` already had a
+`deploy-db -> deploy-auth -> deploy-minio` chain; `deploy-vault` and
+`deploy-observability` hung off `changes` directly and so ran alongside it.
+
+  * Run 31039334078 — `deploy-db` and `deploy-observability` both started at
+    19:25:45Z. They raced on the git checkout and db died with
+    `error: fetching ref refs/remotes/origin/main failed: incorrect old value
+    provided`. `deploy-auth` was then skipped, so of three changed compose
+    files only observability.yml reached production: a PARTIAL deploy,
+    reported as one failed job. (#778)
+
+  * Run 31040415190 — `deploy-auth` restarted Keycloak while the concurrent
+    `deploy-observability` job's `grafana-role-login-test.sh` was mid-assertion
+    against it. It failed with `no Keycloak login form in the response`, naming
+    the wrong service entirely; Grafana was healthy throughout.
+
+The two share a cause and NOT a resource: the first is contention on the git
+checkout, the second on the running estate. That matters, because it rules out
+"give each job its own checkout directory" — that fixes the first and leaves
+the second untouched. Serialising fixes both.
+
+WHAT THIS ASSERTS. For every pair of deploy jobs, one must be reachable from
+the other through `needs`. That is exactly the condition "no two can be in
+flight together", and it is stronger than eyeballing a chain: it also rejects
+a fork, where two jobs each depend on a common ancestor but not on each other.
+
+WHAT IT DOES NOT ASSERT. Not the order, and not that the order is a good one.
+`deploy-observability` is deliberately last because its post-deploy checks
+assert against the other services, but a reshuffle that keeps the chain intact
+passes here — deliberately, so this check does not have to be edited every time
+the estate's dependency story changes.
+
+Hermetic: parses the workflow file. No network, no host. Runs in ci.yml.
+
+Exit 0 PASS, 1 FAIL, 2 CANNOT DETERMINE.
+"""
+import sys
+from pathlib import Path
+
+import yaml
+
+WORKFLOW = Path(__file__).resolve().parents[2] / ".github" / "workflows" / "deploy.yml"
+
+
+def ancestors(job: str, needs: dict) -> set:
+    """Every job that must complete before `job` can start."""
+    seen, stack = set(), list(needs.get(job, []))
+    while stack:
+        cur = stack.pop()
+        if cur in seen:
+            continue
+        seen.add(cur)
+        stack.extend(needs.get(cur, []))
+    return seen
+
+
+def main() -> int:
+    if not WORKFLOW.exists():
+        print(f"CANNOT DETERMINE — {WORKFLOW} does not exist")
+        return 2
+
+    doc = yaml.safe_load(WORKFLOW.read_text())
+    jobs = doc.get("jobs") or {}
+
+    needs = {}
+    for name, body in jobs.items():
+        n = (body or {}).get("needs") or []
+        needs[name] = [n] if isinstance(n, str) else list(n)
+
+    deploy_jobs = sorted(n for n in jobs if n.startswith("deploy-"))
+
+    # The 0-inputs-scanned trap: with fewer than two deploy jobs there is no
+    # pair to check, and "no violations found" would be a vacuous pass over an
+    # empty set. Say so instead.
+    if len(deploy_jobs) < 2:
+        print(
+            f"CANNOT DETERMINE — found {len(deploy_jobs)} job(s) named deploy-*, "
+            "so there is no pair of concurrent deploys to rule out. Either the "
+            "naming convention changed and this check is looking at nothing, or "
+            "the workflow did. Fix this before trusting a green run."
+        )
+        return 2
+
+    concurrent = []
+    for i, a in enumerate(deploy_jobs):
+        for b in deploy_jobs[i + 1 :]:
+            if b not in ancestors(a, needs) and a not in ancestors(b, needs):
+                concurrent.append((a, b))
+
+    if concurrent:
+        print("FAIL — these deploy jobs can run at the same time:")
+        print()
+        for a, b in concurrent:
+            print(f"      {a}  ||  {b}")
+        print()
+        print("  Every deploy job SSHes to the same VPS, works in the same")
+        print("  checkout (/opt/hill90/app) and deploys onto the same running")
+        print("  estate. Two at once race on the git checkout (#778) and on the")
+        print("  containers each other's post-deploy checks assert against.")
+        print()
+        print("  Chain them with `needs:` so the deploy jobs form a single path.")
+        print("  Current graph:")
+        for n in deploy_jobs:
+            print(f"      {n:24} needs={needs[n]}")
+        return 1
+
+    print(f"PASS — the {len(deploy_jobs)} deploy jobs form a single chain; no two")
+    print("       can be in flight against the VPS at once.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scripts/deploy-jobs-serialized-control.bats
+++ b/tests/scripts/deploy-jobs-serialized-control.bats
@@ -1,0 +1,123 @@
+#!/usr/bin/env bats
+
+# POSITIVE CONTROL for scripts/checks/check_deploy_jobs_serialized.py.
+#
+# Two of the mutations below are the workflow AS IT STOOD when each of the two
+# 2026-08-05 failures happened, restored one at a time — so this control is
+# anchored to what actually broke rather than to a rule invented afterwards.
+
+setup() {
+  ROOT="$BATS_TEST_DIRNAME/../.."
+  CTL="$BATS_TEST_TMPDIR/ctl"
+  mkdir -p "$CTL/scripts/checks" "$CTL/.github/workflows"
+  cp "$ROOT/scripts/checks/check_deploy_jobs_serialized.py" "$CTL/scripts/checks/"
+  cp "$ROOT/.github/workflows/deploy.yml" "$CTL/.github/workflows/"
+  CHECK="$CTL/scripts/checks/check_deploy_jobs_serialized.py"
+  WF="$CTL/.github/workflows/deploy.yml"
+}
+
+@test "CONTROL: passes on the real tree" {
+  run python3 "$CHECK"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"PASS"* ]]
+}
+
+@test "CONTROL: it counts the real jobs, not zero" {
+  run python3 "$CHECK"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"the 5 deploy jobs form a single chain"* ]]
+}
+
+# RUN 31039334078, replayed: deploy-observability hanging off `changes` alone,
+# which put it alongside deploy-db. Both started at 19:25:45Z and raced.
+@test "observability parallel to the db chain — the git-race run — is caught" {
+  python3 - "$WF" <<'PY'
+import sys, yaml
+p = sys.argv[1]
+d = yaml.safe_load(open(p))
+d["jobs"]["deploy-observability"]["needs"] = ["changes"]
+yaml.safe_dump(d, open(p, "w"), sort_keys=False)
+PY
+
+  run python3 "$CHECK"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"can run at the same time"* ]]
+  [[ "$output" == *"deploy-observability"* ]]
+}
+
+# RUN 31040415190, replayed: vault off `changes` alone, running beside the
+# chain that restarts Keycloak underneath observability's login check.
+@test "vault parallel to the chain — the Keycloak-restart run — is caught" {
+  python3 - "$WF" <<'PY'
+import sys, yaml
+p = sys.argv[1]
+d = yaml.safe_load(open(p))
+d["jobs"]["deploy-vault"]["needs"] = ["changes"]
+yaml.safe_dump(d, open(p, "w"), sort_keys=False)
+PY
+
+  run python3 "$CHECK"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"deploy-vault"* ]]
+}
+
+# A FORK is the case an eyeball check misses: both jobs have a `needs`, both
+# look chained, and they still run together because neither needs the other.
+@test "a fork — two jobs sharing an ancestor but not each other — is caught" {
+  python3 - "$WF" <<'PY'
+import sys, yaml
+p = sys.argv[1]
+d = yaml.safe_load(open(p))
+# Both hang off deploy-db. Neither is reachable from the other.
+d["jobs"]["deploy-vault"]["needs"] = ["changes", "deploy-db"]
+d["jobs"]["deploy-observability"]["needs"] = ["changes", "deploy-db"]
+d["jobs"]["deploy-auth"]["needs"] = ["changes", "deploy-db"]
+d["jobs"]["deploy-minio"]["needs"] = ["changes", "deploy-auth"]
+yaml.safe_dump(d, open(p, "w"), sort_keys=False)
+PY
+
+  run python3 "$CHECK"
+  [ "$status" -eq 1 ]
+}
+
+# Reordering while keeping ONE chain is allowed on purpose — the check asserts
+# mutual exclusion, not a particular order. Without this test, a later reshuffle
+# would be blocked by a check that was never meant to own the ordering.
+@test "a different but still-serial order passes" {
+  python3 - "$WF" <<'PY'
+import sys, yaml
+p = sys.argv[1]
+d = yaml.safe_load(open(p))
+d["jobs"]["deploy-vault"]["needs"] = ["changes"]
+d["jobs"]["deploy-db"]["needs"] = ["changes", "deploy-vault"]
+d["jobs"]["deploy-auth"]["needs"] = ["changes", "deploy-db"]
+d["jobs"]["deploy-minio"]["needs"] = ["changes", "deploy-auth"]
+d["jobs"]["deploy-observability"]["needs"] = ["changes", "deploy-minio"]
+yaml.safe_dump(d, open(p, "w"), sort_keys=False)
+PY
+
+  run python3 "$CHECK"
+  [ "$status" -eq 0 ]
+}
+
+# Blindness must not read as health.
+@test "a workflow with no deploy-* jobs is CANNOT DETERMINE, not a pass" {
+  python3 - "$WF" <<'PY'
+import sys, yaml
+p = sys.argv[1]
+d = yaml.safe_load(open(p))
+d["jobs"] = {"changes": d["jobs"]["changes"]}
+yaml.safe_dump(d, open(p, "w"), sort_keys=False)
+PY
+
+  run python3 "$CHECK"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"CANNOT DETERMINE"* ]]
+}
+
+# WIRING, not logic (h#736/h#758).
+@test "ci.yml genuinely invokes this check, not just mentions it" {
+  run grep -n "run: python3 scripts/checks/check_deploy_jobs_serialized.py" \
+    "$ROOT/.github/workflows/ci.yml"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Closes #778.

## Plan

Every deploy job SSHes to the same VPS, works in the same checkout (`/opt/hill90/app`) and deploys onto the same running estate. `deploy.yml` already had a `deploy-db → deploy-auth → deploy-minio` chain. `deploy-vault` and `deploy-observability` hung off `changes` directly, so they ran *alongside* it.

Both of 2026-08-05's deploy failures follow from exactly that:

| Run | What ran together | Failure |
|---|---|---|
| `31039334078` | `deploy-db` and `deploy-observability`, both started `19:25:45Z` | `error: fetching ref refs/remotes/origin/main failed: incorrect old value provided` |
| `31040415190` | `deploy-auth` and `deploy-observability` | `no Keycloak login form in the response` |

The first left a **partial deploy**: `deploy-auth` was skipped after db died, so of h#774's three changed compose files only `observability.yml` reached production, and the whole thing surfaced as one failed job. The second **named the wrong service** — Grafana was healthy the whole time (`ok Grafana is serving`, `ok Grafana redirected to https://auth.hill90.com, realm platform`), and the login form serves correctly now; auth's Keycloak restart had simply landed underneath the assertion.

**The two contend on different resources** — the git checkout, and the running estate. That distinction rules out one of the three candidate fixes in #778: per-job checkout directories fix the first and leave the second untouched. Serialising fixes both, and does it by extending a chain that already existed rather than by introducing a locking mechanism.

`deploy-observability` goes **last** on purpose: its post-deploy checks assert against the other services, so it must not start until they have settled.

## Risks

Two, and both are real rather than pro-forma.

- **A five-service deploy is now serial.** It takes roughly the sum of its parts instead of the slowest branch. Accepted: a homelab deploy that is a few minutes slower and correct beats a fast one that half-applies.
- **A db failure now skips vault and observability**, which previously deployed anyway — the chain carries `!failure()`. I read that as the right behaviour (a failed database deploy should not be followed by four more), but it **is** a behaviour change and it is yours to veto. If you would rather keep them independent of db's outcome, the alternative is a VPS-side `flock`, which serialises without coupling outcomes — at the cost of jobs that sit burning runner minutes waiting on the lock, and no protection for anything that deploys outside this workflow.

Not addressed here: nothing serialises this workflow against a *human* running `deploy.sh` on the VPS directly. `concurrency: deploy-prod` only covers runs of this workflow.

## Rollback

Revert the commit. `deploy-vault` and `deploy-observability` return to hanging off `changes`, and both failure modes come back.

## Validation Evidence

Positive control, with both real failures replayed as separate mutations:

```
$ bats tests/scripts/deploy-jobs-serialized-control.bats
1..8
ok 1 CONTROL: passes on the real tree
ok 2 CONTROL: it counts the real jobs, not zero
ok 3 observability parallel to the db chain — the git-race run — is caught
ok 4 vault parallel to the chain — the Keycloak-restart run — is caught
ok 5 a fork — two jobs sharing an ancestor but not each other — is caught
ok 6 a different but still-serial order passes
ok 7 a workflow with no deploy-* jobs is CANNOT DETERMINE, not a pass
ok 8 ci.yml genuinely invokes this check, not just mentions it
```

Test 5 is the one an eyeball misses: two jobs that each have a `needs` and *look* chained, while neither is reachable from the other. The check asserts the property — for every pair of deploy jobs, one must be an ancestor of the other — not a literal graph, which is why test 6 requires a reordering that stays serial to **pass**. This check should not have to be edited every time the dependency story changes.

Resulting graph:

```
changes
deploy-db              needs=['changes']
deploy-auth            needs=['changes', 'deploy-db']
deploy-minio           needs=['changes', 'deploy-auth']
deploy-vault           needs=['changes', 'deploy-minio']
deploy-observability   needs=['changes', 'deploy-vault']
```

Both deploy checks pass on the real tree, and #779's check still passes alongside this one:

```
$ python3 scripts/checks/check_deploy_jobs_serialized.py
PASS — the 5 deploy jobs form a single chain; no two
       can be in flight against the VPS at once.
$ python3 scripts/checks/check_dispatch_targets_one_service.py
PASS — change detection is gated to non-dispatch events, so a manual
       deploy is decided by the `service` input alone.
```

**What this evidence does not cover.** The check is static. It proves no two deploy jobs *can* be scheduled together; it does not prove the serialised deploy still works end to end. None of the four files here is on `deploy.yml`'s `on.push.paths`, so merging deploys nothing — the runtime proof has to be the next real multi-service deploy, and I will post its job timings here when one happens rather than claim it now.

## Estate state

Verified before opening this, after the last of today's deploys:

```
missing: none  unhealthy:0  restarting:0  tenant:7
  hill90.com 200
  auth.hill90.com/realms/platform 200
```
