### PR TITLE
fix(docs): disaster-recovery Step 12/13 revoked root unguarded, and never configured OIDC

### DIFF
--- a/docs/runbooks/disaster-recovery.md
+++ b/docs/runbooks/disaster-recovery.md
@@ -240,7 +240,33 @@ Push all secrets from the SOPS backup into vault KV v2 paths.
 bash scripts/vault.sh seed
 ```
 
-### 8. Generate and Store AppRole Credentials
+### 8. Configure OIDC (Keycloak)
+
+Enable and bind OpenBao's OIDC auth method against the platform Keycloak realm:
+
+```bash
+bash scripts/vault.sh setup-oidc
+```
+
+Reuses the `BAO_TOKEN` already exported for Step 6 — no need to export it again.
+Requires `VAULT_OIDC_CLIENT_SECRET` in SOPS (already present in the production
+store); the command refuses loudly rather than proceeding if it is missing.
+
+> **This step exists because `vault.sh revoke-root` — used in Step 13 below, and
+> called internally by `bootstrap-approles` in Step 9 — refuses to run without
+> it.** `assert_safe_to_revoke` (`scripts/vault.sh:244`) checks whether OIDC is
+> enabled before permitting a root-token revoke, because revoking root without
+> OIDC configured is **irreversible on OpenBao >= 2.5.3**: the unauthenticated
+> root-generation endpoints are disabled by default, so nothing can enable OIDC
+> afterward without redeploying on a recovery config, two vault restarts, and a
+> window in which an unseal key share alone mints root (`vault.sh regain-root`).
+>
+> Not a hypothetical — the guard's own comment names two prior occurrences of
+> exactly this: 2026-07-26, and again on 2026-08-02 by "the documented recovery"
+> this file describes. Skipping this step does not just skip OIDC; it reproduces
+> that failure a third time, at Step 9 or Step 13, in the middle of a recovery.
+
+### 9. Generate and Store AppRole Credentials
 
 Bootstrap all AppRole credentials automatically:
 
@@ -250,7 +276,9 @@ bash scripts/vault.sh bootstrap-approles
 
 This generates role_id + secret_id for the services in `VAULT_SERVICES` and stores
 them in SOPS. It temporarily generates a root token (via unseal key), runs setup,
-creates credentials, then revokes the root token.
+creates credentials, then revokes the root token — through the same
+`assert_safe_to_revoke` guard as Step 13, so it also depends on Step 8 above having
+run first.
 
 > **There are FIVE, not nine.** `Verified 2026-08-05` against `scripts/vault.sh:31`,
 > which is the source of truth:
@@ -275,7 +303,7 @@ creates credentials, then revokes the root token.
 > AppRoles that actually exist in the vault as `db`, `auth`, `infra`,
 > `observability`.
 
-### 9. Deploy Database
+### 10. Deploy Database
 
 ```bash
 bash scripts/deploy.sh db prod
@@ -328,13 +356,13 @@ bash scripts/backup.sh restore db /path/to/backup
 > is a convenience, not a step. Full evidence in
 > [`backup-consistency-options.md`](../decisions/backup-consistency-options.md).
 
-### 10. Deploy All Services
+### 11. Deploy All Services
 
 ```bash
 bash scripts/deploy.sh all prod
 ```
 
-### 11. Verify Health
+### 12. Verify Health
 
 ```bash
 bash scripts/ops.sh health
@@ -342,13 +370,26 @@ bash scripts/ops.sh health
 
 Check each service endpoint responds correctly.
 
-### 12. Revoke Root Token
+### 13. Revoke Root Token
 
 ```bash
