### PR TITLE
fix(common): load_secrets() reported success on a failed decrypt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,10 +42,21 @@ jobs:
       - name: Assert no two deploy jobs can run at once
         run: python3 scripts/checks/check_deploy_jobs_serialized.py
 
-      - name: Install bats
+      # sops and age (age-keygen) are needed by tests/scripts/common-load-secrets-
+      # exit-status-control.bats, which forces a REAL sops decrypt failure
+      # against a genuine mismatched age key rather than a mocked sops binary
+      # — per review, that's a stronger control than a stub for the widest-
+      # reaching instance of this repo's pipeline-exit-status defect family.
+      - name: Install bats, sops and age
         run: |
           sudo apt-get update
-          sudo apt-get install -y bats
+          sudo apt-get install -y bats age
+
+          SOPS_VERSION="3.9.0"
+          curl -Lo /tmp/sops "https://github.com/getsops/sops/releases/download/v${SOPS_VERSION}/sops-v${SOPS_VERSION}.linux.amd64"
+          chmod +x /tmp/sops
+          sudo mv /tmp/sops /usr/local/bin/sops
+          sops --version
 
       - name: Run bats tests
         run: bats tests/scripts/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,13 +47,31 @@ jobs:
       # against a genuine mismatched age key rather than a mocked sops binary
       # — per review, that's a stronger control than a stub for the widest-
       # reaching instance of this repo's pipeline-exit-status defect family.
+      #
+      # The sops install below is copied from audit-hill90-ui-client.yml's
+      # "Setup SOPS/age" step rather than reinvented: same version (a version
+      # mismatch here would test load_secrets against a sops the estate does
+      # not run — the same argument this repo already makes for pinning
+      # promtool to the deployed Prometheus version), same -fsSL (without -f,
+      # curl exits 0 on a 404 and writes the error page to /tmp/sops, which
+      # is exactly the fetch-fails-reporting-success shape this PR fixes,
+      # landing in the very step added to test it), and the same HTML-body
+      # check. `age` (for age-keygen) is this workflow's own addition — the
+      # sibling step doesn't need it, since it uses a real deployed key from
+      # secrets rather than generating throwaway keypairs.
       - name: Install bats, sops and age
+        env:
+          SOPS_VERSION: '3.9.4'
         run: |
           sudo apt-get update
           sudo apt-get install -y bats age
 
-          SOPS_VERSION="3.9.0"
-          curl -Lo /tmp/sops "https://github.com/getsops/sops/releases/download/v${SOPS_VERSION}/sops-v${SOPS_VERSION}.linux.amd64"
+          SOPS_URL="https://github.com/getsops/sops/releases/download/v${SOPS_VERSION}/sops-v${SOPS_VERSION}.linux.amd64"
+          curl -fsSL -o /tmp/sops "$SOPS_URL"
+          if file /tmp/sops | grep -q "HTML"; then
+            echo "::error::SOPS download returned HTML instead of binary — check URL: $SOPS_URL"
+            exit 1
+          fi
           chmod +x /tmp/sops
           sudo mv /tmp/sops /usr/local/bin/sops
           sops --version

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -78,12 +78,28 @@ load_secrets() {
 
     export SOPS_AGE_KEY_FILE="$age_key"
 
+    # Split declaration from assignment on purpose: `local decrypted=$(...)`
+    # would discard sops's own exit status — `local` returns its own status,
+    # and this function is sourced into callers with neither `set -e` nor
+    # `pipefail` (it's a library; that's the caller's choice, not this
+    # file's), so nothing downstream would catch it either. This is the
+    # widest-reaching instance of the pipeline-exit-status shape in this
+    # repo: `decrypted` holds the ENTIRE decrypted secrets store, not one
+    # value the way minio.sh's secret_for() does, so a masked failure here
+    # means every caller of load_secrets silently loads nothing rather than
+    # one script missing one key.
+    local decrypted
+    if ! decrypted=$(sops -d "$secrets_file"); then
+        die "could not decrypt ${secrets_file} — check the age key at ${age_key}"
+    fi
+
     local temp_file
     temp_file=$(mktemp)
     # shellcheck disable=SC2064  # Intentional early expansion of $temp_file
     trap "rm -f '$temp_file'" RETURN
 
-    sops -d "$secrets_file" | grep -E '^[A-Za-z_][A-Za-z0-9_]*=' | while IFS='=' read -r key value; do
+    # Never echo $decrypted — it is the whole store. Only ever piped.
+    printf '%s' "$decrypted" | grep -E '^[A-Za-z_][A-Za-z0-9_]*=' | while IFS='=' read -r key value; do
         printf '%s=%q\n' "$key" "$value"
     done > "$temp_file"
 

--- a/tests/scripts/common-load-secrets-exit-status-control.bats
+++ b/tests/scripts/common-load-secrets-exit-status-control.bats
@@ -1,0 +1,70 @@
+#!/usr/bin/env bats
+
+# POSITIVE CONTROL for scripts/_common.sh's load_secrets().
+#
+# `sops -d "$secrets_file" | grep ... | while read ...; done > "$temp_file"`
+# had no pipefail (this file sets neither `set -e` nor `pipefail` — it's a
+# sourced library, safety is the caller's choice), so the pipeline's exit
+# status came from the `while` loop, which exits 0 on empty input. A failed
+# `sops -d` therefore gave an empty temp_file, a successful `source`, and a
+# clean return — the widest-reaching instance of this shape in the repo,
+# since load_secrets is the primary secret-loading entrypoint and
+# `decrypted` holds the entire store, not one value.
+#
+# This forces a REAL sops decrypt failure — a genuine age key that does not
+# match the file's recipient, not a mocked sops binary — the same standard
+# used for #783's minio.sh control.
+
+setup() {
+  ROOT="$BATS_TEST_DIRNAME/../.."
+  CTL="$BATS_TEST_TMPDIR/ctl"
+  mkdir -p "$CTL"
+  cp "$ROOT/scripts/_common.sh" "$CTL/_common.sh"
+
+  age-keygen -o "$CTL/real.key" 2>"$CTL/real.pub.txt"
+  REAL_PUB="$(grep -oE 'age1[a-z0-9]+' "$CTL/real.pub.txt")"
+  age-keygen -o "$CTL/bogus.key" 2>/dev/null
+
+  cat > "$CTL/plain.env" <<'PLAIN'
+FOO_SECRET=hunter2
+BAR_TOKEN=abc123
+PLAIN
+  sops --age "$REAL_PUB" -e "$CTL/plain.env" > "$CTL/secrets.enc.env"
+}
+
+run_load_secrets() {
+  local key_file="$1"
+  SOPS_AGE_KEY_FILE="$key_file" CTL_SECRETS_FILE="$CTL/secrets.enc.env" bash -c '
+    source "'"$CTL"'/_common.sh"
+    load_secrets "$CTL_SECRETS_FILE"
+    echo "REACHED_AFTER_LOAD_SECRETS"
+    echo "FOO_SECRET=${FOO_SECRET:-<unset>}"
+  '
+}
+
+@test "THE ASSERTION THAT MATTERS: a real sops decrypt failure returns non-zero, not success" {
+  run run_load_secrets "$CTL/bogus.key"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"could not decrypt"* ]]
+  # The old defect's whole shape: does it stop here, or plow on and act as
+  # if the secrets loaded?
+  [[ "$output" != *"REACHED_AFTER_LOAD_SECRETS"* ]]
+}
+
+@test "THE ASSERTION THAT MATTERS: a decrypt failure exports nothing, not an empty environment silently accepted" {
+  run run_load_secrets "$CTL/bogus.key"
+  [[ "$output" != *"FOO_SECRET=hunter2"* ]]
+}
+
+@test "CONTROL: a successful decrypt exports the secrets and returns success" {
+  run run_load_secrets "$CTL/real.key"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"REACHED_AFTER_LOAD_SECRETS"* ]]
+  [[ "$output" == *"FOO_SECRET=hunter2"* ]]
+}
+
+@test "no decrypted secret content is ever printed on a decrypt failure" {
+  run run_load_secrets "$CTL/bogus.key"
+  [[ "$output" != *"hunter2"* ]]
+  [[ "$output" != *"abc123"* ]]
+}


