### PR TITLE
fix(scripts): minio.sh no longer reports unqualified success when a legacy policy can't be removed — h#750

### DIFF
--- a/scripts/minio.sh
+++ b/scripts/minio.sh
@@ -236,18 +236,33 @@ cmd_apply() {
     # so a run that removed the old ones and then failed cannot leave MinIO with
     # neither. `mc admin policy rm` is a no-op-with-error on an absent policy, so
     # absence is reported rather than treated as a failure.
+    #
+    # h#750: a deletion failure used to be downgraded to `warn` and the run
+    # still printed the unqualified "Policies provisioned." success line —
+    # with no signal that a retired policy might still be attached. Per this
+    # file's own header comment, MinIO grants the UNION of every claim value
+    # that names a policy, so a leftover retired policy costs nothing today
+    # and becomes a real, unrequested grant the moment anyone is later given
+    # the matching realm role. `legacy_failed` makes that outcome visible in
+    # both the message and the exit code instead of only in a `warn` line
+    # that a caller reading the final banner would never see.
+    local legacy_failed=0
     for policy in $LEGACY_POLICIES; do
         if echo "$existing" | grep -qx "$policy"; then
             mc admin policy rm local "$policy" >/dev/null 2>&1 \
                 && echo "  - ${policy} deleted (retired)" \
-                || warn "  ! ${policy} could not be deleted — check nothing is attached to it"
+                || { warn "  ! ${policy} could not be deleted — check nothing is attached to it"; legacy_failed=$((legacy_failed + 1)); }
         else
             echo "  . ${policy} already absent"
         fi
     done
 
     echo ""
-    success "Policies provisioned."
+    if [ "$legacy_failed" -gt 0 ]; then
+        warn "Policies provisioned, but ${legacy_failed} legacy polic(ies) could not be removed — see the warning(s) above. A leftover retired policy becomes a real grant the moment its name matches a realm role."
+    else
+        success "Policies provisioned."
+    fi
     echo ""
     echo "  A Keycloak user with realm role 'platform-admin' now receives the"
     echo "  MinIO 'platform-admin' policy when exchanging a token via"
@@ -256,6 +271,10 @@ cmd_apply() {
     echo ""
     echo "  This is the S3/STS path only. MinIO's console has no SSO login in"
     echo "  the AGPL build — see docs/runbooks/object-store.md."
+
+    # The message alone is not enough — a caller checking only the exit code
+    # (CI, another script) must also be able to tell this run was incomplete.
+    [ "$legacy_failed" -eq 0 ] || return 1
 }
 
 cmd_status() {

--- a/tests/scripts/minio-legacy-policy-failure.bats
+++ b/tests/scripts/minio-legacy-policy-failure.bats
@@ -1,0 +1,118 @@
+#!/usr/bin/env bats
+#
+# h#750: minio.sh's cmd_apply() downgraded a legacy-policy deletion failure
+# to a `warn` and still printed the unqualified "Policies provisioned." —
+# per this file's own header, MinIO grants the UNION of every claim value
+# that names a policy, so a leftover retired policy costs nothing today and
+# becomes a real, unrequested grant the moment anyone is later given the
+# matching realm role. A caller reading the final banner had no signal that
+# might have happened.
+#
+# `docker` is stubbed (every `mc` call in this file is itself a wrapper
+# function around `docker exec ... mc "$@"`, defined at minio.sh:159), so no
+# real MinIO or Docker daemon is involved. MINIO_ROOT_USER/PASSWORD are set
+# in the environment so secret_for() resolves without touching SOPS.
+
+setup() {
+  ROOT="$BATS_TEST_DIRNAME/../.."
+  STUB="$BATS_TEST_TMPDIR/bin"
+  mkdir -p "$STUB"
+  PATH="$STUB:$PATH"
+
+  export MINIO_ROOT_USER=testuser
+  export MINIO_ROOT_PASSWORD=testpass
+  export MINIO_CONTAINER=fake-minio
+}
+
+# $1 = space-separated legacy policies that should FAIL to delete (empty = all succeed)
+make_docker_stub() {
+  local failing="$1"
+  cat > "$STUB/docker" <<EOF
+#!/usr/bin/env bash
+FAILING="$failing"
+args=("\$@")
+# docker inspect \$MINIO_CONTAINER — require_running
+if [ "\${args[0]}" = "inspect" ]; then
+  exit 0
+fi
+# docker exec ... \$MINIO_CONTAINER mc <subcommand...>
+if [ "\${args[0]}" = "exec" ]; then
+  # Find the mc subcommand words after the literal "mc" token.
+  mc_idx=-1
+  for i in "\${!args[@]}"; do
+    if [ "\${args[\$i]}" = "mc" ]; then mc_idx=\$i; break; fi
+  done
+  rest=("\${args[@]:\$((mc_idx+1))}")
+  case "\${rest[0]} \${rest[1]}" in
+    "admin info")
+      echo '{"info":{"mode":"standalone"}}'
+      exit 0
+      ;;
+    "admin policy")
+      case "\${rest[2]}" in
+        ls)
+          printf 'platform-admin\nplatform-viewer\nadmin\neditor\nviewer\n'
+          exit 0
+          ;;
+        create)
+          exit 0
+          ;;
+        rm)
+          policy="\${rest[4]}"
+          for f in \$FAILING; do
+            if [ "\$f" = "\$policy" ]; then
+              echo "mc: <ERROR> Unable to remove policy. policy in use." >&2
+              exit 1
+            fi
+          done
+          exit 0
+          ;;
+      esac
+      ;;
+  esac
+  exit 0
+fi
+exit 0
+EOF
+  chmod +x "$STUB/docker"
+}
+
+run_apply() {
+  cd "$ROOT"
+  # shellcheck disable=SC1091
+  source scripts/minio.sh >/dev/null 2>&1
+  cmd_apply
+}
+
+@test "cmd_apply: all legacy deletions succeed — unqualified success, exit 0" {
+  make_docker_stub ""
+  run run_apply
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Policies provisioned."* ]]
+  [[ "$output" != *"could not be removed"* ]]
+}
+
+@test "cmd_apply: THE CASE THAT MATTERS — one legacy deletion fails, message is qualified and exit is non-zero" {
+  make_docker_stub "editor"
+  run run_apply
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"could not be deleted"* ]]
+  [[ "$output" == *"Policies provisioned, but 1 legacy polic(ies) could not be removed"* ]]
+  [[ "$output" != *$'\n'"Policies provisioned."$'\n'* ]]
+}
+
+@test "cmd_apply: multiple legacy deletion failures are all counted, not just the first" {
+  make_docker_stub "editor viewer"
+  run run_apply
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Policies provisioned, but 2 legacy polic(ies) could not be removed"* ]]
+}
+
+@test "cmd_apply: a legacy deletion failure does not prevent the real policies from being created" {
+  # The creates happen BEFORE the legacy deletions and must not be skipped
+  # or rolled back just because cleanup afterward had a problem.
+  make_docker_stub "admin"
+  run run_apply
+  [[ "$output" == *"+ platform-admin"* || "$output" == *"= platform-admin"* ]]
+  [[ "$output" == *"+ platform-viewer"* || "$output" == *"= platform-viewer"* ]]
+}


