### PR TITLE
docs(recreate-vps): note the vestigial backup-file cleanup step

### DIFF
--- a/.github/workflows/recreate-vps.yml
+++ b/.github/workflows/recreate-vps.yml
@@ -155,6 +155,13 @@ jobs:
       # ========================================
       # 6. CLEANUP
       # ========================================
+      # Vestigial: workflow-silent-success sweep (2026-08-05) traced this and
+      # found no step in THIS file that ever creates a *.backup.* under
+      # infra/secrets — the pattern only comes from scripts/secrets.sh and
+      # scripts/vault.sh, neither of which this workflow calls. `find` here
+      # matches nothing on every run. Left in place rather than deleted
+      # (harmless, `|| true`), and noted so the next sweep doesn't
+      # re-investigate it as a live always()-after-failure candidate.
       - name: Cleanup backup files
         if: always()
         run: |


### PR DESCRIPTION
## Companion to #780's vault workflow sweep

Swept all 17 remaining \`.github/workflows/*.yml\` files for the same "operation fails but reports success" family — zero real findings beyond the three already fixed in #780. One hit traced and ruled out, recorded here so the next sweep doesn't re-spend time on it.

\`recreate-vps.yml\`'s "Cleanup backup files" step pattern-matches "always() cleanup after a step that may have failed," but there's nothing for it to clean up: confirmed no step in this file ever creates a \`*.backup.*\` file under \`infra/secrets\`. That pattern only comes from \`scripts/secrets.sh\` and \`scripts/vault.sh\`, neither called anywhere in this workflow — likely copied from \`vault-sync-to-sops.yml\`'s similar-looking step. \`find\` matches nothing on every real run, and \`|| true\` means it can't fail either way regardless.

Left in place rather than removed (harmless, not dangerous), just commented.

## Test plan
- [x] YAML validates
- [x] No behavior change — comment only

🤖 Generated with [Claude Code](https://claude.com/claude-code)