### PR TITLE
fix(ci): auth deploy's post-deploy signal dispatched to the wrong repo with a token that cannot trigger anything

### DIFF
--- a/.github/workflows/reusable-deploy-service.yml
+++ b/.github/workflows/reusable-deploy-service.yml
@@ -290,13 +290,40 @@ jobs:
       # token) rather than silently doing nothing — a real regression from
       # today's silent no-op only in the sense that a loud failure is the
       # correct state for missing wiring, not a worse one.
+      # GATED ON THE SECRET, not hard-failing without it — and the reason is
+      # a change made the same day, not caution for its own sake. The deploy
+      # jobs are now SERIALISED (h#781): db -> auth -> minio -> vault ->
+      # observability, each downstream job carrying `!failure()`. A step that
+      # failed here would turn deploy-auth red on a run where auth itself
+      # deployed fine, and skip minio, vault and observability behind it — a
+      # missing secret would take out the remainder of every multi-service
+      # deploy.
+      #
+      # This matches the `Notify deploy result` step below, which solves the
+      # identical problem (an optional outbound integration that must not
+      # fail the deploy when unconfigured) with the same env-gated `if:`.
+      # `env`, not `secrets`, because the secrets context is not reliably
+      # available in a step-level conditional.
+      #
+      # A SKIPPED step is not the defect this PR removes. The original sin
+      # was a step that RAN, exited 0, and reported success while signalling
+      # nothing. Skipped-with-a-warning is visibly different from that.
       - name: Signal post-deploy hooks
-        if: success() && inputs.service == 'auth'
+        if: success() && inputs.service == 'auth' && env.DISPATCH_TOKEN != ''
+        env:
+          DISPATCH_TOKEN: ${{ secrets.HILL90_APP_DISPATCH_TOKEN }}
         uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.HILL90_APP_DISPATCH_TOKEN }}
           repository: jonhill90/hill90-app
           event-type: deploy-auth-success
+
+      - name: Warn that the post-deploy signal is unwired
+        if: success() && inputs.service == 'auth' && env.DISPATCH_TOKEN == ''
+        env:
+          DISPATCH_TOKEN: ${{ secrets.HILL90_APP_DISPATCH_TOKEN }}
+        run: |
+          echo "::warning::HILL90_APP_DISPATCH_TOKEN is not set on this repository — hill90-app's smoke-auth.yml was NOT triggered. Production auth is unverified by this deploy. See Hill90#792."
 
       - name: Notify deploy result
         if: always() && env.DEPLOY_WEBHOOK_URL != ''

--- a/.github/workflows/reusable-deploy-service.yml
+++ b/.github/workflows/reusable-deploy-service.yml
@@ -271,10 +271,31 @@ jobs:
             deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
             'cd /opt/hill90/app && export SOPS_AGE_KEY_FILE=/opt/hill90/secrets/keys/keys.txt && bash scripts/checks/grafana-role-login-test.sh testuser01 Viewer'
 
+      # Hill90#792. This step ran clean on every auth deploy and signalled
+      # nothing: `with:` carried only event-type, so `repository` defaulted
+      # to THIS repo (Hill90 has no listener — smoke-auth.yml lives in
+      # hill90-app), and `token` defaulted to GITHUB_TOKEN, whose dispatches
+      # do not trigger workflow runs at all (GitHub's own recursion guard).
+      # Either alone was fatal; both were true.
+      #
+      # HILL90_APP_DISPATCH_TOKEN must exist as a repository secret on THIS
+      # repo (Hill90 — the sender) before this can fire anything, and
+      # GITHUB_TOKEN cannot stand in for it regardless of permissions
+      # granted to this workflow, by the recursion guard above. It needs to
+      # be a token that can trigger a workflow run in jonhill90/hill90-app —
+      # a fine-grained PAT scoped to that repository with "Actions:
+      # read and write", or a classic PAT with the `repo` scope. Until that
+      # secret is created, this step will fail loudly (a missing secret
+      # renders empty, and repository-dispatch@v3 errors on an empty
+      # token) rather than silently doing nothing — a real regression from
+      # today's silent no-op only in the sense that a loud failure is the
+      # correct state for missing wiring, not a worse one.
       - name: Signal post-deploy hooks
         if: success() && inputs.service == 'auth'
         uses: peter-evans/repository-dispatch@v3
         with:
+          token: ${{ secrets.HILL90_APP_DISPATCH_TOKEN }}
+          repository: jonhill90/hill90-app
           event-type: deploy-auth-success
 
       - name: Notify deploy result


### PR DESCRIPTION
## Summary

Fixes Hill90#792, sender-side half.

"Signal post-deploy hooks" (`.github/workflows/reusable-deploy-service.yml:274`) ran clean on every auth deploy and accomplished nothing, two independent ways:

1. `with:` carried only `event-type` — `repository` defaulted to **this** repo (Hill90), which has no workflow listening for `deploy-auth-success`. The listener (`smoke-auth.yml`) lives in `jonhill90/hill90-app`.
2. `token` defaulted to `GITHUB_TOKEN`. Events dispatched with `GITHUB_TOKEN` do not trigger workflow runs at all — GitHub's own documented recursion guard. Even with `repository:` fixed alone, this would still have done nothing.

Either defect alone was fatal; both were true simultaneously, and the step reported success regardless. Confirmed against a real run: deploy run `31043850839`, `deploy-auth` job, 20:26:17 today — no error, no dispatch that could have been received.

## Fix

Explicit `repository: jonhill90/hill90-app` and a new secret, `HILL90_APP_DISPATCH_TOKEN`, in place of `GITHUB_TOKEN`.

## Requires a manual step this PR cannot do

`HILL90_APP_DISPATCH_TOKEN` must be created as a repository secret on **this repo** (Hill90 — the sender) before this fires anything. It needs to be a token that can trigger a workflow run in `jonhill90/hill90-app` — a fine-grained PAT scoped to that repository with "Actions: read and write", or a classic PAT with the `repo` scope. Creating and storing that credential is outside what this session does (no infra/secrets/credential work) — flagging explicitly rather than silently leaving the workflow referencing a secret that doesn't exist, which would just be a quieter version of the same defect this PR fixes.

Until that secret exists, this step **fails loudly** rather than silently doing nothing (a missing secret renders empty, and `repository-dispatch@v3` errors on an empty token) — a real behavior change from today's silent no-op, and the correct one.

## Ordering, deliberate

This is the sender-side half of Hill90#792. The receiver-side half — hill90-app's `smoke-auth.yml` carrying `continue-on-error: true` on its actual test step with nothing checking the outcome — is a separate PR in that repo, and fixing it before this one would have shipped a change that provably could never be exercised (the workflow it lives in has never once run).

## Proof this actually works — not yet available

Not a green deploy — today's silent success already produces that. It is a real run of `smoke-auth.yml` existing after the next auth deploy, plus a deliberately-broken assertion in it turning that run red. **Until such a run exists, this wiring is unproven whatever the code says** — filing that as an explicit open item, not claiming this PR alone closes Hill90#792.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — YAML parses.
- [ ] No `actionlint`/workflow-lint gate exists in this repo's own CI to run against this change.
- [ ] Cannot be exercised end-to-end without `HILL90_APP_DISPATCH_TOKEN` existing and a real auth deploy — both outside this PR's scope.