### PR TITLE
fix(scripts): ops.sh's legacy backup path verifies its archives instead of trusting a clean docker exit — h#748

### DIFF
--- a/scripts/ops.sh
+++ b/scripts/ops.sh
@@ -317,11 +317,24 @@ cmd_backup() {
     echo "Backup directory: $backup_dir"
     echo ""
 
+    # h#748: `set -e` already catches `docker run`/`tar` itself returning
+    # non-zero, but that is not the failure this checks for. It cannot catch
+    # a CLEAN exit that produced an empty or truncated archive — an empty
+    # volume, a race with something still writing to it, or a host out of
+    # disk mid-write can all exit 0 with a useless file. `backup.sh`'s own
+    # `verify_artifacts` treats an empty required artifact as `die`-worthy,
+    # not a soft warning — matching that severity here, since an empty
+    # backup file is not a partial success, it is a failure of the one
+    # thing this function exists to do. This file previously had NO check
+    # beyond `set -e`'s implicit protection, and ended unconditionally at
+    # "Backup Complete!" regardless of what the archives actually contained.
     echo "Backing up Docker volumes..."
     docker run --rm \
         -v traefik-certs:/data \
         -v "$(pwd)/$backup_dir":/backup \
         alpine tar czf /backup/traefik-certs.tar.gz -C /data .
+    [ -s "$backup_dir/traefik-certs.tar.gz" ] \
+        || die "Backup produced an empty archive: $backup_dir/traefik-certs.tar.gz — nothing was actually backed up"
 
     if docker volume inspect prometheus-data > /dev/null 2>&1; then
         echo "Backing up Prometheus data..."
@@ -329,6 +342,8 @@ cmd_backup() {
             -v prometheus-data:/data \
             -v "$(pwd)/$backup_dir":/backup \
             alpine tar czf /backup/prometheus-data.tar.gz -C /data .
+        [ -s "$backup_dir/prometheus-data.tar.gz" ] \
+            || die "Backup produced an empty archive: $backup_dir/prometheus-data.tar.gz — nothing was actually backed up"
     else
         echo "Skipping Prometheus backup (volume not found)"
     fi
@@ -339,6 +354,8 @@ cmd_backup() {
             -v grafana-data:/data \
             -v "$(pwd)/$backup_dir":/backup \
             alpine tar czf /backup/grafana-data.tar.gz -C /data .
+        [ -s "$backup_dir/grafana-data.tar.gz" ] \
+            || die "Backup produced an empty archive: $backup_dir/grafana-data.tar.gz — nothing was actually backed up"
     else
         echo "Skipping Grafana backup (volume not found)"
     fi
@@ -348,6 +365,13 @@ cmd_backup() {
     echo "Backup Complete!"
     echo "================================"
     echo "Location: $backup_dir"
+    # h#748: this is materially incomplete versus scripts/backup.sh — no
+    # database dump at all. An operator invoking this expecting parity with
+    # the real tool (easily done: same "Hill90 Backup"/"Backup Complete!"
+    # message shape) previously had no indication of the gap. Said out loud
+    # rather than left implicit; not attempting to add database backup here,
+    # which is a feature decision, not this bug fix's scope.
+    warn "This is a legacy, volume-only backup — it does NOT back up any database. For a complete backup, use: bash scripts/backup.sh backup-all"
 }
 
 # ---------------------------------------------------------------------------

--- a/tests/scripts/ops-backup-verify.bats
+++ b/tests/scripts/ops-backup-verify.bats
@@ -1,0 +1,136 @@
+#!/usr/bin/env bats
+#
+# h#748: ops.sh's cmd_backup() — a second, cruder backup path, easily
+# confused with the real (now-hardened) backup.sh by name and message shape
+# alone ("Hill90 Backup" / "Backup Complete!") — had zero artifact
+# verification. `set -e` catches `docker run`/`tar` returning non-zero, but
+# not a CLEAN exit that produced an empty or truncated archive (an empty
+# volume, a race with something still writing to it, disk full mid-write).
+# The function ended unconditionally at "Backup Complete!" regardless of
+# what the archives actually contained.
+#
+# `docker` is stubbed rather than exercised against real named volumes,
+# DELIBERATELY: cmd_backup hardcodes real volume names (traefik-certs,
+# prometheus-data, grafana-data) with no prefix parameterization, and those
+# same names back actual local dev infra on a machine running this stack —
+# running the real function against real docker here risks reading or
+# clobbering a developer's genuine local volumes. The stub writes bytes (or
+# doesn't) directly to the host path docker would have bind-mounted, so the
+# archive-emptiness check is exercised against a real file on disk, just
+# not through a real container.
+
+setup() {
+  ROOT="$BATS_TEST_DIRNAME/../.."
+  STUB="$BATS_TEST_TMPDIR/bin"
+  mkdir -p "$STUB"
+  PATH="$STUB:$PATH"
+  WORKDIR="$BATS_TEST_TMPDIR/work"
+  mkdir -p "$WORKDIR"
+}
+
+# $1 = "clean" | "empty-traefik" | "empty-prometheus"
+# Prometheus and Grafana volumes are reported as NOT FOUND unless their name
+# appears in $2 (space-separated) — keeps the stub from claiming volumes
+# exist that a given test doesn't care about.
+make_docker_stub() {
+  local mode="$1"
+  local present_volumes="${2:-prometheus-data grafana-data}"
+  cat > "$STUB/docker" <<EOF
+#!/usr/bin/env bash
+MODE="$mode"
+PRESENT="$present_volumes"
+args=("\$@")
+
+if [ "\${args[0]}" = "volume" ] && [ "\${args[1]}" = "inspect" ]; then
+  vol="\${args[2]}"
+  for p in \$PRESENT; do
+    [ "\$p" = "\$vol" ] && exit 0
+  done
+  exit 1
+fi
+
+if [ "\${args[0]}" = "run" ]; then
+  # Find "-v <host>:/backup" and the archive name in "tar czf /backup/X.tar.gz"
+  host_backup=""
+  archive=""
+  for i in "\${!args[@]}"; do
+    case "\${args[\$i]}" in
+      *:/backup) host_backup="\${args[\$i]%:/backup}" ;;
+      /backup/*.tar.gz) archive="\$(basename "\${args[\$i]}")" ;;
+    esac
+  done
+  case "\$MODE" in
+    empty-traefik)
+      [ "\$archive" = "traefik-certs.tar.gz" ] && { : > "\$host_backup/\$archive"; exit 0; }
+      ;;
+    empty-prometheus)
+      [ "\$archive" = "prometheus-data.tar.gz" ] && { : > "\$host_backup/\$archive"; exit 0; }
+      ;;
+  esac
+  printf 'fake tar bytes for %s\n' "\$archive" > "\$host_backup/\$archive"
+  exit 0
+fi
+exit 0
+EOF
+  chmod +x "$STUB/docker"
+}
+
+run_backup() {
+  cd "$WORKDIR"
+  # shellcheck disable=SC1091
+  source "$ROOT/scripts/ops.sh" help >/dev/null 2>&1
+  cmd_backup
+}
+
+@test "clean run: all volumes present with real content — Backup Complete, no die" {
+  make_docker_stub "clean"
+  run run_backup
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Backup Complete!"* ]]
+  # The materially-incomplete-vs-backup.sh note is now surfaced, not silent.
+  [[ "$output" == *"does NOT back up any database"* ]]
+}
+
+@test "THE CASE THAT MATTERS: a clean docker exit with an EMPTY traefik-certs archive is refused, not reported as Backup Complete!" {
+  make_docker_stub "empty-traefik"
+  run run_backup
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Backup produced an empty archive"* ]]
+  [[ "$output" == *"traefik-certs.tar.gz"* ]]
+  [[ "$output" != *"Backup Complete!"* ]]
+}
+
+@test "an empty PROMETHEUS archive is also refused, distinct from the traefik case" {
+  make_docker_stub "empty-prometheus"
+  run run_backup
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Backup produced an empty archive"* ]]
+  [[ "$output" == *"prometheus-data.tar.gz"* ]]
+  [[ "$output" != *"Backup Complete!"* ]]
+}
+
+@test "an ABSENT optional volume (prometheus/grafana not found) is correctly skipped, not treated as an empty-archive failure" {
+  make_docker_stub "clean" "grafana-data"
+  run run_backup
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Skipping Prometheus backup (volume not found)"* ]]
+  [[ "$output" == *"Backup Complete!"* ]]
+  [[ "$output" != *"Backup produced an empty archive"* ]]
+}
+
+@test "the real traefik-certs archive file left on disk genuinely has content in the clean case" {
+  make_docker_stub "clean"
+  run_backup >/dev/null 2>&1
+  local dir
+  dir=$(find "$WORKDIR/backups" -mindepth 1 -maxdepth 1 -type d | head -1)
+  [ -s "$dir/traefik-certs.tar.gz" ]
+}
+
+@test "the empty traefik-certs archive file genuinely IS empty on disk — the die is not testing a phantom" {
+  make_docker_stub "empty-traefik"
+  run run_backup
+  local dir
+  dir=$(find "$WORKDIR/backups" -mindepth 1 -maxdepth 1 -type d | head -1)
+  [ -f "$dir/traefik-certs.tar.gz" ]
+  [ ! -s "$dir/traefik-certs.tar.gz" ]
+}


### PR DESCRIPTION
Closes h#748. Part 6 of h#757's remaining findings — last of the sweep's own enumerated code fixes. #752 and #753 turned out to already be fixed by other work landing mid-sweep (verified against current code, not just their closed status), and #756 is a separate live-host audit task the tracking issue explicitly scopes out of casual pickup.

## What's real

`ops.sh`'s `cmd_backup()` — a second, cruder backup path, easily confused with the real (now-hardened) `backup.sh` by name and message shape alone ("Hill90 Backup" / "Backup Complete!") — had zero artifact verification beyond `set -e`'s implicit protection. `set -e` catches `docker run`/`tar` returning non-zero, but not a *clean* exit that produced an empty or truncated archive. The function ended unconditionally at "Backup Complete!" regardless of what the three archives actually contained.

## Fix

`[ -s "$backup_dir/X.tar.gz" ] || die "..."` after each of the three `tar czf` invocations. Matches `backup.sh`'s own `verify_artifacts`, which treats an empty required artifact as `die`-worthy, not a soft warning.

Also surfaced (not fixed): the issue's second finding that this path has no database backup at all and is "materially incomplete versus the real tool" with no indication of the gap. Added one line pointing at `backup.sh backup-all`. Did **not** add database backup capability — the issue frames that as a deliberate choice ("delete this... or bring it up to the same verification standard"), not something to decide unilaterally inside a bug-fix PR.

## Tests — real files on disk, docker stubbed for a stated safety reason

`docker` is stubbed rather than exercised against real named volumes, deliberately: `cmd_backup` hardcodes real volume names (traefik-certs, prometheus-data, grafana-data) with no prefix parameterization, and those same names back actual local dev infra on a machine running this stack — running the real function against real docker here risks reading or clobbering a developer's genuine local volumes. The stub writes bytes (or doesn't) directly to the host path docker would have bind-mounted, so the archive-emptiness check runs against a real file on disk — two tests confirm the file is genuinely non-empty in the clean case and genuinely empty in the failure case.

Six cases including: an absent optional volume is correctly *skipped*, not treated as an empty-archive failure — the pre-existing correct behavior this fix must not disturb.

**Positive control:** reverted via `git stash`, reran — 3 of 6 tests failed. The empty-archive test cases specifically show the actual pre-fix defect: `$status -eq 0`, i.e. genuinely reported as "Backup Complete!". Restored, reran: 6/6.

## Test plan

- [x] `bash -n scripts/ops.sh` clean
- [x] `bats tests/scripts/ops-backup-verify.bats` — 6/6
- [x] Positive control: revert → 3/6 fail, empty-archive cases concretely reproduce reported success against pre-fix code; restore → 6/6
- [x] `bats --recursive tests/scripts/` — 732/732, no regressions
- [x] `git diff --stat` shows exactly the 2 intended files