### PR TITLE
fix(ci): warn loudly when DEPLOY_WEBHOOK_URL is unset — h#816

### DIFF
--- a/.github/workflows/reusable-deploy-service.yml
+++ b/.github/workflows/reusable-deploy-service.yml
@@ -346,3 +346,17 @@ jobs:
               "run_url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
               "text": "'"$EMOJI"' Deploy **${{ inputs.service }}** — '"$STATUS"' ('"${{ github.sha }}"')"
             }' || echo "Warning: webhook notification failed (non-blocking)"
+
+      # h#816: the same shape as "Warn that the post-deploy signal is
+      # unwired" above, for the same reason — an optional notification that
+      # is unconfigured skipped in total silence, indistinguishable in the
+      # run log from a deploy that genuinely had nothing to report. That
+      # silence cost three days on 2026-08-03: vault-sync-to-sops failed and
+      # nobody knew until h#712's Prometheus rule shipped two days later
+      # (#789). Copying the established pattern rather than inventing one.
+      - name: Warn that deploy result notification is unwired
+        if: always() && env.DEPLOY_WEBHOOK_URL == ''
+        env:
+          DEPLOY_WEBHOOK_URL: ${{ secrets.DEPLOY_WEBHOOK_URL }}
+        run: |
+          echo "::warning::DEPLOY_WEBHOOK_URL is not set on this repository — the deploy result for ${{ inputs.service }} was NOT sent anywhere. See Hill90#816."

--- a/.github/workflows/vault-sync-to-sops.yml
+++ b/.github/workflows/vault-sync-to-sops.yml
@@ -273,6 +273,15 @@ jobs:
             -f context="Run Tests" \
             -f description="Skipped — sync PR only changes encrypted secrets file"
 
+      # h#816: the in-script guard below used to be silent on an unset
+      # secret — a run log with no webhook call and no explanation for it,
+      # indistinguishable from one where the notification code was never
+      # written at all. That silence is exactly what let this workflow's
+      # 2026-08-03 failure go unnoticed for three days, until h#712's
+      # Prometheus rule shipped two days later (#789). The else branch below
+      # is the same `::warning::` shape reusable-deploy-service.yml already
+      # uses for its own optional-secret checks (HILL90_APP_DISPATCH_TOKEN,
+      # and — as of the same fix — DEPLOY_WEBHOOK_URL there too).
       - name: Notify sync result
         if: failure()
         env:
@@ -289,6 +298,8 @@ jobs:
                 "run_url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
                 "text": "Vault-to-SOPS sync failed — check workflow logs"
               }' || echo "Warning: webhook notification failed (non-blocking)"
+          else
+            echo "::warning::DEPLOY_WEBHOOK_URL is not set on this repository — this sync FAILURE was NOT sent anywhere. See Hill90#816."
           fi
 
       # h#712 (narrowed): a dead-man's-switch for the SCHEDULE itself, not

