### PR TITLE
docs(decisions): app-auth's certificate outlives its retirement, decision not fix — h#802

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,7 +107,12 @@ docs/                   runbooks, reference, architecture, decisions
    refuses to render without it, and `ACME_REQUIRE_PRODUCTION=1` guards the
    opposite mistake. Switching CAs means Traefik will not reissue certificates it
    considers valid, so returning to production requires clearing the ACME
-   stores — and `acme-dns.json` holds all four DNS-01 certificates in one file.
+   stores — and `acme-dns.json` holds **six** DNS-01 certificates in one file,
+   `Verified 2026-08-06` directly against the live store (`grafana`, `litellm`,
+   `portainer`, `storage`, `traefik`, `vault`). *(This line said "four" — true
+   when written, and stale by the time `litellm` and `storage` joined the DNS-01
+   resolver; found while investigating h#802, corrected here rather than left to
+   mislead the next person reading it as current.)*
    Read [`docs/architecture/certificates.md`](docs/architecture/certificates.md)
    first.
 5. **This repo owns the shared networks.** `docker-compose.infra.yml` and

--- a/docs/architecture/certificates.md
+++ b/docs/architecture/certificates.md
@@ -187,9 +187,12 @@ Recovery means deleting the stored certificates so Traefik requests new ones:
 
 - The ACME stores live in the `traefik-certs` Docker volume, **root-owned**
   inside the container.