### PR DESCRIPTION
Closes h#750. Part 2 of h#757's remaining findings.

## What's real

`cmd_apply()`'s legacy-policy deletion loop downgraded an `mc admin policy rm` failure for a retired policy (admin/editor/viewer) to `warn`, and the run still printed the unqualified "Policies provisioned." success line. Per this file's own header comment, MinIO grants the UNION of every claim value that names a policy, so a leftover retired policy costs nothing today and becomes a real, unrequested grant the moment anyone is later given the matching realm role — a real prior incident this file's own comments describe, not hypothetical.

## Fix

A `legacy_failed` counter, same idiom as the accumulator pattern already used elsewhere in this sweep (`local.sh`'s `cmd_health`): the message is now qualified — "Policies provisioned, but N legacy polic(ies) could not be removed" — and `cmd_apply` returns 1 when any legacy deletion failed, so a caller checking only the exit code can tell too.

## Tests

`docker` is stubbed — every `mc` call in this file is a wrapper around `docker exec ... mc "$@"` (minio.sh:159), so stubbing `docker` covers everything; `MINIO_ROOT_USER`/`PASSWORD` are set in the environment so `secret_for()` resolves without SOPS. Four cases: all succeed (unqualified, exit 0); ONE fails (qualified, exit 1 — the case that matters); multiple failures all counted; and a failure doesn't prevent or roll back the real policy creates that happen first.

**Positive control:** reverted via `git stash`, reran — exactly the 2 tests asserting new qualified-failure behavior failed; the happy-path and creates-still-happen tests correctly stayed green. Restored, reran: 4/4.

## Test plan

- [x] `bash -n scripts/minio.sh` clean
- [x] `bats tests/scripts/minio-legacy-policy-failure.bats` — 4/4
- [x] Positive control: revert → 2/4 fail (exactly the new-behavior tests); restore → 4/4
- [x] `bats --recursive tests/scripts/` — 701/701, no regressions
- [x] `git diff --stat` shows exactly the 2 intended files