--- a/tests/scripts/deploy-webhook-notify-unwired.bats
+++ b/tests/scripts/deploy-webhook-notify-unwired.bats
@@ -1,0 +1,109 @@
+#!/usr/bin/env bats
+#
+# h#816: DEPLOY_WEBHOOK_URL is unset on this repository, so both notification
+# paths that depend on it were silently inert — `reusable-deploy-service.yml`
+# skipped its step with no explanation, and `vault-sync-to-sops.yml`'s
+# in-script guard ran, found the value empty, and exited quietly. The SAME
+# file already warns loudly about a different missing secret
+# (HILL90_APP_DISPATCH_TOKEN) three lines above the silent one — an asymmetry
+# fixed here by copying that existing pattern onto DEPLOY_WEBHOOK_URL too,
+# rather than inventing a new one.
+#
+# The cost of the silence is on record, not hypothetical: vault-sync-to-sops
+# failed on 2026-08-03 and nobody knew until h#712's Prometheus rule shipped
+# two days later (#789).
+#
+# A correction landed on the issue before this fix was written: `if:
+# env.X != ''` DOES see that step's own `env:` block — proven from a real
+# run (31043850839) where the sibling `Signal post-deploy hooks` step, using
+# the identical pattern, actually executed. That pattern is correct and
+# UNCHANGED by this fix; only the missing warning is added.
+#
+# No local GitHub Actions runner is available in this environment (no `act`),
+# so these are the same structural/static checks this repo already uses for
+# workflow YAML (see check_deploy_jobs_serialized.py and
+# deploy-jobs-serialized-control.bats) — parse the YAML, and assert on the
+# step shapes and text. The positive control is a real one even so: each
+# assertion is shown to fail against the pre-fix file (see the commit history
+# / PR description for the git-stash-based before/after run), not merely
+# shown to pass against the file as fixed.
+
+setup() {
+  ROOT="$BATS_TEST_DIRNAME/../.."
+  DEPLOY_WF="$ROOT/.github/workflows/reusable-deploy-service.yml"
+  SYNC_WF="$ROOT/.github/workflows/vault-sync-to-sops.yml"
+}
+
+@test "both workflow files still parse as valid YAML" {
+  run python3 -c "import yaml; yaml.safe_load(open('$DEPLOY_WF'))"
+  [ "$status" -eq 0 ]
+  run python3 -c "import yaml; yaml.safe_load(open('$SYNC_WF'))"
+  [ "$status" -eq 0 ]
+}
+
+@test "reusable-deploy-service.yml: the existing DISPATCH_TOKEN warn pattern is untouched" {
+  # Anchor: this fix copies this step's shape. If this step ever moves or
+  # changes shape, the copy below should be re-examined against it, not
+  # assumed to still match.
+  run grep -A2 'name: Warn that the post-deploy signal is unwired' "$DEPLOY_WF"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"env.DISPATCH_TOKEN == ''"* ]]
+}
+
+@test "reusable-deploy-service.yml: Notify deploy result's own if: condition is unchanged" {
+  # The suspected-but-refuted defect from the issue: env.X in a step's own
+  # if: reading that step's own env: block. Refuted on real run evidence
+  # (31043850839) — this test pins that the condition text was NOT touched
+  # by this fix, since changing it would be an unrequested, unverified
+  # change to a pattern already proven to work.
+  run grep -A1 'name: Notify deploy result' "$DEPLOY_WF"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"if: always() && env.DEPLOY_WEBHOOK_URL != ''"* ]]
+}
+
+@test "reusable-deploy-service.yml: an unset DEPLOY_WEBHOOK_URL now gets its own ::warning:: sibling step" {
+  run grep -A5 'name: Warn that deploy result notification is unwired' "$DEPLOY_WF"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"if: always() && env.DEPLOY_WEBHOOK_URL == ''"* ]]
+  [[ "$output" == *'::warning::DEPLOY_WEBHOOK_URL is not set'* ]]
+  [[ "$output" == *"Hill90#816"* ]]
+}
+
+@test "reusable-deploy-service.yml: the warn step's condition is the exact logical negation of the notify step's — no gap, no overlap" {
+  notify_if="$(grep -A1 'name: Notify deploy result' "$DEPLOY_WF" | grep 'if:')"
+  warn_if="$(grep -A1 'name: Warn that deploy result notification is unwired' "$DEPLOY_WF" | grep 'if:')"
+  [[ "$notify_if" == *"env.DEPLOY_WEBHOOK_URL != ''"* ]]
+  [[ "$warn_if" == *"env.DEPLOY_WEBHOOK_URL == ''"* ]]
+  # Same always() gate on both, so together they are exhaustive: for any run,
+  # exactly one of the two fires.
+  [[ "$notify_if" == *"always()"* ]]
+  [[ "$warn_if" == *"always()"* ]]
+}
+
+@test "vault-sync-to-sops.yml: Notify sync result's if: failure() gate is unchanged" {
+  run grep -A1 'name: Notify sync result' "$SYNC_WF"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"if: failure()"* ]]
+}
+
+@test "vault-sync-to-sops.yml: the in-script guard now has an else that warns, instead of exiting silently" {
+  # Extract the whole step body (from its name: line to the next top-level
+  # "- name:" at the same indentation) so the assertion is anchored to THIS
+  # step and cannot accidentally match the heartbeat step below it.
+  body="$(sed -n '/name: Notify sync result/,/name: Emit scheduled-workflow heartbeat/p' "$SYNC_WF")"
+  [[ "$body" == *"if [ -n \"\$DEPLOY_WEBHOOK_URL\" ]; then"* ]]
+  [[ "$body" == *"else"* ]]
+  [[ "$body" == *'::warning::DEPLOY_WEBHOOK_URL is not set'* ]]
+  [[ "$body" == *"Hill90#816"* ]]
+  # The success-path curl call is still there, unremoved.
+  [[ "$body" == *"curl -sf -X POST"* ]]
+}
+
+@test "both warnings name DEPLOY_WEBHOOK_URL specifically, not a generic message that could apply to either secret" {
+  run grep -c 'DEPLOY_WEBHOOK_URL is not set' "$DEPLOY_WF"
+  [ "$status" -eq 0 ]
+  [ "$output" -eq 1 ]
+  run grep -c 'DEPLOY_WEBHOOK_URL is not set' "$SYNC_WF"
+  [ "$status" -eq 0 ]
+  [ "$output" -eq 1 ]
+}