-- `acme-dns.json` holds **all four DNS-01 certificates in one file** — traefik,
-  portainer, grafana, vault. There is no way to clear one host's certificate
-  without clearing the others; every one of them is reissued.
+- `acme-dns.json` holds **six DNS-01 certificates in one file**, `Verified
+  2026-08-06` — grafana, litellm, portainer, storage, traefik, vault. There is
+  no way to clear one host's certificate without clearing the others; every one
+  of them is reissued. *(Said "all four ... traefik, portainer, grafana, vault"
+  until `litellm` and `storage` joined the DNS-01 resolver; found while
+  investigating h#802.)*
 - `acme.json` separately holds the HTTP-01 certificate for `auth`.
 - The stored ACME **account registrations** are production registrations, which
   is a further mismatch when the resolver has been pointed at staging.

--- a/docs/decisions/retired-hostname-certificate-h802-2026-08-06.md
+++ b/docs/decisions/retired-hostname-certificate-h802-2026-08-06.md
@@ -1,0 +1,118 @@
+# `app-auth.hill90.com`'s certificate outlives its retirement — a documented decision, not a fix
+
+`Verified 2026-08-06`. Filed against [h#802](https://github.com/jonhill90/Hill90/issues/802):
+a retired hostname (`app-auth.hill90.com`, container and router removed 2026-07-30) still
+holds a Let's Encrypt certificate, and `CertificateExpiringSoon` / `CertificateExpiringCritical`
+have no exclusion for it.
+
+## The question the issue asked, answered
+
+The issue asked whether the alarm is wrong or the certificate is — they need opposite fixes,
+and guessing wrong repairs the wrong thing. **The alarm is wrong. The certificate is not
+broken and is not going to expire unattended.**
+
+## Why: Traefik's renewal loop does not check whether a router still wants the domain
+
+This repo pins Traefik v2.11 (`docs/architecture/certificates.md`). `renewCertificates` in
+`pkg/provider/acme/provider.go` (tag `v2.11.24`, read directly, lines 781-834) iterates
+`p.certificates` — the full ACME store loaded at startup — and renews anything inside the
+renewal window. There is no check against the current router/dynamic configuration:
+
+```go
+for _, cert := range p.certificates {
+    crt, err := getX509Certificate(ctx, &cert.Certificate)
+    if err != nil || crt == nil || crt.NotAfter.Before(time.Now().Add(renewPeriod)) {
+        certificates = append(certificates, cert)
+    }
+}
+...
+logger.Infof("Renewing certificate from LE : %+v", cert.Domain)
+renewedCert, err := client.Certificate.RenewWithOptions(res, opts)
+```
+
+Removing a router does not remove the certificate from the store, and nothing about removing
+a router tells Traefik to stop renewing it. This is a known, general Traefik behavior — the
+ACME store is never garbage-collected — not something specific to this deployment.
+
+## The renewal precondition is confirmed live, not assumed
+
+A renewal only completes if the HTTP-01 challenge can still be served, so that was checked too:
+
+- `dig +short app-auth.hill90.com A` → `76.13.26.69`, the same IP as `hill90.com`. DNS was
+  never repointed when the router was retired.
+- A harmless probe to `http://app-auth.hill90.com/.well-known/acme-challenge/test` was
+  answered by Traefik's own internal, always-on challenge router:
+  ```
+  RouterName: "acme-http@internal"
+  {"level":"error","msg":"Cannot retrieve the ACME challenge for app-auth.hill90.com (token \"test\")",...}
+  ```
+  That error is the expected response to a fake token — no real challenge was in progress and
+  nothing was mutated. What it proves: the challenge path answers for this hostname
+  unconditionally, independent of whether a router exists for it.
+
+Both things a renewal needs are live. `app-auth.hill90.com` is currently tracking the exact
+same ~60-day cadence as its issuance-batch siblings — `hill90.com`, `api.hill90.com` and
+`ai.hill90.com` are all at 81.7-81.8 days remaining alongside it, decaying in lockstep, not
+diverging. It will almost certainly keep auto-renewing indefinitely.
+
+*(Honest limit: Traefik's container only started 2026-08-03, so no renewal cycle has actually
+completed inside it yet — the nearest is `portainer`/`grafana` at ~37 days out. This is read
+from the mechanism plus its confirmed live preconditions, not witnessed end to end, because
+witnessing it means waiting two months.)*
+
+## What this means for the two questions the issue posed
+
+**The alarm does not need repair.** `CertificateExpiringSoon`/`Critical` firing for
+`app-auth.hill90.com` specifically is unlikely — renewal happens well before the 21-day
+threshold, same as every other certificate on the host. The threshold expressions are correct
+as written and adding a CN exclusion would be solving a problem that doesn't exist while
+opening the one the issue explicitly warned against: a hostname allowlist inside an alert
+rule, going stale exactly like this document would if left unquestioned.
+
+**The estate is not failing, but it is not clean either.** The retirement was incomplete: the
+container and router are gone, the ACME entry is not, and it will silently keep renewing
+forever — consuming one of the 5-certificates-per-domain-per-week Let's Encrypt budget every
+~60 days, indefinitely, for a hostname that serves nothing.
+
+## The corrected risk framing on removing it
+
+The issue cited `acme-dns.json`'s multi-certificate bundling as the reason to be cautious
+about dropping the stale certificate. Checked live: **`app-auth.hill90.com` is not in that
+file.** Its router used `certresolver=letsencrypt` (HTTP-01, confirmed in
+`docker-compose.auth.yml`'s git history), so it lives in the separate, smaller `acme.json`:
+
+```
+acme.json (resolver "letsencrypt", HTTP-01) — 5 entries:
+  ai.hill90.com, api.hill90.com, app-auth.hill90.com, auth.hill90.com, hill90.com (+www SAN)
+
+acme-dns.json (resolver "letsencrypt-dns", DNS-01) — 6 entries, the one worth being careful with:
+  grafana, litellm, portainer, storage, traefik, vault
+```
+(Domain names only — no key material was read or printed. This count also corrected
+`CLAUDE.md`'s own invariant 4, which said "four": see that PR's other change.)
+
+`Certificates` is a plain JSON array per resolver. Removing the single element where
+`.domain.main == "app-auth.hill90.com"` from `acme.json` touches neither `acme-dns.json` nor
+the other 4 entries in `acme.json`. The blast radius is real but small — smaller than the
+issue's framing suggested, because it conflated the two files' risk.
+
+## Recommendation — not executed here, deliberately
+
+Remove `app-auth.hill90.com`'s entry from `acme.json` (only that file, only that entry), then
+restart Traefik so the in-memory store drops it. Nothing re-adds it afterward: the router that
+would trigger reissuance was already removed 2026-07-30.
+
+**This is a documented decision, not a fix, because the trade is bad to make unilaterally
+regardless of how small the edit is.** The entire benefit is Let's Encrypt rate-limit headroom
+for a hostname nobody uses. The cost is a live edit to a production certificate store plus a
+Traefik restart, on the estate's only public TLS path — "the blast radius is smaller than
+feared" is an argument that the edit is *safe*, not an argument that it is *worth doing
+unilaterally*. Execution is left to Jon.
+
+## What happens if nothing is done
+
+Nothing, as far as anyone can tell from here: the certificate renews quietly forever, the
+alarm does not fire, and the only ongoing cost is a slice of unused rate-limit budget. That is
+a legitimate steady state to simply accept, distinct from "accept it and note the date" as
+originally framed in the issue — there is no date after which this becomes true, because
+nothing here is expected to change on its own.


### PR DESCRIPTION
## Summary

Closes the investigation on #802 as a documented decision, not a code/config change — per Jon's explicit instruction not to execute the surgical `acme.json` edit.

- **The alarm's premise is wrong, not the certificate.** Traefik's ACME renewal loop (`pkg/provider/acme/provider.go`, v2.11.24) has no router/domain filter — it renews everything in the persisted store on schedule regardless of whether a router still requests the domain. Confirmed live that the renewal precondition (HTTP-01 challenge reachability) still holds for `app-auth.hill90.com`. It will almost certainly keep auto-renewing indefinitely; `CertificateExpiringSoon`/`Critical` firing for it specifically is unlikely.
- **So the check doesn't need fixing** — thresholds are correct, no CN exclusion added.
- **The estate isn't failing, but the retirement was incomplete** — the ACME entry outlives the router, silently spending Let's Encrypt rate-limit budget forever on a hostname nobody uses.
- **Recommendation, not executed:** remove the single `acme.json` entry (confirmed to live there, not in the more delicate `acme-dns.json`) and restart Traefik. Not done here — the entire benefit is unused rate-limit headroom, the cost is a live edit + restart on the estate's only public TLS path, and that's a bad trade to make unilaterally regardless of how small the edit is. Left to Jon.
- **Corrects CLAUDE.md invariant 4 and `docs/architecture/certificates.md`**, both of which said `acme-dns.json` holds four DNS-01 certificates. Verified live today: six (`litellm` and `storage` joined the DNS-01 resolver since that text was written). Old text kept alongside the correction, per this repo's own stated convention.

## Test plan

- [x] Read Traefik v2.11.24's `renewCertificates` source directly (not summarized) to confirm no router-based filtering exists.
- [x] Live-confirmed DNS still resolves `app-auth.hill90.com` to the production host.
- [x] Live-confirmed Traefik's internal `acme-http@internal` router answers the ACME challenge path for `app-auth.hill90.com` unconditionally (harmless probe, no mutation).
- [x] Live-confirmed via Prometheus that `app-auth.hill90.com`'s cert is decaying in lockstep with its issuance-batch siblings, not diverging.
- [x] Live-confirmed `acme.json` vs `acme-dns.json` membership by reading domain names only (no key material read or printed) from both files on the host.
- [x] No production state was mutated at any point in this investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)