### PR TITLE
fix(vps): Tailscale key-generation failures collapsed into one useless message

### DIFF
--- a/scripts/vps.sh
+++ b/scripts/vps.sh
@@ -41,8 +41,22 @@ _tailscale_generate_key() {
 
     info "Generating Tailscale auth key..."
 
-    local response key
-    response=$(curl -s -X POST "https://api.tailscale.com/api/v2/tailnet/$TAILSCALE_TAILNET/keys" \
+    # Four genuinely different failure states used to collapse into one
+    # message ("Failed to generate auth key. Response: $response") — or
+    # worse, into nothing at all once cmd_recreate's own capture below
+    # discarded it. "The API rejected us", "the API answered something we
+    # could not parse", and "the API answered fine but with no key field"
+    # each point at a different fix; a run that never reached the API at
+    # all (DNS/TLS/connection failure) points at a fourth. Distinguished
+    # here so whichever one happens is nameable from the log, not
+    # re-diagnosed from scratch next time — which is what happened to the
+    # run that surfaced this (recreate-vps.yml, 2026-06-14): the log shows
+    # only a generic failure, and it is not possible to tell from it alone
+    # whether the cause was an expired credential or something else.
+    local http_code response_body response_file curl_exit=0
+    response_file=$(mktemp)
+    http_code=$(curl -sS -o "$response_file" -w '%{http_code}' -X POST \
+        "https://api.tailscale.com/api/v2/tailnet/$TAILSCALE_TAILNET/keys" \
         -H "Authorization: Bearer $TAILSCALE_API_KEY" \
         -H "Content-Type: application/json" \
         --data '{
@@ -56,10 +70,24 @@ _tailscale_generate_key() {
                 }
             },
             "expirySeconds": 7776000
-        }')
+        }') || curl_exit=$?
+    response_body=$(cat "$response_file" 2>/dev/null || true)
+    rm -f "$response_file"
 
-    key=$(echo "$response" | jq -r '.key // empty')
-    [[ -n "$key" ]] || die "Failed to generate auth key. Response: $response"
+    if [[ "$curl_exit" -ne 0 ]]; then
+        die "Could not reach the Tailscale API (curl exit ${curl_exit}) — DNS, TLS, or connection failure. No HTTP response was received, so this is not the API rejecting the request; the request never arrived."
+    fi
+
+    if [[ "$http_code" != "200" ]]; then
+        die "Tailscale API rejected the request (HTTP ${http_code}). Response: ${response_body}"
+    fi
+
+    local key
+    if ! key=$(printf '%s' "$response_body" | jq -r '.key // empty' 2>/dev/null); then
+        die "Tailscale API returned HTTP 200 with a body that could not be parsed as JSON. Response: ${response_body}"
+    fi
+
+    [[ -n "$key" ]] || die "Tailscale API returned HTTP 200 with valid JSON but no 'key' field. Response: ${response_body}"
 
     success "✓ Auth key generated"
     echo "$key"
