### PR TITLE
fix(deploy): distinguish vault_login's three failure causes — h#815

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -148,6 +148,32 @@ vault_available() {
         python3 -c "import sys,json; d=json.load(sys.stdin); exit(0 if not d.get('sealed',True) else 1)" 2>/dev/null
 }
 
+# Three failure modes used to `return 1` indistinguishably — h#791 sat
+# undiagnosable for days because of it. deploy.sh's call sites redirected this
+# function's entire output (both streams) to /dev/null, so whichever of the
+# three fired, the operator saw the same sentence: "OpenBao available but
+# login failed... falling back to SOPS". For the decrypt case that sentence is
+# actively wrong — it names OpenBao when OpenBao was never contacted.
+#
+# Fix: a short, credential-free reason on stderr, and a DISTINCT return code
+# per cause, so a caller that wants to tell them apart can. Stdout carries
+# ONLY the token on success, exactly as before — callers that do
+# `token=$(vault_login ...)` are unaffected.
+#
+#   2 = sops decrypt failed                  — nothing to do with OpenBao
+#   3 = AppRole credentials missing/empty    — permanent/structural, no request sent
+#   4 = OpenBao rejected the login, or the response could not be parsed
+#
+# CREDENTIAL SAFETY, checked rather than assumed. OpenBao's own rejection text
+# for a bad AppRole login is the fixed string "invalid role or secret ID" —
+# confirmed against a real rejection captured in
+# docs/decisions/approle-rejection-2026-08-01.md, not a submitted value
+# interpolated into a template — so surfacing OpenBao's own error line cannot
+# echo role_id/secret_id back. role_id and secret_id themselves are never
+# printed by this function on any path, and neither is the token except on
+# genuine success, on stdout, exactly as it always was.
+# tests/scripts/vault-login-diagnostics.bats asserts this directly rather than
+# trusting the reasoning above.
 vault_login() {
     local service="$1"
     local secrets_file="${2:-$PROJECT_ROOT/infra/secrets/prod.enc.env}"
@@ -161,7 +187,11 @@ vault_login() {
     # shellcheck disable=SC2064
     trap "rm -f '$temp_file'" RETURN
 
-    sops -d "$secrets_file" > "$temp_file" 2>/dev/null || { rm -f "$temp_file"; trap - RETURN; return 1; }
+    if ! sops -d "$secrets_file" > "$temp_file" 2>/dev/null; then
+        rm -f "$temp_file"; trap - RETURN
+        echo "vault_login: sops decrypt failed for ${secrets_file} — check the age key, not OpenBao" >&2
+        return 2
+    fi
 
     local role_id secret_id
     role_id=$(grep "^${role_id_var}=" "$temp_file" | cut -d= -f2-)
@@ -170,13 +200,28 @@ vault_login() {
     rm -f "$temp_file"
     trap - RETURN
 
-    [ -z "$role_id" ] && return 1
-    [ -z "$secret_id" ] && return 1
+    if [ -z "$role_id" ] || [ -z "$secret_id" ]; then
+        echo "vault_login: AppRole credentials missing for ${service} (${role_id_var}/${secret_id_var} not set in ${secrets_file}) — no request was sent" >&2
+        return 3
+    fi
 
-    docker exec -e "BAO_ADDR=http://127.0.0.1:8200" \
+    local response rc
+    response=$(docker exec -e "BAO_ADDR=http://127.0.0.1:8200" \
         -e "ROLE_ID=$role_id" -e "SECRET_ID=$secret_id" openbao \
-        sh -c 'bao write -format=json auth/approle/login role_id="$ROLE_ID" secret_id="$SECRET_ID"' | \
-        python3 -c "import sys,json; print(json.load(sys.stdin)['auth']['client_token'])"
+        sh -c 'bao write -format=json auth/approle/login role_id="$ROLE_ID" secret_id="$SECRET_ID"' 2>&1)
+    rc=$?
+
+    if [ "$rc" -ne 0 ]; then
+        local reason
+        reason=$(printf '%s' "$response" | grep -oE '\* .*' | head -1)
+        echo "vault_login: OpenBao rejected login for ${service}: ${reason:-request failed (exit ${rc})}" >&2
+        return 4
+    fi
+
+    printf '%s' "$response" | python3 -c "import sys,json; print(json.load(sys.stdin)['auth']['client_token'])" 2>/dev/null || {
+        echo "vault_login: OpenBao login for ${service} succeeded but the response could not be parsed" >&2
+        return 4
+    }
 }
 
 # Read one KV v2 path. NON-ZERO if the path cannot be read for ANY reason.

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -157,11 +157,18 @@ cmd_infra() {
     # Vault-first, SOPS-fallback for infra secrets
     local vault_ok=false
     if vault_available; then
-        if (vault_login "infra" "$secrets_file") >/dev/null 2>&1; then
+        # h#815: capture ONLY vault_login's stderr — its stdout is a bare
+        # credential token on success, which must never reach a log. `2>&1
+        # >/dev/null` (in that order) swaps the streams for the duration of
+        # the substitution: stderr goes to the pipe captured into
+        # $login_reason, stdout goes to /dev/null. See vault_login's own
+        # header in _common.sh for why the reason it prints is safe to log.
+        local login_reason
+        if login_reason=$(vault_login "infra" "$secrets_file" 2>&1 >/dev/null); then
             vault_ok=true
             info "OpenBao authenticated for infra"
         else
-            warn "OpenBao available but login failed for infra, falling back to SOPS"
+            warn "OpenBao login failed for infra: ${login_reason:-no reason given} — falling back to SOPS"
         fi
     else
         warn "OpenBao not available, using SOPS fallback for infra"
@@ -481,11 +488,15 @@ cmd_service() {
     # Vault-first, SOPS-fallback for service secrets
     local vault_ok=false
     if vault_available; then
-        if (vault_login "$service" "$secrets_file") >/dev/null 2>&1; then
+        # h#815: see the identical capture on the infra path above for why the
+        # stream order matters here — stdout (a bare token on success) must
+        # never reach a log; only vault_login's stderr reason is captured.
+        local login_reason
+        if login_reason=$(vault_login "$service" "$secrets_file" 2>&1 >/dev/null); then
             vault_ok=true
             info "OpenBao authenticated for ${service}"
         else
-            warn "OpenBao available but login failed for ${service}, falling back to SOPS"
+            warn "OpenBao login failed for ${service}: ${login_reason:-no reason given} — falling back to SOPS"
         fi
     else
         warn "OpenBao not available, using SOPS fallback"

--- a/tests/scripts/vault-login-diagnostics.bats
+++ b/tests/scripts/vault-login-diagnostics.bats
@@ -1,0 +1,334 @@
+#!/usr/bin/env bats
+#
+# h#815: vault_login has (at least) three failure modes that all used to
+# `return 1` indistinguishably — sops decrypt failing, AppRole credentials
+# being absent/empty, and OpenBao itself rejecting the login. deploy.sh's two
+# call sites then discarded BOTH streams with `(vault_login ...) >/dev/null
+# 2>&1`, so an operator saw the identical sentence regardless of cause. For
+# the sops case that sentence was actively WRONG — "OpenBao available but
+# login failed" names OpenBao as at fault when OpenBao was never contacted.
+#
+# h#791 sat undiagnosable for days because of exactly this: the real cause
+# (minio and vault have no AppRole at all — mode 2, permanent) had to be
+# reconstructed statically by reading VAULT_SERVICES and the SOPS key names,
+# because the live message covered it and the intermittent OpenBao-rejection
+# failures on other services (mode 3) under the same one sentence.
+#
+# THE POSITIVE-CONTROL REQUIREMENT THE ISSUE STATES EXPLICITLY: force each of
+# the three modes and show the warning naming a DIFFERENT cause for each. A
+# single "now it prints an error" demonstration would not prove the modes are
+# distinguishable, which is the entire point — so this file's load-bearing
+# test compares all three messages and all three return codes pairwise.
+#
+# `docker` and `sops` are stubbed; no OpenBao and no VPS are involved. Mode
+# 3's stub uses the EXACT text a real OpenBao rejection returned, captured in
+# docs/decisions/approle-rejection-2026-08-01.md — a fixed sentence with no
+# submitted value interpolated into it, not an invented string.
+
+setup() {
+  ROOT="$BATS_TEST_DIRNAME/../.."
+  STUB="$BATS_TEST_TMPDIR/bin"
+  mkdir -p "$STUB"
+  PATH="$STUB:$PATH"
+}
+
+stub_sops_decrypt_fails() {
+  cat > "$STUB/sops" <<'EOF'
+#!/usr/bin/env bash
+echo "sops: no matching creation rule found, cannot decrypt" >&2
+exit 1
+EOF
+  chmod +x "$STUB/sops"
+}
+
+# $1 = service name whose ROLE_ID/SECRET_ID sops should NOT yield
+stub_sops_no_credentials_for() {
+  cat > "$STUB/sops" <<EOF
+#!/usr/bin/env bash
+echo "SOME_UNRELATED_KEY=x"
+EOF
+  chmod +x "$STUB/sops"
+}
+
+# $1 = role_id value, $2 = secret_id value to hand out for VAULT_AUTH_*
+stub_sops_credentials() {
+  cat > "$STUB/sops" <<EOF
+#!/usr/bin/env bash
+echo "VAULT_AUTH_ROLE_ID=$1"
+echo "VAULT_AUTH_SECRET_ID=$2"
+EOF
+  chmod +x "$STUB/sops"
+}
+
+stub_docker_rejects_login() {
+  cat > "$STUB/docker" <<'EOF'
+#!/usr/bin/env bash
+cat >&2 <<'ERR'
+Error writing data to auth/approle/login: Error making API request.
+URL: PUT http://127.0.0.1:8200/v1/auth/approle/login
+Code: 400. Errors:
+* invalid role or secret ID
+ERR
+exit 2
+EOF
+  chmod +x "$STUB/docker"
+}
+
+# ---------------------------------------------------------------------------
+# vault_login itself — the function this issue is about
+# ---------------------------------------------------------------------------
+
+@test "MODE 1 (sops decrypt fails): distinct code, names sops, explicitly clears OpenBao" {
+  stub_sops_decrypt_fails
+  cd "$ROOT"
+  source scripts/_common.sh
+  run vault_login api /some/file.env
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"sops decrypt failed"* ]]
+  [[ "$output" == *"not OpenBao"* ]]
+}
+
+@test "MODE 2 (AppRole credentials missing): distinct code, names the missing vars, says no request was sent" {
+  stub_sops_no_credentials_for minio
+  cd "$ROOT"
+  source scripts/_common.sh
+  run vault_login minio /some/file.env
+  [ "$status" -eq 3 ]
+  [[ "$output" == *"AppRole credentials missing"* ]]
+  [[ "$output" == *"VAULT_MINIO_ROLE_ID"* ]]
+  [[ "$output" == *"VAULT_MINIO_SECRET_ID"* ]]
+  [[ "$output" == *"no request was sent"* ]]
+}
+
+@test "MODE 3 (OpenBao rejects the login): distinct code, surfaces OpenBao's own reason" {
+  stub_sops_credentials "11111111-1111-1111-1111-111111111111" "22222222-2222-2222-2222-222222222222"
+  stub_docker_rejects_login
+  cd "$ROOT"
+  source scripts/_common.sh
+  run vault_login auth /some/file.env
+  [ "$status" -eq 4 ]
+  [[ "$output" == *"OpenBao rejected login"* ]]
+  [[ "$output" == *"invalid role or secret ID"* ]]
+}
+
+@test "POSITIVE CONTROL: the three modes report three DIFFERENT codes AND three DIFFERENT messages" {
+  cd "$ROOT"
+  source scripts/_common.sh
+
+  stub_sops_decrypt_fails
+  run vault_login api /some/file.env
+  code1="$status"; msg1="$output"
+
+  stub_sops_no_credentials_for minio
+  run vault_login minio /some/file.env
+  code2="$status"; msg2="$output"
+
+  stub_sops_credentials "r" "s"
+  stub_docker_rejects_login
+  run vault_login auth /some/file.env
+  code3="$status"; msg3="$output"
+
+  # None of the three return codes may collide with another.
+  [ "$code1" -ne "$code2" ]
+  [ "$code2" -ne "$code3" ]
+  [ "$code1" -ne "$code3" ]
+
+  # None of the three messages may collide with another — a single shared
+  # sentence across all three is exactly the bug h#791 hit.
+  [ "$msg1" != "$msg2" ]
+  [ "$msg2" != "$msg3" ]
+  [ "$msg1" != "$msg3" ]
+
+  # Each names ITS OWN cause, not one of the other two's.
+  [[ "$msg1" == *"sops"* ]]
+  [[ "$msg1" != *"AppRole credentials"* ]]
+  [[ "$msg1" != *"OpenBao rejected"* ]]
+
+  [[ "$msg2" == *"AppRole credentials"* ]]
+  [[ "$msg2" != *"sops decrypt"* ]]
+  [[ "$msg2" != *"OpenBao rejected"* ]]
+
+  [[ "$msg3" == *"OpenBao rejected"* ]]
+  [[ "$msg3" != *"sops decrypt"* ]]
+  [[ "$msg3" != *"AppRole credentials"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Credential safety — the issue's explicit caution. What is surfaced must be
+# a REASON, never a VALUE, on every failure path, not just the OpenBao one.
+# ---------------------------------------------------------------------------
+
+@test "credential safety: OpenBao's real rejection text (mode 3) contains no submitted value to leak" {
+  # The exact text a real OpenBao rejection returned — captured in
+  # docs/decisions/approle-rejection-2026-08-01.md — is a fixed sentence,
+  # "* invalid role or secret ID", with no submitted role_id/secret_id
+  # interpolated into it. Confirmed against that real measurement, not
+  # assumed: this test fails loudly if that documented text ever changes to
+  # include one.
+  run grep -A2 '^\* invalid role or secret ID' "$ROOT/docs/decisions/approle-rejection-2026-08-01.md"
+  [ "$status" -eq 0 ] || run grep '^\* invalid role or secret ID$' "$ROOT/docs/decisions/approle-rejection-2026-08-01.md"
+  [ "$status" -eq 0 ]
+
+  ROLE_VAL="deadbeef-role-id-marker-should-never-print"
+  SECRET_VAL="deadbeef-secret-id-marker-should-never-print"
+  stub_sops_credentials "$ROLE_VAL" "$SECRET_VAL"
+  stub_docker_rejects_login
+  cd "$ROOT"
+  source scripts/_common.sh
+  run vault_login auth /some/file.env
+  [[ "$output" != *"$ROLE_VAL"* ]]
+  [[ "$output" != *"$SECRET_VAL"* ]]
+}
+
+@test "credential safety: a partially-set credential pair (mode 2) never echoes the half that WAS read" {
+  # role_id resolves to a real value here; only secret_id is absent. The
+  # function has the role_id in memory and must still never print it.
+  ROLE_VAL="deadbeef-role-id-marker-should-never-print"
+  cat > "$STUB/sops" <<EOF
+#!/usr/bin/env bash
+echo "VAULT_MINIO_ROLE_ID=${ROLE_VAL}"
+EOF
+  chmod +x "$STUB/sops"
+  cd "$ROOT"
+  source scripts/_common.sh
+  run vault_login minio /some/file.env
+  [ "$status" -eq 3 ]
+  [[ "$output" != *"$ROLE_VAL"* ]]
+}
+
+@test "credential safety: no path ever prints a client_token" {
+  # A successful login prints the token on STDOUT by design (callers do
+  # token=\$(vault_login ...)) — that is unchanged and correct. What must
+  # never happen is a TOKEN VALUE appearing in a failure path's stderr
+  # reason. Simulate a malformed-but-200 response (mode 4's second branch,
+  # sharing return code 4 with mode 3) and confirm no token-shaped value
+  # leaks into the reason.
+  stub_sops_credentials "r" "s"
+  cat > "$STUB/docker" <<'EOF'
+#!/usr/bin/env bash
+echo 'not valid json, and does not contain the word tـo_k_e_n either'
+exit 0
+EOF
+  chmod +x "$STUB/docker"
+  cd "$ROOT"
+  source scripts/_common.sh
+  run vault_login auth /some/file.env
+  [ "$status" -eq 4 ]
+  [[ "$output" == *"could not be parsed"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# deploy.sh's two call sites — extracted VERBATIM from the shipped script and
+# eval'd, not reimplemented, so this proves the actual code, not a stand-in
+# for it. Each call site must capture vault_login's reason and fold it into
+# its own warn() message, and must never let a successful token reach stdout
+# unredirected (the credential-safety half of the fix, at the call-site
+# level rather than inside vault_login).
+# ---------------------------------------------------------------------------
+
+extract_service_probe() {
+  sed -n '/# Vault-first, SOPS-fallback for service secrets/,/# Helper: run compose deploy with secrets from SOPS/p' \
+    "$ROOT/scripts/deploy.sh" | sed '$d'
+}
+
+extract_infra_probe() {
+  sed -n '/# Vault-first, SOPS-fallback for infra secrets/,/# Helper: infra deploy with SOPS/p' \
+    "$ROOT/scripts/deploy.sh" | sed '$d'
+}
+
+run_service_probe() {
+  # $1 = service, sops+docker already stubbed by the caller. The extracted
+  # snippet uses `local`, so it must run inside a function, not at a script's
+  # top level — wrapping it in one here, rather than stripping `local` from
+  # the extraction, keeps the eval'd text byte-for-byte what deploy.sh ships.
+  local snippet
+  snippet="$(extract_service_probe)"
+  cd "$ROOT"
+  bash -c "
+    source scripts/_common.sh
+    vault_available() { return 0; }
+    probe() {
+      local service='$1'
+      local secrets_file=/some/file.env
+      $snippet
+      echo \"VAULT_OK=\$vault_ok\"
+    }
+    probe
+  "
+}
+
+@test "the service call site's warn() message differs across the three modes (real deploy.sh code, not a copy)" {
+  stub_sops_decrypt_fails
+  run run_service_probe api
+  msg1="$output"
+
+  stub_sops_no_credentials_for minio
+  run run_service_probe minio
+  msg2="$output"
+
+  stub_sops_credentials "r" "s"
+  stub_docker_rejects_login
+  run run_service_probe auth
+  msg3="$output"
+
+  [ "$msg1" != "$msg2" ]
+  [ "$msg2" != "$msg3" ]
+  [ "$msg1" != "$msg3" ]
+
+  [[ "$msg1" == *"sops decrypt failed"* ]]
+  [[ "$msg2" == *"AppRole credentials missing"* ]]
+  [[ "$msg3" == *"OpenBao rejected login"* ]]
+
+  # And in every case the fallback still fires — VAULT_OK stays false, which
+  # is what the issue is explicit must not change: the SOPS fallback itself.
+  [[ "$msg1" == *"VAULT_OK=false"* ]]
+  [[ "$msg2" == *"VAULT_OK=false"* ]]
+  [[ "$msg3" == *"VAULT_OK=false"* ]]
+}
+
+@test "the service call site still authenticates and sets VAULT_OK=true on a real success" {
+  stub_sops_credentials "r" "s"
+  cat > "$STUB/docker" <<'EOF'
+#!/usr/bin/env bash
+echo '{"auth":{"client_token":"s.faketoken"}}'
+exit 0
+EOF
+  chmod +x "$STUB/docker"
+
+  run run_service_probe auth
+  [[ "$output" == *"OpenBao authenticated for auth"* ]]
+  [[ "$output" == *"VAULT_OK=true"* ]]
+  # The fallback's own suggested wording never fires on the success path.
+  [[ "$output" != *"falling back to SOPS"* ]]
+}
+
+@test "the infra call site (deploy.sh's other vault_login site) is fixed the same way" {
+  stub_sops_decrypt_fails
+  snippet="$(extract_infra_probe)"
+  cd "$ROOT"
+  run bash -c "
+    source scripts/_common.sh
+    vault_available() { return 0; }
+    probe() {
+      local secrets_file=/some/file.env
+      $snippet
+    }
+    probe
+  "
+  [[ "$output" == *"sops decrypt failed"* ]]
+  [[ "$output" == *"not OpenBao"* ]]
+}
+
+@test "neither call site uses the old both-streams-discarded pattern anymore" {
+  # The exact shape the issue names: (vault_login ...) >/dev/null 2>&1,
+  # which threw away the reason at precisely the point that would explain
+  # it. Neither call site should match this shape any longer.
+  run grep -n '(vault_login .*) >/dev/null 2>&1' "$ROOT/scripts/deploy.sh"
+  [ "$status" -ne 0 ]
+}
+
+@test "both call sites capture vault_login's stderr with stdout discarded, stream order 2>&1 then >/dev/null" {
+  run grep -c 'vault_login .* 2>&1 >/dev/null' "$ROOT/scripts/deploy.sh"
+  [ "$status" -eq 0 ]
+  [ "$output" -eq 2 ]
+}


### PR DESCRIPTION
Closes h#815. Split out of h#791, where this was the reason the issue sat undiagnosable for days.

## What was wrong

`deploy.sh`'s two `vault_login` call sites (infra, and the generic service path) ran `(vault_login "$service" "$secrets_file") >/dev/null 2>&1` — discarding every stream at exactly the point that would explain a failure. `vault_login` has (at least) three failure modes that all `return 1` indistinguishably:

1. `sops -d` fails (age key / decryption problem) — nothing to do with OpenBao.
2. `VAULT_<SVC>_ROLE_ID`/`_SECRET_ID` are absent or empty — no request is ever sent. Permanent and structural (h#791's actual cause for `minio` and `vault`, which have no AppRole at all).
3. OpenBao itself rejects `auth/approle/login`.

The old message — "OpenBao available but login failed... falling back to SOPS" — was actively **wrong** for case 1: it named OpenBao as the subsystem at fault when OpenBao was never contacted.

## Fix

`vault_login` now returns a distinct code per cause (2/3/4) and prints a short reason to stderr — never a value. Both deploy.sh call sites capture ONLY that stderr via `2>&1 >/dev/null` (stdout, a bare token on success, still never reaches a log) and fold the reason into the existing `warn()` call. The SOPS fallback itself is untouched — same trigger condition, same behavior, per the issue's explicit instruction.

## Credential safety — checked, not assumed

OpenBao's real rejection text for a bad AppRole login is the fixed string `* invalid role or secret ID`, confirmed against a real measurement captured in `docs/decisions/approle-rejection-2026-08-01.md` — a template with no submitted value interpolated into it, so surfacing OpenBao's own error line cannot echo `role_id`/`secret_id` back. Neither value, nor the token, is ever printed by `vault_login` on any path except the token on genuine success, on stdout, exactly as before. `tests/scripts/vault-login-diagnostics.bats` asserts this directly with distinct marker values fed through the missing-credentials and login-rejected paths.

## Tests — positive-controlled per the issue's explicit requirement

A single "now it prints an error" demonstration would not prove the three modes are distinguishable — that's the whole point. `tests/scripts/vault-login-diagnostics.bats` forces all three failure modes with stubbed `sops`/`docker` and asserts:

- three distinct return codes, pairwise
- three distinct messages, pairwise, each naming only its own cause
- deploy.sh's actual shipped code (extracted verbatim via `sed` and eval'd inside a wrapper function — not a reimplementation) produces three different `warn()` messages for the three modes, and the SOPS fallback (`VAULT_OK=false`) still fires in all three
- the success path is unaffected: `VAULT_OK=true`, no fallback message
- neither call site still matches the old `(vault_login ...) >/dev/null 2>&1` shape
- credential markers never appear in `vault_login`'s output on the missing-credentials or login-rejected paths

**Positive control:** reverted `scripts/_common.sh` and `scripts/deploy.sh` via `git stash`, reran the new file — 10 of 12 tests failed (exactly the ones asserting the new diagnostic behavior); the 2 that stayed green were the credential-safety and success-path tests, which held before this fix too and aren't meant to discriminate old from new code. Restored the fix, reran: 12/12.

## Test plan

- [x] `bash -n` on both modified scripts, clean
- [x] `shellcheck scripts/_common.sh` — zero warnings
- [x] `shellcheck scripts/deploy.sh` — only pre-existing warnings at unrelated lines
- [x] `bats tests/scripts/vault-login-diagnostics.bats` — 12/12
- [x] Positive control: revert → 10/12 fail (exactly the diagnostic tests); restore → 12/12
- [x] `bats tests/scripts/vault-empty-guard.bats tests/scripts/deploy.bats tests/scripts/vault.bats` — 148/148, no regressions
- [x] `bats --recursive tests/scripts/` — 677/677, no regressions