### PR TITLE
fix(deploy): Complete! now requires a passing verify, and a dormant missing set -e is closed

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -315,6 +315,18 @@ cmd_infra() {
     sops exec-env "$secrets_file" 'bash scripts/portainer.sh apply' \
         || warn "portainer.sh apply failed — Portainer SSO may be unconfigured. The local admin login is unaffected; see docs/runbooks/sso-fallback.md"
 
+    # h#752. "Complete!" used to print the instant `docker compose up -d`
+    # returned, which proves containers STARTED, not that they are healthy —
+    # the estate's own defining defect, worn by this file. The real
+    # production path (deploy-infra.yml) already runs its own separate
+    # container/log/TLS checks after this script exits, so this was
+    # mitigated in CI — but never for a human or another script invoking
+    # `deploy.sh infra` directly, and cmd_verify already knows how to check
+    # this exact service. `exit 1` inside cmd_verify on failure means this
+    # line is never reached and "Complete!" is never printed if the stack
+    # did not actually come up healthy.
+    cmd_verify "infra" "$env"
+
     echo ""
     echo "================================"
     echo "Edge Stack Deployment Complete!"
@@ -529,7 +541,23 @@ cmd_service() {
                 docker compose -p "'"$project_name"'" -f '"$compose_file"' up -d
             '
         else
+            # h#752. Dormant, not live: `stateful` is `true` in every case arm
+            # above (db, minio, auth, vault, observability), so `deploy_mode`
+            # can never actually be "stateless" for any service this function
+            # currently dispatches — verified by running this exact branch
+            # directly with a failing `docker compose build`, which is the
+            # only way to observe it: the stateless call site itself is
+            # provably unreachable. Adding `set -e` here changes nothing for
+            # today's five services (this diff does not touch a single line
+            # the stateful branch runs), but the stateful sibling above
+            # carries the same restatement for the same reason — `sops
+            # exec-env` runs this string in a NEW shell that does not
+            # inherit deploy.sh's `set -e` — and without it here, a failed
+            # `build`/`pull` would not stop `up -d` from running anyway
+            # against stale or missing images the moment a stateless service
+            # is ever added.
             sops exec-env "$secrets_file" '
+                set -e
                 echo "Building and pulling images..."
                 docker compose -p "'"$project_name"'" -f '"$compose_file"' build --parallel --no-cache
                 docker compose -p "'"$project_name"'" -f '"$compose_file"' pull --ignore-buildable
@@ -656,6 +684,21 @@ cmd_service() {
         bash "$SCRIPT_DIR/keycloak.sh" apply \
             || warn "keycloak.sh apply failed — SSO clients may be missing. Local admin logins are unaffected; see docs/runbooks/sso-fallback.md"
     fi
+
+    # h#752. "Complete!" used to print the instant `docker compose up -d`
+    # returned — proof containers STARTED, not that they are healthy. The
+    # real production path (reusable-deploy-service.yml) already runs
+    # `deploy.sh verify <service>` as a separate mandatory workflow step
+    # afterward, so this was mitigated for every CI-driven deploy — but
+    # never for a human or another script invoking `deploy.sh <service>`
+    # directly, which the docs do reference. cmd_verify already covers
+    # every service this function handles; calling it here makes the
+    # standalone path honest too, at the cost of running the same check
+    # twice on the CI path (cheap — a health check that is already passing
+    # returns on its first attempt). `exit 1` inside cmd_verify on failure
+    # means this line is never reached and "Complete!" is never printed for
+    # a service that did not actually come up healthy.
+    cmd_verify "$service" "$env"
 
     echo ""
     echo "================================"

--- a/tests/scripts/deploy-stateless-set-e-dormant.bats
+++ b/tests/scripts/deploy-stateless-set-e-dormant.bats
@@ -1,0 +1,207 @@
+#!/usr/bin/env bats
+
+# h#752, half two: `_deploy_with_sops`'s STATELESS branch was missing the
+# `set -e` its stateful sibling explicitly has and explains at length —
+# `sops exec-env` runs its argument string in a NEW shell that does NOT
+# inherit deploy.sh's own `set -e`, so without restating it, a failed
+# `docker compose build`/`pull` would not abort; `up -d` would run anyway
+# against stale or missing images.
+#
+# DORMANT MEANS NOT CURRENTLY CAUSING HARM — and this file exists to prove
+# that claim rather than assert it. Every case arm in cmd_service's
+# dispatch (db, minio, auth, vault, observability) sets `stateful=true`
+# unconditionally; nothing anywhere sets it false. `deploy_mode` defaults
+# to "stateless" and only ever becomes "stateful" when `stateful=true`, so
+# for every service this script can currently deploy, `_deploy_with_sops`
+# is ALWAYS called with "stateful" — the branch this fix touches is
+# unreachable today, mechanically, not by luck.
+#
+# WHETHER ADDING set -e CHANGES ANYTHING TODAY IS ANSWERED BY RUNNING IT,
+# NOT BY READING IT. Two things are shown, separately, because they answer
+# different questions:
+#   1. The five real services' own dispatch logic never selects
+#      "stateless" — proven by exercising the actual case-arm variables,
+#      not by trusting the grep above.
+#   2. The changed branch itself, called directly (bypassing dispatch, the
+#      only way to reach it at all today) is NOT a no-op once reached: a
+#      failing `docker compose build` now aborts instead of continuing to
+#      `up -d` — proving the fix does something real, for the day a
+#      stateless service exists. The SUCCESS path (what every hypothetical
+#      future stateless deploy looks like when nothing fails) is diffed
+#      byte-for-byte between the pre-fix and post-fix branch bodies and
+#      found IDENTICAL — the fix costs nothing when nothing is wrong.
+
+setup() {
+    ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    DEPLOY="$ROOT/scripts/deploy.sh"
+
+    STUB="$BATS_TEST_TMPDIR/bin"
+    mkdir -p "$STUB"
+    PATH="$STUB:$PATH"
+
+    # A minimal exec-env that just runs the script string directly — no
+    # real secrets file or decryption needed to observe the SHELL LOGIC
+    # this fix changes.
+    cat > "$STUB/sops" <<'EOF'
+#!/usr/bin/env bash
+if [ "$1" = "exec-env" ]; then
+    shift 2
+    exec bash -c "$1"
+fi
+exit 1
+EOF
+    chmod +x "$STUB/sops"
+
+    HARNESS_VARS='
+SCRIPT_DIR="'"$BATS_TEST_TMPDIR"'"
+secrets_file="/dev/null"
+pre_up_hook=""
+service="testsvc"
+project_name="test-project"
+compose_file="test.yml"
+containers="testsvc"
+'
+}
+
+# $1 = 0 (docker succeeds) or 1 (docker build fails)
+make_docker_stub() {
+    if [ "$1" -eq 0 ]; then
+        cat > "$STUB/docker" <<'EOF'
+#!/usr/bin/env bash
+echo "docker $*"
+exit 0
+EOF
+    else
+        cat > "$STUB/docker" <<'EOF'
+#!/usr/bin/env bash
+echo "docker $*"
+if [[ "$*" == *"build"* ]]; then
+    echo "SIMULATED BUILD FAILURE" >&2
+    exit 1
+fi
+exit 0
+EOF
+    fi
+    chmod +x "$STUB/docker"
+}
+
+extract_deploy_with_sops() {
+    sed -n '/^    _deploy_with_sops() {$/,/^    }$/p' "$DEPLOY"
+}
+
+build_harness() {
+    local out="$1"
+    {
+        echo "#!/usr/bin/env bash"
+        echo "$HARNESS_VARS"
+        extract_deploy_with_sops
+    } > "$out"
+}
+
+@test "sanity: exactly five case arms set stateful=true and none set it false" {
+    run grep -c 'stateful=true' "$DEPLOY"
+    [ "$output" -eq 5 ]
+    run grep -c 'stateful=false' "$DEPLOY"
+    [ "$output" -eq 0 ]
+}
+
+@test "THE FIVE REAL SERVICES: each one's own dispatch resolves to stateful, never stateless — exercised, not just grepped" {
+    # Extracts cmd_service's own case statement and deploy_mode computation
+    # verbatim, and runs it once per real service name, asserting the
+    # variable it actually assigns — not a hand-copied re-statement of the
+    # case arms.
+    local block
+    block=$(sed -n '/^    local compose_file banner containers summary stack stateful pre_up_hook$/,/^    esac$/p' "$DEPLOY")
+    [ -n "$block" ]
+
+    local mode_calc
+    mode_calc=$(sed -n '/^    local deploy_mode="stateless"$/,/^    \[ "\$stateful" = true \] && deploy_mode="stateful"$/p' "$DEPLOY")
+    [ -n "$mode_calc" ]
+
+    for svc in db minio auth vault observability; do
+        run bash -c "
+            set -uo pipefail
+            service='${svc}'
+            env='prod'
+            SCRIPT_DIR='/tmp'
+            ${block}
+            ${mode_calc}
+            echo \"MODE=\${deploy_mode}\"
+        "
+        [ "$status" -eq 0 ]
+        [[ "$output" == *"MODE=stateful"* ]]
+    done
+}
+
+@test "THE STATELESS BRANCH ITSELF, called directly (the only way to reach it today): a failed build now aborts instead of continuing to up -d" {
+    make_docker_stub 1
+    build_harness "$BATS_TEST_TMPDIR/harness.sh"
+
+    run bash -c '
+        source "'"$BATS_TEST_TMPDIR"'/harness.sh"
+        _deploy_with_sops "stateless"
+    '
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"SIMULATED BUILD FAILURE"* ]]
+    # THE ASSERTION THAT MATTERS: up -d must never have been reached.
+    [[ "$output" != *"up -d"* ]]
+}
+
+@test "CONTROL, THE DORMANT RISK REPRODUCED: the pre-fix stateless branch (no set -e) continues past the same failed build to up -d" {
+    make_docker_stub 1
+    {
+        echo "#!/usr/bin/env bash"
+        echo "$HARNESS_VARS"
+        git -C "$ROOT" show HEAD:scripts/deploy.sh | sed -n '/^    _deploy_with_sops() {$/,/^    }$/p'
+    } > "$BATS_TEST_TMPDIR/harness_old.sh"
+
+    run bash -c '
+        source "'"$BATS_TEST_TMPDIR"'/harness_old.sh"
+        _deploy_with_sops "stateless"
+    '
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"SIMULATED BUILD FAILURE"* ]]
+    # The old shape: the build failure is visible in the log, but nothing
+    # stopped for it — up -d ran anyway.
+    [[ "$output" == *"up -d --force-recreate --no-deps"* ]]
+}
+
+@test "THE STATELESS BRANCH ITSELF, called directly: the fix is a no-op on the SUCCESS path — byte-for-byte identical output to pre-fix" {
+    make_docker_stub 0
+
+    build_harness "$BATS_TEST_TMPDIR/harness_post.sh"
+    {
+        echo "#!/usr/bin/env bash"
+        echo "$HARNESS_VARS"
+        git -C "$ROOT" show HEAD:scripts/deploy.sh | sed -n '/^    _deploy_with_sops() {$/,/^    }$/p'
+    } > "$BATS_TEST_TMPDIR/harness_pre.sh"
+
+    bash -c '
+        source "'"$BATS_TEST_TMPDIR"'/harness_pre.sh"
+        _deploy_with_sops "stateless"
+    ' > "$BATS_TEST_TMPDIR/pre.out" 2>&1
+    pre_status=$?
+
+    bash -c '
+        source "'"$BATS_TEST_TMPDIR"'/harness_post.sh"
+        _deploy_with_sops "stateless"
+    ' > "$BATS_TEST_TMPDIR/post.out" 2>&1
+    post_status=$?
+
+    [ "$pre_status" -eq "$post_status" ]
+    run diff "$BATS_TEST_TMPDIR/pre.out" "$BATS_TEST_TMPDIR/post.out"
+    [ "$status" -eq 0 ]
+}
+
+@test "THE STATEFUL SIBLING IS UNTOUCHED: this diff adds a line only inside the stateless branch" {
+    # The stateful branch's OWN behaviour must be provably unaffected — not
+    # merely unlikely to be — since this diff should not touch a single
+    # line it executes. Confirmed by diffing the stateful branch's body
+    # specifically between pre-fix and this file.
+    local pre post
+    pre=$(git -C "$ROOT" show HEAD:scripts/deploy.sh | sed -n '/^        if \[ "\$mode" = "stateful" \]; then$/,/^        else$/p')
+    post=$(sed -n '/^        if \[ "\$mode" = "stateful" \]; then$/,/^        else$/p' "$DEPLOY")
+    [ "$pre" = "$post" ]
+}

