### PR TITLE
fix(scripts): vps.sh reads secrets-update writes back instead of trusting the exit code alone — h#751

### DIFF
--- a/scripts/vps.sh
+++ b/scripts/vps.sh
@@ -286,10 +286,29 @@ cmd_config() {
     # Step 3: Update TAILSCALE_IP in secrets
     echo -e "${CYAN}[3/3] Updating TAILSCALE_IP and VPS_HOST in encrypted secrets...${NC}"
     cd "$PROJECT_ROOT"
+
+    # h#751: `set -e` protects against `make`/`sops --set` returning non-zero,
+    # but a write that exits 0 is not proof the value actually landed as
+    # intended — the same distinction the rest of this sweep draws elsewhere.
+    # Read each value back with the same `sops -d --extract` mechanism
+    # secrets.sh's own `get` command uses (and this function already uses a
+    # few lines above, for TRAEFIK_ADMIN_PASSWORD_HASH/HOSTINGER_API_KEY/
+    # TAILSCALE_IP) and compare it against what was just written, matching
+    # the verification discipline provision-tenant-db.sh already applies to
+    # its own writes.
     make secrets-update KEY=TAILSCALE_IP VALUE="$tailscale_ip" > /dev/null 2>&1
-    success "   ✓ TAILSCALE_IP updated"
+    local readback_ts
+    readback_ts=$(sops -d --extract '["TAILSCALE_IP"]' infra/secrets/prod.enc.env 2>/dev/null || echo "")
+    [ "$readback_ts" = "$tailscale_ip" ] \
+        || die "TAILSCALE_IP update did not take: wrote '${tailscale_ip}', read back '${readback_ts}'. The secrets store may be inconsistent — check infra/secrets/prod.enc.env by hand before continuing."
+    success "   ✓ TAILSCALE_IP updated (verified)"
+
     make secrets-update KEY=VPS_HOST VALUE="$tailscale_ip" > /dev/null 2>&1
-    success "   ✓ VPS_HOST updated (SSH via Tailscale)"
+    local readback_host
+    readback_host=$(sops -d --extract '["VPS_HOST"]' infra/secrets/prod.enc.env 2>/dev/null || echo "")
+    [ "$readback_host" = "$tailscale_ip" ] \
+        || die "VPS_HOST update did not take: wrote '${tailscale_ip}', read back '${readback_host}'. The secrets store may be inconsistent — check infra/secrets/prod.enc.env by hand before continuing."
+    success "   ✓ VPS_HOST updated (verified, SSH via Tailscale)"
     echo ""
 
     echo ""

--- a/tests/scripts/vps-secrets-readback.bats
+++ b/tests/scripts/vps-secrets-readback.bats
@@ -1,0 +1,95 @@
+#!/usr/bin/env bats
+#
+# h#751: vps.sh's two `make secrets-update` calls trusted the exit code
+# alone and never read the value back — lower severity than the rest of
+# this sweep, since `set -euo pipefail` (verified active in this file)
+# already aborts on a hard `make`/`sops --set` failure. The gap `set -e`
+# cannot cover: a write that exits 0 without the value actually landing as
+# intended (a race with another writer, a key/value that `sops --set`
+# quietly mis-parsed, a wrong file resolved).
+#
+# These tests extract the REAL "Step 3" block verbatim from scripts/vps.sh
+# (via sed, not retyped) and eval it inside a wrapper function, with `make`
+# and `sops` stubbed to make the write/read-back mismatch controllable and
+# deterministic. Scaled to the issue's own stated severity: this is the
+# lowest-priority item in the tracking issue, so the test proves the
+# comparison-and-die logic fires correctly rather than standing up a full
+# real sops/age/repo round trip the way the higher-severity items in this
+# sweep did.
+
+setup() {
+  ROOT="$BATS_TEST_DIRNAME/../.."
+  STUB="$BATS_TEST_TMPDIR/bin"
+  mkdir -p "$STUB"
+  PATH="$STUB:$PATH"
+}
+
+extract_step3() {
+  sed -n '/# Step 3: Update TAILSCALE_IP/,/^    echo ""$/p' "$ROOT/scripts/vps.sh" | sed '$d'
+}
+
+# $1 = value `sops -d --extract` should report back for BOTH keys (simulates
+#      a write that landed correctly when equal to the intended IP, or one
+#      that silently didn't when different / empty)
+make_stubs() {
+  cat > "$STUB/make" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+  chmod +x "$STUB/make"
+
+  cat > "$STUB/sops" <<EOF
+#!/usr/bin/env bash
+echo "$1"
+EOF
+  chmod +x "$STUB/sops"
+}
+
+run_step3() {
+  local tailscale_ip="$1"
+  local snippet
+  snippet="$(extract_step3)"
+  bash -c "
+    source '$ROOT/scripts/_common.sh'
+    PROJECT_ROOT='$ROOT'
+    probe() {
+      local tailscale_ip='$tailscale_ip'
+      $snippet
+    }
+    probe
+  "
+}
+
+@test "a correct read-back is verified and reports success for both keys" {
+  make_stubs "10.20.30.40"
+  run run_step3 "10.20.30.40"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"TAILSCALE_IP updated (verified)"* ]]
+  [[ "$output" == *"VPS_HOST updated (verified, SSH via Tailscale)"* ]]
+}
+
+@test "THE CASE THAT MATTERS: a write that returns 0 but does not read back correctly is refused, not reported as success" {
+  # sops reports back a DIFFERENT value than what was written — exactly the
+  # "make/sops exited 0 but the value didn't actually land" case set -e
+  # alone cannot catch.
+  make_stubs "0.0.0.0"
+  run run_step3 "10.20.30.40"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"TAILSCALE_IP update did not take"* ]]
+  [[ "$output" == *"wrote '10.20.30.40'"* ]]
+  [[ "$output" == *"read back '0.0.0.0'"* ]]
+  [[ "$output" != *"(verified)"* ]]
+}
+
+@test "an empty read-back (sops -d --extract failing silently) is also refused" {
+  make_stubs ""
+  run run_step3 "10.20.30.40"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"TAILSCALE_IP update did not take"* ]]
+  [[ "$output" == *"read back ''"* ]]
+}
+
+@test "STATIC: set -euo pipefail is genuinely active in this file, as the issue's own severity note assumes" {
+  run head -10 "$ROOT/scripts/vps.sh"
+  [[ "$output" == *"set -euo pipefail"* ]]
+}


