### PR TITLE
fix(auth): catch a realm-import substitution that installs a public placeholder as hill90-ui's client secret

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -339,6 +339,17 @@ jobs:
       - name: Prove the platform realm actually serves the tenant
         run: bash scripts/checks/realm-tenant-serves-test.sh
 
+      # h#835: hill90-ui's client secret is deliberately NOT guarded at the
+      # compose level (fad9fefa — it is legitimately unset on every routine
+      # auth deploy after the first import), so a first import running with
+      # it unset succeeds silently and installs the literal, unsubstituted
+      # string "${HILL90_UI_CLIENT_SECRET}" as the client secret fronting
+      # hill90.com — readable in this PUBLIC repo's own platform-realm.json.
+      # Same shape as the step above: builds and destroys its own throwaway
+      # Keycloak containers, only Docker required, no live secret involved.
+      - name: Prove a realm-import substitution failure is caught, not silently installed
+        run: bash scripts/checks/realm-secret-substitution-test.sh
+
       - name: Setup Python
         uses: actions/setup-python@v5
         with:

--- a/scripts/checks/check_realm_secret_not_literal.sh
+++ b/scripts/checks/check_realm_secret_not_literal.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# Assert that after a realm import, no Keycloak client secret is an
+# unsubstituted ${...} placeholder — h#835.
+#
+# THE FAILURE THIS CATCHES: platform-realm.json declares hill90-vault's and
+# hill90-ui's secrets as ${VAULT_OIDC_CLIENT_SECRET} / ${HILL90_UI_CLIENT_SECRET}.
+# `start --import-realm` substitutes them from the container's environment.
+# VAULT_OIDC_CLIENT_SECRET is guarded at the compose level (${VAR:?...}), so a
+# deploy with it unset refuses before Keycloak ever starts. HILL90_UI_CLIENT_SECRET
+# is deliberately NOT guarded there (fad9fefa) — it is legitimately unset on
+# every routine `auth` deploy after the first import, and a compose-level guard
+# would refuse every one of those. So an import that runs with it unset (a VPS
+# rebuild, specifically) succeeds silently, and the resulting client secret for
+# hill90-ui — the client fronting hill90.com — is the literal, unsubstituted
+# string "${HILL90_UI_CLIENT_SECRET}". This repository is public, so that exact
+# string is readable in platform-realm.json by anyone, without needing to guess it.
+#
+# WHY THIS IS NOT check_env_surface.py'S JOB: that check already guarantees (its
+# rule 4) that HILL90_UI_CLIENT_SECRET carries no non-empty compose default, which
+# stops a KNOWN bad value from ever being configured as a silent fallback. It is a
+# static check of the compose YAML text. It cannot see what THIS script checks:
+# Keycloak's own import-time substitution behavior when the variable is genuinely
+# absent, which only exists once a real import has actually run. That is why this
+# has to ask a live realm, not read the template file — platform-realm.json always
+# contains the literal ${...} placeholder, correctly, and always will.
+#
+# WHY THIS IS SCOPED THE WAY IT IS, DELIBERATELY NARROW: this checks exactly one
+# shape — a ${...}-looking literal landing as a CLIENT SECRET after an import —
+# not a general realm validator. It generalises to any future templated secret
+# field without being rewritten, but it does not grow into checking anything else
+# about the realm.
+#
+# "CANNOT DETERMINE" IS NOT "PASS": an unreachable Keycloak, a failed admin login,
+# or an empty client list must never read as "no placeholder found" — each is its
+# own distinct outcome. An empty query result silently passing as clean is the
+# exact trap this repo has already named once (h#736/h#758's shape, applied here
+# to a query result instead of a check-invocation record).
+#
+# Usage:
+#   check_realm_secret_not_literal.sh <container> <realm> <admin-user> <admin-password>
+#
+# Exit codes:
+#   0  PASS               every confidential client's secret is real, not a ${...} literal
+#   1  PLACEHOLDER FOUND   at least one client secret IS an unsubstituted ${...} literal
+#   2  CANNOT DETERMINE    Keycloak unreachable, admin auth failed, or the client query was empty/unparseable
+set -uo pipefail
+
+# argv-ok: this script's admin-password argument is only ever a disposable
+# throwaway credential for a container the CALLER creates and destroys (see
+# realm-secret-substitution-test.sh) — never a real one. Production reuses
+# keycloak.sh's own already-authenticated kc() session instead of calling
+# this script at all (verify_realm_secrets_substituted, wired into
+# cmd_apply), for exactly the reason kc_login itself passes the real admin
+# password through the environment rather than argv.
+CONTAINER="${1:?Usage: check_realm_secret_not_literal.sh <container> <realm> <admin-user> <admin-password>}"
+REALM="${2:?realm required}"
+ADMIN_USER="${3:?admin user required}"
+ADMIN_PW="${4:?admin password required}"
+
+say()  { printf '%s\n' "$*"; }
+fail() { printf '::error::%s\n' "$*" >&2; }
+
+kc() { docker exec "$CONTAINER" /opt/keycloak/bin/kcadm.sh "$@" 2>&1; }
+
+if ! docker inspect "$CONTAINER" >/dev/null 2>&1; then
+    fail "CANNOT DETERMINE: container '${CONTAINER}' does not exist — Keycloak is unreachable, not proven clean."
+    exit 2
+fi
+
+# argv-ok: caller-supplied credentials for a container this script does not
+# create or own; same pattern as realm-tenant-serves-test.sh's own kcadm login.
+if ! kc config credentials --server http://127.0.0.1:8080 --realm master \
+       --user "$ADMIN_USER" --password "$ADMIN_PW" >/dev/null 2>&1; then
+    fail "CANNOT DETERMINE: kcadm admin login failed against '${CONTAINER}' — cannot query client secrets, not proven clean."
+    exit 2
+fi
+
+CLIENTS_RAW=$(kc get clients -r "$REALM" --fields id,clientId,publicClient --format csv --noquotes 2>/dev/null | tr -d '\r')
+if [ -z "$CLIENTS_RAW" ]; then
+    fail "CANNOT DETERMINE: the client list for realm '${REALM}' came back empty. An empty result is not the same as 'no placeholders found' — it usually means the query itself failed. Not proven clean."
+    exit 2
+fi
+
+say "Checking every confidential client's secret in realm '${REALM}' for an unsubstituted \${...} literal"
+found=0
+checked=0
+while IFS=, read -r id client_id public; do
+    [ -n "$id" ] || continue
+    if [ "$public" = "true" ]; then
+        say "  ${client_id}: public client, no secret to check — skipped"
+        continue
+    fi
+    secret_raw=$(kc get "clients/${id}/client-secret" -r "$REALM" --fields value --format csv --noquotes 2>/dev/null | tr -d '\r')
+    if [ -z "$secret_raw" ]; then
+        # A confidential client can legitimately have no stored secret (e.g. a
+        # bearer-only client Keycloak never issued a login secret for) — that
+        # is absence, not a substitution failure, so it is reported and
+        # skipped rather than treated as CANNOT DETERMINE for the whole run.
+        say "  ${client_id}: confidential, no secret value returned — skipped (not a substitution failure)"
+        continue
+    fi
+    checked=$((checked + 1))
+    if [[ "$secret_raw" =~ ^\$\{[A-Za-z0-9_]+\}$ ]]; then
+        fail "PLACEHOLDER FOUND: client '${client_id}' secret is the literal unsubstituted string '${secret_raw}' — the import ran with the backing variable unset or empty, and the client secret is now a public template value."
+        found=1
+    else
+        say "  ${client_id}: secret substituted (not a literal placeholder)"
+    fi
+done <<< "$CLIENTS_RAW"
+
+if [ "$checked" -eq 0 ]; then
+    fail "CANNOT DETERMINE: no confidential client returned a secret to check at all — not proven clean."
+    exit 2
+fi
+
+if [ "$found" -eq 1 ]; then
+    exit 1
+fi
+say "PASS: checked ${checked} confidential client secret(s) in realm '${REALM}' — none is an unsubstituted \${...} literal."
+exit 0

