### PR TITLE
fix(observability): two rules built to catch a vanished series were themselves blind to it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -372,10 +372,11 @@ gh workflow run deploy.yml -f service=all
 
 - **Alerts reach a human.** `Verified 2026-08-03 13:45 UTC` by firing two real alerts and
   reading Alertmanager's own counters: `notifications_total{integration="email"}`
-  incremented and every `notifications_failed_total` stayed at 0. **26 rules in 10
-  groups** — h#712's `scheduled-workflows` group (8 rules) landed since this was
-  last counted at 18/9; this entry previously said 16 and 8, counted before #617
-  and never re-counted.
+  incremented and every `notifications_failed_total` stayed at 0. **27 rules in 10
+  groups** — h#789's absence-blindness sweep added `LokiIngestionSignalMissing` to the
+  existing `loki` group, taking this from 26/10; before that, h#712's
+  `scheduled-workflows` group (8 rules) landed since this was last counted at 18/9;
+  this entry previously said 16 and 8, counted before #617 and never re-counted.
   Delivered over email to `ACME_EMAIL` via the SMTP account the estate already
   had. Delivery is proven end to end, not assumed — but note the boundary: this
   proves Alertmanager handed the message to the mail server, not that it reached

--- a/platform/observability/prometheus/alerts.yml
+++ b/platform/observability/prometheus/alerts.yml
@@ -83,6 +83,13 @@ groups:
 
   - name: service-health
     rules:
+      # This rule is itself comparison-shaped, so it cannot fire if `up` has no
+      # series for a target at all — but that is not a silent gap the way it is
+      # elsewhere in this file: Prometheus synthesises `up` for every configured
+      # scrape target on its own, so total absence means the target was removed
+      # from scrape_configs, a deliberate edit, not a service failing quietly.
+      # Recorded here so the absence-blindness sweep (h#789) is not rediscovered
+      # as a finding against this rule specifically.
       - alert: ServiceDown
         expr: up == 0
         for: 5m
@@ -295,9 +302,17 @@ groups:
       # three quarters of an hour of silence before this pages, which is right for
       # "you have lost observability" rather than "the estate is down".
       #
-      # If Loki itself is down the series goes stale and this does NOT fire —
-      # ServiceDown covers that case. This one catches Loki healthy and receiving
-      # nothing, which is the case nothing else sees.
+      # If Loki itself is down long enough to trip ServiceDown (`up{job="loki"}`,
+      # 5m), that rule covers it — REAL coverage is container-down. It does NOT
+      # cover Loki running and answering scrapes while this specific series is
+      # renamed or relabeled away, e.g. by a version bump: `up` would stay 1 and
+      # ServiceDown would never fire, while this rule's own series would vanish
+      # with it. That gap is what LokiIngestionSignalMissing below closes — h#789's
+      # absence-blindness sweep flagged this comment for previously claiming
+      # ServiceDown as full coverage, which it was not.
+      #
+      # This one catches Loki healthy and receiving nothing, which is the case
+      # nothing else sees.
       - alert: LokiIngestionStalled
         expr: rate(loki_distributor_lines_received_total[15m]) == 0
         for: 30m
@@ -317,6 +332,37 @@ groups:
             target, so this alert is the only signal that it has stopped. If promtail
             is healthy, `docker logs --tail 50 loki` and confirm the push endpoint
             with `docker exec loki wget -qO- http://localhost:3100/ready`.
+          runbook: docs/runbooks/observability.md
+
+      # The watcher-watching case for LokiIngestionStalled — mirrors
+      # BackupSignalMissing/ScheduledWorkflowSignalMissing. If
+      # loki_distributor_lines_received_total is renamed, relabeled away, or
+      # simply never emitted by a future Loki version, `rate(<absent>[15m]) == 0`
+      # yields NO RESULT and LokiIngestionStalled can never fire — a stalled-
+      # ingestion alert silent about the metric it depends on not existing. `for`
+      # is short relative to the Backup/ScheduledWorkflow SignalMissing rules'
+      # 6h: those watch a once-nightly textfile heartbeat, where hours of gap are
+      # normal; this watches a continuously-scraped metric, where the standard
+      # ~5m staleness window already accounts for a single missed scrape, so 10m
+      # is margin, not tolerance for an expected gap.
+      - alert: LokiIngestionSignalMissing
+        expr: absent(loki_distributor_lines_received_total)
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "The Loki ingestion-rate metric has disappeared entirely"
+          description: >-
+            loki_distributor_lines_received_total is absent, so LokiIngestionStalled
+            cannot fire at all. If Loki is also down, ServiceDown should be firing
+            separately — check that first. If Loki is up and answering scrapes, the
+            metric was likely renamed or relabeled, most plausibly after a version
+            change.
+          action: >-
+            `docker ps --filter name=loki` to rule out the down case (ServiceDown
+            should already be firing if so). If Loki is running, `docker exec loki
+            wget -qO- http://localhost:3100/metrics | grep -i lines_received` to find
+            what the metric is now called, and update this rule's expr to match.
           runbook: docs/runbooks/observability.md
 
       # Logs actively rejected, as opposed to absent. 429 is rate-limiting or a
