### PR TITLE
feat(observability): assert container_profiles fits hill90-app's own resource ceilings, on the existing deploy-drift schedule

### DIFF
--- a/.github/workflows/deploy-drift.yml
+++ b/.github/workflows/deploy-drift.yml
@@ -177,6 +177,110 @@ jobs:
           esac
           exit $rc
 
+      # h#845 (split from hill90-app#598, which itself came from
+      # hill90-app#593). hill90-app#593's containerProfileCeilingViolations()
+      # only ever console.error()s a live violation on API startup — nothing
+      # reads that. #598 checked whether the api could just expose a
+      # Prometheus gauge instead: it does not today, and building a metrics
+      # pipeline sideways for one rare condition is a bigger decision than
+      # this warranted (see #598's own writeup, including that app-api and
+      # this repo's prometheus DO share a docker network, so it was never a
+      # capability question, only a scope one). This is the alternative Jon
+      # chose: piggyback on THIS scheduled workflow, which already reaches
+      # the VPS every four hours and already has a reader — no new
+      # workflow, no new watchdog wiring, no new metrics pipeline.
+      #
+      # WHERE THE CEILINGS COME FROM, NOT A HARDCODED COPY. MAX_AGENT_CPUS/
+      # MAX_AGENT_MEM_BYTES/MAX_AGENT_PIDS_LIMIT live in hill90-app's
+      # services/api/src/helpers/agent-resource-limits.ts (consolidated
+      # there by hill90-app#596's own review — before that they were
+      # scattered across two files in that repo, and typing a THIRD copy
+      # into THIS repo would be the identical twin-drift shape, one
+      # repository over. Sparse-checked-out below and grepped directly, so
+      # this always compares against whatever hill90-app's main branch
+      # currently says.
+      - name: Checkout hill90-app, for its own resource-ceiling constants
+        if: always() && inputs.deployed_sha_override == ''
+        uses: actions/checkout@v4
+        with:
+          repository: jonhill90/hill90-app
+          path: tenant
+          sparse-checkout: |
+            services/api/src/helpers/agent-resource-limits.ts
+          sparse-checkout-cone-mode: false
+
+      - name: Extract MAX_AGENT_* from hill90-app's own source
+        id: ceilings
+        if: always() && inputs.deployed_sha_override == ''
+        run: |
+          f=tenant/services/api/src/helpers/agent-resource-limits.ts
+          if [ ! -f "$f" ]; then
+            echo "::warning::hill90-app has not merged agent-resource-limits.ts yet (or moved it) — the ceiling check will report this as UNKNOWN."
+            echo "ok=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          cpus=$(grep -oE 'MAX_AGENT_CPUS = [0-9.]+' "$f" | grep -oE '[0-9.]+$' || true)
+          mem=$(grep -oE 'MAX_AGENT_MEM_BYTES = [0-9]+' "$f" | grep -oE '[0-9]+$' || true)
+          pids=$(grep -oE 'MAX_AGENT_PIDS_LIMIT = [0-9]+' "$f" | grep -oE '[0-9]+$' || true)
+          if [ -z "$cpus" ] || [ -z "$mem" ] || [ -z "$pids" ]; then
+            echo "::warning::Could not extract all three MAX_AGENT_* constants from $f (cpus='$cpus' mem='$mem' pids='$pids') — the ceiling check will report this as UNKNOWN."
+            echo "ok=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "ok=true" >> "$GITHUB_OUTPUT"
+          echo "cpus=${cpus}" >> "$GITHUB_OUTPUT"
+          echo "mem=${mem}" >> "$GITHUB_OUTPUT"
+          echo "pids=${pids}" >> "$GITHUB_OUTPUT"
+
+      # Read-only. `-U hill90`, the platform admin role — NOT `postgres`,
+      # which does not exist on this Postgres, and not the tenant's own
+      # `hill90_app` role, to keep this on the same credential every other
+      # cross-cutting platform check in this repo already uses. The `ERROR`
+      # sentinel (rather than an empty string) is deliberate: an empty
+      # profiles-json argument and a failed-to-read one must be
+      # distinguishable to the Python script, which treats an empty LIST
+      # as its own, different finding (see its own docstring) — collapsing
+      # "could not ask" and "asked, got nothing" into the same string would
+      # blur exactly the distinction this issue is about.
+      - name: Read container_profiles from the live database
+        id: profiles
+        if: always() && inputs.deployed_sha_override == '' && steps.ceilings.outputs.ok == 'true'
+        run: |
+          json=$(ssh -i ~/.ssh/vps_key -o StrictHostKeyChecking=no -o ConnectTimeout=15 \
+            deploy@${{ steps.get-ip.outputs.tailscale_ip }} \
+            "docker exec postgres psql -U hill90 -d hill90_api -tAc \"SELECT COALESCE(json_agg(row_to_json(t)), '[]') FROM (SELECT name, default_cpus, default_mem_limit, default_pids_limit FROM container_profiles) t;\"" \
+            2>/dev/null)
+          if [ -z "$json" ]; then
+            echo "::warning::Could not read container_profiles from the host (unreachable, or the query failed) — the ceiling check will report this as CANNOT DETERMINE."
+            json="ERROR"
+          fi
+          # Multi-line-safe GITHUB_OUTPUT write — the JSON is one line from
+          # psql -t, but this avoids re-learning that the hard way later.
+          echo "json<<CEILINGS_EOF" >> "$GITHUB_OUTPUT"
+          echo "$json" >> "$GITHUB_OUTPUT"
+          echo "CEILINGS_EOF" >> "$GITHUB_OUTPUT"
+
+      - name: Assert every container_profiles row fits under hill90-app's own ceilings
+        if: always() && inputs.deployed_sha_override == ''
+        run: |
+          if [ "${{ steps.ceilings.outputs.ok }}" != "true" ]; then
+            echo "::error::CANNOT DETERMINE: hill90-app's MAX_AGENT_* constants were not readable this run. Not a pass — see the extraction step above."
+            exit 2
+          fi
+          rc=0
+          python3 scripts/checks/check_container_profile_ceilings.py \
+            --max-cpus "${{ steps.ceilings.outputs.cpus }}" \
+            --max-mem-bytes "${{ steps.ceilings.outputs.mem }}" \
+            --max-pids-limit "${{ steps.ceilings.outputs.pids }}" \
+            --profiles-json '${{ steps.profiles.outputs.json }}' || rc=$?
+          case "$rc" in
+            0) echo "::notice::Every container_profiles row fits under hill90-app's MAX_AGENT_* ceilings." ;;
+            1) echo "Fix the named profile row, or raise the ceiling in hill90-app's agent-resource-limits.ts with a deliberate reason." ;;
+            2) echo "Could not determine — treat as unverified, not as fine." ;;
+            *) echo "::error::Unrecognised exit code $rc from check_container_profile_ceilings.py." ;;
+          esac
+          exit $rc
+
       # h#712 (narrowed): a dead-man's-switch for the SCHEDULE itself. Same
       # reasoning as the equivalent step in audit-hill90-ui-client.yml —
       # `if: always()` so a REAL drift finding (already emailed immediately

