### PR TITLE
docs(runbooks): h#807 — bootstrap-approles' credential entangles with h#832

### DIFF
--- a/docs/runbooks/disaster-recovery.md
+++ b/docs/runbooks/disaster-recovery.md
@@ -312,10 +312,26 @@ bash scripts/vault.sh bootstrap-approles
 ```
 
 This generates role_id + secret_id for the services in `VAULT_SERVICES` and stores
-them in SOPS. It temporarily generates a root token (via unseal key), runs setup,
-creates credentials, then revokes the root token — through the same
-`assert_safe_to_revoke` guard as Step 13, so it also depends on Step 8 above having
-run first.
+them in SOPS. It reuses `BAO_TOKEN` if one is already exported and valid — the same
+root token Step 4's `vault.sh init` wrote to disk, still in hand at this point in the
+sequence — runs setup, creates credentials, then revokes the root token through the
+same `assert_safe_to_revoke` guard as Step 13, so it also depends on Step 8 above
+having run first.
+
+> **The "generate a temporary root token" fallback this used to describe is
+> currently dead, not just conditional.** `Verified 2026-08-06` by reading
+> `cmd_bootstrap_approles` directly: if no valid `BAO_TOKEN` is already exported, it
+> falls back to `bao operator generate-root`, and that CLI command's own `die`
+> message in the script says it "targets a LEGACY endpoint and returns 403 on 2.6.1
+> **whatever the configuration** — it cannot mint one here." **Followed in order from
+> Step 4, this step works** — it never reaches that fallback, because Step 4's root
+> token is still exported and valid. But it means this step has no working fallback
+> of its own if the sequence is broken and re-entered after root has already been
+> revoked. **Entangled with Hill90#832** (found 2026-08-06): outside a fresh-init
+> window like this one, there is currently no automation credential able to write to
+> vault at all — the only path #832 identifies is a human logging into
+> `vault.hill90.com` via Keycloak SSO (`platform-admin` → `policy-oidc-admin`), and
+> #832 itself says that path has not recently been exercised for an actual write.
 
 > **There are FIVE, not nine.** `Verified 2026-08-05` against `scripts/vault.sh:31`,
 > which is the source of truth:

--- a/docs/runbooks/vps-rebuild.md
+++ b/docs/runbooks/vps-rebuild.md
@@ -159,6 +159,45 @@ two runbooks drifting out of sync with each other the way this gap itself happen
 5. Configure OIDC (Keycloak) — `bash scripts/vault.sh setup-oidc`
 6. Generate and store AppRole credentials — `bash scripts/vault.sh bootstrap-approles`
 
+> **Step 6 (`bootstrap-approles`) depends on a credential that only exists for a
+> narrow window, and this sequence has to stay unbroken for it to work.**
+> `Verified 2026-08-06` by reading `cmd_bootstrap_approles` in `scripts/vault.sh`
+> directly. It needs a root token, and gets one one of two ways:
+>
+> - **An already-exported `BAO_TOKEN`, used as-is if valid.** In this sequence, that's
+>   the SAME root token Step 1's `vault.sh init` just wrote to
+>   `/opt/hill90/secrets/openbao-root.token` — reused the same way Steps 3-5 above
+>   already do (`BAO_TOKEN="$(cat /opt/hill90/secrets/openbao-root.token)"`). Followed
+>   in order, with nothing in between that revokes it, this step works.
+> - **Otherwise, it tries to generate a temporary one — and this fallback is
+>   currently dead, unconditionally, not just sometimes.** `cmd_bootstrap_approles`'s
+>   own `die` message says so: the `bao operator generate-root` CLI command it calls
+>   "targets a LEGACY endpoint and returns 403 on 2.6.1 **whatever the
+>   configuration** — it cannot mint one here." The message names the real fallback
+>   as `vault-regain-root.yml` (a deliberate recovery-config redeploy with two vault
+>   restarts, not a routine step) or supplying an existing root token by hand.
+>
+> **This entangles with Hill90#832, found the same day this runbook was corrected.**
+> #832 established that OUTSIDE a fresh-init window like this one — i.e. on the
+> normal, already-configured, already-running production vault, where root is
+> deliberately revoked as standing policy — there is currently **no automation
+> credential able to write to vault at all**. The only path #832 identifies is a
+> **human** logging into `vault.hill90.com` via Keycloak SSO (`platform-admin` role →
+> `policy-oidc-admin`, which grants full `create/read/update/delete/list` on
+> `secret/*`) — and #832 is explicit that even that path "has not been exercised
+> recently" for an actual write.
+>
+> **What this means for this step specifically:** if you run Steps 1-6 above in order,
+> without interruption, on a truly fresh vault, `bootstrap-approles` rides the
+> just-minted root token and should work — this is the scenario this runbook
+> documents. If this sequence is ever interrupted **after** root is revoked (Step 13
+> in `disaster-recovery.md`, or any other point root is deliberately dropped) and
+> `bootstrap-approles` needs to be re-run later, **there is currently no known
+> automatable way to get it a valid credential** — the generate-root fallback is
+> dead by the script's own admission, and the human OIDC path is unexercised. That
+> is a real gap, stated here rather than written around; see #832 for the credential
+> problem itself, which this runbook does not attempt to resolve.
+
 **Not verified here** whether `vault.sh auto-unseal` against a truly fresh,
 never-initialized `openbao-data` volume errors cleanly, hangs, or silently no-ops —
 what's stated above is the intended sequence from `disaster-recovery.md`, not a

--- a/tests/scripts/dr-runbooks-content.bats
+++ b/tests/scripts/dr-runbooks-content.bats
@@ -109,6 +109,32 @@ setup() {
   [ "$status" -eq 0 ]
 }
 
+@test "h#807: vps-rebuild.md states the bootstrap-approles credential entanglement with h#832" {
+  run grep -F 'Hill90#832' "$VPS"
+  [ "$status" -eq 0 ]
+  run grep -F 'policy-oidc-admin' "$VPS"
+  [ "$status" -eq 0 ]
+}
+
+@test "h#807: vps-rebuild.md says the generate-root fallback is dead, not merely conditional" {
+  run grep -F 'currently dead, unconditionally' "$VPS"
+  [ "$status" -eq 0 ]
+}
+
+@test "h#807 corroborated against the script: cmd_bootstrap_approles's own die message names the same 403-regardless-of-config limit" {
+  run grep -F 'returns 403 on 2.6.1' "$ROOT/scripts/vault.sh"
+  [ "$status" -eq 0 ]
+  run grep -F 'whatever the' "$ROOT/scripts/vault.sh"
+  [ "$status" -eq 0 ]
+}
+
+@test "h#807: disaster-recovery.md's Step 9 carries the same corrected description and h#832 entanglement" {
+  run grep -F 'currently dead, not just conditional' "$DR"
+  [ "$status" -eq 0 ]
+  run grep -F 'Hill90#832' "$DR"
+  [ "$status" -eq 0 ]
+}
+
 # ---------------------------------------------------------------------------
 # h#808 (docs half) — observability undercounted by 2
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Follow-up to #830 (merged, closed h#804-h#808's docs half) — strengthens h#807's fix per instruction to finish the DR group before moving on, incorporating a same-day finding from #832.

## What's real

`cmd_bootstrap_approles` (`scripts/vault.sh`) needs a root token and gets one one of two ways: an already-exported `BAO_TOKEN`, or a `generate-root` fallback that the function's own `die` message says is dead — "targets a LEGACY endpoint and returns 403 on 2.6.1 whatever the configuration — it cannot mint one here", regardless of vault's listener config.

Followed in the order the runbook now specifies (init → unseal → setup → seed → setup-oidc → bootstrap-approles), the step works: it reuses the same root token `vault.sh init` wrote to disk, still valid at that point in the sequence. It has no working fallback of its own if that sequence is ever broken and re-entered after root has already been revoked.

That's exactly the situation **#832** found the same day, on the other end: outside a fresh-init window, there is currently no automation credential able to write to vault at all — the only path #832 identifies is a human logging into `vault.hill90.com` via Keycloak SSO (`policy-oidc-admin`, bound to `platform-admin`), and #832 itself says that path has not recently been exercised for an actual write.

## Fix

Stated in both runbooks: `vps-rebuild.md`'s Step 3b (the fix #830 already made) and `disaster-recovery.md`'s own Step 9, which Step 3b now points readers to as the canonical source — leaving Step 9 with an inaccurate description of its own credential mechanism would have undermined that pointer. `disaster-recovery.md`'s prior text ("it temporarily generates a root token via unseal key") is corrected in place: that describes the fallback, not the primary path, and the fallback doesn't work.

**No credential problem is resolved here — #832 is not touched.** This only makes both runbooks say plainly what is and isn't currently possible, rather than documenting a step that cannot be followed once its one working path (a still-valid root token) is gone.

## Tests

Four new cases in `dr-runbooks-content.bats`: both runbooks state the #832 entanglement by number and name `policy-oidc-admin`; both say the generate-root fallback is dead, not merely conditional; one corroborates directly against `vault.sh`'s own die message rather than trusting the doc's paraphrase.

**Positive control:** reverted both docs files via `git stash`, reran — exactly 3 of the 4 new tests failed; the script-corroboration test correctly stayed green (independent of the doc edits, already true). Restored, reran: 19/19.

## Test plan

- [x] `bats tests/scripts/dr-runbooks-content.bats` — 19/19
- [x] Positive control: revert → 3 of 4 new tests fail; restore → 19/19
- [x] `bats --recursive tests/scripts/` — 767/767, no regressions
- [x] `git diff --stat` shows exactly the 3 intended files