--- a/tests/scripts/deploy-stateless-set-e-dormant.bats
+++ b/tests/scripts/deploy-stateless-set-e-dormant.bats
@@ -89,6 +89,59 @@ extract_deploy_with_sops() {
     sed -n '/^    _deploy_with_sops() {$/,/^    }$/p' "$DEPLOY"
 }
 
+# PINNED FIXTURE, not a git reference. The three arms below used to
+# reconstruct "pre-fix" via `git -C "$ROOT" show HEAD:scripts/deploy.sh` —
+# which stops meaning "pre-fix" the instant this fix is committed, because
+# HEAD then IS the fix. One arm (the control) started failing outright;
+# the other two (the no-op and untouched-sibling claims) started diffing
+# the fixed code against itself and passing vacuously, which is worse,
+# because a green test that cannot fail reads as coverage.
+#
+# This is the literal body of `_deploy_with_sops` from the commit
+# immediately before this fix (c522ffb1, the parent of 1fbf204a) — byte
+# for byte, confirmed via `git show c522ffb1:scripts/deploy.sh | sed -n
+# '/^    _deploy_with_sops() {$/,/^    }$/p'`. It cannot drift with the
+# branch because nothing here reads git state at test time.
+pre_fix_deploy_with_sops_body() {
+    cat <<'PRE_FIX_FIXTURE'
+    _deploy_with_sops() {
+        local mode="$1"  # "stateful" or "stateless"
+        if [ "$mode" = "stateful" ]; then
+            sops exec-env "$secrets_file" '
+                set -e
+                if [ -n "'"$pre_up_hook"'" ]; then
+                    # ALERT_EMAIL_TO falls back to ACME_EMAIL: both are addresses
+                    # already configured in the store, and ACME_EMAIL is already
+                    # where certificate-expiry notices go. The fallback is to
+                    # another explicit value, never to a hardcoded guess — the
+                    # render script still refuses if both are empty.
+                    export ALERT_EMAIL_TO="${ALERT_EMAIL_TO:-$ACME_EMAIL}"
+                    bash "'"$SCRIPT_DIR"'/'"$pre_up_hook"'"
+                fi
+                echo "Stopping existing '"$service"' containers..."
+                docker compose -p "'"$project_name"'" -f '"$compose_file"' down || true
+                for container in '"$containers"'; do
+                    docker rm -f "$container" 2>/dev/null || true
+                done
+                echo "Building and pulling images..."
+                docker compose -p "'"$project_name"'" -f '"$compose_file"' build --parallel --no-cache
+                docker compose -p "'"$project_name"'" -f '"$compose_file"' pull --ignore-buildable
+                echo "Deploying '"$service"' service..."
+                docker compose -p "'"$project_name"'" -f '"$compose_file"' up -d
+            '
+        else
+            sops exec-env "$secrets_file" '
+                echo "Building and pulling images..."
+                docker compose -p "'"$project_name"'" -f '"$compose_file"' build --parallel --no-cache
+                docker compose -p "'"$project_name"'" -f '"$compose_file"' pull --ignore-buildable
+                echo "Deploying '"$service"' service..."
+                docker compose -p "'"$project_name"'" -f '"$compose_file"' up -d --force-recreate --no-deps
+            '
+        fi
+    }
+PRE_FIX_FIXTURE
+}
+
 build_harness() {
     local out="$1"
     {
@@ -153,7 +206,7 @@ build_harness() {
     {
         echo "#!/usr/bin/env bash"
         echo "$HARNESS_VARS"
-        git -C "$ROOT" show HEAD:scripts/deploy.sh | sed -n '/^    _deploy_with_sops() {$/,/^    }$/p'
+        pre_fix_deploy_with_sops_body
     } > "$BATS_TEST_TMPDIR/harness_old.sh"
 
     run bash -c '
@@ -175,7 +228,7 @@ build_harness() {
     {
         echo "#!/usr/bin/env bash"
         echo "$HARNESS_VARS"
-        git -C "$ROOT" show HEAD:scripts/deploy.sh | sed -n '/^    _deploy_with_sops() {$/,/^    }$/p'
+        pre_fix_deploy_with_sops_body
     } > "$BATS_TEST_TMPDIR/harness_pre.sh"
 
     bash -c '
@@ -201,7 +254,7 @@ build_harness() {
     # line it executes. Confirmed by diffing the stateful branch's body
     # specifically between pre-fix and this file.
     local pre post
-    pre=$(git -C "$ROOT" show HEAD:scripts/deploy.sh | sed -n '/^        if \[ "\$mode" = "stateful" \]; then$/,/^        else$/p')
+    pre=$(pre_fix_deploy_with_sops_body | sed -n '/^        if \[ "\$mode" = "stateful" \]; then$/,/^        else$/p')
     post=$(sed -n '/^        if \[ "\$mode" = "stateful" \]; then$/,/^        else$/p' "$DEPLOY")
     [ "$pre" = "$post" ]
 }

--- a/tests/scripts/deploy-verify-before-complete.bats
+++ b/tests/scripts/deploy-verify-before-complete.bats
@@ -1,0 +1,203 @@
+#!/usr/bin/env bats
+
+# h#752, half one: "Complete!" used to print the instant `docker compose up
+# -d` returned — proof containers STARTED, not that they are healthy. This
+# is the estate's own defining defect (an operation that succeeds while
+# proving nothing) wearing its plainest form: the script announces success
+# for work it did not confirm.
+#
+# WHICH PATHS REACHED "Complete!" WITHOUT A VERIFY, established before
+# choosing the fix. `cmd_service`'s workflow (reusable-deploy-service.yml)
+# already runs `deploy.sh verify <service>` as a separate mandatory step
+# after deploying — so a CI-driven deploy of db/auth/minio/vault/
+# observability was already caught by the WORKFLOW if health failed, even
+# though the SCRIPT's own "Complete!" line was printed regardless.
+# `cmd_infra`'s workflow (deploy-infra.yml) does its own bespoke inline
+# checks (container status, Traefik logs, TLS) rather than calling
+# `deploy.sh verify infra` — also real verification, just not via this
+# function. Neither workflow finding changes what this fixes: anyone
+# invoking `deploy.sh infra` or `deploy.sh <service>` directly — which the
+# docs do reference — got "Complete!" with no verification at all, from the
+# script itself. `cmd_teardown` was checked too and correctly excluded: it
+# never prints "Complete!" (it prints "torn down", a genuinely different and
+# already-honest claim), so forcing a verify there would be forcing one onto
+# a command that never claimed health in the first place.
+#
+# THE FIX: cmd_verify is called immediately before each "Complete!" banner,
+# for both cmd_infra and cmd_service. cmd_verify already covers every
+# service either function can deploy (including "infra"), so no new
+# check logic — this makes the STANDALONE path honest using what already
+# existed, rather than inventing something new. cmd_verify calls `exit 1`
+# on failure (not `return`), so a failing check aborts the whole script and
+# "Complete!" is never reached.
+#
+# Every assertion here is about whether "Complete!" was ACTUALLY PRINTED,
+# not about a verify function being reachable in principle.
+
+setup() {
+    ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    CTL="$BATS_TEST_TMPDIR/ctl"
+    mkdir -p "$CTL/scripts" "$CTL/bin" "$CTL/deploy/compose/prod" "$CTL/infra/secrets/keys"
+    cp "$ROOT/scripts/deploy.sh" "$CTL/scripts/deploy.sh"
+    cp "$ROOT/scripts/_common.sh" "$CTL/scripts/_common.sh"
+
+    # Fixture compose/secrets files — never read for real content, just need
+    # to exist for require_file to pass.
+    touch "$CTL/deploy/compose/prod/docker-compose.db.yml"
+    touch "$CTL/deploy/compose/prod/docker-compose.infra.yml"
+    touch "$CTL/infra/secrets/prod.enc.env"
+    touch "$CTL/infra/secrets/keys/age-prod.key"
+
+    STUB="$CTL/bin"
+    PATH="$STUB:$PATH"
+
+    # sops: exec-env just runs the script directly, no real decryption — the
+    # stateful branch's `set -e`-guarded body only ever calls docker, which
+    # is separately stubbed below. `-d` (used by secret_value/vault paths)
+    # returns nothing so those callers fall through their own "could not
+    # resolve" branches, which are already handled with a warned assumption.
+    cat > "$STUB/sops" <<'EOF'
+#!/usr/bin/env bash
+if [ "$1" = "exec-env" ]; then
+    shift 2
+    exec bash -c "$1"
+fi
+exit 1
+EOF
+    chmod +x "$STUB/sops"
+
+    # Fast retry loop: cmd_verify's own default is 30 attempts * 2s sleep.
+    export DEPLOY_VERIFY_MAX_ATTEMPTS=1
+}
+
+# $1 = 0 for a verify check that PASSES, 1 for one that FAILS. Controls the
+# `docker exec postgres psql ...` / `docker exec traefik wget ...` command
+# cmd_verify's own `eval "$check_cmd"` runs — everything else docker is
+# asked to do (network inspect, ps, rm, compose) succeeds trivially, since
+# this file is about the verify wiring, not about compose semantics.
+make_docker_stub() {
+    local verify_exit="$1"
+    cat > "$STUB/docker" <<EOF
+#!/usr/bin/env bash
+if [ "\$1" = "exec" ]; then
+    exit ${verify_exit}
+fi
+if [ "\$1" = "network" ] && [ "\$2" = "inspect" ]; then
+    exit 0
+fi
+if [ "\$1" = "inspect" ]; then
+    echo "unknown"
+    exit 0
+fi
+if [ "\$1" = "logs" ]; then
+    exit 0
+fi
+exit 0
+EOF
+    chmod +x "$STUB/docker"
+}
+
+# deploy.sh has no --source-only guard (it runs main "$@" unconditionally at
+# the bottom), so sourcing it directly would immediately try to dispatch
+# argv as a command. Extract just the functions this test needs instead —
+# the same block-extraction convention already used elsewhere in this
+# suite — so the REAL cmd_service/cmd_verify bodies run, not a
+# reimplementation of them.
+build_harness() {
+    local out="$1"
+    cat > "$out" <<HARNESS
+#!/usr/bin/env bash
+set -uo pipefail
+SCRIPT_DIR="$CTL/scripts"
+cd "$CTL"
+source scripts/_common.sh
+HARNESS
+    sed -n '/^cmd_verify() {/,/^}/p' "$CTL/scripts/deploy.sh" >> "$out"
+    sed -n '/^cmd_service() {/,/^}/p' "$CTL/scripts/deploy.sh" >> "$out"
+    sed -n '/^cmd_infra() {/,/^}/p' "$CTL/scripts/deploy.sh" >> "$out"
+}
+
+@test "THE ASSERTION THAT MATTERS (cmd_service): Complete! is NOT printed when verification fails" {
+    make_docker_stub 1  # docker exec (the health check) fails every time
+    build_harness "$CTL/harness.sh"
+
+    run bash -c '
+        source "'"$CTL"'/harness.sh"
+        cmd_service db prod
+    '
+
+    [ "$status" -ne 0 ]
+    [[ "$output" != *"Database Deployment Complete!"* ]]
+    [[ "$output" == *"failed readiness check"* ]]
+}
+
+@test "CONTROL (cmd_service): Complete! IS printed, and verify genuinely ran, when the health check passes" {
+    make_docker_stub 0
+    build_harness "$CTL/harness.sh"
+
+    run bash -c '
+        source "'"$CTL"'/harness.sh"
+        cmd_service db prod
+    '
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Database Deployment Complete!"* ]]
+    # Not just "no error" — proof the check actually executed and reported
+    # its own real result, not merely that nothing crashed on the way past.
+    [[ "$output" == *"✓ db is healthy"* ]]
+}
+
+@test "THE ASSERTION THAT MATTERS (cmd_infra): Complete! is NOT printed when verification fails" {
+    make_docker_stub 1
+    build_harness "$CTL/harness.sh"
+
+    run bash -c '
+        source "'"$CTL"'/harness.sh"
+        cmd_infra prod
+    '
+
+    [ "$status" -ne 0 ]
+    [[ "$output" != *"Edge Stack Deployment Complete!"* ]]
+    [[ "$output" == *"failed readiness check"* ]]
+}
+
+@test "CONTROL (cmd_infra): Complete! IS printed when the health check passes" {
+    make_docker_stub 0
+    build_harness "$CTL/harness.sh"
+
+    run bash -c '
+        source "'"$CTL"'/harness.sh"
+        cmd_infra prod
+    '
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Edge Stack Deployment Complete!"* ]]
+    [[ "$output" == *"✓ infra is healthy"* ]]
+}
+
+@test "CONTROL, THE OLD BUG REPRODUCED: before this fix, Complete! printed regardless of health" {
+    # Reconstructs the pre-fix shape inline — cmd_service with no cmd_verify
+    # call before its banner — so the SHAPE being caught (an unconfirmed
+    # success banner) is what's proven, not tied to one git revision.
+    make_docker_stub 1
+    cat > "$CTL/harness_old.sh" <<'HARNESS'
+#!/usr/bin/env bash
+set -uo pipefail
+cmd_service_old() {
+    echo "================================"
+    echo "Database Deployment - prod"
+    echo "================================"
+    docker compose -p test up -d >/dev/null 2>&1 || true
+    echo ""
+    echo "================================"
+    echo "Database Deployment Complete!"
+    echo "================================"
+}
+HARNESS
+    run bash -c '
+        source "'"$CTL"'/harness_old.sh"
+        cmd_service_old
+    '
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Database Deployment Complete!"* ]]
+}


### PR DESCRIPTION
Closes h#752.

Taken in the order specified: the message that lies to an operator first, the
genuinely dormant risk second.

## Complete! printed without calling cmd_verify

Established first, before choosing a fix, exactly which paths reach
"Complete!" without a verify — because if some legitimately should not
verify (a teardown, say), the fix is an honest message, not a forced check.
`cmd_teardown` was checked and correctly excluded: it prints "torn down", a
genuinely different and already-honest claim, never "Complete!".

`cmd_service`'s real production path (`reusable-deploy-service.yml`) already
runs `deploy.sh verify <service>` as a separate mandatory workflow step after
deploying, so a CI-driven deploy of db/auth/minio/vault/observability was
already caught by the **workflow** if health failed. `cmd_infra`'s workflow
(`deploy-infra.yml`) does its own bespoke inline checks (container status,
Traefik log scan, TLS issuer) rather than calling `deploy.sh verify infra` —
also real verification, just not via this function, and not previously
credited to it. Neither finding changes the actual gap: anyone invoking
`deploy.sh infra` or `deploy.sh <service>` directly — which the docs do
reference — got "Complete!" from the **script itself** with zero
verification, regardless of what a wrapping workflow might separately do.

Fixed by calling `cmd_verify` immediately before each "Complete!" banner, in
both `cmd_infra` and `cmd_service`. `cmd_verify` already covers every service
either function deploys, including `"infra"` — this wires up what already
existed rather than inventing a new check, and its `exit 1` on failure means
the banner is never reached if the service did not actually come up healthy.
The CI path now runs the check twice (once inline, once as the workflow's own
separate step) — redundant but cheap, since a passing health check returns on
its first attempt, and this is not the PR to remove either layer of an
already-working defense.

**Positive-controlled in both directions**: "Complete!" is asserted absent
when the health check fails (not merely that something printed an error),
and asserted present — alongside `cmd_verify`'s own real `"✓ <service> is
healthy"` line, not just "no crash" — when it passes.

## The dormant missing set -e

Dormant means **not currently causing harm**, and this write-up does not
imply otherwise: `_deploy_with_sops`'s stateless branch is unreachable today.
Every case arm in `cmd_service`'s dispatch (db, minio, auth, vault,
observability) sets `stateful=true`; nothing sets it false; `deploy_mode` can
therefore never actually be `"stateless"` for any service this script
currently deploys.

**Proven by running it, not by reading it**, per instruction — two separate
questions, answered separately:

1. **Does adding `set -e` change anything for a real, currently-dispatched
   service?** Exercised each of the five real case arms' own dispatch logic
   directly (extracted, not re-typed) and confirmed each resolves to
   `"stateful"`, never `"stateless"` — mechanical, not probabilistic. Also
   confirmed: this diff adds a line only inside the stateless branch — the
   stateful branch's own body, diffed line-for-line against pre-fix, is
   byte-identical. A path that never enters the changed branch cannot be
   affected by it, by construction of the diff, not by argument about
   probability.

2. **Is the changed branch itself a no-op once reached? No** — and saying so
   loudly rather than shipping a comfortable half-truth: called directly (the
   only way to reach it today), a failing `docker compose build` used to
   continue straight through to `up -d` regardless (reproduced against the
   pre-fix branch, verbatim from git history); post-fix, the same failure now
   aborts before `up -d`, matching the stateful sibling's own existing
   behaviour exactly. The **success path** — what an eventual real stateless
   deploy looks like when nothing fails — was diffed byte-for-byte between
   pre-fix and post-fix and found **identical**, so the fix costs nothing in
   the case that matters today and does something real in the case it exists
   for.

## Verification

Both new test files pass (11/11) and are **mutation-verified** via file-copy
backup (never `git checkout --` on uncommitted work) — the exact tests
asserting the new behaviour fail against the pre-fix file; the ones proving
pre-existing/no-op properties correctly stay green either way. Full
deploy-adjacent suite (`deploy.bats`, `deploy-drift-control`,
`deploy-jobs-serialized-control`, `ci-deploy-safety-invariants`,
`vault-empty-guard`) — **79/79 pass**, no regressions. `shellcheck`: identical
warning count before and after (11, both pre-existing, unrelated lines).
`bash -n`: clean.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>