@@ -76,9 +104,20 @@ cmd_recreate() {
     # Step 1: Rotate Tailscale auth key
     info "Step 1/3: Rotating Tailscale auth key..."
 
+    # Deliberately NOT `2>&1 | tail -1`. _tailscale_generate_key sends every
+    # info/success/die message to stderr and returns only the key on stdout,
+    # so capturing stdout alone is enough — and it stops this step from
+    # discarding _tailscale_generate_key's own specific failure message. The
+    # old pattern mixed stdout and stderr, kept only the last combined line
+    # in $auth_key, and then threw that value away on the failure branch in
+    # favor of the generic message below — so no matter how specific
+    # _tailscale_generate_key's own diagnosis was, only "Failed to generate
+    # Tailscale auth key" ever reached the log. It still runs first and is
+    # still visible above this line; this message is step-level context, not
+    # a replacement for it.
     local auth_key
-    if ! auth_key=$(_tailscale_generate_key 2>&1 | tail -1); then
-        die "Failed to generate Tailscale auth key"
+    if ! auth_key=$(_tailscale_generate_key); then
+        die "Failed to generate Tailscale auth key — see the specific cause above."
     fi
 
     success "✓ Auth key generated"

--- a/tests/scripts/tailscale-key-diagnostics.bats
+++ b/tests/scripts/tailscale-key-diagnostics.bats
@@ -158,7 +158,18 @@ run_recreate() {
     [[ "$output" == *"tskey-auth-abc123fake"* ]]
 }
 
-@test "THE ASSERTION THAT MATTERS: three failure scenarios produce three DISTINCT messages, not the same one" {
+@test "THE ASSERTION THAT MATTERS: each failure scenario names its OWN cause, and only its own" {
+    # NOT a mere-inequality check. The pre-fix message was "Failed to
+    # generate auth key. Response: $response" for every scenario, and the
+    # three stub bodies already differ — so three DIFFERENT strings came
+    # free from echoing the body back, with no diagnosis in any of them.
+    # Inequality was never the missing property; it would pass whether or
+    # not the actual cause was named. What was actually absent, and what
+    # this asserts instead: that each message names ITS cause specifically
+    # — 401 names the HTTP status, the malformed body names a parse
+    # failure, the missing-key body names the missing field — and does not
+    # also claim either of the other two, which is what "distinct causes"
+    # has to mean for a human reading the log, not just "distinct bytes".
     run run_generate_key "scenario-401"
     local msg_401="$output"
     run run_generate_key "scenario-badjson"
@@ -166,9 +177,17 @@ run_recreate() {
     run run_generate_key "scenario-nokey"
     local msg_nokey="$output"
 
-    [ "$msg_401" != "$msg_badjson" ] || { echo "401 and badjson produced the SAME message: $msg_401"; return 1; }
-    [ "$msg_401" != "$msg_nokey" ] || { echo "401 and nokey produced the SAME message: $msg_401"; return 1; }
-    [ "$msg_badjson" != "$msg_nokey" ] || { echo "badjson and nokey produced the SAME message: $msg_badjson"; return 1; }
+    [[ "$msg_401" == *"HTTP 401"* ]] || { echo "401 case does not name HTTP 401: $msg_401"; return 1; }
+    [[ "$msg_401" != *"could not be parsed as JSON"* ]] || { echo "401 case also claims a parse failure: $msg_401"; return 1; }
+    [[ "$msg_401" != *"no 'key' field"* ]] || { echo "401 case also claims a missing key field: $msg_401"; return 1; }
+
+    [[ "$msg_badjson" == *"could not be parsed as JSON"* ]] || { echo "badjson case does not name a parse failure: $msg_badjson"; return 1; }
+    [[ "$msg_badjson" != *"HTTP 401"* ]] || { echo "badjson case also claims HTTP 401: $msg_badjson"; return 1; }
+    [[ "$msg_badjson" != *"no 'key' field"* ]] || { echo "badjson case also claims a missing key field: $msg_badjson"; return 1; }
+
+    [[ "$msg_nokey" == *"no 'key' field"* ]] || { echo "nokey case does not name the missing key field: $msg_nokey"; return 1; }
+    [[ "$msg_nokey" != *"HTTP 401"* ]] || { echo "nokey case also claims HTTP 401: $msg_nokey"; return 1; }
+    [[ "$msg_nokey" != *"could not be parsed as JSON"* ]] || { echo "nokey case also claims a parse failure: $msg_nokey"; return 1; }
 }
 
 @test "cmd_recreate surfaces the specific cause, not just a step-level generic message" {

--- a/tests/scripts/tailscale-key-diagnostics.bats
+++ b/tests/scripts/tailscale-key-diagnostics.bats
@@ -1,0 +1,203 @@
+#!/usr/bin/env bats
+
+# _tailscale_generate_key (scripts/vps.sh) used to collapse three genuinely
+# different failure states into one message — "Failed to generate auth key.
+# Response: $response" — and cmd_recreate's own `2>&1 | tail -1` capture
+# then discarded even that on every failure, replacing it with a static
+# "Failed to generate Tailscale auth key" no matter what actually happened.
+# recreate-vps.yml's real 2026-06-14 failure shows exactly this: the log
+# names no cause at all.
+#
+# Never touches the real Tailscale API. A local HTTP server on an
+# OS-assigned free port stands in for api.tailscale.com, and a `curl` shim
+# earlier in PATH rewrites requests to it — everything else about the real
+# curl invocation (flags, -o, -w) passes through unmodified. Four scenarios:
+# the API rejecting the request (401), the API answering with a body that
+# is not valid JSON, the API answering with valid JSON but no `key` field,
+# and the request never arriving at all (closed port — curl-level failure,
+# no HTTP response to have an opinion about).
+#
+# THE ASSERTION THAT MATTERS is not "the function exits nonzero" — a
+# version that collapses all three responses into the same message exits
+# nonzero too. What's asserted is that the four scenarios produce four
+# DISTINCT messages, each naming its actual cause, all the way through
+# cmd_recreate — not just inside _tailscale_generate_key alone, since that
+# inner message meant nothing if cmd_recreate discarded it on the way out.
+
+setup() {
+    VPS_SCRIPT="$BATS_TEST_DIRNAME/../../scripts/vps.sh"
+    [ -f "$VPS_SCRIPT" ] || skip "scripts/vps.sh not found"
+    command -v python3 >/dev/null || skip "python3 not available"
+
+    WORKDIR=$(mktemp -d)
+    REAL_CURL=$(command -v curl)
+
+    cat > "$WORKDIR/stub_server.py" << 'PYEOF'
+import http.server
+import socket
+import sys
+
+SCENARIOS = {
+    "scenario-401": (401, b'{"message":"unauthorized"}'),
+    "scenario-badjson": (200, b'not json at all {'),
+    "scenario-nokey": (200, b'{"id":"abc123"}'),
+    "scenario-ok": (200, b'{"key":"tskey-auth-abc123fake"}'),
+}
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    def do_POST(self):
+        parts = self.path.strip("/").split("/")
+        scenario = parts[3] if len(parts) > 3 else None
+        status, body = SCENARIOS.get(scenario, (500, b'{"error":"unknown scenario"}'))
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+    def log_message(self, *a):
+        pass
+
+s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+s.bind(("127.0.0.1", 0))
+port = s.getsockname()[1]
+s.close()
+print(port, flush=True)
+http.server.HTTPServer(("127.0.0.1", port), Handler).serve_forever()
+PYEOF
+
+    python3 "$WORKDIR/stub_server.py" > "$WORKDIR/port.txt" 2>"$WORKDIR/server.log" &
+    SERVER_PID=$!
+    # Poll for the port line rather than a fixed sleep — the server prints
+    # it before entering serve_forever(), so its presence means the socket
+    # is bound and ready.
+    for _ in $(seq 1 50); do
+        [ -s "$WORKDIR/port.txt" ] && break
+        sleep 0.1
+    done
+    STUB_PORT=$(cat "$WORKDIR/port.txt" 2>/dev/null)
+    [ -n "$STUB_PORT" ] || skip "stub server did not start"
+
+    mkdir -p "$WORKDIR/fakebin"
+    # STUB_PORT read from THIS shim's own environment at call time, not
+    # baked in here — the closed-port test below reassigns it per-test to
+    # a port nothing listens on, and that reassignment has to actually
+    # reach curl, not just this setup step.
+    cat > "$WORKDIR/fakebin/curl" << EOF
+#!/usr/bin/env bash
+args=()
+for a in "\$@"; do
+  case "\$a" in
+    https://api.tailscale.com/*)
+      a="http://127.0.0.1:\${STUB_PORT}/\${a#https://api.tailscale.com/}"
+      ;;
+  esac
+  args+=("\$a")
+done
+exec "$REAL_CURL" "\${args[@]}"
+EOF
+    chmod +x "$WORKDIR/fakebin/curl"
+
+    # main() at the bottom of vps.sh runs on invocation; strip it so this
+    # can be sourced to reach the functions directly, matching the actual
+    # file everywhere else. vps.sh resolves _common.sh relative to its own
+    # BASH_SOURCE, so the copy needs it alongside, not just present at its
+    # real repo path.
+    sed '$ d' "$VPS_SCRIPT" > "$WORKDIR/vps_under_test.sh"
+    cp "$BATS_TEST_DIRNAME/../../scripts/_common.sh" "$WORKDIR/_common.sh"
+
+    export STUB_PORT
+    export PATH="$WORKDIR/fakebin:$PATH"
+    export TAILSCALE_API_KEY="test-key-not-real"
+}
+
+teardown() {
+    [ -n "${SERVER_PID:-}" ] && kill "$SERVER_PID" 2>/dev/null
+    [ -n "${WORKDIR:-}" ] && rm -rf "$WORKDIR"
+}
+
+run_generate_key() {
+    local scenario="$1"
+    TAILSCALE_TAILNET="$scenario" bash -c "
+        source '$WORKDIR/vps_under_test.sh'
+        _tailscale_generate_key
+    "
+}
+
+run_recreate() {
+    local scenario="$1"
+    TAILSCALE_TAILNET="$scenario" bash -c "
+        source '$WORKDIR/vps_under_test.sh'
+        cmd_recreate
+    "
+}
+
+@test "401 (API rejects the request) names HTTP 401, not a generic failure" {
+    run run_generate_key "scenario-401"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"HTTP 401"* ]] || { echo "expected HTTP 401 named in output, got: $output"; return 1; }
+    [[ "$output" == *"unauthorized"* ]]
+}
+
+@test "malformed JSON body names a parse failure, distinctly from a rejection" {
+    run run_generate_key "scenario-badjson"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"could not be parsed as JSON"* ]] || { echo "expected a parse-failure message, got: $output"; return 1; }
+    [[ "$output" != *"HTTP 401"* ]]
+}
+
+@test "valid JSON with no key field names that specifically, distinctly from a parse failure" {
+    run run_generate_key "scenario-nokey"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"no 'key' field"* ]] || { echo "expected a missing-key message, got: $output"; return 1; }
+    [[ "$output" != *"could not be parsed as JSON"* ]]
+}
+
+@test "a successful response still returns the key" {
+    run run_generate_key "scenario-ok"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"tskey-auth-abc123fake"* ]]
+}
+
+@test "THE ASSERTION THAT MATTERS: three failure scenarios produce three DISTINCT messages, not the same one" {
+    run run_generate_key "scenario-401"
+    local msg_401="$output"
+    run run_generate_key "scenario-badjson"
+    local msg_badjson="$output"
+    run run_generate_key "scenario-nokey"
+    local msg_nokey="$output"
+
+    [ "$msg_401" != "$msg_badjson" ] || { echo "401 and badjson produced the SAME message: $msg_401"; return 1; }
+    [ "$msg_401" != "$msg_nokey" ] || { echo "401 and nokey produced the SAME message: $msg_401"; return 1; }
+    [ "$msg_badjson" != "$msg_nokey" ] || { echo "badjson and nokey produced the SAME message: $msg_badjson"; return 1; }
+}
+
+@test "cmd_recreate surfaces the specific cause, not just a step-level generic message" {
+    run run_recreate "scenario-401"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"HTTP 401"* ]] || { echo "cmd_recreate discarded the specific cause; got: $output"; return 1; }
+}
+
+@test "THE ASSERTION THAT MATTERS, end to end: cmd_recreate's three failure scenarios stay distinct, not collapsed on the way out" {
+    run run_recreate "scenario-401"
+    local msg_401="$output"
+    run run_recreate "scenario-badjson"
+    local msg_badjson="$output"
+    run run_recreate "scenario-nokey"
+    local msg_nokey="$output"
+
+    [ "$msg_401" != "$msg_badjson" ] || { echo "cmd_recreate: 401 and badjson collapsed to the same output"; return 1; }
+    [ "$msg_401" != "$msg_nokey" ] || { echo "cmd_recreate: 401 and nokey collapsed to the same output"; return 1; }
+    [ "$msg_badjson" != "$msg_nokey" ] || { echo "cmd_recreate: badjson and nokey collapsed to the same output"; return 1; }
+}
+
+@test "a request that never arrives (closed port) is distinguished from the API rejecting it" {
+    STUB_PORT=1
+    run run_generate_key "scenario-ok"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Could not reach the Tailscale API"* ]] || { echo "expected a connection-failure message, got: $output"; return 1; }
+    # Not "the substring HTTP never appears" — the message itself correctly
+    # says "no HTTP response was received", which contains that word. What
+    # must not appear is a CLAIMED status, which only the rejected-request
+    # and no-key branches ever produce.
+    [[ "$output" != *"HTTP 200"* && "$output" != *"HTTP 401"* ]] || { echo "a connection failure should not claim a specific HTTP status — none was received"; return 1; }
+}


