### PR TITLE
docs(runbooks): disaster-recovery.md and vps-rebuild.md — h#804, h#805, h#806, h#807, h#808 (docs half)

### DIFF
--- a/docs/runbooks/disaster-recovery.md
+++ b/docs/runbooks/disaster-recovery.md
@@ -32,6 +32,23 @@ You can restore `openbao-data.tar.gz` perfectly and still have nothing, because 
 is ciphertext and the unseal key that opens it is itself inside a SOPS file you cannot
 decrypt.
 
+> **This chain illustrates a hazard — it is not an instruction to restore
+> `openbao-data.tar.gz`.** (h#806) The numbered [Recovery Steps](#recovery-steps) below
+> never do a volume-tar restore of vault; [Step 4](#step-4)
+> mints a brand-new unseal key and root token with a fresh `vault.sh init` against an
+> empty volume, which is what this runbook actually recommends and is unaffected by the
+> problem this chain describes.
+>
+> **If you are instead considering restoring `openbao-data.tar.gz` from a volume
+> backup** — do not, for any backup taken after 2026-08-02, using the
+> `OPENBAO_UNSEAL_KEY` currently in `main`'s SOPS store. **Hill90#799** established that
+> `main`'s copy predates the 2026-08-02 vault reinitialize, which minted a new unseal
+> key that was pushed to an unmerged branch and never landed on `main`. A tar taken
+> after that reinitialize is sealed with the key on that branch, not the one you would
+> read from `main` today. #799 is Jon's open decision, not resolved by this note — this
+> paragraph exists so that fact is not silently discovered mid-recovery by an operator
+> who chose the tar-restore path instead of Step 4's fresh init.
+
 **Where the key is, and is not.** `Verified 2026-07-31 08:12 UTC.`
 
 | Location | Present? | Survives total VPS loss? |
@@ -186,6 +203,7 @@ Deploy Traefik (reverse proxy) and Portainer.
 bash scripts/deploy.sh infra prod
 ```
 
+<a id="step-4"></a>
 ### 4. Deploy and Initialize Vault
 
 Deploy the OpenBao container:
@@ -194,28 +212,47 @@ Deploy the OpenBao container:
 bash scripts/deploy.sh vault prod
 ```
 
-Initialize vault (generates new unseal key and root token):
+Initialize vault (generates a new unseal key and root token):
 
 ```bash
 bash scripts/vault.sh init
 ```
 
-Save the unseal key and root token as instructed by the output.
+> (h#805) **There is nothing to "save from the output."** `cmd_init` never prints the
+> unseal key or root token — deliberately: an SSH session, a CI job, or any terminal
+> with scrollback would otherwise be a durable copy of complete control of the vault.
+> It writes both to disk itself, already correctly owned (`deploy:deploy`, mode
+> `0600`, since it runs as the user invoking it):
+>
+> ```
+> ✓ Unseal key written to /opt/hill90/secrets/openbao-unseal.key (0600, deploy:deploy)
+> ✓ Root token written to /opt/hill90/secrets/openbao-root.token (0600)
+> ```
+>
+> **Do not run a manual `sudo tee` / `chown` / `chmod` sequence against
+> `openbao-unseal.key`.** A prior version of this step said to, and that shape is what
+> produced the exact regression `cmd_init`'s own comments now name explicitly: a
+> root-owned key file the auto-unseal systemd unit (`User=deploy`) cannot read, which
+> is a vault that never comes back after a reboot. That bug is fixed in the script;
+> reintroducing the same manual step here would reintroduce the bug.
 
-Store the unseal key on the host:
+Update SOPS with the new unseal key, so it survives loss of this host too — `make
+secrets-update` edits the local checkout's SOPS file, so this runs on your
+**workstation**, not the VPS; the host checkout is reset on every deploy, so a SOPS
+edit made there is discarded (see [`vault-unseal.md`](vault-unseal.md)). Since the key
+is no longer printed anywhere (that is the fix in #805 — see above), get it off the VPS
+without ever displaying it in a scrollback, e.g. `scp` the file down and read it locally:
 
 ```bash
-# On VPS:
-echo "<unseal-key>" | sudo tee /opt/hill90/secrets/openbao-unseal.key
-sudo chown deploy:deploy /opt/hill90/secrets/openbao-unseal.key
-sudo chmod 0600 /opt/hill90/secrets/openbao-unseal.key
+# On your workstation:
+scp -i ~/.ssh/remote.hill90.com deploy@<tailscale-ip>:/opt/hill90/secrets/openbao-unseal.key /tmp/openbao-unseal.key
+make secrets-update KEY=OPENBAO_UNSEAL_KEY VALUE="$(cat /tmp/openbao-unseal.key)"
+rm -f /tmp/openbao-unseal.key
 ```
 
-Update SOPS with the new unseal key:
-
-```bash
-make secrets-update KEY=OPENBAO_UNSEAL_KEY VALUE="<unseal-key>"
-```
+**This exact sequence has not been run end-to-end** — it follows from `cmd_init`'s own
+documented behavior and `make secrets-update`'s existing usage elsewhere in this
+runbook, but is stated here, not asserted as proven.
 
 ### 5. Unseal Vault
 
@@ -356,11 +393,32 @@ bash scripts/backup.sh restore db /path/to/backup
 > is a convenience, not a step. Full evidence in
 > [`backup-consistency-options.md`](../decisions/backup-consistency-options.md).
 
-### 11. Deploy All Services
+### 11. Deploy Remaining Services
+
+`deploy.sh` has no `all` command (h#804) — `Verified 2026-08-06` by reading its
+dispatcher directly (`scripts/deploy.sh`, `main()`'s `case "$cmd" in` block): it
+recognizes `infra`, `db`, `auth`, `minio`, `vault`, `observability`, `teardown`,
+`verify`, `backup`, and `help`, each deployed with its own invocation — nothing in
+this script loops over stacks. Running `deploy.sh all prod` as previously written
+here prints `Unknown command: all` and exits 1 without deploying anything.
+
+By this point in the runbook, `infra` (Step 3), `vault` (Steps 4-9) and `db` (Step 10)
+are already deployed. What remains is `auth`, `minio` and `observability` — each its
+own call, in this order, matching the dependency chain
+`.github/workflows/deploy.yml` enforces for a normal production deploy (h#781:
+`db -> auth -> minio -> vault -> observability`, minus the two stacks this runbook
+has already deployed earlier by other means):
 
 ```bash
-bash scripts/deploy.sh all prod
+bash scripts/deploy.sh auth prod
+bash scripts/deploy.sh minio prod
+bash scripts/deploy.sh observability prod
 ```
+
+**Not verified end-to-end against a real rebuild** — whether each of these three
+succeeds individually against a freshly-bootstrapped host, in this order, is not
+exercised here. What would settle it: running each by hand against a real rebuild and
+recording the result per stack.
 
 ### 12. Verify Health
 
@@ -402,8 +460,8 @@ bash scripts/vault.sh sync-to-sops
 
 ```
 VPS recreate -> VPS config -> infra -> vault (deploy+init+unseal+setup+seed)
-  -> OIDC config -> AppRole creds -> db (+ restore) -> all services -> health check
-  -> revoke root token -> sync vault to SOPS
+  -> OIDC config -> AppRole creds -> db (+ restore) -> auth -> minio -> observability
+  -> health check -> revoke root token -> sync vault to SOPS
 ```
 
 ## Notes

--- a/docs/runbooks/vps-rebuild.md
+++ b/docs/runbooks/vps-rebuild.md
@@ -4,11 +4,16 @@ Complete automated rebuild of the Hill90 VPS from catastrophic failure.
 
 ## Overview
 
-The VPS rebuild is fully automated and requires **zero manual intervention**. The process takes ~8-13 minutes and consists of 4 steps:
+The host-level rebuild (VPS OS, Ansible bootstrap, Traefik/Portainer, observability)
+is fully automated. **Vault is not** — initializing, configuring, seeding and
+generating AppRole credentials for a freshly-deployed OpenBao are manual steps this
+runbook does not itself walk through (see Step 3b, h#807). The process takes
+~8-13 minutes for the automated portion and consists of 4 steps, plus vault setup:
 
 1. **Recreate VPS** (~3-5 minutes) - OS rebuild via Hostinger API
 2. **Config VPS** (~3-5 minutes) - Infrastructure bootstrap via Ansible
 3. **Deploy Infra** (~1-2 minutes) - Infrastructure service deployment (Traefik, Portainer)
+3b. **Deploy AND configure Vault** (manual — not on the automated clock) - see Step 3b
 4. **Deploy All** (~2-3 minutes) - Application service deployment
 
 ## Prerequisites
@@ -122,13 +127,44 @@ make deploy-infra
 
 ---
 
-### Step 3b: Deploy Vault
+### Step 3b: Deploy AND Configure Vault
 
 ```bash
 make deploy-vault
 ```
 
 Deploys OpenBao and calls `vault.sh auto-unseal` automatically after compose up.
+
+**This alone is not enough (h#807).** `Verified 2026-08-06` by diffing this step
+against `disaster-recovery.md`'s: `make deploy-vault` deploys OpenBao and auto-unseals
+it against whatever volume already exists, but on a truly fresh rebuild that volume is
+empty — there is nothing to unseal yet, and `auto-unseal` exits 0 gracefully in that
+case rather than failing. Deploying alone does **not** initialize, configure, or seed
+the vault, and does not generate AppRole credentials. Following only this step leaves
+a vault that is deployed and answering `bao status`, but has no KV v2 mount, no
+AppRole roles, no secrets loaded, and no service credentials — and because every
+service that authenticates against vault already has a SOPS fallback, `make health`
+would plausibly still report clean while everything silently runs on SOPS instead
+(the same shape as Hill90#791, but a documentation gap here rather than a runtime
+one).
+
+**Do the following instead, in order** — this is [`disaster-recovery.md`](disaster-recovery.md)'s
+[Step 4](disaster-recovery.md#step-4) through Step 9, not repeated here to avoid the
+two runbooks drifting out of sync with each other the way this gap itself happened:
+
+1. [Initialize](disaster-recovery.md#step-4) — `bash scripts/vault.sh init`
+2. Unseal — `bash scripts/vault.sh unseal`
+3. Setup (KV v2, AppRole auth, audit logging, policies, service roles) — `bash scripts/vault.sh setup`
+4. Seed from SOPS — `bash scripts/vault.sh seed`
+5. Configure OIDC (Keycloak) — `bash scripts/vault.sh setup-oidc`
+6. Generate and store AppRole credentials — `bash scripts/vault.sh bootstrap-approles`
+
+**Not verified here** whether `vault.sh auto-unseal` against a truly fresh,
+never-initialized `openbao-data` volume errors cleanly, hangs, or silently no-ops —
+what's stated above is the intended sequence from `disaster-recovery.md`, not a
+rebuild that was run to confirm it. What would settle it: running `make deploy-vault`
+alone against a disposable vault instance and observing what `auto-unseal` actually
+does when there is nothing to unseal.
 
 ---
 
@@ -141,13 +177,21 @@ make deploy-observability   # or: bash scripts/deploy.sh observability prod
 **What happens automatically:**
 1. Validates configuration
 2. Decrypts secrets with SOPS
-3. Deploys Prometheus, Grafana, Loki, Tempo, Promtail, node-exporter and cAdvisor
+3. Deploys Prometheus, Alertmanager, Blackbox Exporter, Grafana, Loki, Tempo, Promtail,
+   node-exporter and cAdvisor — nine services (h#808: `Verified 2026-08-06` against
+   `docker-compose.observability.yml` directly; this list previously omitted
+   Alertmanager and Blackbox Exporter, both real and already deployed)
 4. Waits for containers to become healthy
 
 **Result:**
-- ✅ Ten containers running
+- ✅ Nine observability containers running (infra 2 + vault 1 + observability 9 = 12
+  platform containers total, not ten — h#808)
 - ✅ Grafana at https://grafana.hill90.com (Tailscale-only)
 - ✅ Prometheus scrape targets healthy
+
+**Not verified against the live host** — this correction is against the compose file
+and `scripts/ops.sh` (see the code-side fix, h#808), not a container count taken from
+a running rebuild.
 
 ---
 
@@ -172,7 +216,7 @@ make health
 ```
 
 **Checks performed:**
-- ✅ All ten Docker containers running
+- ✅ All twelve Docker containers running (infra 2 + vault 1 + observability 9 — h#808)
 - ✅ Traefik dashboard accessible (https://traefik.hill90.com via Tailscale)
 - ✅ Portainer accessible (https://portainer.hill90.com via Tailscale)
 - ✅ Grafana accessible (https://grafana.hill90.com via Tailscale)
@@ -321,7 +365,10 @@ ssh deploy@<vps-ip> "cd /opt/hill90/app && docker compose logs"
 3. Bootstrap infrastructure: `make config-vps VPS_IP=<ip>`
 4. Deploy infrastructure: `make deploy-infra`
 5. Deploy vault: `make deploy-vault`
-6. Deploy observability: `make deploy-observability`
+6. Initialize, unseal, configure, seed and generate AppRole credentials for vault —
+   see [Step 3b](#step-3b-deploy-and-configure-vault) above; **not automated**, and
+   not optional (h#807)
+7. Deploy observability: `make deploy-observability`
 8. Verify health: `make health`
 
 **Fully automated (no intervention):**

--- a/tests/scripts/dr-runbooks-content.bats
+++ b/tests/scripts/dr-runbooks-content.bats
@@ -1,0 +1,133 @@
+#!/usr/bin/env bats
+#
+# h#804-h#807 (+ h#808's docs half): disaster-recovery.md and vps-rebuild.md
+# are the runbooks read when the estate is already down and there is no
+# working system left to check a claim against — a defect here is a latent
+# outage extension, not a documentation nit. These are static content
+# checks, the same proportionate verification this session already applies
+# to prose: they cannot prove a rebuild succeeds (nothing here has been
+# exercised against a real rebuild — see each fix's own "not verified"
+# notes), only that the specific defects reported are actually gone from
+# the text and the specific replacement content is actually present.
+
+setup() {
+  ROOT="$BATS_TEST_DIRNAME/../.."
+  DR="$ROOT/docs/runbooks/disaster-recovery.md"
+  VPS="$ROOT/docs/runbooks/vps-rebuild.md"
+}
+
+# ---------------------------------------------------------------------------
+# h#804 — deploy.sh has no `all` command
+# ---------------------------------------------------------------------------
+
+@test "h#804: disaster-recovery.md no longer has 'bash scripts/deploy.sh all prod' as a runnable command" {
+  run grep -F 'bash scripts/deploy.sh all prod' "$DR"
+  [ "$status" -ne 0 ]
+}
+
+@test "h#804: the fixed step deploys the three stacks not already covered earlier in the same runbook" {
+  run grep -c 'bash scripts/deploy.sh auth prod' "$DR"
+  [ "$output" -ge 1 ]
+  run grep -c 'bash scripts/deploy.sh minio prod' "$DR"
+  [ "$output" -ge 1 ]
+  run grep -c 'bash scripts/deploy.sh observability prod' "$DR"
+  [ "$output" -ge 1 ]
+}
+
+@test "h#804: deploy.sh's dispatcher genuinely has no 'all' case — the claim this fix rests on" {
+  run grep -F '*)' "$ROOT/scripts/deploy.sh"
+  [ "$status" -eq 0 ]
+  run grep -c '^\s*all)' "$ROOT/scripts/deploy.sh"
+  [ "$output" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# h#805 — stale sudo tee unseal-key instructions
+# ---------------------------------------------------------------------------
+
+@test "h#805: disaster-recovery.md no longer instructs a manual sudo tee of the unseal key" {
+  # The fixed text mentions "sudo tee" once, inside a "do NOT run this" warning —
+  # assert the actual OLD EXECUTABLE command line is gone, not the substring.
+  run grep -F 'echo "<unseal-key>" | sudo tee' "$DR"
+  [ "$status" -ne 0 ]
+  run grep -F 'sudo chown deploy:deploy /opt/hill90/secrets/openbao-unseal.key' "$DR"
+  [ "$status" -ne 0 ]
+}
+
+@test "h#805: Step 4 now says the key is not printed and the script already writes it correctly" {
+  run grep -F 'never prints the' "$DR"
+  [ "$status" -eq 0 ]
+  run grep -F 'Unseal key written to' "$DR"
+  [ "$status" -eq 0 ]
+}
+
+@test "h#805 corroborated against the script: cmd_init's own comment documents it no longer echoes credentials to stdout" {
+  run grep -F 'This used to echo the unseal key and root token to stdout' "$ROOT/scripts/vault.sh"
+  [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# h#806 — Step 0's tar-restore chain is illustrative, not an instruction;
+# coupling to h#799 stated, h#799 NOT resolved here
+# ---------------------------------------------------------------------------
+
+@test "h#806: Step 0 explicitly says the tar-restore chain is a hazard illustration, not an instruction" {
+  run grep -F 'not an instruction to restore' "$DR"
+  [ "$status" -eq 0 ]
+}
+
+@test "h#806: the h#799 coupling is stated by number, plainly" {
+  run grep -F 'Hill90#799' "$DR"
+  [ "$status" -eq 0 ]
+}
+
+@test "h#806: h#799 is named as Jon's OPEN decision, not resolved by this doc" {
+  run grep -F "#799 is Jon's open decision" "$DR"
+  [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# h#807 — vps-rebuild.md's vault step omitted init/setup/seed/approles
+# ---------------------------------------------------------------------------
+
+@test "h#807: vps-rebuild.md's vault step now says deploy alone is not enough" {
+  run grep -F 'This alone is not enough' "$VPS"
+  [ "$status" -eq 0 ]
+}
+
+@test "h#807: vps-rebuild.md now names all four missing sub-steps (init, setup, seed, bootstrap-approles)" {
+  for word in init setup seed bootstrap-approles; do
+    run grep -F "vault.sh $word" "$VPS"
+    [ "$status" -eq 0 ]
+  done
+}
+
+@test "h#807: the overview no longer claims zero manual intervention without qualifying vault" {
+  run grep -F 'requires **zero manual intervention**' "$VPS"
+  [ "$status" -ne 0 ]
+  run grep -F 'Vault is not' "$VPS"
+  [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# h#808 (docs half) — observability undercounted by 2
+# ---------------------------------------------------------------------------
+
+@test "h#808 docs: vps-rebuild.md's observability service list now includes alertmanager and blackbox-exporter" {
+  run grep -F 'Alertmanager' "$VPS"
+  [ "$status" -eq 0 ]
+  run grep -iF 'blackbox' "$VPS"
+  [ "$status" -eq 0 ]
+}
+
+@test "h#808 docs: vps-rebuild.md no longer claims ten total platform containers" {
+  run grep -F 'All ten Docker containers' "$VPS"
+  [ "$status" -ne 0 ]
+  run grep -F 'All twelve Docker containers' "$VPS"
+  [ "$status" -eq 0 ]
+}
+
+@test "h#808 corroborated against the compose file: exactly 9 observability services are defined" {
+  run bash -c "grep -oE '^  [a-z-]+:' '$ROOT/deploy/compose/prod/docker-compose.observability.yml' | tr -d ' :' | grep -vE '^(edge|internal)\$' | grep -cE '^(prometheus|alertmanager|blackbox-exporter|loki|tempo|grafana|promtail|node-exporter|cadvisor)\$'"
+  [ "$output" -eq 9 ]
+}


### PR DESCRIPTION
Closes h#804, h#805, h#806, h#807, and the docs half of h#808 (code half is #829, merged).

Five findings taken together per their shared cause and shared reader: every other defect fixed this week failed while someone was watching a running system to compare against. These fail when the estate is already down and the person following them has nothing working left to check a step against — a runbook step that cannot succeed is a latent outage extension, not a documentation nit.

Verified each against the actual script, compose file, or a related issue's own verified evidence — not against the runbook's own prose, per instruction.

## h#804 — `deploy.sh all prod` is not a valid invocation

Verified by reading `scripts/deploy.sh`'s dispatcher directly: no `all` case, falls through to `Unknown command: all`, exit 1. Fixed the step to deploy the three stacks not already covered earlier in the *same* runbook (infra/vault/db are done by Steps 3-10) — `auth`, `minio`, `observability`, in the order `.github/workflows/deploy.yml`'s own serialized dependency chain uses. **Not verified against a real rebuild** whether these three succeed in this order — stated plainly in the doc, not asserted as proven.

## h#805 — Step 4's manual `sudo tee` reintroduces a fixed bug

Verified against `vault.sh`'s `cmd_init` directly: it no longer prints the unseal key/root token anywhere, and writes both files itself, already correctly owned. The runbook's `sudo tee` sequence is word-for-word the previous broken instructions `cmd_init`'s own comments describe reintroducing (a root-owned key file the auto-unseal systemd unit can't read). Removed it; Step 4 now explains there's nothing to save from the output. The `make secrets-update` line the issue said not to touch is preserved but corrected to actually work (the old placeholder could never have been filled in since the key was never displayed) — flagged as **not run end-to-end**.

## h#806 — Step 0's tar-restore chain is coupled to the open h#799

There is no literal "restore openbao-data.tar.gz" step anywhere in the numbered Recovery Steps — Step 0's chain is illustrative prose, not an instruction. The numbered steps use fresh `vault.sh init` exclusively, sidestepping h#799 entirely. Made this explicit, and separately warns against a volume-tar restore of any post-2026-08-02 backup using `main`'s current key, naming h#799 by number and stating it is **Jon's open decision, not resolved here** — h#799 itself is untouched.

## h#807 — vps-rebuild.md's vault step omits init/setup/seed/approles

Verified by diffing against disaster-recovery.md's fuller five steps. `make deploy-vault` alone deploys and auto-unseals whatever volume exists — on a fresh rebuild that's empty, and auto-unseal exits 0 gracefully, so the step "succeeds" while leaving vault uninitialized. Every vault-consuming service has a SOPS fallback, so `make health` would plausibly still report clean. Fixed by pointing explicitly at disaster-recovery.md's Steps 4-9 rather than duplicating them — two copies of the same procedure is exactly the drift that let h#804/h#805 go stale. Corrected the "zero manual intervention" framing. **Not verified**: what `auto-unseal` does against a truly fresh volume.

## h#808 (docs half) — observability undercounted by 2

Verified directly against `docker-compose.observability.yml`: nine services, not seven. Corrected the service list and container-count claims (12 total, not 10). Code half is #829, already merged.

## Not attempted, deliberately

Reading vps-rebuild.md in full while fixing h#807 surfaced that it never mentions deploying `db`, `auth`, or `minio` at all. That's a larger, separate gap than any of h#804-h#808 named — filing separately rather than silently fixing or ignoring it.

## Tests

`tests/scripts/dr-runbooks-content.bats` — static content checks: they cannot prove a rebuild succeeds, only that the specific defects are gone from the text and the replacement content is present. Several tests corroborate a doc claim against the actual script/compose file it describes, not just the doc text.

**Positive control:** reverted both docs files via `git stash`, reran — 12 of 15 tests failed, exactly the new-content ones; the 3 code/compose-corroboration tests correctly stayed green. Restored, reran: 15/15.

## Test plan

- [x] `bats tests/scripts/dr-runbooks-content.bats` — 15/15
- [x] Positive control: revert → 12/15 fail (exactly the new-content tests); restore → 15/15
- [x] `bats --recursive tests/scripts/` — 759/759, no regressions
- [x] `git diff --stat` shows exactly the 3 intended files