### PR TITLE
fix(auth): close residual read-failure gap in remove_realm_roles() composite-parents check

### DIFF
--- a/scripts/keycloak.sh
+++ b/scripts/keycloak.sh
@@ -323,12 +323,49 @@ remove_realm_roles() {
             failed=1
             continue
         fi
-        parents=$(printf '%s' "$roles_raw" | while read -r other; do
+        # h#746 (residual): the outer roles_raw read above was fixed to
+        # refuse on failure, but the INNER per-candidate composites lookup,
+        # one `kc get` per role in this loop, was not — the exact same
+        # `... | grep -qx ... && echo` shape, just one level deeper.
+        # Verified live (a real local Keycloak, never production): a role
+        # that genuinely WAS a composite parent moments earlier, whose
+        # per-role lookup then fails (its own removal between the outer
+        # list and this loop reaching it — a real TOCTOU, not contrived —
+        # or equally a network blip), silently contributed nothing to
+        # `parents`, exactly like the outer reads used to.
+        #
+        # The loop body runs in a subshell (it is the left side of a pipe
+        # into `grep -c .`), so a failing inner `kc get` cannot set a
+        # variable the outer scope can see directly — a marker file is the
+        # established way past that boundary, checked once the loop ends.
+        #
+        # `|| [ -n "$other" ]` matters and is not defensive boilerplate:
+        # $(...) command substitution always strips the trailing newline
+        # from $roles_raw, so without this, `read` hits EOF on the LAST
+        # role in the list, returns non-zero despite having populated
+        # $other, and the while loop exits before running the body for
+        # it — silently skipping the last candidate's composites check
+        # every single time, found empirically (bats stub test, the
+        # candidate list's last entry was exactly the one whose read was
+        # made to fail, and the failure went undetected).
+        local parents_fail_marker; parents_fail_marker=$(mktemp)
+        parents=$(printf '%s' "$roles_raw" | while read -r other || [ -n "$other" ]; do
             [ -n "$other" ] || continue
             [ "$other" = "$role" ] && continue
-            kc get "roles/${other}/composites" -r "$KC_REALM" --fields name --format csv --noquotes 2>/dev/null \
-                | tr -d '\r' | grep -qx "$role" && echo "$other"
+            local composites_raw
+            if ! composites_raw=$(kc get "roles/${other}/composites" -r "$KC_REALM" --fields name --format csv --noquotes 2>/dev/null | tr -d '\r'); then
+                echo "1" >> "$parents_fail_marker"
+                continue
+            fi
+            printf '%s' "$composites_raw" | grep -qx "$role" && echo "$other"
         done | grep -c . || true)
+        if [ -s "$parents_fail_marker" ]; then
+            rm -f "$parents_fail_marker"
+            warn "  ! ${role} NOT deleted — could not read composites for at least one candidate parent role (the query failed). A failed read is not the same as zero holders; retirement is blocked until it succeeds."
+            failed=1
+            continue
+        fi
+        rm -f "$parents_fail_marker"
 
         if [ "$users" -ne 0 ] || [ "$groups" -ne 0 ] || [ "$parents" -ne 0 ]; then
             warn "  ! ${role} NOT deleted — holders found (users=${users} groups=${groups} composite-parents=${parents}). Retirement is blocked until it has none; do not force it."

--- a/tests/scripts/keycloak-role-holder-read-failure.bats
+++ b/tests/scripts/keycloak-role-holder-read-failure.bats
@@ -20,7 +20,8 @@ setup() {
   PATH="$STUB:$PATH"
 }
 
-# $1 = "users-fail" | "groups-fail" | "roles-fail" | "has-holders" | "clean"
+# $1 = "users-fail" | "groups-fail" | "roles-fail" | "inner-composite-fail" |
+#      "has-holders" | "clean"
 make_docker_stub() {
   local mode="$1"
   local counter="$BATS_TEST_TMPDIR/roles-call-count"
@@ -40,13 +41,18 @@ case "\$sub \$target" in
     # check the role still exists, once per role inside the composite-
     # parents check. roles-fail must let the FIRST through (so the loop is
     # reached at all) and fail the SECOND — the one this fix actually
-    # guards.
+    # guards. inner-composite-fail needs a SECOND role name in both calls
+    # so the composite-parents loop below has a candidate other than
+    # "admin" itself to iterate over.
     n=\$(cat "\$COUNTER"); n=\$((n + 1)); echo "\$n" > "\$COUNTER"
     if [ "\$MODE" = "roles-fail" ] && [ "\$n" -ge 2 ]; then
       echo "kcadm: connection refused" >&2
       exit 1
     fi
     echo "admin"
+    if [ "\$MODE" = "inner-composite-fail" ]; then
+      echo "other-role"
+    fi
     exit 0
     ;;
   "get roles/admin/users")
@@ -67,6 +73,21 @@ case "\$sub \$target" in
     exit 0
     ;;
   "get roles/admin/composites")
+    exit 0
+    ;;
+  "get roles/other-role/composites")
+    # The residual gap this fix closes: the OUTER "kc get roles" list read
+    # (and users/groups) already refused on failure before this fix. This
+    # is one level deeper — the PER-CANDIDATE composites lookup inside the
+    # loop that builds that same outer list's answer. A real TOCTOU (the
+    # candidate role is removed between the outer snapshot and this lookup
+    # reaching it) produces exactly this: the outer "get roles" call that
+    # named "other-role" already succeeded, but asking for ITS composites
+    # now fails.
+    if [ "\$MODE" = "inner-composite-fail" ]; then
+      echo "kcadm: connection refused" >&2
+      exit 1
+    fi
     exit 0
     ;;
   "delete roles/admin")
