### PR TITLE
fix(scripts): a failed holder-count read no longer lets keycloak.sh delete a role that might still be in use — h#746

### DIFF
--- a/scripts/keycloak.sh
+++ b/scripts/keycloak.sh
@@ -287,11 +287,40 @@ remove_realm_roles() {
             continue
         fi
 
-        local users groups parents
-        users=$(kc get "roles/${role}/users"  -r "$KC_REALM" --fields id --format csv --noquotes 2>/dev/null | tr -d '\r' | grep -c . || true)
-        groups=$(kc get "roles/${role}/groups" -r "$KC_REALM" --fields id --format csv --noquotes 2>/dev/null | tr -d '\r' | grep -c . || true)
-        # Composite parents: any role whose composites include this one.
-        parents=$(kc get roles -r "$KC_REALM" --fields name --format csv --noquotes 2>/dev/null | tr -d '\r' | while read -r other; do
+        # h#746: `... | grep -c . || true` used to make a transient read
+        # failure indistinguishable from a genuine "zero holders" result —
+        # grep -c on empty stdin (whether because kc get legitimately found
+        # nothing, or because it failed and produced no output at all)
+        # prints the literal string "0" and exits 1, and `|| true` swallowed
+        # that. Whichever of the three checks failed, the role proceeded
+        # toward deletion as if the holder-count had genuinely been
+        # verified. Extends this file's own existing pattern
+        # (ensure_event_logging's `|| die` on a load-bearing write) rather
+        # than inventing a new one: each read's own exit status is now
+        # checked BEFORE counting, so a failed read refuses the retirement
+        # instead of silently counting as zero.
+        local users groups parents users_raw groups_raw roles_raw
+        if ! users_raw=$(kc get "roles/${role}/users" -r "$KC_REALM" --fields id --format csv --noquotes 2>/dev/null | tr -d '\r'); then
+            warn "  ! ${role} NOT deleted — could not read current USER holders (the query failed). A failed read is not the same as zero holders; retirement is blocked until it succeeds."
+            continue
+        fi
+        users=$(printf '%s' "$users_raw" | grep -c . || true)
+
+        if ! groups_raw=$(kc get "roles/${role}/groups" -r "$KC_REALM" --fields id --format csv --noquotes 2>/dev/null | tr -d '\r'); then
+            warn "  ! ${role} NOT deleted — could not read current GROUP holders (the query failed). A failed read is not the same as zero holders; retirement is blocked until it succeeds."
+            continue
+        fi
+        groups=$(printf '%s' "$groups_raw" | grep -c . || true)
+
+        # Composite parents: any role whose composites include this one. The
+        # outer list of candidate roles is read explicitly for the same
+        # reason as users/groups above — its failure would otherwise zero
+        # out every composite-parent check at once, not just one role's.
+        if ! roles_raw=$(kc get roles -r "$KC_REALM" --fields name --format csv --noquotes 2>/dev/null | tr -d '\r'); then
+            warn "  ! ${role} NOT deleted — could not read the realm's role list to check composite parents (the query failed). A failed read is not the same as zero holders; retirement is blocked until it succeeds."
+            continue
+        fi
+        parents=$(printf '%s' "$roles_raw" | while read -r other; do
             [ -n "$other" ] || continue
             [ "$other" = "$role" ] && continue
             kc get "roles/${other}/composites" -r "$KC_REALM" --fields name --format csv --noquotes 2>/dev/null \

--- a/tests/scripts/keycloak-role-holder-read-failure.bats
+++ b/tests/scripts/keycloak-role-holder-read-failure.bats
@@ -1,0 +1,123 @@
+#!/usr/bin/env bats
+#
+# h#746: remove_realm_roles()'s three holder-count checks (users, groups,
+# composite-parents) each piped `kc get ... | tr -d '\r' | grep -c . ||
+# true`. `grep -c .` on empty stdin prints the literal string "0" and exits
+# 1 regardless of WHY stdin was empty — a genuine zero-holder result and a
+# failed `kc get` (API blip, container restart mid-run) were indistinguishable,
+# and `|| true` discarded the difference. On the retirement path that means a
+# transient read failure let a role proceed toward `kc delete roles/${role}`
+# as if the holder-count had genuinely been verified as zero.
+#
+# `docker` is stubbed — kc() is a one-line wrapper around
+# `docker exec "$KC_CONTAINER" kcadm.sh "$@"` (keycloak.sh:115) — so no real
+# Keycloak is involved. These tests call remove_realm_roles() directly.
+
+setup() {
+  ROOT="$BATS_TEST_DIRNAME/../.."
+  STUB="$BATS_TEST_TMPDIR/bin"
+  mkdir -p "$STUB"
+  PATH="$STUB:$PATH"
+}
+
+# $1 = "users-fail" | "groups-fail" | "roles-fail" | "has-holders" | "clean"
+make_docker_stub() {
+  local mode="$1"
+  local counter="$BATS_TEST_TMPDIR/roles-call-count"
+  echo 0 > "$counter"
+  cat > "$STUB/docker" <<EOF
+#!/usr/bin/env bash
+MODE="$mode"
+COUNTER="$counter"
+args=("\$@")
+# args: exec <container> /opt/keycloak/bin/kcadm.sh <subcmd> <target> ...
+sub="\${args[3]}"
+target="\${args[4]:-}"
+
+case "\$sub \$target" in
+  "get roles")
+    # remove_realm_roles calls "kc get roles" TWICE: once at the top to
+    # check the role still exists, once per role inside the composite-
+    # parents check. roles-fail must let the FIRST through (so the loop is
+    # reached at all) and fail the SECOND — the one this fix actually
+    # guards.
+    n=\$(cat "\$COUNTER"); n=\$((n + 1)); echo "\$n" > "\$COUNTER"
+    if [ "\$MODE" = "roles-fail" ] && [ "\$n" -ge 2 ]; then
+      echo "kcadm: connection refused" >&2
+      exit 1
+    fi
+    echo "admin"
+    exit 0
+    ;;
+  "get roles/admin/users")
+    if [ "\$MODE" = "users-fail" ]; then
+      echo "kcadm: connection refused" >&2
+      exit 1
+    fi
+    if [ "\$MODE" = "has-holders" ]; then
+      echo "user-uuid-1"
+    fi
+    exit 0
+    ;;
+  "get roles/admin/groups")
+    if [ "\$MODE" = "groups-fail" ]; then
+      echo "kcadm: connection refused" >&2
+      exit 1
+    fi
+    exit 0
+    ;;
+  "get roles/admin/composites")
+    exit 0
+    ;;
+  "delete roles/admin")
+    echo "deleted (0 users, 0 groups, 0 composite parents)" >&2
+    exit 0
+    ;;
+esac
+exit 0
+EOF
+  chmod +x "$STUB/docker"
+}
+
+run_remove() {
+  cd "$ROOT"
+  # shellcheck disable=SC1091
+  source scripts/keycloak.sh help >/dev/null 2>&1
+  REALM_ROLES_REMOVED=admin remove_realm_roles
+}
+
+@test "clean read, zero holders: the role is genuinely deleted" {
+  make_docker_stub "clean"
+  run run_remove
+  [[ "$output" == *"deleted (0 users, 0 groups, 0 composite parents)"* ]]
+  [[ "$output" != *"could not read"* ]]
+}
+
+@test "clean read, real holders: the role is correctly NOT deleted" {
+  make_docker_stub "has-holders"
+  run run_remove
+  [[ "$output" != *"deleted (0 users, 0 groups, 0 composite parents)"* ]]
+  [[ "$output" == *"NOT deleted — holders found"* ]]
+}
+
+@test "THE CASE THAT MATTERS: a failed USERS read refuses the delete, names the read failure, not holders" {
+  make_docker_stub "users-fail"
+  run run_remove
+  [[ "$output" != *"deleted (0 users, 0 groups, 0 composite parents)"* ]]
+  [[ "$output" == *"could not read current USER holders"* ]]
+  [[ "$output" != *"NOT deleted — holders found"* ]]
+}
+
+@test "a failed GROUPS read also refuses the delete, distinct message from the users case" {
+  make_docker_stub "groups-fail"
+  run run_remove
+  [[ "$output" != *"deleted (0 users, 0 groups, 0 composite parents)"* ]]
+  [[ "$output" == *"could not read current GROUP holders"* ]]
+}
+
+@test "a failed realm ROLE LIST read (the composite-parents check's own source) refuses the delete" {
+  make_docker_stub "roles-fail"
+  run run_remove
+  [[ "$output" != *"deleted (0 users, 0 groups, 0 composite parents)"* ]]
+  [[ "$output" == *"could not read the realm's role list"* ]]
+}


