### PR TITLE
fix(scripts): aggregate per-item warn failures into the final success message and exit code — h#749

### DIFF
--- a/scripts/keycloak.sh
+++ b/scripts/keycloak.sh
@@ -279,7 +279,7 @@ ensure_realm_roles() {
 # must be empty.
 remove_realm_roles() {
     echo "Retired realm roles..."
-    local role existing
+    local role existing failed=0
     existing=$(kc get roles -r "$KC_REALM" --fields name --format csv --noquotes 2>/dev/null | tr -d '\r')
     for role in $REALM_ROLES_REMOVED; do
         if ! echo "$existing" | grep -qx "$role"; then
@@ -302,12 +302,14 @@ remove_realm_roles() {
         local users groups parents users_raw groups_raw roles_raw
         if ! users_raw=$(kc get "roles/${role}/users" -r "$KC_REALM" --fields id --format csv --noquotes 2>/dev/null | tr -d '\r'); then
             warn "  ! ${role} NOT deleted — could not read current USER holders (the query failed). A failed read is not the same as zero holders; retirement is blocked until it succeeds."
+            failed=1
             continue
         fi
         users=$(printf '%s' "$users_raw" | grep -c . || true)
 
         if ! groups_raw=$(kc get "roles/${role}/groups" -r "$KC_REALM" --fields id --format csv --noquotes 2>/dev/null | tr -d '\r'); then
             warn "  ! ${role} NOT deleted — could not read current GROUP holders (the query failed). A failed read is not the same as zero holders; retirement is blocked until it succeeds."
+            failed=1
             continue
         fi
         groups=$(printf '%s' "$groups_raw" | grep -c . || true)
@@ -318,6 +320,7 @@ remove_realm_roles() {
         # out every composite-parent check at once, not just one role's.
         if ! roles_raw=$(kc get roles -r "$KC_REALM" --fields name --format csv --noquotes 2>/dev/null | tr -d '\r'); then
             warn "  ! ${role} NOT deleted — could not read the realm's role list to check composite parents (the query failed). A failed read is not the same as zero holders; retirement is blocked until it succeeds."
+            failed=1
             continue
         fi
         parents=$(printf '%s' "$roles_raw" | while read -r other; do
@@ -329,13 +332,20 @@ remove_realm_roles() {
 
         if [ "$users" -ne 0 ] || [ "$groups" -ne 0 ] || [ "$parents" -ne 0 ]; then
             warn "  ! ${role} NOT deleted — holders found (users=${users} groups=${groups} composite-parents=${parents}). Retirement is blocked until it has none; do not force it."
+            failed=1
             continue
         fi
 
         kc delete "roles/${role}" -r "$KC_REALM" >/dev/null 2>&1 \
             && echo "  - ${role} deleted (0 users, 0 groups, 0 composite parents)" \
-            || warn "  ! ${role} could not be deleted"
+            || { warn "  ! ${role} could not be deleted"; failed=1; }
     done
+    # h#749: every warn above used to be logged and then forgotten — cmd_apply
+    # printed an unconditional "Realm configured." regardless of how many of
+    # these fired. Returning the accumulated status is what lets the caller
+    # actually gate its own final message on it, the same accumulator shape
+    # local.sh's cmd_health already uses for its own per-check loop.
+    return "$failed"
 }
 
 # Grant the platform administrators their roles, idempotently.
@@ -361,7 +371,14 @@ remove_realm_roles() {
 # meant to close, so it warns.
 ensure_platform_admins() {
     echo "Platform administrators..."
-    local user uuid missing=0
+    # h#749: `missing` and `grant_failed` are tracked SEPARATELY on purpose.
+    # A missing user on a fresh realm is documented above as an EXPECTED
+    # no-op ("ON A FRESH REALM THIS IS A NO-OP, AND IT SAYS SO LOUDLY"), not
+    # a failure — folding it into the same signal a real grant failure uses
+    # would make cmd_apply warn on every normal fresh-realm bootstrap. Only
+    # grant_failed feeds this function's return status; missing stays
+    # informational, exactly as it already was.
+    local user uuid missing=0 grant_failed=0
     for user in $PLATFORM_ADMIN_USERS; do
         uuid=$(kc get users -r "$KC_REALM" -q "username=${user}" --fields id --format csv --noquotes 2>/dev/null | tr -d '\r' | head -1)
         if [ -z "$uuid" ]; then
@@ -372,7 +389,7 @@ ensure_platform_admins() {
         # add-roles is idempotent in kcadm: re-adding an existing mapping is a no-op.
         kc add-roles -r "$KC_REALM" --uusername "$user" --rolename platform-admin >/dev/null 2>&1 \
             && echo "  = ${user}: platform-admin" \
-            || warn "  ! ${user}: could not grant platform-admin"
+            || { warn "  ! ${user}: could not grant platform-admin"; grant_failed=1; }
         local rmrole
         # view-events added 2026-08-02. Event storage was deliberately enabled so
         # that "has anyone logged in, and when" is answerable — and it is not
@@ -381,10 +398,11 @@ ensure_platform_admins() {
         for rmrole in manage-users view-clients view-realm view-events; do
             kc add-roles -r "$KC_REALM" --uusername "$user" --cclientid realm-management --rolename "$rmrole" >/dev/null 2>&1 \
                 && echo "  = ${user}: realm-management:${rmrole}" \
-                || warn "  ! ${user}: could not grant realm-management:${rmrole}"
+                || { warn "  ! ${user}: could not grant realm-management:${rmrole}"; grant_failed=1; }
         done
     done
     [ "$missing" -eq 0 ] || warn "  ${missing} administrator(s) not present. On a rebuilt realm this is expected until the accounts are recreated — the realm import ships no users."
+    return "$grant_failed"
 }
 
 # ---------------------------------------------------------------------------
@@ -520,11 +538,20 @@ cmd_apply() {
     minio_secret=$(secret_for MINIO_OIDC_CLIENT_SECRET) \
         || die "Cannot resolve MINIO_OIDC_CLIENT_SECRET — refusing to reconfigure any client"
 
+    # h#749: individual warn() calls inside remove_realm_roles and
+    # ensure_platform_admins used to be logged and then forgotten — this
+    # function ended with an unconditional "Realm configured." regardless of
+    # how many of them fired, e.g. one of five per-user role grants failing
+    # partway through. `apply_failed` aggregates both, matching the
+    # accumulator shape local.sh's cmd_health already uses for its own
+    # per-check loop.
+    local apply_failed=0
+
     ensure_realm_roles
     # AFTER creating the replacements, never before: a run that deleted the old
     # roles and then failed would leave the realm with neither.
-    remove_realm_roles
-    ensure_platform_admins
+    remove_realm_roles || apply_failed=1
+    ensure_platform_admins || apply_failed=1
 
     echo ""
     echo "Event logging..."
@@ -589,7 +616,11 @@ cmd_apply() {
         "${MINIO_OIDC_CLAIM_NAME:-minio_policy}"
 
     echo ""
-    success "Realm '${KC_REALM}' configured."
+    if [ "$apply_failed" -eq 0 ]; then
+        success "Realm '${KC_REALM}' configured."
+    else
+        warn "Realm '${KC_REALM}' configured with warnings above — some role retirements or admin grants did not complete. Re-run 'bash scripts/keycloak.sh apply' after addressing them."
+    fi
     echo ""
     echo "  Grant a user access by assigning a realm role:"
     echo "    docker exec ${KC_CONTAINER} /opt/keycloak/bin/kcadm.sh add-roles \\"
@@ -597,6 +628,8 @@ cmd_apply() {
     echo ""
     echo "  Every service keeps its local admin login. If Keycloak is down, see"
     echo "  docs/runbooks/sso-fallback.md."
+
+    [ "$apply_failed" -eq 0 ] || return 1
 }
 
 cmd_status() {
@@ -647,7 +680,7 @@ for c in json.load(sys.stdin):
 
 ensure_client_roles() {
     local uuid="$1"; shift
-    local existing role
+    local existing role failed=0
     existing=$(kc get "clients/${uuid}/roles" -r "$KC_REALM" --fields name --format csv --noquotes 2>/dev/null | tr -d '\r')
     for role in "$@"; do
         if echo "$existing" | grep -qx "$role"; then
@@ -655,9 +688,12 @@ ensure_client_roles() {
         else
             kc create "clients/${uuid}/roles" -r "$KC_REALM" -s "name=${role}" >/dev/null 2>&1 \
                 && echo "    + client role ${role}" \
-                || warn "could not create client role ${role}"
+                || { warn "could not create client role ${role}"; failed=1; }
         fi
     done
+    # h#749: same accumulator shape as remove_realm_roles/ensure_platform_admins
+    # — a per-role warn used to be logged and then forgotten by cmd_tenant_clients.
+    return "$failed"
 }
 
 ensure_audience_mapper() {
@@ -803,13 +839,23 @@ print(json.dumps({
         echo "  = hill90-ui (URLs and flags reconciled; secret untouched)"
     fi
 
-    ensure_client_roles "$ui_uuid" user admin
+    # h#749: a per-role warn inside ensure_client_roles used to be logged and
+    # then forgotten — this function ended unconditionally with "reconciled"
+    # regardless of whether every client role actually got created.
+    local tenant_failed=0
+    ensure_client_roles "$ui_uuid" user admin || tenant_failed=1
     ensure_audience_mapper "$ui_uuid" "hill90-api"
     remove_realm_roles_mapper "$ui_uuid" "hill90-ui"
     remove_realm_roles_mapper "$api_uuid" "hill90-api"
 
     echo ""
-    success "Tenant clients reconciled in realm '${KC_REALM}'."
+    if [ "$tenant_failed" -eq 0 ]; then
+        success "Tenant clients reconciled in realm '${KC_REALM}'."
+    else
+        warn "Tenant clients reconciled in realm '${KC_REALM}' with warnings above — not every client role could be created. Re-run 'bash scripts/keycloak.sh tenant-clients' after addressing them."
+    fi
+
+    [ "$tenant_failed" -eq 0 ] || return 1
 }
 
 cmd_client_secret() {

--- a/scripts/local.sh
+++ b/scripts/local.sh
@@ -226,6 +226,14 @@ cmd_up() {
     require_env
 
     local domain; domain=$(base_domain)
+    # h#749: the sslRequired relax, vault redirect URIs, and tenant-clients
+    # reconcile below each already log their own warn() on failure — visible
+    # to a developer watching the terminal, which is why this was ranked
+    # lower than the same shape in keycloak.sh's CI-facing commands — but
+    # none of it was ever aggregated into the final banner, so "Local stack
+    # is up." printed identically whether all three succeeded or all three
+    # failed. Same accumulator shape as cmd_health's own `failed` var below.
+    local up_failed=0
 
     echo "================================"
     echo "Hill90 local bring-up"
@@ -338,6 +346,7 @@ cmd_up() {
         success "Relaxed sslRequired on the local platform realm"
     else
         warn "Could not relax sslRequired on the platform realm — http://auth.$(base_domain):$(http_port)/realms/platform will return 403 until it is set to NONE"
+        up_failed=1
     fi
 
     # Same shape, second delta: hill90-vault ships production redirect URIs, so
@@ -368,6 +377,7 @@ print(json.dumps([
         success "Added local OIDC callbacks to the hill90-vault client"
     else
         warn "Could not add local OIDC callbacks to hill90-vault — 'local.sh vault setup-oidc' logins will fail with 'Invalid parameter: redirect_uri'"
+        up_failed=1
     fi
 
     # The tenant's clients need more than a URL delta: platform-realm.json is
@@ -392,6 +402,7 @@ print(json.dumps([
         success "Tenant clients reconciled on the local platform realm (callback ${ui_local})"
     else
         warn "Could not reconcile the tenant clients — pointing the tenant's local stack at this Keycloak will fail. Run: bash scripts/keycloak.sh tenant-clients"
+        up_failed=1
     fi
     info "Starting the object store (minio)..."
     compose_minio up -d || die "Object store failed to start"
@@ -444,7 +455,13 @@ print(json.dumps([
     echo ""
     cmd_urls
     echo ""
-    success "Local stack is up. Run 'bash scripts/local.sh health' to verify."
+    if [ "$up_failed" -eq 0 ]; then
+        success "Local stack is up. Run 'bash scripts/local.sh health' to verify."
+    else
+        warn "Local stack is up, but with warnings above (sslRequired / vault OIDC / tenant clients) — see the messages higher up before assuming SSO works locally."
+    fi
+
+    [ "$up_failed" -eq 0 ] || return 1
 }
 
 cmd_down() {

--- a/tests/scripts/warn-aggregation.bats
+++ b/tests/scripts/warn-aggregation.bats
@@ -1,0 +1,215 @@
+#!/usr/bin/env bats
+#
+# h#749: keycloak.sh's cmd_apply/cmd_tenant_clients and local.sh's cmd_up all
+# end with an unconditional success message, regardless of how many per-item
+# warn() calls fired inside the loops they run — e.g. one of five per-user
+# role grants failing partway through ensure_platform_admins was logged and
+# then forgotten. cmd_health (local.sh) already has the right shape: a
+# `failed` accumulator gates both the final message and the function's own
+# return value. This applies that same shape to the four functions the issue
+# names.
+#
+# `docker` is stubbed for the keycloak.sh functions — kc() wraps `docker exec
+# "$KC_CONTAINER" kcadm.sh "$@"` (keycloak.sh:115) — so no real Keycloak is
+# involved. cmd_apply/cmd_tenant_clients/cmd_up themselves do far more
+# (require_running, kc_login, multiple secret_for calls, docker compose) than
+# is practical to stub for a full run, so those three are checked statically:
+# that the aggregation wiring (`fn || failed=1`, gated final message, gated
+# return) is actually present, rather than retested from scratch — the
+# underlying accumulator LOGIC is what the functional tests below prove.
+
+setup() {
+  ROOT="$BATS_TEST_DIRNAME/../.."
+  STUB="$BATS_TEST_TMPDIR/bin"
+  mkdir -p "$STUB"
+  PATH="$STUB:$PATH"
+}
+
+# ---------------------------------------------------------------------------
+# remove_realm_roles — functional
+# ---------------------------------------------------------------------------
+
+make_kc_stub_remove_roles() {
+  local mode="$1"  # "clean" | "holders" | "delete-fails" | "users-read-fails"
+  cat > "$STUB/docker" <<EOF
+#!/usr/bin/env bash
+MODE="$mode"
+args=("\$@")
+sub="\${args[3]}"; target="\${args[4]:-}"
+case "\$sub \$target" in
+  "get roles") echo "admin"; exit 0 ;;
+  "get roles/admin/users")
+    [ "\$MODE" = "users-read-fails" ] && exit 1
+    [ "\$MODE" = "holders" ] && echo "u1"
+    exit 0 ;;
+  "get roles/admin/groups") exit 0 ;;
+  "get roles/admin/composites") exit 0 ;;
+  "delete roles/admin")
+    [ "\$MODE" = "delete-fails" ] && exit 1
+    exit 0 ;;
+esac
+exit 0
+EOF
+  chmod +x "$STUB/docker"
+}
+
+run_remove_roles() {
+  cd "$ROOT"
+  source scripts/keycloak.sh help >/dev/null 2>&1
+  REALM_ROLES_REMOVED=admin remove_realm_roles
+}
+
+@test "remove_realm_roles: clean run (real deletion) returns 0" {
+  make_kc_stub_remove_roles "clean"
+  run run_remove_roles
+  [ "$status" -eq 0 ]
+}
+
+@test "remove_realm_roles: a role blocked by real holders returns non-zero" {
+  make_kc_stub_remove_roles "holders"
+  run run_remove_roles
+  [ "$status" -ne 0 ]
+}
+
+@test "remove_realm_roles: a failed delete returns non-zero" {
+  make_kc_stub_remove_roles "delete-fails"
+  run run_remove_roles
+  [ "$status" -ne 0 ]
+}
+
+@test "remove_realm_roles: a h#746-style failed READ also feeds this function's return status, not just its own warn" {
+  # Rebased onto h#746 (#826), which added three read-failure warn+continue
+  # branches to this same function without touching its return value. This
+  # asserts they were actually wired into the failed accumulator this PR
+  # adds, not merely left to coexist with it unconnected.
+  make_kc_stub_remove_roles "users-read-fails"
+  run run_remove_roles
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"could not read current USER holders"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# ensure_platform_admins — functional. "missing" and "grant failure" are
+# deliberately different outcomes: a missing user on a fresh realm is a
+# documented, expected no-op and must NOT fail the function; an actual grant
+# failure must.
+# ---------------------------------------------------------------------------
+
+make_kc_stub_admins() {
+  local mode="$1"  # "clean" | "missing-user" | "grant-fails"
+  cat > "$STUB/docker" <<EOF
+#!/usr/bin/env bash
+MODE="$mode"
+args=("\$@")
+sub="\${args[3]}"; target="\${args[4]:-}"
+case "\$sub \$target" in
+  "get users")
+    [ "\$MODE" = "missing-user" ] && exit 0
+    echo "user-uuid-1"
+    exit 0 ;;
+  "add-roles "*)
+    [ "\$MODE" = "grant-fails" ] && exit 1
+    exit 0 ;;
+esac
+exit 0
+EOF
+  chmod +x "$STUB/docker"
+}
+
+run_admins() {
+  cd "$ROOT"
+  source scripts/keycloak.sh help >/dev/null 2>&1
+  PLATFORM_ADMIN_USERS=jon ensure_platform_admins
+}
+
+@test "ensure_platform_admins: clean grants return 0" {
+  make_kc_stub_admins "clean"
+  run run_admins
+  [ "$status" -eq 0 ]
+}
+
+@test "ensure_platform_admins: a MISSING user is informational only — still returns 0" {
+  make_kc_stub_admins "missing-user"
+  run run_admins
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"does not exist"* ]]
+}
+
+@test "THE CASE THAT MATTERS: an actual grant FAILURE returns non-zero, distinct from the missing-user case" {
+  make_kc_stub_admins "grant-fails"
+  run run_admins
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"could not grant platform-admin"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# ensure_client_roles — functional
+# ---------------------------------------------------------------------------
+
+make_kc_stub_client_roles() {
+  local mode="$1"  # "clean" | "create-fails"
+  cat > "$STUB/docker" <<EOF
+#!/usr/bin/env bash
+MODE="$mode"
+args=("\$@")
+sub="\${args[3]}"; target="\${args[4]:-}"
+case "\$sub \$target" in
+  "get clients/uuid-1/roles") exit 0 ;;
+  "create clients/uuid-1/roles")
+    [ "\$MODE" = "create-fails" ] && exit 1
+    exit 0 ;;
+esac
+exit 0
+EOF
+  chmod +x "$STUB/docker"
+}
+
+run_client_roles() {
+  cd "$ROOT"
+  source scripts/keycloak.sh help >/dev/null 2>&1
+  ensure_client_roles uuid-1 user admin
+}
+
+@test "ensure_client_roles: clean creation returns 0" {
+  make_kc_stub_client_roles "clean"
+  run run_client_roles
+  [ "$status" -eq 0 ]
+}
+
+@test "ensure_client_roles: a failed role creation returns non-zero" {
+  make_kc_stub_client_roles "create-fails"
+  run run_client_roles
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"could not create client role"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# STATIC: the aggregation wiring in cmd_apply / cmd_tenant_clients / cmd_up
+# ---------------------------------------------------------------------------
+
+@test "STATIC: cmd_apply aggregates remove_realm_roles and ensure_platform_admins, gates its final message and return" {
+  run bash -c "sed -n '/^cmd_apply()/,/^cmd_status()/p' '$ROOT/scripts/keycloak.sh'"
+  [[ "$output" == *"remove_realm_roles || apply_failed=1"* ]]
+  [[ "$output" == *"ensure_platform_admins || apply_failed=1"* ]]
+  [[ "$output" == *'if [ "$apply_failed" -eq 0 ]'* ]]
+  [[ "$output" == *'[ "$apply_failed" -eq 0 ] || return 1'* ]]
+}
+
+@test "STATIC: cmd_tenant_clients aggregates ensure_client_roles, gates its final message and return" {
+  run bash -c "sed -n '/^cmd_tenant_clients()/,/^cmd_client_secret()/p' '$ROOT/scripts/keycloak.sh'"
+  [[ "$output" == *"ensure_client_roles \"\$ui_uuid\" user admin || tenant_failed=1"* ]]
+  [[ "$output" == *'if [ "$tenant_failed" -eq 0 ]'* ]]
+  [[ "$output" == *'[ "$tenant_failed" -eq 0 ] || return 1'* ]]
+}
+
+@test "STATIC: cmd_up aggregates all three local deltas, gates its final banner and return" {
+  run bash -c "sed -n '/^cmd_up()/,/^cmd_down()/p' '$ROOT/scripts/local.sh'"
+  [[ "$output" == *"local up_failed=0"* ]]
+  [[ "$output" == *'up_failed=1'* ]]
+  [[ "$output" == *'if [ "$up_failed" -eq 0 ]'* ]]
+  [[ "$output" == *'[ "$up_failed" -eq 0 ] || return 1'* ]]
+  # All three deltas set it, not just one — the exact count of the shape
+  # named in the issue (sslRequired, vault redirect URIs, tenant clients).
+  run bash -c "sed -n '/^cmd_up()/,/^cmd_down()/p' '$ROOT/scripts/local.sh' | grep -c 'up_failed=1'"
+  [ "$output" -eq 3 ]
+}


### PR DESCRIPTION
Closes h#749. Part 5 of h#757's remaining findings.

## What's real

`keycloak.sh`'s `cmd_apply` and `cmd_tenant_clients`, and `local.sh`'s `cmd_up`, each end with an unconditional success message regardless of how many per-item `warn()` calls fired inside the loops they run — e.g. one of five per-user role grants failing partway through `ensure_platform_admins` was logged and then forgotten. A caller checking only the exit code saw full success even when part of the run genuinely failed. `cmd_health` (local.sh) already had the right shape: a `failed` accumulator gates both the final message and the return value. This applies that same existing pattern rather than inventing a new one.

## Fix

Four functions now return non-zero when any of their per-item failures fired, and their three callers aggregate and gate on it:

- `remove_realm_roles`, `ensure_platform_admins`, `ensure_client_roles` (keycloak.sh) each gained a `failed` accumulator, returned at the end.
- `cmd_apply` aggregates `remove_realm_roles` + `ensure_platform_admins`; `cmd_tenant_clients` aggregates `ensure_client_roles`. Both gate their final message and return value.
- `local.sh`'s `cmd_up` aggregates its three local-only deltas (sslRequired relax, vault redirect URIs, tenant-clients reconcile) the same way.

**`ensure_platform_admins`'s `missing` and `grant_failed` are tracked separately on purpose.** A missing platform-admin user on a fresh realm is documented in this file's own header as an *expected* no-op — folding it into the same failure signal a real grant failure uses would make `cmd_apply` warn on every normal fresh-realm bootstrap. Only an actual `kc add-roles` failure feeds the return status.

## Merge note: rebased onto h#746 (#826), which also touched `remove_realm_roles`

#746 added three of its own `warn`+`continue` read-failure branches to the same function. After rebasing, I found the auto-merge hadn't actually wired those branches into my new accumulator — added `failed=1` to all three so a transient read failure on users/groups/composite-parents now also feeds `apply_failed` via `remove_realm_roles`'s return status, not just the two failure modes this PR originally targeted. Added a dedicated test for this specifically since it's a claim about a merge, not just my own diff.

## Tests

`docker` is stubbed for the three keycloak.sh functions — `kc()` wraps `docker exec ... kcadm.sh "$@"` — so no real Keycloak is involved; functional tests cover clean/failure paths for all three, including the deliberate missing-vs-grant-failed distinction. `cmd_apply`/`cmd_tenant_clients`/`cmd_up` do far more than practical to stub for a full run, so those three are checked statically — that the aggregation wiring is present with the exact variable names and gating shape — since the underlying accumulator logic is what the functional tests already prove.

**Positive control:** reverted both files via `git stash`, reran — 7 of 11 (later 12) tests failed, exactly the new-behavior ones; the happy-path/informational tests correctly stayed green. Restored, reran: 12/12.

## Test plan

- [x] `bash -n scripts/keycloak.sh` / `bash -n scripts/local.sh` clean
- [x] `bats tests/scripts/warn-aggregation.bats` — 12/12
- [x] Positive control: revert → majority fail (exactly the new-behavior tests); restore → 12/12
- [x] `bats --recursive tests/scripts/` — 734/734, no regressions
- [x] `git diff --stat` shows exactly the 3 intended files