--- a/scripts/checks/check_container_profile_ceilings.py
+++ b/scripts/checks/check_container_profile_ceilings.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Does every live container_profiles row still fit under hill90-app's own
+resource ceilings?
+
+    python3 scripts/checks/check_container_profile_ceilings.py \\
+        --max-cpus 4 --max-mem-bytes 16761118720 --max-pids-limit 300 \\
+        --profiles-json '[{"name":"standard","default_cpus":"1.0", ...}]'
+
+WHY THIS EXISTS (Hill90#845, split from hill90-app#598). hill90-app#593 added
+MAX_AGENT_CPUS/MAX_AGENT_MEM_BYTES/MAX_AGENT_PIDS_LIMIT and a startup check,
+containerProfileCeilingViolations(), that queries container_profiles on boot
+and console.error()s a violation. Nothing reads that. hill90-app#598 asked
+whether the api already exposes Prometheus metrics for this — checked
+directly, it does not, and hill90-app#598 itself says do not build one
+sideways for a single rare gauge. This is the alternative: piggyback on
+Hill90's existing deploy-drift.yml, a scheduled workflow that already SSHes
+into the VPS every four hours and already has a reader (Alertmanager email,
+plus #712's scheduled-workflow-not-triggering watchdog) — reuse a machine
+that already works rather than build a new one for this single condition.
+
+WHERE THE CEILINGS COME FROM, NOT A HARDCODED COPY. MAX_AGENT_CPUS/
+MAX_AGENT_MEM_BYTES/MAX_AGENT_PIDS_LIMIT live in hill90-app's
+services/api/src/routes/agents.ts, a different repository. Typing three
+numbers into THIS repo would be exactly the twin-drift shape this session
+has already closed five times (h#839's shared-secret-agreement,
+hill90-app#141/#153's resource-bound literals, among others) — a second copy
+that can silently disagree with the first the moment either changes. The
+caller (deploy-drift.yml) sparse-checks-out agents.ts and greps the three
+`export const MAX_AGENT_*` lines directly out of the source on every run, so
+this script always compares against whatever hill90-app's main branch
+currently says, not a number typed here once and forgotten.
+
+CANNOT-DETERMINE IS NOT A PASS (Hill90#845's own point, stated as a
+constraint rather than left to chance). An unreachable host, a failed psql
+query, or an EMPTY profiles list are not "zero violations" — they are
+"nothing was checked". At least one profile (`standard`) has existed since
+container_profiles was created (Hill90-app migration 032) and is seeded on
+every fresh bootstrap, so an empty result here is itself suspicious, not a
+clean state — treated as CANNOT DETERMINE, not PASS, same as an unauthenticated
+`bao list` returning empty is not "no AppRoles" (app#791's own instrument
+trap, the same shape one level over).
+
+Exit codes:
+  0  every profile fits under every ceiling
+  1  ACTIONABLE — at least one profile's own default exceeds a ceiling,
+     each one named
+  2  CANNOT DETERMINE (a ceiling could not be parsed, the profiles JSON
+     could not be parsed, or the profiles list came back empty). Never a
+     pass: a check that cannot see the thing it compares must not report
+     agreement.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+
+
+def parse_mem_limit(raw: object) -> float | None:
+    """Same shape as hill90-app's parseMemLimit/memLimitValidationError
+    (services/api/src/services/docker.ts, services/api/src/routes/agents.ts)
+    — bare bytes, or a number with a k/m/g unit, case-insensitive, optional
+    trailing 'b'. Returns None (never raises) on anything that does not
+    match, since a malformed value here is itself a finding, not a crash."""
+    if not isinstance(raw, str):
+        return None
+    m = re.match(r'^(\d+(?:\.\d+)?)\s*([kmg]?)b?$', raw.strip(), re.IGNORECASE)
+    if not m:
+        return None
+    value = float(m.group(1))
+    unit = m.group(2).lower()
+    multiplier = {'k': 1024, 'm': 1024 * 1024, 'g': 1024 * 1024 * 1024}.get(unit, 1)
+    return value * multiplier
+
+
+def parse_cpus(raw: object) -> float | None:
+    if not isinstance(raw, str):
+        return None
+    m = re.match(r'^(\d+(?:\.\d+)?)$', raw.strip())
+    if not m:
+        return None
+    return float(m.group(1))
+
+
+def violations(
+    profiles: list[dict],
+    max_cpus: float,
+    max_mem_bytes: float,
+    max_pids_limit: int,
+) -> list[dict]:
+    """Pure comparison — no I/O, no exit codes, so it can be unit tested
+    directly against a fabricated fixture without a live host or database."""
+    found = []
+    for p in profiles:
+        name = p.get('name', '<unnamed>')
+
+        cpus = parse_cpus(p.get('default_cpus'))
+        if cpus is None:
+            found.append({'profile': name, 'field': 'default_cpus',
+                           'detail': f"unparseable value {p.get('default_cpus')!r}"})
+        elif cpus > max_cpus:
+            found.append({'profile': name, 'field': 'default_cpus',
+                           'detail': f"{cpus} exceeds MAX_AGENT_CPUS={max_cpus}"})
+
+        mem = parse_mem_limit(p.get('default_mem_limit'))
+        if mem is None:
+            found.append({'profile': name, 'field': 'default_mem_limit',
+                           'detail': f"unparseable value {p.get('default_mem_limit')!r}"})
+        elif mem > max_mem_bytes:
+            found.append({'profile': name, 'field': 'default_mem_limit',
+                           'detail': f"{mem:.0f} bytes exceeds MAX_AGENT_MEM_BYTES={max_mem_bytes}"})
+
+        pids = p.get('default_pids_limit')
+        if not isinstance(pids, int) or isinstance(pids, bool):
+            found.append({'profile': name, 'field': 'default_pids_limit',
+                           'detail': f"not an integer: {pids!r}"})
+        elif pids > max_pids_limit:
+            found.append({'profile': name, 'field': 'default_pids_limit',
+                           'detail': f"{pids} exceeds MAX_AGENT_PIDS_LIMIT={max_pids_limit}"})
+    return found
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument('--max-cpus', required=True, type=float)
+    p.add_argument('--max-mem-bytes', required=True, type=float)
+    p.add_argument('--max-pids-limit', required=True, type=int)
+    p.add_argument('--profiles-json', required=True,
+                    help='JSON array of {name, default_cpus, default_mem_limit, default_pids_limit}, '
+                         'or the literal string "ERROR" if the caller could not read the table at all.')
+    args = p.parse_args()
+
+    if args.profiles_json.strip() == 'ERROR':
+        print("::error::CANNOT DETERMINE: the caller could not read container_profiles at all "
+              "(host unreachable, or the psql query failed). This is NOT a pass — nothing was compared.",
+              file=sys.stderr)
+        return 2
+
+    try:
+        profiles = json.loads(args.profiles_json)
+    except json.JSONDecodeError as e:
+        print(f"::error::CANNOT DETERMINE: --profiles-json did not parse as JSON ({e}). "
+              "NOT a pass.", file=sys.stderr)
+        return 2
+
+    if not isinstance(profiles, list) or len(profiles) == 0:
+        print("::error::CANNOT DETERMINE: container_profiles returned zero rows. "
+              "The 'standard' profile is seeded on every bootstrap (migration 032) and has "
+              "never legitimately been absent — an empty result means the query silently "
+              "matched nothing, not that there is nothing to violate. NOT a pass.",
+              file=sys.stderr)
+        return 2
+
+    found = violations(profiles, args.max_cpus, args.max_mem_bytes, args.max_pids_limit)
+
+    print(f"Checked {len(profiles)} container_profiles row(s) against "
+          f"MAX_AGENT_CPUS={args.max_cpus}, MAX_AGENT_MEM_BYTES={args.max_mem_bytes:.0f}, "
+          f"MAX_AGENT_PIDS_LIMIT={args.max_pids_limit} (read live from hill90-app's own source).")
+
+    if not found:
+        print("No violations. Every profile fits under every ceiling.")
+        return 0
+
+    print(f"::error::{len(found)} CEILING VIOLATION(S):", file=sys.stderr)
+    for v in found:
+        print(f"  {v['profile']}.{v['field']}: {v['detail']}", file=sys.stderr)
+    print(
+        "A profile whose own default exceeds hill90-app's MAX_AGENT_* ceiling cannot "
+        "safely have that default wired into agent creation — see hill90-app#593's "
+        "\"not in this fix\" section. Fix the profile row, or raise the ceiling in "
+        "agents.ts with a deliberate reason.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/checks/test_check_container_profile_ceilings.py
+++ b/tests/checks/test_check_container_profile_ceilings.py
@@ -1,0 +1,157 @@
+"""Tests for scripts/checks/check_container_profile_ceilings.py (Hill90#845).
+
+Two layers, deliberately separate:
+
+1. `violations` — the pure comparison against a fabricated fixture. No live
+   host, no database, no hill90-app checkout. Fast, and where the
+   cannot-determine-vs-pass discrimination is easiest to pin precisely.
+
+2. The CLI, invoked as a subprocess with the real live container_profiles
+   rows (Verified 2026-08-06 against production Postgres) as a fixture —
+   proving the exit codes and messages the caller (deploy-drift.yml)
+   actually depends on, not just the internal function's return value.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "checks" / "check_container_profile_ceilings.py"
+
+sys.path.insert(0, str(ROOT / "scripts" / "checks"))
+from check_container_profile_ceilings import violations, parse_cpus, parse_mem_limit  # noqa: E402
+
+# The real, live rows (container_profiles migrations 032/039), Verified
+# 2026-08-06 against production Postgres.
+LIVE_PROFILES = [
+    {"name": "standard", "default_cpus": "1.0", "default_mem_limit": "1g", "default_pids_limit": 200},
+    {"name": "browser", "default_cpus": "2.0", "default_mem_limit": "2g", "default_pids_limit": 300},
+    {"name": "monitor", "default_cpus": "0.5", "default_mem_limit": "256m", "default_pids_limit": 100},
+]
+MAX_CPUS = 4
+MAX_MEM_BYTES = 16761118720
+MAX_PIDS_LIMIT = 300
+
+
+class TestParsers:
+    def test_parse_cpus_accepts_a_plain_decimal(self):
+        assert parse_cpus("2.0") == 2.0
+
+    def test_parse_cpus_rejects_garbage_without_raising(self):
+        assert parse_cpus("unlimited") is None
+        assert parse_cpus(None) is None
+        assert parse_cpus(9999) is None  # not a string at all
+
+    def test_parse_mem_limit_units(self):
+        assert parse_mem_limit("1g") == 1024 ** 3
+        assert parse_mem_limit("256m") == 256 * 1024 ** 2
+        assert parse_mem_limit("1024") == 1024
+
+    def test_parse_mem_limit_rejects_garbage_without_raising(self):
+        assert parse_mem_limit("lots") is None
+        assert parse_mem_limit(None) is None
+
+
+class TestViolationsPureLogic:
+    def test_the_real_current_rows_violate_nothing(self):
+        assert violations(LIVE_PROFILES, MAX_CPUS, MAX_MEM_BYTES, MAX_PIDS_LIMIT) == []
+
+    # THE POSITIVE CONTROL: raise ONE bound in the fixture past the ceiling
+    # and confirm this specific function is what catches it — named, and
+    # only that field.
+    def test_POSITIVE_CONTROL_a_profile_default_pids_limit_raised_past_the_ceiling_is_caught(self):
+        mutated = [dict(p) for p in LIVE_PROFILES]
+        mutated[1]["default_pids_limit"] = 301  # browser
+
+        found = violations(mutated, MAX_CPUS, MAX_MEM_BYTES, MAX_PIDS_LIMIT)
+
+        assert len(found) == 1
+        assert found[0]["profile"] == "browser"
+        assert found[0]["field"] == "default_pids_limit"
+        assert "301" in found[0]["detail"]
+        assert "300" in found[0]["detail"]
+
+    def test_TWIN_exactly_at_the_ceiling_is_not_a_violation(self):
+        mutated = [dict(p) for p in LIVE_PROFILES]
+        mutated[1]["default_pids_limit"] = 300  # already there, but explicit
+        assert violations(mutated, MAX_CPUS, MAX_MEM_BYTES, MAX_PIDS_LIMIT) == []
+
+    def test_default_cpus_over_ceiling_is_independent_of_the_other_two_fields(self):
+        mutated = [dict(p) for p in LIVE_PROFILES]
+        mutated[1]["default_cpus"] = "5.0"
+        found = violations(mutated, MAX_CPUS, MAX_MEM_BYTES, MAX_PIDS_LIMIT)
+        assert len(found) == 1
+        assert found[0]["field"] == "default_cpus"
+
+    def test_default_mem_limit_over_ceiling_is_independent_of_the_other_two_fields(self):
+        mutated = [dict(p) for p in LIVE_PROFILES]
+        mutated[1]["default_mem_limit"] = "9999g"
+        found = violations(mutated, MAX_CPUS, MAX_MEM_BYTES, MAX_PIDS_LIMIT)
+        assert len(found) == 1
+        assert found[0]["field"] == "default_mem_limit"
+
+    def test_multiple_violated_profiles_are_all_reported(self):
+        mutated = [{**p, "default_pids_limit": 9999} for p in LIVE_PROFILES]
+        found = violations(mutated, MAX_CPUS, MAX_MEM_BYTES, MAX_PIDS_LIMIT)
+        assert sorted(v["profile"] for v in found) == ["browser", "monitor", "standard"]
+
+    def test_an_unparseable_field_is_a_violation_not_a_silent_skip(self):
+        mutated = [dict(p) for p in LIVE_PROFILES]
+        mutated[0]["default_cpus"] = "not-a-number"
+        found = violations(mutated, MAX_CPUS, MAX_MEM_BYTES, MAX_PIDS_LIMIT)
+        assert any(v["field"] == "default_cpus" and "unparseable" in v["detail"] for v in found)
+
+
+def run_cli(profiles_json: str, max_cpus="4", max_mem_bytes="16761118720", max_pids_limit="300") -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [
+            sys.executable, str(SCRIPT),
+            "--max-cpus", max_cpus,
+            "--max-mem-bytes", max_mem_bytes,
+            "--max-pids-limit", max_pids_limit,
+            "--profiles-json", profiles_json,
+        ],
+        capture_output=True, text=True,
+    )
+
+
+class TestCLI:
+    def test_the_real_current_rows_exit_0(self):
+        result = run_cli(json.dumps(LIVE_PROFILES))
+        assert result.returncode == 0, result.stderr
+        assert "No violations" in result.stdout
+
+    def test_POSITIVE_CONTROL_a_genuine_violation_exits_1_and_names_it(self):
+        mutated = [dict(p) for p in LIVE_PROFILES]
+        mutated[1]["default_pids_limit"] = 301
+        result = run_cli(json.dumps(mutated))
+        assert result.returncode == 1
+        assert "browser.default_pids_limit" in result.stderr
+        assert "301" in result.stderr
+
+    # THE CANNOT-DETERMINE ARM, distinct from a pass — the reason this issue
+    # exists. Each of these must be exit 2, never 0.
+    def test_the_sentinel_ERROR_string_from_a_failed_live_read_is_CANNOT_DETERMINE(self):
+        result = run_cli("ERROR")
+        assert result.returncode == 2
+        assert "CANNOT DETERMINE" in result.stderr
+
+    def test_unparseable_json_is_CANNOT_DETERMINE(self):
+        result = run_cli("{not valid json")
+        assert result.returncode == 2
+        assert "CANNOT DETERMINE" in result.stderr
+
+    def test_an_empty_list_is_CANNOT_DETERMINE_not_a_pass(self):
+        # THE TRAP THIS ISSUE IS NAMED FOR: zero rows must never read as
+        # "zero violations". At least `standard` always exists.
+        result = run_cli("[]")
+        assert result.returncode == 2
+        assert "CANNOT DETERMINE" in result.stderr
+        assert "zero rows" in result.stderr
+
+    def test_a_json_object_instead_of_a_list_is_CANNOT_DETERMINE(self):
+        result = run_cli(json.dumps({"not": "a list"}))
+        assert result.returncode == 2


### PR DESCRIPTION
## Summary

Addresses part of h#845 (the #596-specific ceiling-assertion instance only — h#845 itself explicitly says not to close it on this fix alone; the general Loki-ruler/LogQL log-content-alerting question it raises remains open). Sequencing: this PR carries the alert/check half in Hill90; the ceilings it reads come from hill90-app#596 (already merged the fix for a review finding on the constant duplication — see that PR).

hill90-app#593 added `containerProfileCeilingViolations()` with two arms: a test fixture (can't see a profile added tomorrow) and a startup check against the live table (can see it, but only `console.error()`s — nothing reads it). h#845 named this the estate's own "alarm with no reader" shape, recurring.

**hill90-app#598 checked first, per instruction**, whether the api already exposes Prometheus metrics: it does not (no `prom-client`, no `/metrics` route, no scrape job in this repo's `prometheus.yml`). Stopped there rather than building a metrics pipeline unilaterally.

**Decision made here: not a new metrics pipeline.** `deploy-drift.yml` already SSHes into the VPS every four hours, already has Tailscale/SSH/SOPS wired, and already has a reader (the `workflow_run` watchdog, plus the scheduled-workflow-not-triggering alarm). A rare, near-static condition fits a scheduled query better than a scraped series — reuse, not new machinery.

## Where the ceilings come from — not a hardcoded copy

`MAX_AGENT_CPUS`/`MAX_AGENT_MEM_BYTES`/`MAX_AGENT_PIDS_LIMIT` live in hill90-app's `services/api/src/helpers/agent-resource-limits.ts` (consolidated there by hill90-app#596's own review). This workflow sparse-checks-out that one file from hill90-app on every run and greps the three `export const MAX_AGENT_*` lines directly — always comparing against whatever hill90-app's main branch currently says, never a number typed here once.

`-U hill90`, not `-U postgres` (doesn't exist) and not the tenant's own `hill90_app` role — the platform admin role every other cross-cutting check in this repo already uses.

## Cannot-determine is distinct from pass — the named constraint

An unreachable host, a failed query, an unparseable ceiling extraction, or an **empty** profiles result all exit 2, never 0. `standard` is seeded on every bootstrap, so zero rows is itself suspicious — the same shape app#791's own "an unauthenticated `bao list` returns empty" trap, one level over.

## Test plan

- [x] `tests/checks/test_check_container_profile_ceilings.py` (17 tests): pure comparison against the real live rows; **positive control** raising `browser.default_pids_limit` to 301, exactly one violation named; boundary twin at 300; independent per-field/multi-profile coverage; CLI exercised for all three exit codes including every distinct cannot-determine case (the `ERROR` sentinel, bad JSON, a non-list, and an **empty list** specifically).
- [x] **Live positive control**, not merely valid to an isolated script: spun up a throwaway local Postgres (never the VPS), seeded the real three rows, ran the check through the exact SQL + JSON pipeline the workflow uses — passed clean. Set a genuine violation — failed cleanly, named exactly. Reverted — clean again. Emptied the table — CANNOT DETERMINE, not a pass. Scratch container removed, production never touched.
- [x] Verified the extraction regex against the real, current `agent-resource-limits.ts`: `cpus=4 mem=16761118720 pids=300` — exact match.
- [x] Full `tests/checks/` suite: 111 passed, 1 skipped (pre-existing), no regressions. YAML parses. `check_checks_are_wired.py` reports the new script wired. `check_destructive_commands.sh`/`check_argv_secrets.sh` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