@@ -441,10 +487,25 @@ groups:
       # not double-report it. Verified that `offset 1h` has data (count 11 both
       # now and an hour ago), so the comparison evaluates rather than silently
       # returning an empty vector.
+      #
+      # `or vector(0)` ON BOTH SIDES, added after h#789's absence-blindness sweep:
+      # this rule exists specifically to catch certificates vanishing, but as
+      # originally written it could not see the total case. `count()` over zero
+      # matching series returns NO RESULT, not the number 0 — so if
+      # traefik_tls_certs_not_after disappeared ENTIRELY (not one host dropping
+      # out of eleven, but all eleven at once), both sides of the comparison went
+      # empty and the rule that exists to catch disappearance was itself blind to
+      # the total case. `or vector(0)` makes an empty side read as a real zero
+      # instead of dropping out of the comparison, so 0 < 11 correctly fires. It
+      # does NOT cover the metric never having existed at all (both sides
+      # legitimately 0 at once) — that state is outside what a before/after
+      # comparison can distinguish from "nothing to compare", and is the same
+      # boundary the certificates section's own header comment already assumes
+      # away by verifying the series exists before these rules were written.
       - alert: CertificateCountDropped
         expr: |
-          count(traefik_tls_certs_not_after)
-            < count(traefik_tls_certs_not_after offset 1h)
+          (count(traefik_tls_certs_not_after) or vector(0))
+            < (count(traefik_tls_certs_not_after offset 1h) or vector(0))
         for: 2h
         labels:
           severity: warning

--- a/platform/observability/prometheus/alerts.yml
+++ b/platform/observability/prometheus/alerts.yml
@@ -482,11 +482,30 @@ groups:
       # certificate that VANISHED rather than aged. Self-adjusting, so adding or
       # retiring a host needs no edit here.
       #
-      # for: 2h is load-bearing. A Traefik restart makes every series disappear
-      # briefly, and ServiceDown already reports Traefik being down — this must
-      # not double-report it. Verified that `offset 1h` has data (count 11 both
-      # now and an hour ago), so the comparison evaluates rather than silently
-      # returning an empty vector.
+      # `for:` WAS 2h, AND THAT MEANT THIS RULE COULD NEVER FIRE AT ALL — not on
+      # a total wipeout, not on the single-cert drop it was written for. Caught
+      # while positive-controlling h#789's absence fix, and worth stating
+      # plainly: `offset 1h` means the comparison is true for AT MOST one hour
+      # after any single, permanent count change. Once elapsed time since the
+      # change exceeds the offset duration, the right-hand side has rolled
+      # forward past the change too and reads the same post-change value as the
+      # left, so the condition goes false again on its own — self-resolving,
+      # not sustained. `for: 2h` demanded two continuous hours from a condition
+      # that is structurally incapable of holding true for more than one. This
+      # rule had been decoration since the day it was written: a change that
+      # only made its expression absence-safe, without also fixing this, would
+      # have reported success while leaving it exactly as unable to fire as
+      # before — the same defect family this rule exists to catch, applied to
+      # the fix itself.
+      #
+      # for: 15m is comfortably inside the one-hour window the comparison can
+      # actually sustain, and long enough to absorb an ordinary fast Traefik
+      # restart, which makes every series disappear for a few seconds and
+      # self-heals well under 15m once scraping resumes. A restart slow enough
+      # to still be dropping this 15 minutes in is also slow enough that
+      # ServiceDown (for: 5m) is already firing — overlap there is accepted
+      # deliberately, the same as BackupSignalMissing's overlap with ServiceDown
+      # above.
       #
       # `or vector(0)` ON BOTH SIDES, added after h#789's absence-blindness sweep:
       # this rule exists specifically to catch certificates vanishing, but as
@@ -502,19 +521,33 @@ groups:
       # comparison can distinguish from "nothing to compare", and is the same
       # boundary the certificates section's own header comment already assumes
       # away by verifying the series exists before these rules were written.
+      #
+      # DELIBERATE ASYMMETRY WITH LokiIngestionSignalMissing, stated so two
+      # different mechanisms in one PR read as a choice rather than
+      # inconsistency: Loki's absence guard is a LEVEL detector — absent()
+      # stays true and keeps firing for as long as the metric is genuinely
+      # gone, so its for: only needs to filter out one missed scrape. This
+      # rule's guard is an EDGE detector bounded by `offset 1h` — it can only
+      # ever see a change, not a state, and stops firing on its own once the
+      # offset window rolls past it. Two different absence shapes, two
+      # different detectors; `absent()` was not used here because there is
+      # nothing to alias it to that would preserve the before/after comparison
+      # a partial drop needs.
       - alert: CertificateCountDropped
         expr: |
           (count(traefik_tls_certs_not_after) or vector(0))
             < (count(traefik_tls_certs_not_after offset 1h) or vector(0))