### PR DESCRIPTION
Closes h#746. Part 4 of h#757's remaining findings.

## What's real

`remove_realm_roles()`'s three holder-count checks (users, groups, composite-parents) each piped `kc get ... | tr -d '\r' | grep -c . || true`. `grep -c .` on empty stdin prints the literal string "0" and exits 1 regardless of *why* stdin was empty — a genuine zero-holder result and a failed `kc get` (API blip, container restart mid-run) were indistinguishable, and `|| true` discarded the difference.

**Verified directly by positive control, not just read:** with the pre-fix code, forcing any one of the three reads to fail resulted in the role being genuinely **deleted** — exactly as if the holder-count had been verified as zero. The three-way check exists specifically so a delete can't silently strip access from someone who holds it via one of the other two paths, and a transient read failure on any one of the three defeated that safeguard the same way an incomplete design would.

## Fix

Extends this file's own existing pattern (`ensure_event_logging`'s `|| die` on a load-bearing write) rather than inventing a new one. Each of the three reads now has its own exit status checked *before* anything is counted. A failed read refuses the retirement for that role with a message naming exactly which read failed — distinct from the existing "holders found" message.

## Scope boundary, stated rather than silently narrowed

The composite-parents check has a second, per-candidate-role read nested inside a `while read` loop. That inner read is **not** individually guarded — propagating a failure signal out of a `while` piped into `grep -c .` needs restructuring the loop itself, a larger change than this issue asked for, and its failure mode is narrower (undercounts by at most one potential parent, vs. zeroing the whole check).

## Tests

`docker` is stubbed — `kc()` wraps `docker exec ... kcadm.sh "$@"` — so no real Keycloak is involved. Five cases including the composite-parents check's *own* `kc get roles` call, which runs twice per invocation (once at the top of the function, once per role in the loop) — a call counter in the stub lets the first through and fails only the second, the one this fix actually guards.

**Positive control:** reverted via `git stash`, reran — the 3 new-behavior tests failed, and the observed behavior against pre-fix code was the role being deleted in all three forced-failure scenarios, the exact defect described. The 2 happy-path tests correctly stayed green. Restored, reran: 5/5.

## Test plan

- [x] `bash -n scripts/keycloak.sh` clean
- [x] `bats tests/scripts/keycloak-role-holder-read-failure.bats` — 5/5
- [x] Positive control: revert → 3/5 fail, pre-fix code genuinely deletes the role in all three forced-failure cases; restore → 5/5
- [x] `bats --recursive tests/scripts/` — 718/718, no regressions
- [x] `git diff --stat` shows exactly the 2 intended files