### PR TITLE
fix(minio): secret_for() couldn't distinguish a decrypt failure from an absent key

### DIFF
--- a/scripts/minio.sh
+++ b/scripts/minio.sh
@@ -60,7 +60,21 @@ secret_for() {
     if [ -z "$value" ]; then
         require_file "$SECRETS_FILE" "Secrets file"
         ensure_age_key prod
-        value=$(sops -d "$SECRETS_FILE" 2>/dev/null | grep "^${var}=" | cut -d= -f2- || true)
+        # Split declaration from assignment on purpose: `local decrypted=$(...)`
+        # would discard sops's own exit status — `local` returns its own status,
+        # and set -e does not see the command substitution's failure inside it.
+        # That is exactly the shape this fix exists to close, so writing it the
+        # natural way would reintroduce the defect while fixing it.
+        local decrypted
+        if ! decrypted=$(sops -d "$SECRETS_FILE" 2>/dev/null); then
+            die "could not decrypt ${SECRETS_FILE} — check the age key for prod"
+        fi
+        # A decrypt failure and a genuinely-absent key used to produce the
+        # identical "not set and was not found" message, sending an operator
+        # debugging the wrong file instead of their age key. Never echo
+        # $decrypted itself — only pipe it, so the file's contents never reach
+        # stdout/stderr regardless of which branch below fires.
+        value=$(printf '%s' "$decrypted" | grep "^${var}=" | cut -d= -f2- || true)
     fi
     [ -n "$value" ] || die "${var} is not set and was not found in ${SECRETS_FILE}"
     printf '%s' "$value"

--- a/tests/scripts/minio-secret-for-control.bats
+++ b/tests/scripts/minio-secret-for-control.bats
@@ -1,0 +1,96 @@
+#!/usr/bin/env bats
+
+# POSITIVE CONTROL for scripts/minio.sh's secret_for().
+#
+# A sops decrypt failure (bad/missing age key, corrupted store) and a
+# genuinely-absent key used to print the IDENTICAL "not set and was not
+# found" message, sending an operator debugging the wrong file instead of
+# their age key. Each test here extracts the REAL secret_for() out of the
+# real file with sed, so this tests the actual fix rather than a
+# reimplementation of it.
+
+setup() {
+  ROOT="$BATS_TEST_DIRNAME/../.."
+  CTL="$BATS_TEST_TMPDIR/ctl"
+  mkdir -p "$CTL"
+  touch "$CTL/fake_secrets.enc.env" "$CTL/fake-age.key"
+
+  # The harness every test sources: real _common.sh (for die/require_file/
+  # ensure_age_key), the real secret_for() extracted from minio.sh, and a
+  # fake `sops` the test itself defines afterward.
+  cat > "$CTL/harness.sh" <<HARNESS
+set -e
+PROJECT_ROOT="$CTL"
+SECRETS_FILE="$CTL/fake_secrets.enc.env"
+export SOPS_AGE_KEY_FILE="$CTL/fake-age.key"
+source "$ROOT/scripts/_common.sh"
+eval "\$(sed -n '/^secret_for() {/,/^}/p' "$ROOT/scripts/minio.sh")"
+HARNESS
+}
+
+@test "CONTROL: resolves a real key from a successful decrypt" {
+  cat >> "$CTL/harness.sh" <<'EOF'
+sops() { printf 'MINIO_ROOT_USER=realvalue123\nOTHER=x\n'; }
+MINIO_ROOT_USER="" secret_for MINIO_ROOT_USER
+EOF
+  run bash "$CTL/harness.sh"
+  [ "$status" -eq 0 ]
+  [ "$output" = "realvalue123" ]
+}
+
+# THE ASSERTION THAT MATTERS: a decrypt failure must be distinguishable from
+# a genuinely-absent key, not collapse into the same message.
+@test "THE ASSERTION THAT MATTERS: a sops decrypt failure names the file and failure mode, not the generic not-found message" {
+  cat >> "$CTL/harness.sh" <<'EOF'
+sops() { return 1; }
+MINIO_ROOT_USER="" secret_for MINIO_ROOT_USER
+EOF
+  run bash "$CTL/harness.sh"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"could not decrypt"* ]]
+  [[ "$output" == *"fake_secrets.enc.env"* ]]
+  [[ "$output" == *"age key"* ]]
+  [[ "$output" != *"is not set and was not found"* ]]
+}
+
+@test "CONTROL: a genuinely-absent key (decrypt succeeds) still gets the not-found message" {
+  cat >> "$CTL/harness.sh" <<'EOF'
+sops() { printf 'SOME_OTHER_KEY=x\n'; }
+MINIO_ROOT_USER="" secret_for MINIO_ROOT_USER
+EOF
+  run bash "$CTL/harness.sh"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"is not set and was not found"* ]]
+  [[ "$output" != *"could not decrypt"* ]]
+}
+
+@test "CONTROL: the two failure messages are distinct, not the same string" {
+  cat > "$CTL/harness_fail.sh" <<EOF
+$(cat "$CTL/harness.sh")
+sops() { return 1; }
+MINIO_ROOT_USER="" secret_for MINIO_ROOT_USER
+EOF
+  cat > "$CTL/harness_absent.sh" <<EOF
+$(cat "$CTL/harness.sh")
+sops() { printf 'SOME_OTHER_KEY=x\n'; }
+MINIO_ROOT_USER="" secret_for MINIO_ROOT_USER
+EOF
+  run bash "$CTL/harness_fail.sh"
+  local fail_output="$output"
+  run bash "$CTL/harness_absent.sh"
+  local absent_output="$output"
+  [ "$fail_output" != "$absent_output" ]
+}
+
+@test "no decrypted content is ever printed on a decrypt failure" {
+  cat >> "$CTL/harness.sh" <<'EOF'
+sops() { echo "THIS-WOULD-BE-A-LEAKED-SECRET" >&2; return 1; }
+MINIO_ROOT_USER="" secret_for MINIO_ROOT_USER
+EOF
+  run bash "$CTL/harness.sh"
+  [ "$status" -eq 1 ]
+  # The fake sops writes to its OWN stderr as a stand-in for what real sops
+  # might emit on failure — secret_for's fix redirects sops's stderr to
+  # /dev/null (2>/dev/null), so this must never reach the caller's output.
+  [[ "$output" != *"THIS-WOULD-BE-A-LEAKED-SECRET"* ]]
+}