### PR DESCRIPTION
## Summary

Follow-up to #800. Code only — no credential touched, no rebuild run, no
real Tailscale API call made anywhere in this change or its verification.

## What was actually wrong, and it was worse than it first looked

#800's own report suspected an expired `TAILSCALE_API_KEY`, but the real
production log (run `27486916725`, 2026-06-14) names no cause at all —
just `ERROR: Failed to generate Tailscale auth key`. Driving the real
code against a local stub (see Verification) found why, and it's two
defects stacked, not one.

**1. `_tailscale_generate_key` collapsed three genuinely different
failure states into one template.** "The API rejected us", "the API
answered something we could not parse", and "the API answered fine but
with no key field" all read as the same shape of message
(`Failed to generate auth key. Response: $response`), differing only in
whatever text happened to be in `$response`. A fourth state — the
request never reaching the API at all (DNS/TLS/connection failure) —
produced an *empty* Response field with no explanation at all.

**2. `cmd_recreate` then discarded even that.**
`auth_key=$(_tailscale_generate_key 2>&1 | tail -1)` mixed stdout and
stderr, kept only the combined last line, and — critically — threw that
value away entirely on the failure branch in favor of a hardcoded
`"Failed to generate Tailscale auth key"`, replacing whatever
`_tailscale_generate_key` had actually said. **This second defect is why
the real log shows nothing**: even though the inner function's diagnosis
reaches its own stderr, nothing downstream was still listening for it.