-        for: 2h
+        for: 15m
         labels:
           severity: warning
         annotations:
           summary: "Traefik is serving fewer certificates than it was an hour ago"
           description: >-
-            The number of certificates Traefik holds has dropped and stayed down for two
-            hours. An expiry alert cannot see this: a certificate that disappears has no
-            series left to be near expiry. Traefik being down is a different alert.
+            The number of certificates Traefik holds has dropped and stayed down for at
+            least 15 minutes. An expiry alert cannot see this: a certificate that
+            disappears has no series left to be near expiry. Traefik being down is a
+            different alert, though a Traefik outage long enough to still be dropping
+            certs 15 minutes in will likely also be tripping ServiceDown.
           action: >-
             `docker exec traefik wget -qO- http://localhost:8082/metrics | grep -c
             '^traefik_tls_certs_not_after'` and compare with the router list. A host

--- a/tests/prometheus/alerts_test.yml
+++ b/tests/prometheus/alerts_test.yml
@@ -468,6 +468,41 @@ tests:
         alertname: LokiIngestionStalled
         exp_alerts: []
 
+  # h#789's absence-blindness sweep: LokiIngestionStalled's own comment used to
+  # claim ServiceDown covered the case where this metric disappears entirely
+  # (renamed/relabeled, Loki still up). ServiceDown watches `up`, a different
+  # metric, so it does not. LokiIngestionSignalMissing is the actual partner.
+  - name: "THE ASSERTION THAT MATTERS: LokiIngestionSignalMissing fires when the ingestion metric never appears at all"
+    # No input_series for loki_distributor_lines_received_total at all — this is
+    # what the metric being renamed away or never emitted by a future Loki
+    # version looks like: not stale, not old, absent from the very first eval.
+    interval: 1m
+    input_series: []
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: LokiIngestionSignalMissing
+        exp_alerts: []          # `for: 10m` not yet satisfied
+      - eval_time: 15m
+        alertname: LokiIngestionSignalMissing
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+            exp_annotations:
+              summary: "The Loki ingestion-rate metric has disappeared entirely"
+              description: "loki_distributor_lines_received_total is absent, so LokiIngestionStalled cannot fire at all. If Loki is also down, ServiceDown should be firing separately — check that first. If Loki is up and answering scrapes, the metric was likely renamed or relabeled, most plausibly after a version change."
+              action: "`docker ps --filter name=loki` to rule out the down case (ServiceDown should already be firing if so). If Loki is running, `docker exec loki wget -qO- http://localhost:3100/metrics | grep -i lines_received` to find what the metric is now called, and update this rule's expr to match."
+              runbook: docs/runbooks/observability.md
+
+  - name: "CONTROL: LokiIngestionSignalMissing stays silent while the ingestion metric is present"
+    interval: 1m
+    input_series:
+      - series: 'loki_distributor_lines_received_total{instance="loki:3100", job="loki", tenant="fake", aggregated_metric="false"}'
+        values: '0+600x60'
+    alert_rule_test:
+      - eval_time: 50m
+        alertname: LokiIngestionSignalMissing
+        exp_alerts: []
+
   - name: LokiPushRejected fires on 429 and names the status code
     # Rate-limited pushes. The old rule tried to express this condition and
     # selected a label that does not exist; this selects status_code, which does.
@@ -513,6 +548,83 @@ tests:
       - eval_time: 12m
         alertname: LokiPushRejected
         exp_alerts: []
