### PR TITLE
fix(observability): retune TempoIngestionErrors from any-nonzero-rate to a 5% loss ratio

### DIFF
--- a/platform/observability/prometheus/alerts.yml
+++ b/platform/observability/prometheus/alerts.yml
@@ -400,20 +400,86 @@ groups:
 
   - name: tempo
     rules:
+      # h#836, 2026-08-06: `> 0` measured what it says, and what it says is not
+      # what the rule's own description claims. Over the 24h investigated,
+      # append_failures_total ran at a STEADY ~1.1% of appends
+      # (rate(failures[5m])=0.0035/s against rate(appends[5m])=0.305/s) —
+      # ALERTS showed 636 pending + 78 firing samples, i.e. on almost the
+      # entire window. "Traces are being LOST while this fires" was TRUE at
+      # that rate; the problem was that `> 0` over a 5m window alarms on any
+      # nonzero rate forever, so a permanent low background rate reads
+      # identically to a real incident and both get the same "warning,
+      # ignore" treatment.
+      #
+      # THE TRAFFIC BEHIND THAT 1.1%, established before retuning rather than
+      # assumed: docker logs against app-api/app-ai/app-knowledge/app-mcp
+      # over the same window showed essentially nothing but periodic health
+      # probes (~30s cadence) — 431 of 437 app-knowledge log lines were
+      # `GET /health`, and app-api/app-ai/app-mcp were the same shape. Chat
+      # has carried zero production traffic to date (README), so this is not
+      # real user traffic being dropped.
+      #
+      # Tempo's own metrics carry no per-service label (single-tenant mode:
+      # tempo_distributor_spans_received_total{tenant="single-tenant"} is the
+      # only tenant dimension that exists), and its logs
+      # ("pusher failed to consume trace data: context canceled") name no
+      # caller either — so per-trace attribution to one service is not
+      # possible from anything Tempo exposes today. Tempo's SEARCH API does
+      # carry service.name, and trace volume by service over a 1h sample
+      # (api 809, knowledge 431, keycloak 272, mcp 130, ai 118) shows api
+      # sending roughly double the next-highest service, not one service
+      # sending everything and the rest sending nothing — consistent with
+      # loss spread across senders roughly by how much each sends, not with
+      # one broken client. Deploy churn was independently ruled out already
+      # (the issue's own evidence: the rate is nonzero with no deploy
+      # running), and no service's own logs show a client-side abort at any
+      # failure timestamp checked.
+      #
+      # DECISION: ~1% loss of low-value, non-production-traffic diagnostic
+      # spans is accepted rather than chased further — the candidate
+      # mechanism (a background export batch occasionally racing Tempo's own
+      # periodic ingest work against the SDK's default ~10s OTLP timeout) is
+      # not a defect in any one service, and "isolate and fix the client"
+      # has no single client to point at on this evidence. What was NOT
+      # accepted is the rule staying permanently on for that: retuned from
+      # "any nonzero failure rate for 5m" to "the failure RATIO exceeds 5%
+      # for 15m" — roughly 4-5x today's measured background rate, so this
+      # stays quiet on the noise actually measured but still fires well
+      # inside the window of a genuine incident (the rule's own history: a
+      # prior occurrence ran for ~1.3 cumulative hours in the week to
+      # 2026-07-31 unwatched). A ratio, not a raw rate, so the threshold
+      # means the same thing regardless of how much total trace volume the
+      # tenant is sending on a given day.
+      #
+      # tests/prometheus/alerts_test.yml has both directions: a genuine
+      # ingestion failure (loss well above 5%, sustained) still fires, and a
+      # background rate matching what was actually measured (~1.1%) does not.
       - alert: TempoIngestionErrors
-        expr: rate(tempo_distributor_ingester_append_failures_total[5m]) > 0
-        for: 5m
+        expr: |
+          (
+            rate(tempo_distributor_ingester_append_failures_total[5m])
+            /
+            (
+              rate(tempo_distributor_ingester_append_failures_total[5m])
+              + rate(tempo_distributor_ingester_appends_total[5m])
+            )
+          ) > 0.05
+        for: 15m
         labels:
           severity: warning
         annotations:
           summary: "Tempo ingestion errors detected"
           description: >-