-docker exec -e BAO_ADDR=http://127.0.0.1:8200 -e BAO_TOKEN="<root-token>" openbao bao token revoke -self
+bash scripts/vault.sh revoke-root
 ```
 
-### 13. Post-Recovery: Sync Vault to SOPS
+> **Not the raw `docker exec ... bao token revoke -self` this step used to
+> document.** That call went straight to the OpenBao API with no safety check.
+> `vault.sh revoke-root` runs the identical revoke through `assert_safe_to_revoke`
+> first (see Step 8 above), which refuses rather than leaving a permanently
+> unconfigurable vault if OIDC somehow isn't enabled by this point. It also reads
+> the root token from `$ROOT_TOKEN_PATH` on the host instead of requiring it typed
+> into a command, and independently confirms the token is dead afterward rather
+> than trusting the API's own always-0 exit code.
+>
+> If Step 9 (`bootstrap-approles`) already completed, it will have revoked this
+> same root token itself. `vault.sh revoke-root` reports "nothing to revoke" and
+> exits 0 in that case — expected, not an error.
+
+### 14. Post-Recovery: Sync Vault to SOPS
 
 Confirm the SOPS backup reflects the current vault state:
 
@@ -361,7 +402,7 @@ bash scripts/vault.sh sync-to-sops
 
 ```
 VPS recreate -> VPS config -> infra -> vault (deploy+init+unseal+setup+seed)
-  -> AppRole creds -> db (+ restore) -> all services -> health check
+  -> OIDC config -> AppRole creds -> db (+ restore) -> all services -> health check
   -> revoke root token -> sync vault to SOPS
 ```
 


### PR DESCRIPTION
## Summary

Closes #803. Documentation-only change — no revoke run, no OpenBao touched,
verified by reading `scripts/vault.sh`, not by executing it.

Two things had to be fixed together, because fixing either alone leaves a
dead end.

**1. The old Step 12 revoked root with a raw, unguarded command.**
`docker exec ... bao token revoke -self` goes straight to the OpenBao API
with no safety check. `vault.sh revoke-root` runs the identical revoke
through `assert_safe_to_revoke` (`scripts/vault.sh:244`) first, which
refuses unless OIDC is already enabled: revoking root without it is
**irreversible on OpenBao >= 2.5.3** (unauthenticated root-generation
endpoints are disabled by default), and the guard's own comment names two
prior occurrences of exactly this — 2026-07-26, and again on 2026-08-02
by "the documented recovery" this file describes.

**2. But swapping only the command would have turned a silent lockout
into a hard `die` at the last step of a recovery.** This runbook's 14
steps never configured OIDC anywhere, so `assert_safe_to_revoke` would
refuse regardless of which revoke command was used. New **Step 8** runs
`vault.sh setup-oidc` before anything that revokes root — including
`bootstrap-approles`' own internal revoke (Step 9, which uses the same
guard and would otherwise die at the same point, mid-recovery). The new
step's own paragraph explains why it exists and cites the exact prior
incidents, so a reader two months from now doesn't have to reconstruct
the hazard from the guard's error message alone.

Steps 8-13 renumbered to 9-14 to make room; the Recovery Order Summary
diagram at the bottom updated to match. No other content changed — I
checked both files that link into this doc (`vps-rebuild.md`,
`backup-coverage.md`) and both only anchor to `#step-0`, which this diff
doesn't touch.

## Deliberately not done

No `ALLOW_REVOKE_WITHOUT_OIDC=1` anywhere in this diff. Documenting the
bypass as the procedure would recreate the exact hazard this fixes, with
a flag on it instead of a comment explaining it away.

## What this does not verify

That the corrected sequence (init → unseal → setup → seed → setup-oidc →
bootstrap-approles → ... → revoke-root) works end to end. Proving that
needs a real recovery run against a throwaway vault, which was not done
today — this is a documentation fix, checked against the current script's
actual behavior (`assert_safe_to_revoke`'s gate, `cmd_setup_oidc`'s
requirements — `require_running`, `VAULT_OIDC_CLIENT_SECRET` in SOPS,
confirmed present — and `cmd_revoke_root`'s "nothing to revoke" no-op
path when `bootstrap-approles` already revoked the same token), not a
rehearsed recovery.

## Test plan

- [x] Numbering verified: `### [0-9]` headers run 1-14 with no gaps or
      duplicates.
- [x] No stale references to the old step numbers anywhere in either
      runbook.
- [x] `python3 scripts/checks/check_md_links.py` — 61 files scanned, no
      missing local links.
- [ ] Not run: an actual recovery rehearsal exercising the new Step 8 →
      Step 9 → Step 13 sequence — see "What this does not verify" above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)