@@ -120,4 +141,19 @@ run_remove() {
   run run_remove
   [[ "$output" != *"deleted (0 users, 0 groups, 0 composite parents)"* ]]
   [[ "$output" == *"could not read the realm's role list"* ]]
+}
+
+@test "THE RESIDUAL GAP: a failed per-candidate composites read (one level inside the loop) refuses the delete" {
+  # This is the case the outer roles-fail test above does NOT cover: the
+  # outer "kc get roles" list read succeeds and names "other-role" as a
+  # candidate, but asking for THAT role's own composites then fails — a
+  # realistic TOCTOU (the candidate is removed between the outer snapshot
+  # and this loop reaching it) or a plain network blip on one call among
+  # many. Before this fix, a failure here silently contributed nothing to
+  # the parents count, exactly like the already-fixed outer reads used to.
+  make_docker_stub "inner-composite-fail"
+  run run_remove
+  [[ "$output" != *"deleted (0 users, 0 groups, 0 composite parents)"* ]]
+  [[ "$output" == *"could not read composites for at least one candidate parent role"* ]]
+  [[ "$output" != *"NOT deleted — holders found"* ]]
 }


### PR DESCRIPTION
Closes #746.

## What this fixes

h#746's top-ranked finding: `remove_realm_roles()` decides whether a
retired realm role is safe to delete by checking three things — users,
groups, composite parents — and a transient read failure on any of them
used to be indistinguishable from a genuine "zero holders" result
(`grep -c . || true` on empty stdin prints `"0"` and swallows the exit
code). The outer users/groups/role-list reads were already fixed on
`main` before this branch was cut. This PR closes the one that survived:
the **per-candidate composites lookup inside the composite-parents
loop** — one `kc get` per other role in the realm — had no failure
check at all.

## What I verified before fixing

Empirically, against a disposable local Keycloak 26.4.0 (**never
production**, torn down after): a role that was a genuine composite
parent, whose own composites lookup then fails (a realistic TOCTOU —
the candidate role is removed between the outer role-list snapshot and
this loop reaching it — or a plain network blip), silently contributed
nothing to the `parents` count. Same defect shape as the already-fixed
outer reads, one call site deeper. Not a hypothesis — reproduced and
observed `parents=0` on a role that had a real composite parent moments
earlier.

