### PR TITLE
fix(scripts): ops.sh health now checks alertmanager and blackbox-exporter — h#808 (code half)

### DIFF
--- a/scripts/ops.sh
+++ b/scripts/ops.sh
@@ -85,7 +85,11 @@ cmd_health() {
 
     echo ""
     echo "Checking observability services..."
-    local obs_containers=("prometheus" "grafana" "loki" "tempo" "promtail" "node-exporter" "cadvisor")
+    # h#808: alertmanager and blackbox-exporter are real services defined in
+    # docker-compose.observability.yml (9 total) and were simply absent from
+    # this list (7) — a rebuild could come up with either silently missing or
+    # unhealthy and `ops.sh health` would report clean regardless.
+    local obs_containers=("prometheus" "alertmanager" "blackbox-exporter" "grafana" "loki" "tempo" "promtail" "node-exporter" "cadvisor")
     for container in "${obs_containers[@]}"; do
         echo -n "Checking $container... "
         if docker container inspect "$container" > /dev/null 2>&1; then

--- a/tests/scripts/ops-health-observability-coverage.bats
+++ b/tests/scripts/ops-health-observability-coverage.bats
@@ -1,0 +1,122 @@
+#!/usr/bin/env bats
+#
+# h#808: docker-compose.observability.yml defines nine services (prometheus,
+# alertmanager, blackbox-exporter, loki, tempo, grafana, promtail,
+# node-exporter, cadvisor). ops.sh's cmd_health only checked seven — missing
+# alertmanager and blackbox-exporter entirely. A rebuild could come up with
+# either silently missing or unhealthy and `ops.sh health` would report clean
+# regardless, since a container this loop never names is never inspected.
+#
+# `docker` is stubbed and cmd_health's own `services` array (which does a
+# real `curl` to hill90.com) is overridden to empty before calling it, so
+# this test exercises the observability loop specifically without making any
+# real network calls.
+
+setup() {
+  ROOT="$BATS_TEST_DIRNAME/../.."
+  STUB="$BATS_TEST_TMPDIR/bin"
+  mkdir -p "$STUB"
+  PATH="$STUB:$PATH"
+}
+
+@test "STATIC: docker-compose.observability.yml defines exactly these 9 services" {
+  run bash -c "grep -oE '^  [a-z-]+:' '$ROOT/deploy/compose/prod/docker-compose.observability.yml' | tr -d ' :' | grep -vE '^(edge|internal)\$'"
+  [ "$status" -eq 0 ]
+  expected="prometheus
+alertmanager
+blackbox-exporter
+loki
+tempo
+grafana
+promtail
+node-exporter
+cadvisor"
+  # Volume names collide with nothing here since this compose file's top-level
+  # keys are networks/volumes/services and volume names don't match this
+  # container-name shape, but assert count as a floor against future drift.
+  count=$(echo "$output" | grep -cE '^(prometheus|alertmanager|blackbox-exporter|loki|tempo|grafana|promtail|node-exporter|cadvisor)$')
+  [ "$count" -eq 9 ]
+}
+
+@test "STATIC: ops.sh's obs_containers now lists all 9, not 7" {
+  run bash -c "grep -oE 'local obs_containers=\([^)]*\)' '$ROOT/scripts/ops.sh'"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"alertmanager"* ]]
+  [[ "$output" == *"blackbox-exporter"* ]]
+  count=$(echo "$output" | grep -oE '"[a-z-]+"' | wc -l | tr -d ' ')
+  [ "$count" -eq 9 ]
+}
+
+# ---------------------------------------------------------------------------
+# Functional: the extracted observability loop, run against stubbed docker,
+# actually inspects alertmanager and blackbox-exporter now — not merely
+# listed in the array without being reachable in the loop body.
+# ---------------------------------------------------------------------------
+
+extract_obs_loop() {
+  sed -n '/local obs_containers=/,/^    done$/p' "$ROOT/scripts/ops.sh"
+}
+
+make_docker_stub_all_healthy() {
+  cat > "$STUB/docker" <<'EOF'
+#!/usr/bin/env bash
+if [ "$1" = "container" ] && [ "$2" = "inspect" ]; then
+  exit 0
+fi
+if [ "$1" = "inspect" ]; then
+  case "$*" in
+    *"State.Health"*) echo "healthy" ;;
+    *"State.Running"*) echo "true" ;;
+  esac
+  exit 0
+fi
+exit 0
+EOF
+  chmod +x "$STUB/docker"
+}
+
+run_obs_loop() {
+  # The extracted snippet uses `local`, so it must run inside a function.
+  local snippet
+  snippet="$(extract_obs_loop)"
+  bash -c "
+    probe() {
+      all_healthy=true
+      $snippet
+      echo \"ALL_HEALTHY=\$all_healthy\"
+    }
+    probe
+  "
+}
+
+@test "the observability loop checks alertmanager and blackbox-exporter, not just skips them" {
+  make_docker_stub_all_healthy
+  run run_obs_loop
+  [[ "$output" == *"Checking alertmanager..."* ]]
+  [[ "$output" == *"Checking blackbox-exporter..."* ]]
+  [[ "$output" == *"ALL_HEALTHY=true"* ]]
+}
+
+@test "THE CASE THAT MATTERS: an unhealthy alertmanager now flips all_healthy to false — it did not exist to check before" {
+  cat > "$STUB/docker" <<'EOF'
+#!/usr/bin/env bash
+if [ "$1" = "container" ] && [ "$2" = "inspect" ]; then
+  exit 0
+fi
+if [ "$1" = "inspect" ]; then
+  # Container name is the LAST arg (docker inspect --format='...' <name>).
+  last="${@: -1}"
+  case "$*" in
+    *"State.Health"*)
+      [ "$last" = "alertmanager" ] && echo "unhealthy" || echo "healthy" ;;
+    *"State.Running"*) echo "true" ;;
+  esac
+  exit 0
+fi
+exit 0
+EOF
+  chmod +x "$STUB/docker"
+  run run_obs_loop
+  [[ "$output" == *"Checking alertmanager... "*"✗ Unhealthy (unhealthy)"* ]]
+  [[ "$output" == *"ALL_HEALTHY=false"* ]]
+}