-            Tempo is failing to append traces at {{ $value }}/sec on {{ $labels.instance }}.
-            Traces are being LOST while this fires.
+            Tempo has failed to append {{ $value | humanizePercentage }} of trace
+            appends on {{ $labels.instance }} for 15+ minutes. Traces are being
+            LOST while this fires, at a rate well above the ~1% background this
+            threshold was set against (h#836).
           action: >-
             `docker logs --tail 50 tempo`. This fired for ~1.3 cumulative hours in the
             week to 2026-07-31 with nobody watching, so treat a first delivery as
-            possibly long-standing rather than new.
+            possibly long-standing rather than new. A background rate around 1%
+            no longer fires this rule — see h#836 if this alert appears to have
+            gone quiet; that was deliberate, not a regression.
           runbook: docs/runbooks/observability.md
 
   # ---------------------------------------------------------------------------

--- a/tests/prometheus/alerts_test.yml
+++ b/tests/prometheus/alerts_test.yml
@@ -396,14 +396,34 @@ tests:
         exp_alerts: []
 
   # --- tempo ----------------------------------------------------------------
+  #
+  # h#836, 2026-08-06: retuned from "any nonzero failure rate for 5m" to
+  # "failure ratio > 5% for 15m", against a MEASURED production baseline of
+  # ~1.1% (rate(failures[5m])=0.0035/s, rate(appends[5m])=0.305/s — see
+  # alerts.yml's own comment for how that number and the traffic behind it
+  # were established). Both directions matter equally here: a rule that only
+  # proves it CAN still fire is not the same claim as one that also proves it
+  # STOPPED firing on the exact background rate that used to make it
+  # permanent. Neither test alone would have caught the original defect —
+  # `> 0` also "fires on a rising counter" in a test exactly like the first
+  # one below.
 
-  - name: TempoIngestionErrors fires on a rising append-failure counter
+  - name: TempoIngestionErrors fires on a genuine ingestion failure (well above background)
     interval: 1m
     input_series:
+      # 2/min failures against 8/min appends = 20% loss — four times the 5%
+      # threshold and roughly eighteen times the ~1.1% background this
+      # threshold was set against, so this is unambiguously an incident, not
+      # noise on a busy day.
       - series: 'tempo_distributor_ingester_append_failures_total{instance="tempo:3200", job="tempo", ingester="127.0.0.1:9095"}'
-        values: '0+2x15'
+        values: '0+2x25'
+      - series: 'tempo_distributor_ingester_appends_total{instance="tempo:3200", job="tempo", ingester="127.0.0.1:9095"}'
+        values: '0+8x25'
     alert_rule_test:
-      - eval_time: 12m
+      - eval_time: 10m
+        alertname: TempoIngestionErrors
+        exp_alerts: []          # `for: 15m` not yet satisfied
+      - eval_time: 24m
         alertname: TempoIngestionErrors
         exp_alerts:
           - exp_labels:
@@ -413,17 +433,39 @@ tests:
               ingester: 127.0.0.1:9095
             exp_annotations:
               summary: "Tempo ingestion errors detected"
-              description: "Tempo is failing to append traces at 0.03333333333333333/sec on tempo:3200. Traces are being LOST while this fires."
-              action: "`docker logs --tail 50 tempo`. This fired for ~1.3 cumulative hours in the week to 2026-07-31 with nobody watching, so treat a first delivery as possibly long-standing rather than new."
+              description: "Tempo has failed to append 20% of trace appends on tempo:3200 for 15+ minutes. Traces are being LOST while this fires, at a rate well above the ~1% background this threshold was set against (h#836)."
+              action: "`docker logs --tail 50 tempo`. This fired for ~1.3 cumulative hours in the week to 2026-07-31 with nobody watching, so treat a first delivery as possibly long-standing rather than new. A background rate around 1% no longer fires this rule — see h#836 if this alert appears to have gone quiet; that was deliberate, not a regression."
               runbook: docs/runbooks/observability.md
 
-  - name: TempoIngestionErrors is silent on a flat counter
+  - name: TempoIngestionErrors is silent on the measured production background rate (~1.1%)
     interval: 1m
     input_series:
+      # 1/min failures against 90/min appends = 1/91 ≈ 1.10% — matches the
+      # investigated baseline almost exactly, not an arbitrary "small" number.
+      # This is the case the old `> 0` rule got wrong: pending or firing on
+      # 636+78 of a possible ~1440 samples in 24h, for traffic that was
+      # entirely health-check polling with zero production chat traffic.
       - series: 'tempo_distributor_ingester_append_failures_total{instance="tempo:3200", job="tempo", ingester="127.0.0.1:9095"}'
-        values: '30x15'
+        values: '0+1x25'
+      - series: 'tempo_distributor_ingester_appends_total{instance="tempo:3200", job="tempo", ingester="127.0.0.1:9095"}'
+        values: '0+90x25'
     alert_rule_test:
-      - eval_time: 12m
+      - eval_time: 24m
+        alertname: TempoIngestionErrors
+        exp_alerts: []
+
+  - name: TempoIngestionErrors is silent when nothing is being pushed at all (0/0)
+    interval: 1m
+    input_series:
+      # Both counters flat: rate/rate is 0/0 = NaN in PromQL, and NaN > 0.05
+      # is false — this must stay a non-match, not an error or a false fire,
+      # since a quiet tenant is not the same claim as a failing one.
+      - series: 'tempo_distributor_ingester_append_failures_total{instance="tempo:3200", job="tempo", ingester="127.0.0.1:9095"}'
+        values: '0x25'
+      - series: 'tempo_distributor_ingester_appends_total{instance="tempo:3200", job="tempo", ingester="127.0.0.1:9095"}'
+        values: '0x25'
+    alert_rule_test:
+      - eval_time: 24m
         alertname: TempoIngestionErrors
         exp_alerts: []
 


### PR DESCRIPTION
## Summary

Closes h#836.

**Decision, per the issue's own framing ("one of two opposite things, pick one with evidence"): ~1% loss is accepted; the rule was mistuned.**

**Evidence for that call:**
- The rule's own math checked out — `rate(append_failures_total[5m])=0.0035/s` against `rate(appends_total[5m])=0.305/s` is a real, steady ~1.1% loss, and the description ("traces are being LOST while this fires") was true. The defect is that `> 0` for `5m` cannot distinguish a permanent 1% background rate from a genuine incident — both read identically to the rule, which is why it was pending or firing on 636+78 of ~1440 possible 24h samples.
- What that 1.1% actually is: `docker logs` against all four tenant services over the same window showed essentially nothing but periodic health-check polling (~30s cadence) — 431 of 437 `app-knowledge` lines were bare `GET /health`, and `app-api`/`app-ai`/`app-mcp` were the same shape. Chat has carried zero production traffic to date, so this is diagnostic noise, not lost user data.

**Isolating a single misbehaving service — attempted, and inconclusive, stated rather than hidden:**
Tempo's own metrics carry no per-service label (single-tenant mode). Its "context canceled" log lines name no caller. No service's own logs showed a client-side abort at any checked failure timestamp. Tempo's *search* API does carry `service.name`, and a 1h trace-volume sample (api 809, knowledge 431, keycloak 272, mcp 130, ai 118) shows loss spread roughly in proportion to send volume rather than concentrated in one service — consistent with a systemic export-timeout/Tempo-ingest-latency interaction, not one broken client. Deploy churn was independently ruled out already, matching the issue's own finding.

**The fix:** a ratio, not a raw rate — `failures / (failures + appends) > 0.05` for `15m`, roughly 4-5x the measured background so it stays quiet on the noise actually measured (~1.1%) but well inside the window of a genuine incident (this rule's own history already has one: ~1.3 cumulative hours in the week to 2026-07-31, unwatched). A ratio means the threshold reads the same regardless of total trace volume on a given day, unlike an absolute rate.

## Test plan

- [x] `promtool check rules platform/observability/prometheus/alerts.yml` — `SUCCESS: 27 rules found`, against `prom/prometheus:v3.3.1` (the exact image `ci.yml`'s `prometheus-rules` job pins).
- [x] `promtool test rules tests/prometheus/alerts_test.yml` — `SUCCESS`. New cases:
  - Genuine failure (20% loss, 4x threshold) fires at 15m and **not** at 10m — `for:` honoured.
  - Background matching the measured baseline almost exactly (1/91 ≈ 1.10%) stays silent.
  - 0/0 (no traffic at all) stays silent — a `NaN > 0.05` comparison must not misfire.
- [x] **Positive control, both directions**: reverting only `alerts.yml` (keeping the new tests) makes the background case **fail** — the old `> 0` rule fires on it. That's not just "the new rule can detect something," it's direct proof the old rule could not tell noise from an incident. Restoring the fix returns both directions to green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)