+
+  # --- certificates -----------------------------------------------------------
+  #
+  # CertificateCountDropped's own `for: 2h` cannot be exercised by a promtool
+  # alert_rule_test here: with `offset 1h` on the right-hand side, any single,
+  # permanent count change (partial or total) is only visible to the
+  # comparison for exactly one hour — after that, the offset side has also
+  # rolled forward past the change and reads the same post-change value,
+  # so the comparison goes false again on its own. A `for: 2h` threshold can
+  # therefore never be satisfied by one step change, which is a separate,
+  # pre-existing property of this rule's for/offset pairing, not something
+  # introduced or fixed here — flagged, not touched, out of scope for the
+  # absence-blindness sweep this test file is otherwise for.
+  #
+  # So these use promql_expr_test instead, which evaluates the raw expression
+  # at one instant with no `for:` involved — the right tool for proving what
+  # the absence fix actually changed: whether the guard's expression produces
+  # a matching result at all when the metric is gone, not whether the alert
+  # would go on to fire after two hours.
+
+  # h#789's absence-blindness sweep: this rule exists specifically to catch
+  # certificates vanishing, but as originally written (`count(x) <
+  # count(x offset 1h)`, no fallback) it could not see the TOTAL case —
+  # count() over zero matching series is no result, not the number 0, so if
+  # every series vanished at once, both sides of the comparison went empty
+  # and produced nothing. The `or vector(0)` fix makes an empty side read as
+  # a real zero instead of dropping out of the comparison.
+  - name: "THE ASSERTION THAT MATTERS: the guard evaluates true on a TOTAL wipeout, not just a partial one"
+    # Two certificate series present for the first 69 minutes, then nothing —
+    # not a smaller count, no series left at all. At eval_time 100m: the
+    # un-offset side sees nothing (69m + 5m staleness is long past), the
+    # offset-1h side looks back to the 40m mark, where both series still had
+    # real samples.
+    interval: 1m
+    input_series:
+      - series: 'traefik_tls_certs_not_after{cn="a.example.com", instance="traefik:8082", job="traefik", sans="a.example.com", serial="1"}'
+        values: "1x69"
+      - series: 'traefik_tls_certs_not_after{cn="b.example.com", instance="traefik:8082", job="traefik", sans="b.example.com", serial="2"}'
+        values: "1x69"
+    promql_expr_test:
+      - expr: |
+          (count(traefik_tls_certs_not_after) or vector(0))
+            < (count(traefik_tls_certs_not_after offset 1h) or vector(0))
+        eval_time: 100m
+        exp_samples:
+          - value: 0
+
+  - name: "CONTROL: the guard still catches an ordinary partial drop (regression guard for the fix)"
+    # Two series for the first 69 minutes, then only one — the realistic
+    # failure mode (one host's DNS token revoked), unchanged by the fix.
+    interval: 1m
+    input_series:
+      - series: 'traefik_tls_certs_not_after{cn="a.example.com", instance="traefik:8082", job="traefik", sans="a.example.com", serial="1"}'
+        values: "1x120"
+      - series: 'traefik_tls_certs_not_after{cn="b.example.com", instance="traefik:8082", job="traefik", sans="b.example.com", serial="2"}'
+        values: "1x69"
+    promql_expr_test:
+      - expr: |
+          (count(traefik_tls_certs_not_after) or vector(0))
+            < (count(traefik_tls_certs_not_after offset 1h) or vector(0))
+        eval_time: 100m
+        exp_samples:
+          - value: 1
+
+  - name: "CONTROL: the guard stays quiet when the count has not changed"
+    interval: 1m
+    input_series:
+      - series: 'traefik_tls_certs_not_after{cn="a.example.com", instance="traefik:8082", job="traefik", sans="a.example.com", serial="1"}'
+        values: "1x120"
+      - series: 'traefik_tls_certs_not_after{cn="b.example.com", instance="traefik:8082", job="traefik", sans="b.example.com", serial="2"}'
+        values: "1x120"
+    promql_expr_test:
+      - expr: |
+          (count(traefik_tls_certs_not_after) or vector(0))
+            < (count(traefik_tls_certs_not_after offset 1h) or vector(0))
+        eval_time: 100m
+        exp_samples: []
 
   # --- delivery test facility -----------------------------------------------
 

--- a/tests/prometheus/alerts_test.yml
+++ b/tests/prometheus/alerts_test.yml
@@ -551,22 +551,17 @@ tests:
 
   # --- certificates -----------------------------------------------------------
   #
-  # CertificateCountDropped's own `for: 2h` cannot be exercised by a promtool
-  # alert_rule_test here: with `offset 1h` on the right-hand side, any single,
-  # permanent count change (partial or total) is only visible to the
-  # comparison for exactly one hour — after that, the offset side has also
-  # rolled forward past the change and reads the same post-change value,
-  # so the comparison goes false again on its own. A `for: 2h` threshold can
-  # therefore never be satisfied by one step change, which is a separate,
-  # pre-existing property of this rule's for/offset pairing, not something
-  # introduced or fixed here — flagged, not touched, out of scope for the
-  # absence-blindness sweep this test file is otherwise for.
-  #
-  # So these use promql_expr_test instead, which evaluates the raw expression
-  # at one instant with no `for:` involved — the right tool for proving what
-  # the absence fix actually changed: whether the guard's expression produces
-  # a matching result at all when the metric is gone, not whether the alert
-  # would go on to fire after two hours.
+  # CertificateCountDropped's `for:` USED TO BE 2h, which meant this rule could
+  # never fire at all — not on a total wipeout, not on the single-cert drop it
+  # was written for. `offset 1h` on the right-hand side means the comparison is
+  # true for AT MOST one hour after any single, permanent count change: past
+  # that, the offset side has rolled forward past the change too and reads the
+  # same post-change value as the left, so the condition self-resolves before
+  # a 2-hour `for:` could ever complete. Caught while positive-controlling the
+  # absence fix below, and fixed alongside it — see alerts.yml's own comment on
+  # the rule for the full reasoning. `for: 15m` is comfortably inside the one
+  # hour the comparison can actually sustain, which is also what makes a real
+  # alert_rule_test possible here now — it was not, against the old `for: 2h`.
 
   # h#789's absence-blindness sweep: this rule exists specifically to catch
   # certificates vanishing, but as originally written (`count(x) <
