### PR TITLE
docs(disaster-recovery): the AppRole count was fictional — five, not nine

### DIFF
--- a/docs/runbooks/disaster-recovery.md
+++ b/docs/runbooks/disaster-recovery.md
@@ -248,7 +248,32 @@ Bootstrap all AppRole credentials automatically:
 bash scripts/vault.sh bootstrap-approles
 ```
 
-This generates role_id + secret_id for all 9 services and stores them in SOPS. It temporarily generates a root token (via unseal key), runs setup, creates credentials, then revokes the root token.
+This generates role_id + secret_id for the services in `VAULT_SERVICES` and stores
+them in SOPS. It temporarily generates a root token (via unseal key), runs setup,
+creates credentials, then revokes the root token.
+
+> **There are FIVE, not nine.** `Verified 2026-08-05` against `scripts/vault.sh:31`,
+> which is the source of truth:
+>
+> ```sh
+> VAULT_SERVICES="db auth infra observability sync"
+> ```
+>
+> This line previously said "all 9 services". It was wrong, and wrong in the
+> document someone follows while rebuilding from nothing — expecting nine and
+> finding five during a rebuild is exactly the wrong moment to discover a count
+> is fictional.
+>
+> **`minio` and `vault` deliberately have no AppRole.** They are not in
+> `VAULT_SERVICES` and never have been, so their deploys legitimately fall back
+> to SOPS. A deploy log line reading `WARNING: OpenBao available but login failed
+> for minio, falling back to SOPS` is the **designed** behaviour for those two,
+> not a fault — see #791, where that warning was first read as credential decay.
+>
+> Corroborated independently: the root-level enumeration in
+> [`auth-outage-2026-08-03.md`](../decisions/auth-outage-2026-08-03.md) lists the
+> AppRoles that actually exist in the vault as `db`, `auth`, `infra`,
+> `observability`.
 
 ### 9. Deploy Database
 


### PR DESCRIPTION
## Plan

`docs/runbooks/disaster-recovery.md` told anyone rebuilding the estate that `bootstrap-approles` *"generates role_id + secret_id for all 9 services"*.

`scripts/vault.sh:31` is the source of truth:

```sh
VAULT_SERVICES="db auth infra observability sync"
```

**Five.** The number nine appears nowhere in the code and, as far as I can find, never has.

## Why this is worth a PR rather than a quiet edit

**Where it is.** This is the document someone follows while rebuilding from nothing. Expecting nine AppRoles and finding five, mid-rebuild, is the wrong moment to discover a count was invented — and the natural reaction (hunt for four missing credentials) burns time during the one procedure where time matters most.

**It already propagated.** I filed #791 earlier today reading a deploy log line as credential decay:

```
WARNING: OpenBao available but login failed for minio, falling back to SOPS
```

That reading was wrong, and the estate's own documentation is why it looked right. `minio` and `vault` are **not** in `VAULT_SERVICES` and never have been, so they have no AppRole to log in with, and the SOPS fallback is the designed path for them. That warning is the expected steady state, not a fault. One false number in a runbook produced one false issue within hours.

## Verification

Three independent sources, not one:

- `scripts/vault.sh:31` — `VAULT_SERVICES="db auth infra observability sync"`
- `docs/decisions/auth-outage-2026-08-03.md` — a **root-level enumeration** of the live vault listing `db`, `auth`, `infra`, `observability`
- today's deploy run `31043850839` — `db`, `auth` and `observability` authenticated; `minio` and `vault` fell back, exactly as a service with no AppRole must

```
$ python3 scripts/checks/check_md_links.py
Markdown link check passed: no missing local links found (61 files scanned).
```

## Risks

Documentation only; no code path changes. The stated risk is the opposite one: this now asserts a specific count, so it becomes wrong the moment `VAULT_SERVICES` changes. Mitigated by pointing at the variable as the source of truth and quoting it, so the next reader checks the line rather than trusting the prose — and by carrying a `Verified` date, per the repo's own rule. The claim it replaces carried no date, which is precisely the condition that rule exists to catch.

## What this does NOT do

It does not add anything that would *detect* the drift recurring. The instruments that would — `vault-approle-login-test.sh` and `vault-approle-real-read-test.sh` — exist but are invoked from exactly one place, `vault-regain-root.yml`, a manually-dispatched emergency workflow. So the estate has an AppRole-health check that only runs when someone is already fighting a fire. That is noted on #791 and is a separate piece of work.

It also does not touch the `sync` entry. `VAULT_SERVICES` includes it, the 2026-08-03 root enumeration did not list it, and #789's failing sync token is adjacent to that gap — I have not established whether the sync AppRole exists, and I am not asserting either way here.
