### PR TITLE
fix(ansible): prove SSH access actually works before locking it down — h#787

### DIFF
--- a/infra/ansible/playbooks/04-ssh-lockdown.yml
+++ b/infra/ansible/playbooks/04-ssh-lockdown.yml
@@ -95,6 +95,111 @@
       (see 01-system-prep.yml's authorized_keys copy) and re-run.
     success_msg: "Verified: {{ deploy_user }} has a non-empty authorized_keys — safe to lock down SSH"
 
+# ---------------------------------------------------------------------------
+# GATE 2: a file existing is not proof sshd will accept it (h#787)
+# ---------------------------------------------------------------------------
+#
+# The stat/assert above only proves authorized_keys is a non-empty regular
+# file at the right path. It does NOT prove sshd will honour it: wrong
+# ownership or permissions on the file or its parent .ssh directory (sshd's
+# StrictModes refuses group/world-writable paths), an SELinux context
+# mismatch, or a PubkeyAuthentication/AuthorizedKeysFile setting that points
+# somewhere else, can each leave a correctly-copied, non-empty key file
+# completely unusable — exactly the case a file-existence check waves
+# through.
+#
+# There is no way to test with the REAL key: only its public half was ever
+# copied to this host (01-system-prep.yml), and the matching private key
+# lives with the human operator, never on the VPS. So this generates a
+# throwaway keypair ON THE HOST, appends its public half to the SAME file at
+# the SAME path with the SAME ownership/permissions/context the real key
+# already has, and attempts an actual authenticated connection with the
+# private half — over loopback, which is answered by real OpenSSH, not
+# Tailscale SSH (Tailscale SSH only intercepts traffic arriving on the
+# tailscale0 interface; see the header comment above for the `ssh -v`
+# evidence that a tailnet connection never reaches it). That proves the
+# ACCESS MECHANISM — permissions, ownership, SELinux, sshd config — works for
+# this exact file, without ever needing the real private key. It does not
+# re-prove the real key's own content is well-formed; the non-empty check
+# above already covers that a different way.
+#
+# block/rescue/always, not two independent tasks: the throwaway key MUST be
+# removed from authorized_keys and disk whether the probe connection
+# succeeds, fails, or the play is interrupted mid-block — leaving it behind
+# would be a second, self-inflicted unauthorized key on a host this play is
+# about to lock down.
+- name: Prove an authenticated SSH connection as the deploy user actually works
+  block:
+    - name: Generate a throwaway keypair to probe sshd's acceptance path
+      command: >
+        ssh-keygen -t ed25519 -N '' -q
+        -f /tmp/.hill90-ssh-gate-{{ ansible_date_time.epoch }}
+        -C hill90-ssh-lockdown-gate-probe
+      register: gate_keygen
+      changed_when: false
+
+    - name: Read the probe's public key
+      slurp:
+        src: "/tmp/.hill90-ssh-gate-{{ ansible_date_time.epoch }}.pub"
+      register: gate_pubkey_raw
+
+    - name: Append the probe's public key to the deploy user's authorized_keys
+      lineinfile:
+        path: "{{ deploy_home }}/.ssh/authorized_keys"
+        line: "{{ (gate_pubkey_raw.content | b64decode).strip() }}"
+        create: no
+
+    - name: Attempt an actual authenticated SSH connection as the deploy user, over loopback
+      command: >
+        ssh -i /tmp/.hill90-ssh-gate-{{ ansible_date_time.epoch }}
+        -o BatchMode=yes -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
+        -o ConnectTimeout=5 -o PreferredAuthentications=publickey
+        {{ deploy_user }}@127.0.0.1 true
+      register: gate_connection
+      changed_when: false
+      failed_when: false
+
+  always:
+    - name: Remove the probe's line from authorized_keys
+      lineinfile:
+        path: "{{ deploy_home }}/.ssh/authorized_keys"
+        line: "{{ (gate_pubkey_raw.content | b64decode).strip() }}"
+        state: absent
+      when: gate_pubkey_raw is defined and gate_pubkey_raw.content is defined
+
+    - name: Remove the probe keypair files
+      file:
+        path: "/tmp/.hill90-ssh-gate-{{ ansible_date_time.epoch }}{{ item }}"
+        state: absent
+      loop:
+        - ""
+        - ".pub"
+
+- name: Refuse to proceed unless the probe connection actually authenticated
+  assert:
+    that:
+      - gate_connection.rc == 0
+    fail_msg: |
+      A throwaway key was appended to {{ deploy_home }}/.ssh/authorized_keys
+      in exactly the same way the real key already there was, and sshd
+      refused to authenticate with it over loopback (exit
+      {{ gate_connection.rc | default('?') }}).
+
+      The file existing and being non-empty (verified above) is NOT the same
+      as sshd actually accepting a key from it. Likely causes: wrong
+      ownership or permissions on {{ deploy_home }}/.ssh or its
+      authorized_keys (sshd's StrictModes refuses group/world-writable
+      paths), an SELinux context mismatch, or PubkeyAuthentication /
+      AuthorizedKeysFile misconfigured in sshd_config.
+
+      This play is about to disable PasswordAuthentication and
+      PermitRootLogin. Refusing to continue with an access path that has not
+      been proven to work — a file being present was never sufficient proof.
+
+      stderr from the probe connection:
+      {{ gate_connection.stderr | default('(no output)') }}
+    success_msg: "Verified: an authenticated SSH connection as {{ deploy_user }} actually succeeds — safe to lock down SSH"
+
 - name: Lock SSH to Tailscale network only (100.64.0.0/10)
   firewalld:
     rich_rule: 'rule family="ipv4" source address="100.64.0.0/10" service name="ssh" accept'

--- a/tests/scripts/ssh-hardening.bats
+++ b/tests/scripts/ssh-hardening.bats
@@ -147,3 +147,92 @@ ROLE=infra/ansible/playbooks/04-ssh-lockdown.yml
   run bash -c "grep -c '^check ' scripts/verify-ssh-hardening.sh"
   [ "$output" -ge 6 ]
 }