@@ -575,27 +570,38 @@ tests:
   # every series vanished at once, both sides of the comparison went empty
   # and produced nothing. The `or vector(0)` fix makes an empty side read as
   # a real zero instead of dropping out of the comparison.
-  - name: "THE ASSERTION THAT MATTERS: the guard evaluates true on a TOTAL wipeout, not just a partial one"
+  - name: "THE ASSERTION THAT MATTERS: CertificateCountDropped fires on a TOTAL wipeout, not just a partial one"
     # Two certificate series present for the first 69 minutes, then nothing —
-    # not a smaller count, no series left at all. At eval_time 100m: the
-    # un-offset side sees nothing (69m + 5m staleness is long past), the
-    # offset-1h side looks back to the 40m mark, where both series still had
-    # real samples.
+    # not a smaller count, no series left at all. The un-offset side goes
+    # absent once 69m + 5m staleness has passed (~74m); the offset-1h side
+    # stays real until 74m further on (~134m), since it is still reading the
+    # pre-wipeout sample through then. `for: 15m` inside that ~60m window means
+    # firing begins around 89m and holds until the offset side goes absent too.
     interval: 1m
     input_series:
       - series: 'traefik_tls_certs_not_after{cn="a.example.com", instance="traefik:8082", job="traefik", sans="a.example.com", serial="1"}'
         values: "1x69"
       - series: 'traefik_tls_certs_not_after{cn="b.example.com", instance="traefik:8082", job="traefik", sans="b.example.com", serial="2"}'
         values: "1x69"
-    promql_expr_test:
-      - expr: |
-          (count(traefik_tls_certs_not_after) or vector(0))
-            < (count(traefik_tls_certs_not_after offset 1h) or vector(0))
-        eval_time: 100m
-        exp_samples:
-          - value: 0
+    alert_rule_test:
+      - eval_time: 80m
+        alertname: CertificateCountDropped
+        exp_alerts: []          # true since ~74m, but `for: 15m` not yet satisfied
+      - eval_time: 100m
+        alertname: CertificateCountDropped
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+            exp_annotations:
+              summary: "Traefik is serving fewer certificates than it was an hour ago"
+              description: "The number of certificates Traefik holds has dropped and stayed down for at least 15 minutes. An expiry alert cannot see this: a certificate that disappears has no series left to be near expiry. Traefik being down is a different alert, though a Traefik outage long enough to still be dropping certs 15 minutes in will likely also be tripping ServiceDown."
+              action: "`docker exec traefik wget -qO- http://localhost:8082/metrics | grep -c '^traefik_tls_certs_not_after'` and compare with the router list. A host removed on purpose explains it; otherwise suspect the ACME store. Do NOT delete acme-dns.json — it holds the account key and every DNS-01 certificate, and re-issuance runs straight into rate limits."
+              runbook: docs/runbooks/certificate-renewal.md
+      - eval_time: 150m
+        alertname: CertificateCountDropped
+        exp_alerts: []          # self-resolved: past ~134m the offset side is absent too
 
-  - name: "CONTROL: the guard still catches an ordinary partial drop (regression guard for the fix)"
+  - name: "CONTROL: CertificateCountDropped still catches an ordinary partial drop (regression guard for the fix)"
     # Two series for the first 69 minutes, then only one — the realistic
     # failure mode (one host's DNS token revoked), unchanged by the fix.
     interval: 1m
@@ -604,27 +610,29 @@ tests:
         values: "1x120"
       - series: 'traefik_tls_certs_not_after{cn="b.example.com", instance="traefik:8082", job="traefik", sans="b.example.com", serial="2"}'
         values: "1x69"
-    promql_expr_test:
-      - expr: |
-          (count(traefik_tls_certs_not_after) or vector(0))
-            < (count(traefik_tls_certs_not_after offset 1h) or vector(0))
-        eval_time: 100m
-        exp_samples:
-          - value: 1
+    alert_rule_test:
+      - eval_time: 100m
+        alertname: CertificateCountDropped
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+            exp_annotations:
+              summary: "Traefik is serving fewer certificates than it was an hour ago"
+              description: "The number of certificates Traefik holds has dropped and stayed down for at least 15 minutes. An expiry alert cannot see this: a certificate that disappears has no series left to be near expiry. Traefik being down is a different alert, though a Traefik outage long enough to still be dropping certs 15 minutes in will likely also be tripping ServiceDown."
+              action: "`docker exec traefik wget -qO- http://localhost:8082/metrics | grep -c '^traefik_tls_certs_not_after'` and compare with the router list. A host removed on purpose explains it; otherwise suspect the ACME store. Do NOT delete acme-dns.json — it holds the account key and every DNS-01 certificate, and re-issuance runs straight into rate limits."
+              runbook: docs/runbooks/certificate-renewal.md
 