### PR DESCRIPTION
Closes the code half of h#808. Split from the h#804-h#808 disaster-recovery/rebuild runbook group per their shared cause; kept separate from that group's pure documentation edits since this one is code (docs half tracked separately).

## What's real

`docker-compose.observability.yml` defines nine services: prometheus, alertmanager, blackbox-exporter, loki, tempo, grafana, promtail, node-exporter, cadvisor — verified directly against the compose file, not against any runbook's prose. `ops.sh`'s `cmd_health` only checked seven, missing alertmanager and blackbox-exporter entirely. A rebuild could come up with either silently missing or unhealthy and `ops.sh health` would report clean regardless.

## Fix

Added both names to `obs_containers`. No other change to the loop body — the existing running/health-status logic already applies correctly to any name in the array, it simply never received these two.

## Tests

Two static checks (compose file genuinely defines 9 services; the array genuinely lists 9) plus two functional checks on the observability loop extracted verbatim via `sed` and run against a stubbed `docker` — proving alertmanager and blackbox-exporter are actually inspected in the loop body, and that an unhealthy alertmanager now flips `all_healthy` to false, which it structurally could not do before this fix since the container was never named.

**Positive control:** reverted `scripts/ops.sh` via `git stash`, reran — 3 of 4 tests failed (exactly the ones asserting the new coverage); the compose-file static check correctly stayed green. Restored, reran: 4/4.

**Not verified against the live host** — this session has no VPS access. Verified against `docker-compose.observability.yml` and `scripts/ops.sh` directly.

## Test plan

- [x] `bash -n scripts/ops.sh` clean
- [x] `bats tests/scripts/ops-health-observability-coverage.bats` — 4/4
- [x] Positive control: revert → 3/4 fail (exactly the new-coverage tests); restore → 4/4
- [x] `bats --recursive tests/scripts/` — 736/736, no regressions
- [x] `git diff --stat` shows exactly the 2 intended files