+
+# ---------------------------------------------------------------------------
+# GATE 2 (h#787): a file existing is not proof sshd will accept it.
+#
+# The original gate (#786/#539, tested above) only proves authorized_keys is
+# a non-empty regular file. Wrong ownership, wrong permissions, an SELinux
+# context mismatch, or sshd config pointing elsewhere can each leave a
+# correctly-copied, non-empty key file completely unusable — exactly the
+# case a file-existence check waves through. GATE 2 proves the ACCESS
+# MECHANISM itself: it appends a throwaway keypair to the same file at the
+# same path, attempts a real authenticated SSH connection as the deploy
+# user over loopback, and refuses to proceed if that connection fails.
+#
+# These are structural/static checks, same reasoning and same limits as the
+# tests above — they cannot exercise a real sshd from bats. That exercise
+# was done separately, manually, against a disposable AlmaLinux container
+# with a real sshd (never the production VPS, per h#787's explicit
+# instruction): the real extracted task block from this file authenticated
+# successfully against a correctly-owned key, and correctly REFUSED against
+# a file that existed, was a regular file, and was non-empty, but was owned
+# by root instead of deploy — the exact case GATE 1 alone would wave
+# through. See the PR description for the full commands and captured
+# output.
+# ---------------------------------------------------------------------------
+
+@test "GATE 2 exists and runs before GATE 1's sibling firewalld/sshd tasks" {
+  run bash -c "
+    gate2=\$(grep -n 'name: Prove an authenticated SSH connection as the deploy user actually works' $ROLE | head -1 | cut -d: -f1)
+    refuse2=\$(grep -n 'name: Refuse to proceed unless the probe connection actually authenticated' $ROLE | head -1 | cut -d: -f1)
+    firewall=\$(grep -n 'name: Lock SSH to Tailscale network only' $ROLE | head -1 | cut -d: -f1)
+    dropin=\$(grep -n 'name: Deploy SSH hardening drop-in' $ROLE | head -1 | cut -d: -f1)
+    [ -n \"\$gate2\" ] && [ -n \"\$refuse2\" ] && [ -n \"\$firewall\" ] && [ -n \"\$dropin\" ] \
+      && [ \"\$gate2\" -lt \"\$refuse2\" ] && [ \"\$refuse2\" -lt \"\$firewall\" ] && [ \"\$refuse2\" -lt \"\$dropin\" ]
+  "
+  [ "$status" -eq 0 ]
+}
+
+@test "GATE 2 attempts a REAL ssh connection, not another stat" {
+  run bash -c "grep -A40 'name: Prove an authenticated SSH connection' $ROLE | grep -E '^\s+ssh -i '"
+  [ "$status" -eq 0 ]
+  run bash -c "grep -A40 'name: Prove an authenticated SSH connection' $ROLE | grep -F 'BatchMode=yes'"
+  [ "$status" -eq 0 ]
+}
+
+@test "GATE 2 targets loopback, never the tailnet — Tailscale SSH must not be able to mask a broken key" {
+  # If this probed over the tailnet, Tailscale SSH (up since 03-tailscale.yml,
+  # authorises by tailnet ACL, never reads authorized_keys) could answer the
+  # connection and the gate would pass regardless of whether OpenSSH's own
+  # key path works at all — silently proving nothing.
+  run bash -c "grep -A40 'name: Prove an authenticated SSH connection' $ROLE | grep -F '127.0.0.1'"
+  [ "$status" -eq 0 ]
+}
+
+@test "GATE 2's probe key is generated fresh, never uses a real operator key" {
+  # There is no private key on the host to test with — only the public half
+  # was ever copied there. A throwaway keypair is the only way to test the
+  # mechanism without needing operator secrets.
+  run bash -c "grep -A10 'name: Generate a throwaway keypair' $ROLE | grep -F 'ssh-keygen -t ed25519'"
+  [ "$status" -eq 0 ]
+}
+
+@test "GATE 2 cleans up the probe key unconditionally, via block/always — not two independent tasks" {
+  # A bare task pair would leave the throwaway key behind on any failure
+  # between appending it and removing it — a self-inflicted extra
+  # authorized key on a host this play is about to lock down.
+  run bash -c "grep -A60 'name: Prove an authenticated SSH connection as the deploy user actually works' $ROLE | grep -m1 '^  block:'"
+  [ "$status" -eq 0 ]
+  run bash -c "grep -A60 'name: Prove an authenticated SSH connection as the deploy user actually works' $ROLE | grep -m1 '^  always:'"
+  [ "$status" -eq 0 ]
+  run bash -c "grep -A80 '^  always:' $ROLE | grep -c 'name: Remove the probe'"
+  [ "$output" -ge 2 ]
+}
+
+@test "GATE 2 refuses on the connection's own exit code, not on the append task's success" {
+  # The append (lineinfile) succeeding proves nothing about whether sshd
+  # will honour the result — that is exactly GATE 1's blind spot. The
+  # refusal must key off the SSH command's own rc.
+  run bash -c "grep -A5 'name: Refuse to proceed unless the probe connection actually authenticated' $ROLE | grep -F 'gate_connection.rc == 0'"
+  [ "$status" -eq 0 ]
+}
+
+@test "GATE 2's failure message distinguishes itself from GATE 1's — names mechanism causes, not just 'missing'" {
+  run bash -c "grep -A25 'name: Refuse to proceed unless the probe connection actually authenticated' $ROLE | grep -iF 'ownership'"
+  [ "$status" -eq 0 ]
+  run bash -c "grep -A25 'name: Refuse to proceed unless the probe connection actually authenticated' $ROLE | grep -iF 'SELinux'"
+  [ "$status" -eq 0 ]
+  run bash -c "grep -A25 'name: Refuse to proceed unless the probe connection actually authenticated' $ROLE | grep -iF 'StrictModes'"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Closes h#787.

## The real sequence, established first

`01-system-prep.yml` copies `/root/.ssh/authorized_keys` to the deploy user with `ignore_errors: yes` (deliberately tolerant — not every provider delivers the key there). `bootstrap.yml` imports 01 through 12 in a single play, so that copy and `04-ssh-lockdown.yml`'s `PasswordAuthentication`/`PermitRootLogin` removal run back to back with no human in between.

That ordering is **not** actually lockdown-before-verification in the way the original title suggested, though — the issue's own correction comment establishes (via `ssh -v` against the real host) that Tailscale SSH is up via `03-tailscale.yml` *before* `04` runs at all, and it authorises by tailnet ACL, never by reading `authorized_keys`. A missing key cannot brick a fresh bootstrap through that path. The gate this PR strengthens is defence in depth for three narrower, still-real cases named in the correction: Tailscale SSH later disabled, a connection over the public interface, or an operator with no tailnet access.

## What #788 already fixed, and its stated limit

#788 added a stat+assert gate (GATE 1, unchanged here): refuse to proceed unless `authorized_keys` exists, is a regular file, and is non-empty. Its own PR said plainly this was offline-verified only, and that's exactly the gap this issue asks to close — plus a gap GATE 1 has by construction: a file can exist, be regular, and be non-empty while sshd still refuses it outright. Wrong ownership (sshd's `StrictModes`), an SELinux context mismatch, or `PubkeyAuthentication`/`AuthorizedKeysFile` pointing elsewhere can each do this. A `stat` call can't see any of them.

## Fix: GATE 2, an actual authenticated connection

Added as a second gate, still before any firewalld/sshd task. There's no way to test with the *real* key — only its public half was ever copied to the host; the private half lives with the human operator, never on the VPS. So GATE 2 generates a throwaway ed25519 keypair **on the host**, appends its public half to the **same** `authorized_keys` file at the same path (inheriting whatever ownership/permissions/context the real key already has), and attempts a real `ssh` connection as the deploy user over `127.0.0.1` with the throwaway private key — loopback, not the tailnet, so Tailscale SSH (which only intercepts the `tailscale0` interface) can't answer the probe and mask a broken OpenSSH key path. `block`/`rescue`/`always` removes the probe key and the appended line unconditionally — success, failure, or interruption — so nothing is left behind on a host this play is about to lock down. The final assert gates on the connection's own exit code, not the append task's success.

## Positive control — a real sshd, never the production VPS

Built a disposable AlmaLinux 9 container (`openssh-server`, a `deploy` user, sshd running for real) and ran the **actual extracted GATE 2 task block** against it via Ansible's `community.docker` connection plugin — not a reimplementation, the real YAML from this file.

**Happy path:** `authorized_keys` correctly owned (`deploy:deploy`, mode 600) — GATE 2 ran, appended the probe key, connected successfully, cleaned up, printed `"Verified: an authenticated SSH connection as deploy actually succeeds."`

**The case that matters:** chowned `authorized_keys` to `root:root` (file still exists, still a regular file, still 108 bytes non-empty — GATE 1 alone would have printed `"safe to lock down SSH"` and proceeded) and reran. GATE 2 correctly **refused**:

```
sshd refused to authenticate with it over loopback (exit 255)...
Likely causes: wrong ownership or permissions...
```

and cleanup still ran — no leftover probe key on disk, no leftover line in `authorized_keys`, confirmed by inspecting the container directly afterward. This is not wired into CI (no `act`, no Ansible/Docker harness exists in this repo's CI today, and #788 set the precedent that a real-sshd exercise is a manual/pre-deploy verification, not a CI job) — the shipped tests are static/structural, same limitation #788's own tests already stated plainly.

## Tests

Extended `tests/scripts/ssh-hardening.bats` with 7 new cases: GATE 2 exists and runs before every sshd/firewalld-changing task (line-number ordering, same technique as GATE 1's existing test); it attempts a real `ssh` command, not another stat; it targets loopback specifically; the probe key is freshly generated, never a real operator key; cleanup is unconditional via `block`/`always`, not two independent tasks; the refusal keys off the connection's own exit code; and the failure message names mechanism-level causes distinct from GATE 1's missing/empty message.

**Positive control:** reverted `04-ssh-lockdown.yml` via `git stash`, reran — exactly the 7 new tests failed, the 15 pre-existing GATE 1 tests stayed green. Restored, reran: 22/22.

## Test plan

- [x] `ansible-playbook --syntax-check infra/ansible/playbooks/bootstrap.yml` clean
- [x] `bats tests/scripts/ssh-hardening.bats` — 22/22
- [x] Positive control: revert → 7/22 fail (exactly the new GATE 2 tests); restore → 22/22
- [x] `bats --recursive tests/scripts/` — 684/684, no regressions
- [x] Manual container exercise against a real AlmaLinux sshd (never the production VPS): happy path succeeds and cleans up; the present-but-wrong-owner case is correctly refused and still cleans up
- [x] `git diff --stat` shows exactly the 2 intended files