-  - name: "CONTROL: the guard stays quiet when the count has not changed"
+  - name: "CONTROL: CertificateCountDropped stays quiet when the count has not changed"
     interval: 1m
     input_series:
       - series: 'traefik_tls_certs_not_after{cn="a.example.com", instance="traefik:8082", job="traefik", sans="a.example.com", serial="1"}'
         values: "1x120"
       - series: 'traefik_tls_certs_not_after{cn="b.example.com", instance="traefik:8082", job="traefik", sans="b.example.com", serial="2"}'
         values: "1x120"
-    promql_expr_test:
-      - expr: |
-          (count(traefik_tls_certs_not_after) or vector(0))
-            < (count(traefik_tls_certs_not_after offset 1h) or vector(0))
-        eval_time: 100m
-        exp_samples: []
+    alert_rule_test:
+      - eval_time: 100m
+        alertname: CertificateCountDropped
+        exp_alerts: []
 
   # --- delivery test facility -----------------------------------------------
 

--- a/tests/scripts/alerts-absence-blindness-control.bats
+++ b/tests/scripts/alerts-absence-blindness-control.bats
@@ -1,0 +1,72 @@
+#!/usr/bin/env bats
+
+# POSITIVE CONTROL for platform/observability/prometheus/alerts.yml — the
+# absence-blindness fixes from h#789's sweep.
+#
+# tests/prometheus/alerts_test.yml (promtool) proves the FORMULA behaves
+# correctly under a total series wipeout, but promql_expr_test evaluates
+# whatever expr string is written INTO that test file — it does not read
+# the rule's real expr back out of alerts.yml, so on its own it cannot
+# prove the committed rule actually contains the fix; a test file that
+# still said the old formula would pass the same way a correct one does,
+# since promql_expr_test never looks at the real rule. This file closes
+# that gap: it greps the ACTUAL rule text in alerts.yml, so a future edit
+# that reverts the fix (or never lands it) fails here even if nobody
+# touches the promtool fixture. See that file's own header comment for
+# why alert_rule_test (which does load the real rule) can't be used
+# instead: CertificateCountDropped's for:2h can never be satisfied by a
+# single step change given its offset:1h, a separate pre-existing
+# property of the rule not touched by this fix.
+
+ALERTS=platform/observability/prometheus/alerts.yml
+
+@test "THE ASSERTION THAT MATTERS: CertificateCountDropped's guard is absence-safe on both sides" {
+  # count() over zero matching series is no result, not 0 — `or vector(0)`
+  # is what turns a genuinely-vanished side into a real, comparable zero
+  # instead of dropping the comparison entirely. Needed on BOTH sides:
+  # only guarding the left side still leaves the rule blind if the
+  # right side (the offset comparison point) is itself absent.
+  run bash -c "grep -A5 'alert: CertificateCountDropped' $ALERTS | grep -c 'or vector(0)'"
+  [ "$output" -eq 2 ]
+}
+
+@test "CertificateCountDropped's comparison metric is unchanged by the fix" {
+  # The fix must not have quietly changed WHAT is being compared.
+  run bash -c "grep -A5 'alert: CertificateCountDropped' $ALERTS | grep -c 'count(traefik_tls_certs_not_after'"
+  [ "$output" -eq 2 ]
+  run bash -c "grep -A5 'alert: CertificateCountDropped' $ALERTS | grep -F 'offset 1h'"
+  [ "$status" -eq 0 ]
+}
+
+@test "THE ASSERTION THAT MATTERS: LokiIngestionSignalMissing exists and watches the real metric with absent()" {
+  run grep -F 'alert: LokiIngestionSignalMissing' "$ALERTS"
+  [ "$status" -eq 0 ]
+  run bash -c "grep -A3 'alert: LokiIngestionSignalMissing' $ALERTS | grep -F 'expr: absent(loki_distributor_lines_received_total)'"
+  [ "$status" -eq 0 ]
+}
+
+@test "LokiIngestionSignalMissing's for: is shorter than the Backup/ScheduledWorkflow SignalMissing convention" {
+  # Deliberately: this watches a continuously-scraped metric, not a
+  # once-nightly textfile heartbeat, so it should not inherit the 6h used
+  # elsewhere in this file for that different case.
+  run bash -c "grep -A4 'alert: LokiIngestionSignalMissing' $ALERTS | grep -F 'for: 10m'"
+  [ "$status" -eq 0 ]
+}
+
+@test "LokiIngestionStalled's comment no longer claims blanket ServiceDown coverage" {
+  # The exact claim h#789's sweep flagged: it asserted ServiceDown covers
+  # the metric-disappears case outright, when ServiceDown watches `up`, a
+  # different metric — real coverage there is container-down only.
+  run bash -c "grep -B2 'alert: LokiIngestionStalled$' $ALERTS | grep -F 'ServiceDown covers that case'"
+  [ "$status" -ne 0 ]
+}
+
+@test "LokiIngestionStalled's corrected comment states the real scope of ServiceDown's coverage" {
+  run bash -c "grep -B12 'alert: LokiIngestionStalled$' $ALERTS | grep -F 'REAL coverage is container-down'"
+  [ "$status" -eq 0 ]
+}
+
+@test "ServiceDown records why its own absence-blindness is not a gap" {
+  run bash -c "grep -A6 'name: service-health' $ALERTS | grep -A6 'This rule is itself comparison-shaped' | grep -F 'Prometheus synthesises'"
+  [ "$status" -eq 0 ]
+}