## The fix

Captures the inner `kc get roles/${other}/composites`'s own exit
status. The loop body runs in a subshell (left side of a pipe into
`grep -c .`), so a failing inner read can't set a variable the outer
scope can see directly — a `mktemp` marker file crosses that boundary,
checked once the loop ends, and a failure routes into the same "NOT
deleted — could not read..." refuse-to-delete branch the outer reads
already use. "Cannot tell" now blocks the delete on every one of the
three checks, not just the outer two.

## A second, independent defect the fix's own test surfaced

Building the positive control (a bats scenario where the *last* role
name in the candidate list is exactly the one whose read is made to
fail) exposed that `printf '%s' "$roles_raw" | while read -r other; do
... done` was silently **never running the loop body for the last
role in the list at all** — for every role, not just failure cases.
`$(...)` command substitution always strips the trailing newline, so on
the final line `read` populates the variable but returns non-zero
(EOF, not a delimiter), and `while read` exits before that iteration's
body runs. This predates h#746 (it's a structural blind spot in
iterating the list, not a failure-handling gap), but it lives in the
exact loop this PR touches and would have silently defeated the marker
mechanism above for the list's last entry, so it's fixed in the same
change: `while read -r other || [ -n "$other" ]`, the standard idiom.

## Sibling-path check (h#749's shape — the reason to look)

Grepped the file for `while read` — this loop is the only instance, so
the trailing-newline gap has no other occurrence to fix. Checked every
other `kc get ... | tr -d '\r'` read in the file for the same
"failure reads as zero, gates a deletion" shape:
- `remove_realm_roles_mapper()` — ruled out. A failed read produces an
  empty parsed list and the deletion loop does nothing: fail-safe, not
  fail-dangerous.
- The remaining raw-value reads (name lists, a client UUID, a client
  secret) are consumed directly, not used as a count gating a
  destructive decision.

Nothing else in the file shares h#746's shape.

## Positive control — both arms, and where they ran

**Local Keycloak only, never production, torn down afterward.**

1. Forced the composites read to fail for a genuine composite-parent
   candidate → the guard refuses deletion of both roles under test,
   naming the read failure ("could not read composites... A failed
   read is not the same as zero holders; retirement is blocked until
   it succeeds").
2. No forced failure → a genuine zero-holder role still deletes
   normally, and a genuine composite-parent role is still correctly
   refused, but for the *right* reason (`composite-parents=1`), not the
   new failure-detection path.

## Tests

`tests/scripts/keycloak-role-holder-read-failure.bats` — added test 6
for the residual gap, using a `docker` stub (no real Keycloak). Negative
control: reverting only this commit's hunk in `scripts/keycloak.sh`
makes exactly test 6 fail, at exactly the `could not read composites`
assertion; all 6 pass restored.

```
1..6
ok 1 clean read, zero holders: the role is genuinely deleted
ok 2 clean read, real holders: the role is correctly NOT deleted
ok 3 THE CASE THAT MATTERS: a failed USERS read refuses the delete, names the read failure, not holders
ok 4 a failed GROUPS read also refuses the delete, distinct message from the users case
ok 5 a failed realm ROLE LIST read (the composite-parents check's own source) refuses the delete
ok 6 THE RESIDUAL GAP: a failed per-candidate composites read (one level inside the loop) refuses the delete
```

`bash -n scripts/keycloak.sh` — OK. `shellcheck` — no new findings on
the modified lines (pre-existing info-level SC2015/SC2016/SC2086
elsewhere in the file, untouched by this change).

## Note on timing

Pushed while GitHub Actions is in a known partial outage (jobs failing
at "Set up job" with zero test output) — if CI shows red on this PR for
that reason, it isn't a real failure; will re-check once Actions
recovers.