## The fix

`_tailscale_generate_key` now reads curl's exit code and the HTTP status
separately from the response body, producing four distinct, cause-naming
messages: connection failure, HTTP rejection (with status and body),
unparseable body, and valid-but-empty key. `cmd_recreate` no longer pipes
through `2>&1 | tail -1` — `_tailscale_generate_key` already sends every
info/success/die message to stderr and returns only the key on stdout,
so capturing stdout alone is correct, and it lets the inner function's
own specific message reach the log undisturbed, with `cmd_recreate`'s own
message now added as step-level context rather than a replacement.

## What this does NOT fix

**This does not tell you why the real 2026-06-14 run failed, and does
not touch `TAILSCALE_API_KEY`.** The next real attempt (if and when one
happens) will now say which of the four states occurred — that is the
entire scope of this change. **#800 stays open: the rebuild is still
blocked, and whether the credential needs rotating is Jon's call**, not
resolved here.

**Also named, not fixed here**: `recreate-vps.yml` has no `schedule:`
trigger, so it falls entirely outside this estate's
`ScheduledWorkflowSignalMissing`/`ScheduledWorkflowNotTriggering` alert
family, which only watches cron-triggered workflows by construction.
That's the mechanism behind 53 days passing unnoticed, and a
dispatch-only workflow going stale is invisible to that alert category
no matter how long it rots. May deserve its own issue — flagging it here
rather than silently leaving it out.