--- a/tests/scripts/alerts-absence-blindness-control.bats
+++ b/tests/scripts/alerts-absence-blindness-control.bats
@@ -3,20 +3,15 @@
 # POSITIVE CONTROL for platform/observability/prometheus/alerts.yml — the
 # absence-blindness fixes from h#789's sweep.
 #
-# tests/prometheus/alerts_test.yml (promtool) proves the FORMULA behaves
-# correctly under a total series wipeout, but promql_expr_test evaluates
-# whatever expr string is written INTO that test file — it does not read
-# the rule's real expr back out of alerts.yml, so on its own it cannot
-# prove the committed rule actually contains the fix; a test file that
-# still said the old formula would pass the same way a correct one does,
-# since promql_expr_test never looks at the real rule. This file closes
-# that gap: it greps the ACTUAL rule text in alerts.yml, so a future edit
-# that reverts the fix (or never lands it) fails here even if nobody
-# touches the promtool fixture. See that file's own header comment for
-# why alert_rule_test (which does load the real rule) can't be used
-# instead: CertificateCountDropped's for:2h can never be satisfied by a
-# single step change given its offset:1h, a separate pre-existing
-# property of the rule not touched by this fix.
+# tests/prometheus/alerts_test.yml (promtool) proves the rules actually FIRE
+# (real alert_rule_test cases, not just expression evaluation) using the
+# rule text loaded straight from alerts.yml — for CertificateCountDropped
+# that only became possible once its `for:` moved from 2h to 15m (see
+# below); before that, alert_rule_test could never observe FIRING state
+# from a single step change no matter what the expression said. This file
+# is a second, independent instrument: it greps the ACTUAL committed rule
+# text, so a future edit that reverts either fix (the expression or the
+# `for:` duration) fails here even if nobody touches the promtool fixture.
 
 ALERTS=platform/observability/prometheus/alerts.yml
 
@@ -35,6 +30,28 @@ ALERTS=platform/observability/prometheus/alerts.yml
   run bash -c "grep -A5 'alert: CertificateCountDropped' $ALERTS | grep -c 'count(traefik_tls_certs_not_after'"
   [ "$output" -eq 2 ]
   run bash -c "grep -A5 'alert: CertificateCountDropped' $ALERTS | grep -F 'offset 1h'"
+  [ "$status" -eq 0 ]
+}
+
+@test "THE ASSERTION THAT MATTERS: CertificateCountDropped's for: is inside the window its offset comparison can sustain" {
+  # `for: 2h` against `offset 1h` meant this rule could never fire at all —
+  # not on a total wipeout, not on the partial drop it was written for. A
+  # fix that made the expression absence-safe without also fixing this
+  # would report success while leaving the rule exactly as unable to fire
+  # as before. `for: 15m` is comfortably inside the ~1h window the
+  # comparison can actually sustain.
+  run bash -c "grep -A6 'alert: CertificateCountDropped' $ALERTS | grep -F 'for: 15m'"
+  [ "$status" -eq 0 ]
+  run bash -c "grep -A6 'alert: CertificateCountDropped' $ALERTS | grep -F 'for: 2h'"
+  [ "$status" -ne 0 ]
+}
+
+@test "the deliberate asymmetry between the two absence guards is stated, not left to look like inconsistency" {
+  # Loki's guard is a level detector (absent() stays true for as long as
+  # the metric is gone); the certificate guard is an edge detector bounded
+  # by offset 1h. Two different absence shapes, two different mechanisms —
+  # recorded so it reads as a choice.
+  run bash -c "grep -B15 'alert: CertificateCountDropped' $ALERTS | grep -F 'DELIBERATE ASYMMETRY'"
   [ "$status" -eq 0 ]
 }
 


### PR DESCRIPTION
Prompted by the h#789 (vault-sync-to-sops) absence-blindness sweep across `platform/observability/prometheus/alerts.yml`.

## What's fixed

Both `CertificateCountDropped` and `LokiIngestionStalled` carried a comment claiming coverage that did not exist — worse than an undocumented gap, since the claim stops the next person looking.