--- a/scripts/checks/check_realm_secret_not_literal.sh
+++ b/scripts/checks/check_realm_secret_not_literal.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Assert that after a realm import, no Keycloak client secret is an
-# unsubstituted ${...} placeholder — h#835.
+# unsubstituted ${...} placeholder OR EMPTY — h#835, hardened by h#849.
 #
 # THE FAILURE THIS CATCHES: platform-realm.json declares hill90-vault's and
 # hill90-ui's secrets as ${VAULT_OIDC_CLIENT_SECRET} / ${HILL90_UI_CLIENT_SECRET}.
@@ -15,34 +15,53 @@
 # string "${HILL90_UI_CLIENT_SECRET}". This repository is public, so that exact
 # string is readable in platform-realm.json by anyone, without needing to guess it.
 #
+# h#849: the FIRST version of this script queried each client's secret via the
+# /client-secret sub-endpoint in CSV form and treated ANY empty result as "no
+# secret, skip" — including HILL90_UI_CLIENT_SECRET="" (set but EMPTY, not
+# unset), which produces exit 0 with EMPTY output from that endpoint,
+# byte-identical to a client that genuinely has no secret credential at all
+# (broker, hill90-api, realm-management — verified live). The check ran
+# against the exact case its own message claimed to cover ("unset OR EMPTY")
+# and returned PASS.
+#
+# FIXED by querying the client LIST once, in JSON, and using PRESENCE of the
+# `secret` key — not its value — as the discriminator. Verified live: clients
+# Keycloak never assigned a secret to have NO `secret` key in their JSON at
+# all; clients platform-realm.json explicitly gives a `secret` field to
+# always have the key, whether its value is real, empty, or a literal
+# placeholder. Key-presence distinguishes "nothing to check" from "something
+# to check that turned out empty" — value-emptiness cannot, because both look
+# identical.
+#
 # WHY THIS IS NOT check_env_surface.py'S JOB: that check already guarantees (its
 # rule 4) that HILL90_UI_CLIENT_SECRET carries no non-empty compose default, which
 # stops a KNOWN bad value from ever being configured as a silent fallback. It is a
 # static check of the compose YAML text. It cannot see what THIS script checks:
 # Keycloak's own import-time substitution behavior when the variable is genuinely
-# absent, which only exists once a real import has actually run. That is why this
-# has to ask a live realm, not read the template file — platform-realm.json always
-# contains the literal ${...} placeholder, correctly, and always will.
+# absent OR empty, which only exists once a real import has actually run. That is
+# why this has to ask a live realm, not read the template file — platform-realm.json
+# always contains the literal ${...} placeholder, correctly, and always will.
 #
-# WHY THIS IS SCOPED THE WAY IT IS, DELIBERATELY NARROW: this checks exactly one
-# shape — a ${...}-looking literal landing as a CLIENT SECRET after an import —
-# not a general realm validator. It generalises to any future templated secret
-# field without being rewritten, but it does not grow into checking anything else
-# about the realm.
+# WHY THIS IS SCOPED THE WAY IT IS, DELIBERATELY NARROW: this checks exactly two
+# shapes on a client secret after import — a ${...}-looking literal, and an empty
+# value — not a general realm validator. It generalises to any future templated
+# secret field without being rewritten, but it does not grow into checking
+# anything else about the realm.
 #
 # "CANNOT DETERMINE" IS NOT "PASS": an unreachable Keycloak, a failed admin login,
-# or an empty client list must never read as "no placeholder found" — each is its
-# own distinct outcome. An empty query result silently passing as clean is the
-# exact trap this repo has already named once (h#736/h#758's shape, applied here
-# to a query result instead of a check-invocation record).
+# a failed client-list query, or a realm with no confidential-and-secret-bearing
+# client at all must never read as "no problem found" — each is its own distinct
+# outcome. An empty query result silently passing as clean is the exact trap this
+# repo has already named once (h#736/h#758's shape, applied here to a query result
+# instead of a check-invocation record).
 #
 # Usage:
 #   check_realm_secret_not_literal.sh <container> <realm> <admin-user> <admin-password>
 #
 # Exit codes:
