### PR TITLE
docs(runbooks): warn about HILL90_UI_CLIENT_SECRET before a VPS rebuild — h#809

### DIFF
--- a/docs/runbooks/vps-rebuild.md
+++ b/docs/runbooks/vps-rebuild.md
@@ -25,6 +25,26 @@ runbook does not itself walk through (see Step 3b, h#807). The process takes
   [`disaster-recovery.md`](disaster-recovery.md#step-0)
 - **SSH key:** `~/.ssh/remote.hill90.com` configured
 - **Secrets:** `infra/secrets/prod.enc.env` with VPS credentials
+- **`HILL90_UI_CLIENT_SECRET` set in the store — check this BEFORE starting, not after
+  login breaks.** h#809, `Verified 2026-08-06` against a real
+  `quay.io/keycloak/keycloak:26.4.0` importing the actual `platform-realm.json` with
+  this variable deliberately unset: the import completes with **no warning or error**
+  ("Realm 'platform' imported" / "Import finished successfully"), and the `hill90-ui`
+  client's resulting secret is the **literal, unsubstituted string
+  `${HILL90_UI_CLIENT_SECRET}`** — not empty, and not random. That exact string is
+  sitting in plaintext in `platform-realm.json` in this repository, so an unconfigured
+  rebuild installs a client secret, for the client fronting `hill90.com`, that anyone
+  reading this file already knows. This bites **only** on a first realm import — the
+  case a rebuild is — and nothing in the automated rebuild path checks for it; a
+  compose-level `${VAR:?...}` guard was considered and is deliberately **not** the fix,
+  because `HILL90_UI_CLIENT_SECRET` is legitimately unset on every *routine* auth
+  deploy after the first import (`start --import-realm` no-ops once the realm exists),
+  so a blanket guard would refuse every normal deploy, not just protect this case (see
+  `fad9fefa`, which rejected exactly that for exactly this reason). Confirm the value is
+  present — `grep -c '^HILL90_UI_CLIENT_SECRET=' infra/secrets/prod.enc.env` should
+  print `1` — before running Step 1. If it prints `0`, get the value from Jon first;
+  it must equal what hill90-app's own store holds for `AUTH_KEYCLOAK_SECRET`, or the
+  tenant app cannot sign in against the freshly-imported realm.
 
 ## Rebuild Workflow
 


### PR DESCRIPTION
## Summary

Establishes the actual failure mode empirically (not just from source-reading) and adds the honest, safe mitigation — a runbook warning, not a compose guard.

**The actual failure, reproduced against a real `quay.io/keycloak/keycloak:26.4.0` importing the real `platform-realm.json` with `HILL90_UI_CLIENT_SECRET` deliberately unset**, matching a first-import rebuild:

- Import completes with **no warning, no error**: `Realm 'platform' imported` / `Import finished successfully`.
- `hill90-ui`'s resulting client secret is the **literal, unsubstituted string `${HILL90_UI_CLIENT_SECRET}`** — not empty, not random.
- Control: `hill90-vault`'s client secret, with its env var *set*, substituted correctly (`dryrun-vault-secret-not-real`), confirming Keycloak's `${VAR}` substitution genuinely works and this is a real absence, not a broken test.

This is worse than either outcome the issue speculated about ("halts loudly" vs. "known-wrong placeholder"): the installed secret is a specific, predictable string sitting in plaintext in this repo's own `platform-realm.json`, so anyone reading the repo already knows the exact secret an unconfigured rebuild would install for the client fronting `hill90.com`.

**The issue's own suggested fix — add the same `${VAR:?...}` guard `VAULT_OIDC_CLIENT_SECRET` has — was tested and is wrong.** Verified the guard mechanism works exactly as intended (`docker compose config` refuses cleanly when unset) — but `fad9fefa` already found and *deliberately rejected* this exact guard for `HILL90_UI_CLIENT_SECRET` specifically: it's legitimately unset on every routine `auth` deploy after the first import, since `start --import-realm` no-ops once the realm exists. A blanket guard would refuse every normal auth deploy, not just protect the rare rebuild case. Caught this before shipping it — my first draft of this PR added exactly that guard, and I reverted it once I found the prior rejection.

**No automated pre-flight check exists for the actual rebuild-only case**, and building one correctly means reaching into a multi-workflow chain (`recreate-vps.yml` → `config-vps.yml` → whatever eventually deploys `auth`, which this runbook's own step list doesn't clearly name) — more surface than this task should rush, especially having just gotten the simpler compose-guard version wrong once. Added a **Prerequisites** warning to `vps-rebuild.md` instead: one `grep` to check before starting, with the full empirical finding and the reasoning for not guarding at the compose level, so the next person (human or agent) doesn't rediscover either the failure or the wrong fix.

## Test plan

- [x] Reproduced the unset-variable import against a real `keycloak:26.4.0` + `postgres:16-alpine`, locally, fully disposable (torn down after, nothing touched in production).
- [x] Confirmed the exact resulting client secret value via `kcadm.sh get clients/... --fields secret`.
- [x] Confirmed the substitution mechanism itself works via a positive control (`hill90-vault`'s secret, set, substituted correctly).
- [x] Verified the `${VAR:?...}` guard mechanism separately (`docker compose config`), confirming it would work exactly as advertised — and confirming, independently, why it's still the wrong fix for this specific variable.
- [x] No production secret value was set, read, or guessed at any point — per the standing instruction that the production value is Jon's to provide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)