### PR DESCRIPTION
Closes h#751. Part 3 of h#757's remaining findings — the issue's own lowest-priority item, since `set -euo pipefail` (confirmed active in this file) already aborts on a hard `make`/`sops --set` failure. The gap `set -e` cannot cover: a write that exits 0 without the value actually landing as intended.

## Fix

After each of the two `make secrets-update KEY=... VALUE=...` calls, read the value back with the same `sops -d --extract` mechanism `secrets.sh get` uses (and this same function already uses a few lines above for other secrets) and compare it against what was just written. A mismatch or empty read-back calls `die` naming both values, rather than the write being trusted silently — matching `provision-tenant-db.sh`'s own verification discipline, per the issue's suggested fix.

## Tests

Extracted the real "Step 3" block verbatim via `sed` and ran it with `make`/`sops` stubbed for a deterministic comparison. Scaled to the issue's own stated severity (lowest in the tracking issue) rather than a full real sops/age/repo round trip. Three cases: correct read-back reports "(verified)"; a disagreeing read-back is refused, naming both values; an empty read-back is refused the same way. A fourth static test pins that `set -euo pipefail` really is active, since the fix's rationale depends on it.

**Positive control:** reverted via `git stash`, reran — exactly the 3 new-behavior tests failed; the unrelated static test correctly stayed green. Restored, reran: 4/4.

## Test plan

- [x] `bash -n scripts/vps.sh` clean
- [x] `bats tests/scripts/vps-secrets-readback.bats` — 4/4
- [x] Positive control: revert → 3/4 fail (exactly the new-behavior tests); restore → 4/4
- [x] `bats --recursive tests/scripts/` — 706/706, no regressions
- [x] `git diff --stat` shows exactly the 2 intended files