### PR DESCRIPTION
## scripts/ silent-success sweep, finding 3

\`secret_for()\`'s \`sops\` call piped stderr to \`/dev/null\` and any decrypt failure (bad/missing age key, corrupted store) resolved to the same empty string as a genuinely-absent key — both produced the identical \`"not set and was not found in \${SECRETS_FILE}"\` message, sending an operator debugging the wrong file instead of their age key. \`die()\` still fired either way; this was never a silent-success bug, only a misleading one.

**The fix.** Split the decrypt from the extraction:
\`\`\`bash
local decrypted
if ! decrypted=$(sops -d "$SECRETS_FILE" 2>/dev/null); then
    die "could not decrypt ${SECRETS_FILE} — check the age key for prod"
fi
\`\`\`
then grep the key out of \`$decrypted\` separately. Deliberately **not** \`local decrypted=$(sops -d ...)\` — that natural-looking form discards sops's own exit status, since \`local\` returns its own status and \`set -e\` never sees the command substitution's failure inside it. That's exactly shape 1 of this same sweep (a pipeline/assignment whose exit status comes from the wrong command), so writing the fix that way would reintroduce the defect while fixing it.

**Two constraints honored.** No secret value is ever printed — \`$decrypted\` is only ever piped into \`grep\`, never echoed or included in any message, including the new failure path. The new message names the file and the failure mode (\`"could not decrypt \${SECRETS_FILE} — check the age key for prod"\`), never the value.

**Positive-controlled, both directions**, with a real forced \`sops\` failure — a harness sourcing the real \`_common.sh\` and the real \`secret_for()\` (extracted from the file with \`sed\`, not reimplemented) with a stubbed \`sops\`. Old code: decrypt-fails and key-absent cases produce the byte-identical message, confirmed by diffing the two outputs directly. New code: distinct messages; confirmed the fixed source still resolves a real key correctly; confirmed nothing a stubbed \`sops\` writes to its own stderr ever reaches the caller's output.

**New \`tests/scripts/minio-secret-for-control.bats\`**, 5 tests, all reverted against the pre-fix source first to confirm the 2 relevant ones fail for exactly the predicted reason, then restored and reconfirmed green.

**Full suites**: \`bats tests/scripts/\` 623 passed, 0 failed. \`pytest tests/checks/\` 81 passed, 1 failed (\`test_tenant_privilege_boundary_holds\`) — confirmed unrelated (a container-resource-contention flake) and passes 2/2 clean rerun alone.

## Test plan
- [x] Positive control: real forced \`sops\` failure, old code shown producing the identical message as key-absent
- [x] New code confirmed to distinguish the two cases
- [x] No secret value ever printed, in any path — verified with a stubbed \`sops\` that would leak if the redirect broke
- [x] Full \`bats tests/scripts/\` — 623 passed, 0 failed
- [x] \`pytest tests/checks/\` — 81 passed, 1 unrelated flake confirmed clean alone

🤖 Generated with [Claude Code](https://claude.com/claude-code)