- **`CertificateCountDropped`** exists specifically to catch certificates vanishing rather than aging (`count(x) < count(x offset 1h)`). `count()` over zero matching series is no result, not 0 — so a TOTAL wipeout of `traefik_tls_certs_not_after` (not one host out of eleven, all eleven at once) left both sides empty, and the rule built to catch disappearance was itself blind to the total case. **Does not get a partner rule** — it IS the partner for the two `CertificateExpiring*` rules, so a separate `absent()` would just move the problem. Fixed with `or vector(0)` on both sides.
- **Also `CertificateCountDropped`'s `for:` was 2h against `offset 1h`, which meant the rule could never fire at all** — not on a total wipeout, not on the single-cert drop it was originally written for. `offset 1h` bounds the comparison to true for at most one hour after any single, permanent change; past that, the offset side rolls forward past the change too and self-resolves. Caught while positive-controlling the `or vector(0)` fix, and it matters specifically *because of* that fix: shipping the absence fix without also fixing `for:` would have made the rule read as repaired (title, diff, comment all say "fixed") while it stayed exactly as unable to fire as before — the same defect family this rule exists to catch, applied to the fix itself. `for:` is now `15m`, comfortably inside the ~1h window the comparison can sustain, and long enough to absorb a normal fast Traefik restart (a slower one also trips `ServiceDown`, `for: 5m` — accepted overlap, same as `BackupSignalMissing`'s overlap with `ServiceDown` elsewhere in this file). **Reverting just this piece and rerunning promtool shows both the total-wipeout case and the ordinary partial-drop case fail to fire under the old `for: 2h`** — direct evidence the rule really was decoration, not merely blind to absence.
- **`LokiIngestionStalled`**'s own comment claimed `ServiceDown` covered its metric disappearing — untrue, `ServiceDown` watches `up`, a different metric. Real coverage is container-down; no coverage is container-up-with-the-metric-renamed, the more likely case after a Loki version bump. Fixed the comment and added `LokiIngestionSignalMissing` (`absent()`, `for: 10m` — shorter than the Backup/ScheduledWorkflow SignalMissing convention's 6h, since this watches a continuously-scraped metric, not a once-nightly heartbeat).
- **Deliberate asymmetry recorded**: Loki's absence guard is a level detector (`absent()` stays true for as long as the metric is gone); the certificate guard is an edge detector bounded by `offset 1h` (it can only see a change, not a state, and self-resolves once the offset window rolls past it). Noted next to `CertificateCountDropped` so two different fix mechanisms in one PR read as a choice rather than inconsistency.

**Recorded, not fixed**: `ServiceDown` is itself comparison-shaped, so it can't fire either if `up` vanished — but Prometheus synthesises `up` for every configured target, so total absence there means a target was deliberately removed from scrape_configs. One sentence added at the rule so this isn't rediscovered as a finding.

## Held for a separate pass

The sweep found 12 more unpaired comparison rules (`PublicSiteDown`, `VaultSealedOrUnreachable`, `TenantApiDown`, `ServiceDown` per-job, `ContainerRestartLoop`, `HostMemoryHigh`, `DiskSpaceRunningLow`, `PostgresConnectionsHigh`, `LokiPushRejected`, `TempoIngestionErrors`, `CertificateExpiringSoon`, `CertificateExpiringCritical`). None carries a false coverage claim, so they're not read as accepted by this PR. A dozen new `absent()` rules is a real noise risk — an `absent()` on a metric whose absence is sometimes legitimate is a false-alarm generator, which is how the estate got a `ServiceDown` nobody reads. Each needs "is absence ever normal for this metric?" answered first.

## Test plan
- [x] `promtool check rules` (real promtool via docker, pinned to the same Prometheus version as the rest of CI): 27 rules found
- [x] `promtool test rules tests/prometheus/alerts_test.yml`: certificates section now uses real `alert_rule_test` cases (actual FIRING state against the rule as loaded from `alerts.yml`) — `for: 15m` is what makes that possible; it was not achievable against the old `for: 2h` regardless of the expression. Covers total wipeout firing, an ordinary partial drop firing, silence on no change, and self-resolution once the offset window itself goes stale
- [x] New `tests/scripts/alerts-absence-blindness-control.bats` (9 tests) — ties the promtool fixtures back to the committed rule text (both the `or vector(0)` fix and the `for: 15m` / `for: 2h` gone / asymmetry-note fix), so a future revert of either is caught even if nobody touches the promtool file
- [x] Reverted `alerts.yml` in two stages (the expression fix, then the `for:` fix) and reran both instruments each time: every "assertion that matters" case went red for the predicted reason each time, unrelated controls stayed green throughout; restored and confirmed green again after each
- [x] `CLAUDE.md`'s rule count (26→27, still 10 groups) updated — `check_alert_counts_documented.py` caught the stale count as part of the full suite, exactly the defect class it exists to prevent
- [x] Branch rebased onto latest `origin/main` before the final push
- [x] Full `bats tests/scripts/*.bats`: 649/649 passed
- [x] Full `pytest tests/checks/`: 82/82 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