## Verification — driven against a local stub, not asserted from reading

The real Tailscale API was never called. A local Python HTTP server on
an OS-assigned port stood in for `api.tailscale.com`; a `curl` shim
earlier in `PATH` rewrote only `api.tailscale.com` URLs to it, passing
every other flag through to the real `curl` unmodified. Four scenarios:
HTTP 401, HTTP 200 with an unparseable body, HTTP 200 with valid JSON but
no `key` field, and a closed port (curl-level connection failure).

**Positive-controlled against `origin/main`'s actual pre-fix code, not a
description of it**: reverted `scripts/vps.sh`, ran the new bats file —
6 of 8 tests failed for the exact predicted reason. Three of the four
scenarios produced byte-identical output through `cmd_recreate`, exactly
reproducing the real production log's blindness. The two tests
exercising `_tailscale_generate_key` alone still passed, because that
inner function's message, while genericly templated, does still embed
the differing `$response` text — confirming precisely that the *total*
collapse happens at the `cmd_recreate` layer, not before it. Restored
the fix: all 8 pass.

## Test plan

- [x] New `tests/scripts/tailscale-key-diagnostics.bats` — 8 tests, all
      driven against the local stub described above.
- [x] Confirmed failing against `origin/main`'s pre-fix code (6/8) before
      this commit, for the reasons above.
- [x] All 8 pass after the fix.
- [x] Full suite: `bats tests/scripts/` — 665/665, exit code captured
      directly (not through a truncating pipe) — unrelated regressions
      ruled out.
- [x] `shellcheck --severity=error scripts/*.sh` — clean.
- [x] `python3 scripts/checks/check_md_links.py` — clean, unaffected
      (no docs touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)