-#   0  PASS               every confidential client's secret is real, not a ${...} literal
-#   1  PLACEHOLDER FOUND   at least one client secret IS an unsubstituted ${...} literal
-#   2  CANNOT DETERMINE    Keycloak unreachable, admin auth failed, or the client query was empty/unparseable
+#   0  PASS               every confidential client's secret is real: non-empty, not a ${...} literal
+#   1  PROBLEM FOUND       at least one client secret is empty OR an unsubstituted ${...} literal
+#   2  CANNOT DETERMINE    Keycloak unreachable, admin auth failed, the client-list query failed, or no confidential client has a secret key at all
 set -uo pipefail
 
 # argv-ok: this script's admin-password argument is only ever a disposable
@@ -75,46 +94,89 @@ if ! kc config credentials --server http://127.0.0.1:8080 --realm master \
     exit 2
 fi
 
-CLIENTS_RAW=$(kc get clients -r "$REALM" --fields id,clientId,publicClient --format csv --noquotes 2>/dev/null | tr -d '\r')
-if [ -z "$CLIENTS_RAW" ]; then
-    fail "CANNOT DETERMINE: the client list for realm '${REALM}' came back empty. An empty result is not the same as 'no placeholders found' — it usually means the query itself failed. Not proven clean."
+say "Checking every confidential client's secret in realm '${REALM}' for empty or unsubstituted \${...} values"
+
+CLIENTS_JSON=""
+if ! CLIENTS_JSON=$(kc get clients -r "$REALM" 2>/dev/null); then
+    fail "CANNOT DETERMINE: the client list query for realm '${REALM}' failed. Not proven clean."
     exit 2
 fi
 
-say "Checking every confidential client's secret in realm '${REALM}' for an unsubstituted \${...} literal"
-found=0
-checked=0
-while IFS=, read -r id client_id public; do
-    [ -n "$id" ] || continue
-    if [ "$public" = "true" ]; then
-        say "  ${client_id}: public client, no secret to check — skipped"
+CLASSIFICATION=""
+if CLASSIFICATION=$(CLIENTS_JSON="$CLIENTS_JSON" python3 <<'PYEOF'
+import sys, json, os, re
+
+PLACEHOLDER_RE = re.compile(r'^\$\{[A-Za-z0-9_]+\}$')
+
+try:
+    clients = json.loads(os.environ["CLIENTS_JSON"])
+except Exception as e:
+    print(f"CANNOT_DETERMINE unparseable JSON: {e}")
+    sys.exit(3)
+
+if not isinstance(clients, list):
+    print("CANNOT_DETERMINE client list was not a JSON array")
+    sys.exit(3)
+
+checked = 0
+lines = []
+failed = False
+for c in clients:
+    if c.get("publicClient") is True:
         continue
-    fi
-    secret_raw=$(kc get "clients/${id}/client-secret" -r "$REALM" --fields value --format csv --noquotes 2>/dev/null | tr -d '\r')
-    if [ -z "$secret_raw" ]; then
-        # A confidential client can legitimately have no stored secret (e.g. a
-        # bearer-only client Keycloak never issued a login secret for) — that
-        # is absence, not a substitution failure, so it is reported and
-        # skipped rather than treated as CANNOT DETERMINE for the whole run.
-        say "  ${client_id}: confidential, no secret value returned — skipped (not a substitution failure)"
+    if "secret" not in c:
+        print(f"  {c.get('clientId')}: confidential, no secret key at all — skipped (not a substitution failure)", file=sys.stderr)
         continue
-    fi
-    checked=$((checked + 1))
-    if [[ "$secret_raw" =~ ^\$\{[A-Za-z0-9_]+\}$ ]]; then
-        fail "PLACEHOLDER FOUND: client '${client_id}' secret is the literal unsubstituted string '${secret_raw}' — the import ran with the backing variable unset or empty, and the client secret is now a public template value."
+    checked += 1
+    value = c.get("secret")
+    client_id = c.get("clientId")
+    if not value:
+        lines.append(f"EMPTY {client_id}")
+        failed = True
+    elif PLACEHOLDER_RE.match(value):
+        lines.append(f"PLACEHOLDER {client_id} {value}")
+        failed = True
+    else:
+        print(f"  {client_id}: secret substituted (not empty, not a literal placeholder)", file=sys.stderr)
+
+if checked == 0:
+    print("CANNOT_DETERMINE no confidential client has a secret key at all")
+    sys.exit(3)
+
+if failed:
+    for line in lines:
+        print(line)
+    sys.exit(1)
+
+print(f"PASS {checked}")
+sys.exit(0)
+PYEOF
+); then
+    PY_STATUS=0
+else
+    PY_STATUS=$?
+fi
+
+if [ "$PY_STATUS" -eq 3 ]; then
+    fail "CANNOT DETERMINE: ${CLASSIFICATION#CANNOT_DETERMINE }. Not proven clean."
+    exit 2
+fi
+
+if [ "$PY_STATUS" -eq 1 ]; then
+    found=0
+    while IFS=' ' read -r kind client_id detail; do
+        [ -n "$kind" ] || continue
         found=1
-    else
-        say "  ${client_id}: secret substituted (not a literal placeholder)"
-    fi
-done <<< "$CLIENTS_RAW"
-
-if [ "$checked" -eq 0 ]; then
-    fail "CANNOT DETERMINE: no confidential client returned a secret to check at all — not proven clean."
-    exit 2
-fi
-
-if [ "$found" -eq 1 ]; then
+        if [ "$kind" = "EMPTY" ]; then
+            fail "EMPTY SECRET: client '${client_id}' secret is empty — the import ran with the backing variable set but EMPTY. A confidential client with an empty secret is a broken auth state, not a substitution success."
+        else
+            fail "PLACEHOLDER FOUND: client '${client_id}' secret is the literal unsubstituted string '${detail}' — the import ran with the backing variable unset, and the client secret is now a public template value."
+        fi
+    done <<< "$CLASSIFICATION"
+    [ "$found" -eq 1 ] || fail "CANNOT DETERMINE: a problem was reported but no line could be parsed from it: ${CLASSIFICATION}"
     exit 1
 fi