### PR DESCRIPTION
## Summary
- `load_secrets()`'s `sops -d "$secrets_file" | grep ... | while read ...; done > "$temp_file"` had no `pipefail` (the file sets neither `set -e` nor `pipefail` — it's a sourced library, safety is the caller's choice), so the pipeline's exit status came from the `while` loop, which exits 0 on empty input. A failed `sops -d` therefore produced an empty temp_file, a successful `source`, and a clean return: **every caller of load_secrets silently loaded nothing rather than getting an error.**
- Widest-reaching instance of this shape in the repo (vs. #783's `minio.sh`): `decrypted` holds the *entire* secrets store, not one value — flagging the broader leak exposure explicitly rather than leaving it implicit. `$decrypted` is only ever piped, never echoed.
- `${VAR:?}` guards from h#774 partially cover this already, but only for the compose-render path; any script reading a secret directly after `load_secrets` still proceeded with nothing.

## Fix shape
Same as #783, **not** `pipefail` — setting it inside the function would leak into every caller of this sourced library (bash shell options are global, not function-scoped), changing behavior nobody reviewed. Instead: split declaration from assignment (`local decrypted` on its own line, `decrypted=$(sops -d ...)` checked separately) — a combined `local decrypted=$(...)` would discard sops's own exit status the exact same way this bug did — then `die` naming the file and age key on a real decrypt failure.

## CI cost of the real-binary choice
Per review: choosing a real sops/age decrypt over a mocked binary is a trade, and it should be visible here rather than discovered when CI gets slower. Every future `Run Tests` run now downloads sops (~15MB) and installs the `age`/`age-keygen`/`bats` apt packages, for one test file's positive control. This install step is copied from `audit-hill90-ui-client.yml`'s existing "Setup SOPS/age" step rather than being a second, drifting pin — same sops version (3.9.4), same `-fsSL` + HTML-body check.

## Test plan
- [x] `shellcheck --severity=error scripts/_common.sh` clean
- [x] `bash -n scripts/_common.sh` clean
- [x] New positive control `tests/scripts/common-load-secrets-exit-status-control.bats` (4 tests) — forces a REAL sops decrypt failure via a genuine age key that does not match the encrypted file's recipient, not a mocked `sops` binary
- [x] The core assertion checks exit status, not just an error message — "returns success having loaded nothing" was the actual defect
- [x] Reverted the fix and reran: the exit-status assertion goes red for the predicted reason, all control tests stay green — confirms the defect reproduces and the fix is what closes it
- [x] Restored the fix, reran: all 4 green
- [x] Full `bats tests/scripts/*.bats`: 640/640 passed
- [x] Full `pytest tests/checks/`: 82/82 passed
- [x] Install step now matches `audit-hill90-ui-client.yml`'s sops install verbatim (3.9.4, `-fsSL`, HTML-body check) instead of a second, differently-pinned, unguarded one — verified `curl -fsSL` + HTML check + sops 3.9.4 end to end in a matching `ubuntu:24.04` container

🤖 Generated with [Claude Code](https://claude.com/claude-code)
