### PR TITLE
fix(scripts): cleanup-branches.sh no longer reports success on a failed push — h#747

### DIFF
--- a/scripts/cleanup-branches.sh
+++ b/scripts/cleanup-branches.sh
@@ -274,7 +274,16 @@ cmd_tag_unmerged() {
     if [ "$YES" = true ] && [ "$made" -gt 0 ]; then
         echo ""
         echo "Pushing ${made} tag(s)..."
-        git push "$REMOTE" --tags
+        # h#747: this file uses only `set -uo pipefail`, not `-e` — every
+        # write here has to check its own exit status explicitly. Without
+        # this, a failed push (network blip, permission error, a rejected
+        # ref) fell straight through to the unconditional "Done... safe" —
+        # telling the operator delete-unmerged is safe to run when the
+        # remote tag it depends on never landed.
+        if ! git push "$REMOTE" --tags; then
+            echo "${RED}Failed to push ${made} tag(s) to ${REMOTE}.${NC} Category C branches are NOT yet reversible via a remote tag — do NOT run delete-unmerged until a retry of tag-unmerged succeeds." >&2
+            return 1
+        fi
         echo "${GREEN}Done.${NC} Category C is now reversible; delete-unmerged is safe."
     else
         confirm_or_dry || true
@@ -298,16 +307,31 @@ delete_batch() {
     # Batched: one push, not N round trips.
     local -a refs=()
     for b in "${present[@]}"; do refs+=(":refs/heads/${b}"); done
-    git push "$REMOTE" "${refs[@]}"
+    # h#747: same reasoning as the tag push above — this is the one
+    # write-shaped, irreversible operation in this file, and it was the
+    # least error-checked. A rejected ref or a network failure used to fall
+    # straight through to "Deleted N branch(es)." with no way to tell that
+    # from a real success.
+    if ! git push "$REMOTE" "${refs[@]}"; then
+        echo "${RED}git push failed.${NC} Some or all of these ${#present[@]} branch(es) may NOT have been deleted — check the error above before assuming this batch is gone:" >&2
+        printf '  %s\n' "${present[@]}" >&2
+        return 1
+    fi
     echo "${GREEN}Deleted ${#present[@]} branch(es).${NC}"
 }
 
 cmd_delete_safe() {
     echo "Categories A and B only. Category C is left alone — use delete-unmerged."
     echo ""
-    delete_batch "A — fully preserved" "${CATEGORY_A[@]}"
+    # h#747: two independent delete_batch calls used to run one after the
+    # other with no status check — if A's push failed and B's succeeded,
+    # cmd_delete_safe's own exit code was B's alone, reporting overall
+    # success while A silently was not deleted.
+    local failed=0
+    delete_batch "A — fully preserved" "${CATEGORY_A[@]}" || failed=1
     echo ""
-    delete_batch "B — superseded drafts only" "${CATEGORY_B[@]}"
+    delete_batch "B — superseded drafts only" "${CATEGORY_B[@]}" || failed=1
+    return "$failed"
 }
 
 cmd_delete_unmerged() {

--- a/tests/scripts/cleanup-branches-push-failure.bats
+++ b/tests/scripts/cleanup-branches-push-failure.bats
@@ -1,0 +1,135 @@
+#!/usr/bin/env bats
+#
+# h#747: cleanup-branches.sh has no `set -e` (unlike every sibling script
+# swept the same day), and its two `git push` call sites — the one
+# write-shaped, irreversible operation in the file — trusted the exit code
+# of nothing. A rejected ref, a network blip, or a permission error fell
+# straight through to an unconditional "Deleted N branch(es)." or "Done...
+# now reversible", identical to what a genuine success prints.
+#
+# These tests force a REAL git push rejection (a bare repo with a
+# pre-receive hook that refuses everything) rather than mocking git, so the
+# assertion is against the actual exit-status/output shape a real failure
+# produces, not an assumption about what git does.
+
+setup() {
+  ROOT="$BATS_TEST_DIRNAME/../.."
+  UPSTREAM="$BATS_TEST_TMPDIR/upstream.git"
+  WORK="$BATS_TEST_TMPDIR/work"
+
+  git init --bare -q "$UPSTREAM"
+  git init -q "$WORK"
+  git -C "$WORK" config user.email test@example.com
+  git -C "$WORK" config user.name test
+  echo hi > "$WORK/f.txt"
+  git -C "$WORK" add f.txt
+  git -C "$WORK" commit -q -m init
+  git -C "$WORK" remote add origin "$UPSTREAM"
+  git -C "$WORK" push -q origin HEAD:refs/heads/main
+
+  git -C "$WORK" branch test-branch-a
+  git -C "$WORK" branch test-branch-b
+  git -C "$WORK" push -q origin test-branch-a test-branch-b
+  # `git push` alone does not update the pusher's own refs/remotes/* — the
+  # script's git rev-parse -q --verify "refs/remotes/${REMOTE}/${b}" checks
+  # need a fetch to have populated them, exactly as a real clone would have.
+  git -C "$WORK" fetch -q origin
+}
+
+reject_all_pushes() {
+  cat > "$UPSTREAM/hooks/pre-receive" <<'EOF'
+#!/bin/sh
+echo "rejected by test hook — simulated remote rejection" >&2
+exit 1
+EOF
+  chmod +x "$UPSTREAM/hooks/pre-receive"
+}
+
+@test "delete_batch: a real push rejection is reported as failure, not printed as success" {
+  reject_all_pushes
+
+  run bash -c "
+    cd '$WORK'
+    REMOTE=origin
+    YES=true
+    source '$ROOT/scripts/cleanup-branches.sh' help --yes >/dev/null 2>&1
+    cd '$WORK'
+    delete_batch 'TEST' test-branch-a test-branch-b
+  "
+
+  [ "$status" -ne 0 ]
+  [[ "$output" != *'Deleted 2 branch(es).'* ]]
+  [[ "$output" == *'may NOT have been deleted'* ]]
+
+  # The branches must genuinely still be on the remote — the push really
+  # failed, this isn't just a message change with the delete going through.
+  run git ls-remote "$UPSTREAM" refs/heads/test-branch-a
+  [ -n "$output" ]
+  run git ls-remote "$UPSTREAM" refs/heads/test-branch-b
+  [ -n "$output" ]
+}
+
+@test "delete_batch: a real successful push still reports success and actually deletes" {
+  run bash -c "
+    cd '$WORK'
+    REMOTE=origin
+    YES=true
+    source '$ROOT/scripts/cleanup-branches.sh' help --yes >/dev/null 2>&1
+    cd '$WORK'
+    delete_batch 'TEST' test-branch-a test-branch-b
+  "
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'Deleted 2 branch(es).'* ]]
+
+  run git ls-remote "$UPSTREAM" refs/heads/test-branch-a
+  [ -z "$output" ]
+  run git ls-remote "$UPSTREAM" refs/heads/test-branch-b
+  [ -z "$output" ]
+}
+
+@test "cmd_tag_unmerged: a real push rejection refuses the 'now reversible / safe' claim" {
+  reject_all_pushes
+
+  run bash -c "
+    cd '$WORK'
+    REMOTE=origin
+    source '$ROOT/scripts/cleanup-branches.sh' help --yes >/dev/null 2>&1
+    cd '$WORK'
+    CATEGORY_C=(test-branch-a)
+    cmd_tag_unmerged
+  "
+
+  [ "$status" -ne 0 ]
+  [[ "$output" != *'delete-unmerged is safe.'* ]]
+  [[ "$output" == *'NOT yet reversible'* ]]
+}
+
+@test "cmd_delete_safe: a failed batch A is not masked by a successful batch B" {
+  # The exact silent-partial-success shape: two independent delete_batch
+  # calls with no status aggregation meant a caller checking only the final
+  # exit code could see 0 even though the first batch's push failed.
+  reject_all_pushes
+
+  run bash -c "
+    cd '$WORK'
+    REMOTE=origin
+    source '$ROOT/scripts/cleanup-branches.sh' help --yes >/dev/null 2>&1
+    cd '$WORK'
+    CATEGORY_A=(test-branch-a)
+    CATEGORY_B=()
+    cmd_delete_safe
+  "
+
+  [ "$status" -ne 0 ]
+
+  run git ls-remote "$UPSTREAM" refs/heads/test-branch-a
+  [ -n "$output" ]
+}
+
+@test "STATIC: both git push call sites check their own exit status" {
+  run bash -c "grep -A3 'git push \"\$REMOTE\" --tags' '$ROOT/scripts/cleanup-branches.sh' | grep -F 'return 1'"
+  [ "$status" -eq 0 ]
+  run bash -c "grep -B1 -A4 'git push \"\$REMOTE\" \"\${refs\[@\]}\"' '$ROOT/scripts/cleanup-branches.sh' | grep -F 'return 1'"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Closes h#747. Part 1 of h#757's remaining findings, smallest first.

## What's real

`cleanup-branches.sh` is the one file in this sweep with no `set -e` at all (`set -uo pipefail` only), and its two `git push` call sites — the only write-shaped, irreversible operation in the file — trusted nothing about the exit code. A rejected ref, a network blip, or a permission error fell straight through to an unconditional "Deleted N branch(es)." or "Done... now reversible; delete-unmerged is safe.", identical to a genuine success.

## Why not a blanket `set -e`

The issue's own suggested fix offered two options. Checked the whole file before picking one: `cmd_audit()` has an unguarded `local files; files=$(git diff --name-only "$base".."$b" 2>/dev/null)` — under `set -e` a transient `git diff` failure during a long ~170-branch scan would abort the *entire* re-audit, rather than (as today) misclassify one branch as having no differences. That's a real behavior change to a read-only reporting tool this issue was never about. Went with explicit checks at exactly the two `git push` sites instead.

## Fix

- `cmd_tag_unmerged`'s tag push and `delete_batch`'s branch-deletion push both now check their own exit status, print what actually may or may not have happened, and `return 1` instead of falling through to the success line.
- `cmd_delete_safe` used to call `delete_batch` for category A and B back to back with no status check — if A's push failed and B's succeeded, the function's own exit code was B's alone, silently masking A's failure. Now aggregates both via a `failed` accumulator and returns it.

## Tests — real git, not a mock

`tests/scripts/cleanup-branches-push-failure.bats` builds a real bare repo as the remote and a real working clone, then forces an actual push rejection with a `pre-receive` hook that refuses everything — the exact "remote rejects a ref" scenario named in the issue — rather than mocking `git`. Asserts the failure is reported AND that the branches genuinely still exist on the remote afterward. A parallel happy-path test proves a real successful push still deletes and still reports success. `cmd_delete_safe`'s masking case is tested directly.

**Positive control:** reverted via `git stash`, reran — exactly the 4 tests asserting new behavior failed; the happy-path test correctly stayed green. Restored, reran: 5/5.

## Test plan

- [x] `bash -n scripts/cleanup-branches.sh` clean
- [x] `bats tests/scripts/cleanup-branches-push-failure.bats` — 5/5, against a real git remote and a real push rejection
- [x] Positive control: revert → 4/5 fail (exactly the new-behavior tests); restore → 5/5
- [x] `bats --recursive tests/scripts/` — 695/695, no regressions
- [x] `git diff --stat` shows exactly the 2 intended files