-say "PASS: checked ${checked} confidential client secret(s) in realm '${REALM}' — none is an unsubstituted \${...} literal."
+
+checked_count="${CLASSIFICATION#PASS }"
+say "PASS: checked ${checked_count} confidential client secret(s) in realm '${REALM}' — none empty, none an unsubstituted \${...} literal."
 exit 0

--- a/scripts/checks/realm-secret-substitution-test.sh
+++ b/scripts/checks/realm-secret-substitution-test.sh
@@ -26,8 +26,9 @@ ok()  { echo -e "  ${GREEN}✓${NC} $1"; pass=$((pass+1)); }
 bad() { echo -e "  ${RED}✗${NC} $1"; fail=$((fail+1)); }
 
 FAIL_KC="h835test-fail-kc"
+EMPTY_KC="h849test-empty-kc"
 PASS_KC="h835test-pass-kc"
-cleanup() { docker rm -f "$FAIL_KC" "$PASS_KC" >/dev/null 2>&1 || true; }
+cleanup() { docker rm -f "$FAIL_KC" "$EMPTY_KC" "$PASS_KC" >/dev/null 2>&1 || true; }
 trap cleanup EXIT
 cleanup
 
@@ -46,6 +47,9 @@ start_kc() {
 wait_ready() {
     local name="$1"
     for _ in $(seq 1 60); do
+        # argv-ok: ADMIN_PW is the literal throwaway on line 21, in a
+        # container this script creates and destroys — same pattern as
+        # realm-tenant-serves-test.sh's own kcadm login.
         docker exec "$name" /opt/keycloak/bin/kcadm.sh config credentials \
             --server http://127.0.0.1:8080 --realm master \
             --user "$ADMIN" --password "$ADMIN_PW" >/dev/null 2>&1 && return 0
@@ -67,6 +71,27 @@ else
     bad "fail-arm Keycloak never became ready — could not run this arm at all"
 fi
 docker rm -f "$FAIL_KC" >/dev/null 2>&1
+
+echo ""
+echo -e "${BOLD}Arm 1b (h#849, THE CASE THE ORIGINAL CHECK MISSED): import with HILL90_UI_CLIENT_SECRET SET TO EMPTY STRING${NC}"
+# Empty and unset are NOT the same failure at the Keycloak API level, verified
+# live: an EMPTY value produces exit 0 with empty output from the
+# /client-secret endpoint — byte-identical to a client that genuinely has no
+# secret credential at all. The first version of this check treated both as
+# "nothing to check" and returned PASS against this exact case, even though
+# its own message already claimed to cover "unset OR EMPTY".
+start_kc "$EMPTY_KC" -e HILL90_UI_CLIENT_SECRET=
+if wait_ready "$EMPTY_KC"; then
+    out=$(bash "$CHECK" "$EMPTY_KC" platform "$ADMIN" "$ADMIN_PW" 2>&1); code=$?
+    if [ "$code" -eq 1 ] && echo "$out" | grep -q "EMPTY SECRET: client 'hill90-ui'"; then
+        ok "refused: exit 1, named hill90-ui and EMPTY (not the placeholder message)"
+    else
+        bad "expected exit 1 naming hill90-ui's empty secret, got exit ${code}: $out"
+    fi
+else
+    bad "empty-arm Keycloak never became ready — could not run this arm at all"
+fi
+docker rm -f "$EMPTY_KC" >/dev/null 2>&1
 
 echo ""
 echo -e "${BOLD}Arm 2: import with HILL90_UI_CLIENT_SECRET SET — must pass, and for the RIGHT reason${NC}"
@@ -97,9 +122,14 @@ out=$(bash "$CHECK" "$PASS_KC" platform "$ADMIN" "wrong-password" 2>&1); code=$?
 
 docker exec "$PASS_KC" /opt/keycloak/bin/kcadm.sh create realms -s realm=h835test-empty -s enabled=true >/dev/null 2>&1
 out=$(bash "$CHECK" "$PASS_KC" h835test-empty "$ADMIN" "$ADMIN_PW" 2>&1); code=$?
-[ "$code" -eq 2 ] && echo "$out" | grep -q "no confidential client returned a secret" \
+[ "$code" -eq 2 ] && echo "$out" | grep -q "no confidential client has a secret key at all" \
     && ok "a realm with no real client secret to check: exit 2 (THE TRAP — this must never read as a pass)" \
     || bad "an empty/no-secret realm did not produce CANNOT DETERMINE: exit ${code}: $out"
+
+out=$(bash "$CHECK" "$PASS_KC" nonexistent-realm-xyz "$ADMIN" "$ADMIN_PW" 2>&1); code=$?
+[ "$code" -eq 2 ] && echo "$out" | grep -q "client list query for realm 'nonexistent-realm-xyz' failed" \
+    && ok "a failed client-list query (bad realm): exit 2, not exit 0" \
+    || bad "a failed client-list query did not produce CANNOT DETERMINE: exit ${code}: $out"
 
 echo ""
 if [ "$fail" -eq 0 ]; then

--- a/scripts/checks/realm-secret-substitution-test.sh
+++ b/scripts/checks/realm-secret-substitution-test.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Prove check_realm_secret_not_literal.sh (h#835) in every arm it claims to
+# handle, against real disposable Keycloaks — never the VPS, never a shared
+# stack. Same discipline as realm-tenant-serves-test.sh: build and destroy its
+# own throwaway containers.
+#
+# Order matters and is deliberate: the FAILING arm runs first. A check that has
+# only ever been shown a clean result has not been shown anything — this repo's
+# own recurring lesson (h#736/h#758, the twin-drift bugs surfaced auditing this
+# very issue) is that an unexercised or vacuous-pass check is indistinguishable
+# from a working one until it is actually forced to fail.
+#
+# Usage: bash scripts/checks/realm-secret-substitution-test.sh
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CHECK="$ROOT/scripts/checks/check_realm_secret_not_literal.sh"
+IMG="quay.io/keycloak/keycloak:26.4.0"
+ADMIN="admin"
+# Disposable, for containers this script creates and destroys.
+ADMIN_PW="throwaway-not-a-real-credential"
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; BOLD='\033[1m'; NC='\033[0m'
+pass=0; fail=0
+ok()  { echo -e "  ${GREEN}✓${NC} $1"; pass=$((pass+1)); }
+bad() { echo -e "  ${RED}✗${NC} $1"; fail=$((fail+1)); }
+
+FAIL_KC="h835test-fail-kc"
+PASS_KC="h835test-pass-kc"
+cleanup() { docker rm -f "$FAIL_KC" "$PASS_KC" >/dev/null 2>&1 || true; }
+trap cleanup EXIT
+cleanup
+
+start_kc() {
+    local name="$1"; shift
+    docker run -d --name "$name" -P \
+        -e KC_BOOTSTRAP_ADMIN_USERNAME="$ADMIN" \
+        -e KC_BOOTSTRAP_ADMIN_PASSWORD="$ADMIN_PW" \
+        -e KC_HTTP_ENABLED=true \
+        -e VAULT_OIDC_CLIENT_SECRET=throwaway-vault-secret \
+        "$@" \
+        -v "$ROOT/platform/auth/keycloak/platform-realm.json:/opt/keycloak/data/import/platform-realm.json:ro" \
+        "$IMG" start-dev --import-realm >/dev/null
+}
+
+wait_ready() {
+    local name="$1"
+    for _ in $(seq 1 60); do
+        docker exec "$name" /opt/keycloak/bin/kcadm.sh config credentials \
+            --server http://127.0.0.1:8080 --realm master \
+            --user "$ADMIN" --password "$ADMIN_PW" >/dev/null 2>&1 && return 0
+        sleep 2
+    done
+    return 1
+}
+
+echo -e "${BOLD}Arm 1 (THE CASE THAT MATTERS, run first): import with HILL90_UI_CLIENT_SECRET UNSET${NC}"
+start_kc "$FAIL_KC"
+if wait_ready "$FAIL_KC"; then
+    out=$(bash "$CHECK" "$FAIL_KC" platform "$ADMIN" "$ADMIN_PW" 2>&1); code=$?
+    if [ "$code" -eq 1 ] && echo "$out" | grep -q "PLACEHOLDER FOUND: client 'hill90-ui'"; then
+        ok "refused: exit 1, named hill90-ui and the literal placeholder"
+    else
+        bad "expected exit 1 naming hill90-ui's placeholder, got exit ${code}: $out"
+    fi
+else
+    bad "fail-arm Keycloak never became ready — could not run this arm at all"
+fi
+docker rm -f "$FAIL_KC" >/dev/null 2>&1
+
+echo ""
+echo -e "${BOLD}Arm 2: import with HILL90_UI_CLIENT_SECRET SET — must pass, and for the RIGHT reason${NC}"
+start_kc "$PASS_KC" -e HILL90_UI_CLIENT_SECRET=real-tenant-ui-secret-0123456789
+if wait_ready "$PASS_KC"; then
+    out=$(bash "$CHECK" "$PASS_KC" platform "$ADMIN" "$ADMIN_PW"); code=$?
+    if [ "$code" -eq 0 ] && echo "$out" | grep -q "checked 2 confidential client secret"; then
+        ok "passed: exit 0, both confidential clients (hill90-ui, hill90-vault) checked"
+    else
+        bad "expected exit 0 having checked 2 clients, got exit ${code}: $out"
+    fi
+else
+    bad "pass-arm Keycloak never became ready — could not run this arm at all"
+fi
+
+echo ""
+echo -e "${BOLD}Arm 3: CANNOT DETERMINE must be distinct from PASS, in every way it can arise${NC}"
+
+out=$(bash "$CHECK" h835test-does-not-exist platform "$ADMIN" "$ADMIN_PW" 2>&1); code=$?
+[ "$code" -eq 2 ] && echo "$out" | grep -q "CANNOT DETERMINE.*does not exist" \
+    && ok "unreachable container: exit 2, not exit 0" \
+    || bad "unreachable container did not produce CANNOT DETERMINE: exit ${code}: $out"
+
+out=$(bash "$CHECK" "$PASS_KC" platform "$ADMIN" "wrong-password" 2>&1); code=$?
+[ "$code" -eq 2 ] && echo "$out" | grep -q "CANNOT DETERMINE.*login failed" \
+    && ok "bad admin credentials: exit 2, not exit 0" \
+    || bad "bad admin credentials did not produce CANNOT DETERMINE: exit ${code}: $out"
+
+docker exec "$PASS_KC" /opt/keycloak/bin/kcadm.sh create realms -s realm=h835test-empty -s enabled=true >/dev/null 2>&1
+out=$(bash "$CHECK" "$PASS_KC" h835test-empty "$ADMIN" "$ADMIN_PW" 2>&1); code=$?
+[ "$code" -eq 2 ] && echo "$out" | grep -q "no confidential client returned a secret" \
+    && ok "a realm with no real client secret to check: exit 2 (THE TRAP — this must never read as a pass)" \
+    || bad "an empty/no-secret realm did not produce CANNOT DETERMINE: exit ${code}: $out"
+
+echo ""
+if [ "$fail" -eq 0 ]; then
+    echo -e "${GREEN}${BOLD}All ${pass} assertions passed.${NC}"; exit 0
+fi
+echo -e "${RED}${BOLD}${fail} failed, ${pass} passed.${NC}"; exit 1

--- a/scripts/keycloak.sh
+++ b/scripts/keycloak.sh
@@ -538,35 +538,126 @@ print(json.dumps({
 # Deliberately narrow: this checks exactly one shape — a ${...}-looking literal
 # landing as a CLIENT SECRET after an import — not a general realm validator.
 verify_realm_secrets_substituted() {
-    local clients_raw
-    clients_raw=$(kc get clients -r "$KC_REALM" --fields id,clientId,publicClient --format csv --noquotes 2>/dev/null | tr -d '\r')
-    if [ -z "$clients_raw" ]; then
-        warn "  ! Could not verify client secrets are substituted — the client list for realm '${KC_REALM}' came back empty. Not proven clean; treating as a failure, not a pass."
+    # h#849 review of h#835: the original version queried each confidential
+    # client's secret via the /client-secret sub-endpoint with
+    # `--format csv --noquotes` and treated ANY empty result as "no secret,
+    # skip" — `[ -n "$secret_raw" ] || continue`, discarding the query's own
+    # exit status via `2>/dev/null`. Verified live against a real disposable
+    # Keycloak: HILL90_UI_CLIENT_SECRET="" (set but EMPTY, not unset)
+    # produces exit 0 with EMPTY stdout from that endpoint — byte-identical
+    # to a client that genuinely has no secret credential at all (broker,
+    # hill90-api, realm-management, verified the same way). The check ran
+    # against that exact case and returned PASS. An empty secret is a broken
+    # auth state — this function's own warning text already claimed to cover
+    # "unset OR EMPTY"; the code could not reach the EMPTY half at all.
+    #
+    # Fixed by querying the client LIST once, in JSON (not CSV, not the
+    # per-client /client-secret sub-endpoint), and using PRESENCE of the
+    # `secret` key — not its value — as the discriminator. Verified live:
+    # clients Keycloak never assigned a secret to (broker, hill90-api,
+    # realm-management) have NO `secret` key in their JSON at all; clients
+    # platform-realm.json explicitly gives a `secret` field to (hill90-ui,
+    # hill90-vault) always have the key, whether its value is a real secret,
+    # an empty string, or a literal ${...} placeholder. Key-presence
+    # distinguishes "nothing to check" from "something to check that turned
+    # out empty" — value-emptiness cannot, because both look identical.
+    #
+    # This also fixes the query-failure question the CSV form could not
+    # answer either: `kc get clients` is now a single call whose own exit
+    # status is checked directly (`if !`), not discarded — a failed query
+    # (bad realm, auth session dropped, network fault) is CANNOT DETERMINE,
+    # never silently zero clients checked.
+    local clients_json
+    if ! clients_json=$(kc get clients -r "$KC_REALM" 2>/dev/null); then
+        warn "  ! Could not verify client secrets are substituted — the client list query for realm '${KC_REALM}' failed. Not proven clean; treating as a failure, not a pass."
         return 1
     fi
 
-    local found=0 checked=0
-    while IFS=, read -r id client_id public; do
-        [ -n "$id" ] || continue
-        [ "$public" = "true" ] && continue
-        local secret_raw
-        secret_raw=$(kc get "clients/${id}/client-secret" -r "$KC_REALM" --fields value --format csv --noquotes 2>/dev/null | tr -d '\r')
-        [ -n "$secret_raw" ] || continue
-        checked=$((checked + 1))
-        if [[ "$secret_raw" =~ ^\$\{[A-Za-z0-9_]+\}$ ]]; then
-            warn "  ! client '${client_id}' secret is the literal unsubstituted string '${secret_raw}' — the import ran with the backing variable unset or empty. This is now a public template value, readable in this repo's own platform-realm.json."
-            found=1
-        fi
-    done <<< "$clients_raw"
+    local classification py_status
+    # CLIENTS_JSON via the environment, not a pipe: `python3 <<'PYEOF'` uses
+    # the heredoc as the SCRIPT source (python3 with no filename argument
+    # reads its program from stdin), so stdin isn't free to also carry the
+    # data — piping `clients_json` in would silently starve sys.stdin.read()
+    # instead of feeding it. Caught by testing this against real output
+    # before trusting it, not by inspection.
+    #
+    # `if classification=$(...); then` — NOT a bare `classification=$(...)`
+    # assignment — for the same reason h#746's fix uses `if ! X=$(...); then`
+    # elsewhere in this file: this function's whole POINT is to observe a
+    # non-zero exit (1 = found a problem, 3 = cannot determine) without
+    # aborting. A bare assignment's exit status is the substitution's own,
+    # and under this file's `set -e` that non-zero status kills the script
+    # right there, before py_status=$? is ever reached — caught by actually
+    # running this against the EMPTY-secret case, not by inspection; the
+    # first version of this fix died silently at exactly this line.
+    if classification=$(CLIENTS_JSON="$clients_json" python3 <<'PYEOF'
+import sys, json, os, re
 
-    if [ "$checked" -eq 0 ]; then
-        warn "  ! Could not verify client secrets are substituted — no confidential client in realm '${KC_REALM}' returned a secret to check at all. Not proven clean; treating as a failure, not a pass."
+PLACEHOLDER_RE = re.compile(r'^\$\{[A-Za-z0-9_]+\}$')
+
+try:
+    clients = json.loads(os.environ["CLIENTS_JSON"])
+except Exception:
+    print("CANNOT_DETERMINE unparseable JSON")
+    sys.exit(3)
+
+if not isinstance(clients, list):
+    print("CANNOT_DETERMINE not a JSON array")
+    sys.exit(3)
+
+checked = 0
+failures = []
+for c in clients:
+    if c.get("publicClient") is True:
+        continue
+    if "secret" not in c:
+        continue
+    checked += 1
+    value = c.get("secret")
+    client_id = c.get("clientId")
+    if not value:
+        failures.append(f"EMPTY {client_id}")
+    elif PLACEHOLDER_RE.match(value):
+        failures.append(f"PLACEHOLDER {client_id} {value}")
+
+if checked == 0:
+    print("CANNOT_DETERMINE no confidential client has a secret key at all")
+    sys.exit(3)
+
+if failures:
+    for line in failures:
+        print(line)
+    sys.exit(1)
+
+print(f"PASS {checked}")
+sys.exit(0)
+PYEOF
+    ); then
+        py_status=0
+    else
+        py_status=$?
+    fi
+
+    if [ "$py_status" -eq 3 ]; then
+        warn "  ! Could not verify client secrets are substituted — ${classification#CANNOT_DETERMINE }. Not proven clean; treating as a failure, not a pass."
         return 1
     fi
-    if [ "$found" -eq 1 ]; then
+
+    if [ "$py_status" -eq 1 ]; then
+        local kind client_id detail
+        while IFS=' ' read -r kind client_id detail; do
+            [ -n "$kind" ] || continue
+            if [ "$kind" = "EMPTY" ]; then
+                warn "  ! client '${client_id}' secret is EMPTY — the import ran with the backing variable set but empty. A confidential client with an empty secret is a broken auth state, not a substitution success."
+            else
+                warn "  ! client '${client_id}' secret is the literal unsubstituted string '${detail}' — the import ran with the backing variable unset. This is now a public template value, readable in this repo's own platform-realm.json."
+            fi
+        done <<< "$classification"
         return 1
     fi
-    echo "  = checked ${checked} confidential client secret(s) — none is an unsubstituted \${...} literal"
+
+    local checked_count="${classification#PASS }"
+    echo "  = checked ${checked_count} confidential client secret(s) — none empty, none an unsubstituted \${...} literal"
     return 0
 }
 

--- a/scripts/keycloak.sh
+++ b/scripts/keycloak.sh
@@ -511,6 +511,65 @@ print(json.dumps({
     ensure_realm_roles_mapper "$uuid" "$claim"
 }
 
+# h#835: platform-realm.json declares hill90-vault's and hill90-ui's secrets
+# as ${VAULT_OIDC_CLIENT_SECRET} / ${HILL90_UI_CLIENT_SECRET}, substituted by
+# `start --import-realm` from the container's environment. VAULT_OIDC_CLIENT_SECRET
+# is guarded at the compose level (${VAR:?...}); HILL90_UI_CLIENT_SECRET
+# deliberately is NOT (fad9fefa) — it is legitimately unset on every routine
+# `auth` deploy after the first import, so a compose-level guard would refuse
+# every one of those. An import that runs with it unset (a VPS rebuild) succeeds
+# silently, and hill90-ui's client secret becomes the literal, unsubstituted
+# string "${HILL90_UI_CLIENT_SECRET}" — readable in this PUBLIC repo's own
+# platform-realm.json, no guessing required.
+#
+# This asks the LIVE realm, not the committed file: platform-realm.json always
+# contains the literal ${...} placeholder, correctly. The defect only exists in
+# what Keycloak actually installed at import time.
+#
+# Reuses the kc() session kc_login already established — no separate
+# credentials, matching kc_login's own reason for keeping the real admin
+# password out of argv/a second auth path entirely.
+#
+# "Could not check" must never read as "no placeholder found": an empty or
+# unparseable client list is its own failure, not a pass — the same class of
+# trap check_container_profile_ceilings.py (Hill90#845) and
+# check_realm_secret_not_literal.sh's own CANNOT-DETERMINE arms exist to catch.
+#
+# Deliberately narrow: this checks exactly one shape — a ${...}-looking literal
+# landing as a CLIENT SECRET after an import — not a general realm validator.
+verify_realm_secrets_substituted() {
+    local clients_raw
+    clients_raw=$(kc get clients -r "$KC_REALM" --fields id,clientId,publicClient --format csv --noquotes 2>/dev/null | tr -d '\r')
+    if [ -z "$clients_raw" ]; then
+        warn "  ! Could not verify client secrets are substituted — the client list for realm '${KC_REALM}' came back empty. Not proven clean; treating as a failure, not a pass."
+        return 1
+    fi
+
+    local found=0 checked=0
+    while IFS=, read -r id client_id public; do
+        [ -n "$id" ] || continue
+        [ "$public" = "true" ] && continue
+        local secret_raw
+        secret_raw=$(kc get "clients/${id}/client-secret" -r "$KC_REALM" --fields value --format csv --noquotes 2>/dev/null | tr -d '\r')
+        [ -n "$secret_raw" ] || continue
+        checked=$((checked + 1))
+        if [[ "$secret_raw" =~ ^\$\{[A-Za-z0-9_]+\}$ ]]; then
+            warn "  ! client '${client_id}' secret is the literal unsubstituted string '${secret_raw}' — the import ran with the backing variable unset or empty. This is now a public template value, readable in this repo's own platform-realm.json."
+            found=1
+        fi
+    done <<< "$clients_raw"
+
+    if [ "$checked" -eq 0 ]; then
+        warn "  ! Could not verify client secrets are substituted — no confidential client in realm '${KC_REALM}' returned a secret to check at all. Not proven clean; treating as a failure, not a pass."
+        return 1
+    fi
+    if [ "$found" -eq 1 ]; then
+        return 1
+    fi
+    echo "  = checked ${checked} confidential client secret(s) — none is an unsubstituted \${...} literal"
+    return 0
+}
+
 # ---------------------------------------------------------------------------
 # Commands
 # ---------------------------------------------------------------------------
@@ -518,6 +577,20 @@ print(json.dumps({
 cmd_apply() {
     require_running
     kc_login
+
+    # h#749: individual warn() calls inside remove_realm_roles and
+    # ensure_platform_admins used to be logged and then forgotten — this
+    # function ended with an unconditional "Realm configured." regardless of
+    # how many of them fired, e.g. one of five per-user role grants failing
+    # partway through. `apply_failed` aggregates both, matching the
+    # accumulator shape local.sh's cmd_health already uses for its own
+    # per-check loop. Declared before the h#835 check below so that check
+    # folds into the same accumulator rather than inventing a second one.
+    local apply_failed=0
+
+    echo ""
+    echo "Verifying realm-import substitution..."
+    verify_realm_secrets_substituted || apply_failed=1
 
     echo "================================"
     echo "Keycloak SSO — realm '${KC_REALM}'"
@@ -537,15 +610,6 @@ cmd_apply() {
     local minio_secret
     minio_secret=$(secret_for MINIO_OIDC_CLIENT_SECRET) \
         || die "Cannot resolve MINIO_OIDC_CLIENT_SECRET — refusing to reconfigure any client"
-
-    # h#749: individual warn() calls inside remove_realm_roles and
-    # ensure_platform_admins used to be logged and then forgotten — this
-    # function ended with an unconditional "Realm configured." regardless of
-    # how many of them fired, e.g. one of five per-user role grants failing
-    # partway through. `apply_failed` aggregates both, matching the
-    # accumulator shape local.sh's cmd_health already uses for its own
-    # per-check loop.
-    local apply_failed=0
 
     ensure_realm_roles
     # AFTER creating the replacements, never before: a run that deleted the old


### PR DESCRIPTION
Closes #835.

## What the new failure mode IS

`platform-realm.json` declares hill90-ui's Keycloak client secret as `${HILL90_UI_CLIENT_SECRET}`, substituted by `start --import-realm` from the container's environment. That variable is deliberately **not** guarded at the compose level (`fad9fefa`) — it's legitimately unset on every routine `auth` deploy after the first import. So an import that ran with it unset — a VPS rebuild — succeeded silently, and hill90-ui's client secret became the literal string `${HILL90_UI_CLIENT_SECRET}`. This repo is public, so that exact string is readable at `platform-realm.json:113` by anyone.

With this fix, `keycloak.sh apply` now catches that condition right after Keycloak comes up and reports it as a failure. It doesn't stop the import itself — Keycloak's own `start --import-realm` has already run by the time any script here executes — but a rebuild proceeding with an unconfigured client secret is no longer silent.

## Why that trade is right

The prior behavior — an operation that fails and reports success, on the credential fronting hill90.com — is this estate's own defect family at its worst. A loud failure right after a rebuild's Keycloak comes up is recoverable (rotate the secret, re-run `keycloak.sh apply`); a public placeholder silently installed is not noticed until someone relies on it.

## Blast radius today

`start --import-realm` is `IGNORE_EXISTING` — the live production realm already has the hill90-ui client and is **not** affected by this. It bites only on a **first import**, i.e. a VPS rebuild. Not a live production exposure.

## Why not the obvious one-line fix

The issue's own denominator (2 templated secrets — `VAULT_OIDC_CLIENT_SECRET` guarded, `HILL90_UI_CLIENT_SECRET` not) reads like "add the same `${VAR:?...}` guard here too." That's wrong, and checked against evidence before building anything: `fad9fefa`'s own commit message says it considered and **deliberately excluded** this exact guard for this exact variable — "guarding it at the compose level would have broken every routine auth deploy." The issue's own body says this reasoning "should not be re-litigated." A compose guard is correct for a variable that must always be present and wrong for one legitimately absent on routine deploys — same syntax, opposite correctness, decided by lifecycle, not sensitivity.

## The fix instead

A **post-import assertion**, not a pre-import guard: after Keycloak comes up, query every confidential client's secret and refuse if any is literally an unsubstituted `${...}` token. True only when substitution actually failed, so it can never fire on a routine deploy (which doesn't import), and it generalises to any future templated secret field.

Two implementations, deliberately:
- **`verify_realm_secrets_substituted()`** in `scripts/keycloak.sh`, wired into `cmd_apply` right after `kc_login`, folded into the existing `apply_failed` accumulator (h#749's shape) rather than a second one. This runs against the **real** realm in production, reusing the `kc()` session `kc_login` already authenticated — no separate credential path. Deliberate: a second script taking a real admin password as a positional argument would reintroduce the argv-credential-leak class this repo already guards against (`check_argv_secrets.sh`, in CI).
- **`scripts/checks/check_realm_secret_not_literal.sh`**, standalone, for disposable test Keycloaks only (marked `argv-ok`, matching `realm-tenant-serves-test.sh`'s own precedent for throwaway containers). This is what the positive control actually drives.

## Does not duplicate check_env_surface.py

That check already guarantees (rule 4) `HILL90_UI_CLIENT_SECRET` carries no non-empty compose-level default — a static check of the compose YAML, stopping a *known* bad value from ever being a silent fallback. It can't see what this fix checks: Keycloak's own import-time substitution behavior when the variable is genuinely absent, which only exists once a real import has run. Referenced in both new files rather than re-guaranteeing the same property twice.

## Positive control — all local, never production, every container torn down after

Failing arm run **first**, per instruction — a check only ever shown a clean result has not been shown anything:

1. Real disposable Keycloak 26.4.0, import with `HILL90_UI_CLIENT_SECRET` unset → refused, names `hill90-ui` and the exact literal string. Verified against **both** implementations independently.
2. Same import with the variable set → both implementations pass, having actually checked `hill90-ui` and `hill90-vault` (not merely returning 0).
3. CANNOT DETERMINE kept distinct from PASS in every way it can arise: unreachable container, failed admin login, and a realm with no client secret to check (Keycloak's own default realm) all exit 2, none exits 0.

`scripts/checks/realm-secret-substitution-test.sh` automates all of this and is wired into `ci.yml`, right after its sibling `realm-tenant-serves-test.sh`:

```
Arm 1 (THE CASE THAT MATTERS, run first): import with HILL90_UI_CLIENT_SECRET UNSET
  ✓ refused: exit 1, named hill90-ui and the literal placeholder

Arm 2: import with HILL90_UI_CLIENT_SECRET SET — must pass, and for the RIGHT reason
  ✓ passed: exit 0, both confidential clients (hill90-ui, hill90-vault) checked

Arm 3: CANNOT DETERMINE must be distinct from PASS, in every way it can arise
  ✓ unreachable container: exit 2, not exit 0
  ✓ bad admin credentials: exit 2, not exit 0
  ✓ a realm with no real client secret to check: exit 2 (THE TRAP)

All 5 assertions passed.
```

`check_checks_are_wired.py` confirms both new files are wired as REAL invocations, not orphaned. `check_argv_secrets.sh` passes against both. Existing suites unaffected: `warn-aggregation.bats` (10/10, including the static cmd_apply-aggregation shape test), `keycloak-role-holder-read-failure.bats` (5/5), `platform-services.bats` (all green).