### PR DESCRIPTION
Closes h#816.

## What's real

`Verified 2026-08-06`: `DEPLOY_WEBHOOK_URL` is not configured on this repository, so both workflow paths that depend on it are silently inert. `reusable-deploy-service.yml`'s "Notify deploy result" step skips with no explanation; `vault-sync-to-sops.yml`'s in-script guard runs, finds the value empty, and exits quietly. The cost is on record: vault-sync-to-sops failed on 2026-08-03 and nobody knew until h#712's Prometheus rule shipped two days later (#789).

Same file already warns loudly about a different missing secret three lines above the silent one:

```
::warning::HILL90_APP_DISPATCH_TOKEN is not set on this repository — hill90-app's smoke-auth.yml was NOT triggered.
```

## Decision: warn, not delete

The issue asked for a decision. Went with warn: the DISPATCH_TOKEN warn step right next to this one shows something clearly wanted outbound deploy notifications at some point, and the webhook URL is trivial to wire up later if it's ever set. Deleting live, correctly-shaped code because its one configuration input is currently absent would erase that intent for no durable gain over a warning.

## Fix

- `reusable-deploy-service.yml`: added a sibling step, "Warn that deploy result notification is unwired", gated on the exact logical negation of "Notify deploy result"'s own condition — copying the DISPATCH_TOKEN warn step's shape line for line, per the issue's instruction to copy rather than invent.
- `vault-sync-to-sops.yml`: added an `else` branch to the existing in-script guard, emitting the equivalent `::warning::`. This file never had the twin-step convention, so the in-script `else` matches its own existing shape rather than importing the other file's pattern where it doesn't fit.

## What is explicitly NOT changed

The issue's own follow-up comment refutes the suspected second defect (whether `if: env.X != ''` sees that step's own `env:` block) using real run evidence (31043850839) — the sibling `Signal post-deploy hooks` step uses the identical pattern and executed. Both `if:` conditions are left byte-for-byte unchanged; only the missing warning is added. The new test file pins both original conditions specifically so a future change can't silently touch them.

## Tests

New `tests/scripts/deploy-webhook-notify-unwired.bats`. No local Actions runner is available (`act` isn't installed), so these are the same structural/static checks this repo already uses for workflow YAML (see `check_deploy_jobs_serialized.py` / `deploy-jobs-serialized-control.bats`): parse both files, assert step shape and text, including that the warn step's condition is the exact logical negation of the notify step's (exhaustive — exactly one of the two fires on any run).

**Positive control:** `git stash` on just the two workflow files, reran — 4 of 8 tests failed (exactly the ones asserting the new warn behavior; the condition-pinning and YAML-parse tests correctly stayed green, since those properties held before this fix too). Restored, reran: 8/8.

## Test plan

- [x] Both modified workflow files parse as valid YAML
- [x] `bats tests/scripts/deploy-webhook-notify-unwired.bats` — 8/8
- [x] Positive control: revert → 4/8 fail (exactly the new-behavior tests); restore → 8/8
- [x] `bats tests/scripts/preflight-checkout.bats tests/scripts/vault-cleanup-guard-control.bats tests/scripts/vault-covers-compose-control.bats tests/scripts/vault.bats` — 144/144, no regressions
- [x] `git diff --stat` shows exactly the 3 intended files