### PR TITLE
fix(backup): cmd_prune() counted a backup as pruned even when rm failed

### DIFF
--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -748,8 +748,11 @@ cmd_prune() {
 
             if [ "$backup_epoch" -lt "$cutoff_epoch" ]; then
                 echo "  Removing: ${svc}/${ts}"
-                rm -rf "$backup_dir"
-                pruned=$((pruned + 1))
+                if rm -rf "$backup_dir"; then
+                    pruned=$((pruned + 1))
+                else
+                    warn "failed to remove ${svc}/${ts} — not counting it as pruned"
+                fi
             fi
         done
     done

--- a/tests/scripts/backup-prune-exit-status-control.bats
+++ b/tests/scripts/backup-prune-exit-status-control.bats
@@ -1,0 +1,74 @@
+#!/usr/bin/env bats
+
+# POSITIVE CONTROL for scripts/backup.sh's cmd_prune().
+#
+# The old code ran `rm -rf "$backup_dir"` and unconditionally incremented
+# `pruned`, so a removal that failed (permissions, a mount gone read-only,
+# a file locked by another process) was still reported as pruned — an
+# operator reading "Pruned 1 backup(s)" had no way to know the backup was
+# still on disk. This extracts the REAL cmd_prune from the real file and
+# forces a real rm failure (a read-only parent directory, so `rm -rf`
+# cannot unlink the entry) rather than a mocked one.
+
+setup() {
+  ROOT="$BATS_TEST_DIRNAME/../.."
+  CTL="$BATS_TEST_TMPDIR/ctl"
+  mkdir -p "$CTL"
+  cp "$ROOT/scripts/backup.sh" "$CTL/backup.sh"
+  cp "$ROOT/scripts/_common.sh" "$CTL/_common.sh"
+
+  cat > "$CTL/harness.sh" <<'HARNESS'
+#!/usr/bin/env bash
+set -uo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/_common.sh"
+BACKUP_ROOT="${CTL_BACKUP_ROOT}"
+DEFAULT_RETENTION_DAYS=7
+HARNESS
+  sed -n '/^cmd_prune() {/,/^}/p' "$CTL/backup.sh" >> "$CTL/harness.sh"
+
+  BACKUPS="$CTL/backups"
+  # A timestamp comfortably older than any retention window this suite uses.
+  OLD_TS="20200101_000000"
+  mkdir -p "$BACKUPS/postgres/$OLD_TS"
+  echo "dummy" > "$BACKUPS/postgres/$OLD_TS/dump.sql"
+}
+
+teardown() {
+  # rm -rf below would itself fail on the read-only dir bats' own cleanup
+  # relies on, so always leave it writable behind us.
+  chmod 755 "$BACKUPS/postgres" 2>/dev/null || true
+}
+
+run_prune() {
+  CTL_BACKUP_ROOT="$BACKUPS" bash -c '
+    source "'"$CTL"'/harness.sh"
+    cmd_prune 7
+  '
+}
+
+@test "THE ASSERTION THAT MATTERS: a removal that actually fails is not counted as pruned" {
+  # No write permission on the containing directory means rm cannot unlink
+  # the timestamp directory entry, even though the directory itself is
+  # otherwise removable — a real, reproducible rm -rf failure, not a stub.
+  chmod 555 "$BACKUPS/postgres"
+  run run_prune
+  [ -d "$BACKUPS/postgres/$OLD_TS" ]
+  [[ "$output" == *"failed to remove"* ]]
+  [[ "$output" == *"Pruned 0 backup(s)"* ]]
+}
+
+@test "CONTROL: a removal that succeeds is counted as pruned and the directory is gone" {
+  run run_prune
+  [ ! -d "$BACKUPS/postgres/$OLD_TS" ]
+  [[ "$output" == *"Pruned 1 backup(s)"* ]]
+  [[ "$output" != *"failed to remove"* ]]
+}
+
+@test "CONTROL: a backup newer than the retention window is left alone and not counted" {
+  NEW_TS="$(date -u +%Y%m%d)_120000"
+  mkdir -p "$BACKUPS/postgres/$NEW_TS"
+  echo "dummy" > "$BACKUPS/postgres/$NEW_TS/dump.sql"
+  run run_prune
+  [ -d "$BACKUPS/postgres/$NEW_TS" ]
+  [[ "$output" == *"Pruned 1 backup(s)"* ]]
+}


### PR DESCRIPTION
## Summary
- `cmd_prune()`'s `rm -rf "$backup_dir"` exit status was unchecked and `pruned` incremented unconditionally, so a removal that failed (permissions, a read-only mount, a file locked elsewhere) was still reported as pruned — an operator reading "Pruned N backup(s)" had no way to know the backup was still on disk.
- Named family per the `scripts/` silent-success sweep, kept as a standalone third PR rather than parked, per instruction.

## Test plan
- [x] `shellcheck --severity=error scripts/backup.sh` clean
- [x] `bash -n scripts/backup.sh` clean
- [x] New positive control `tests/scripts/backup-prune-exit-status-control.bats` (3 tests) extracts the real `cmd_prune` and forces a real `rm -rf` failure via a read-only parent directory — not a stub
- [x] Reverted the fix and reran: the "assertion that matters" test goes red for the predicted reason, both control tests stay green — confirms the defect reproduces and the fix is what closes it
- [x] Restored the fix, reran: all 3 green
- [x] Full `bats tests/scripts/*.bats`: 633/633 passed
- [x] Full `pytest tests/checks/`: 82/82 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)