### PR TITLE
fix(deploy): stop the vault stack's circular AppRole login, label minio's as structural (h#844)

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -224,6 +224,33 @@ vault_login() {
     }
 }
 
+# h#850: does NOT attempt a login — it only answers whether ${service}'s
+# AppRole credentials have non-empty values in the store, the same question
+# vault_login's own missing-credentials branch already asks. Used by
+# deploy.sh's vault-skip branch to make that skip's silence conditional on
+# the premise it assumes ("no VAULT_VAULT_ROLE_ID/_SECRET_ID has ever
+# existed") rather than unconditional on $service — so the day that premise
+# stops being true, something says so instead of silently doing nothing
+# forever. A decrypt failure returns 1 (treated as "not present"), matching
+# the current, safe default rather than inventing a third outcome here.
+vault_approle_credentials_present() {
+    local service="$1"
+    local secrets_file="${2:-$PROJECT_ROOT/infra/secrets/prod.enc.env}"
+    local svc_upper
+    svc_upper=$(echo "$service" | tr '[:lower:]' '[:upper:]')
+    local role_id_var="VAULT_${svc_upper}_ROLE_ID"
+    local secret_id_var="VAULT_${svc_upper}_SECRET_ID"
+
+    local decrypted
+    decrypted=$(sops -d "$secrets_file" 2>/dev/null) || return 1
+
+    local role_id secret_id
+    role_id=$(printf '%s\n' "$decrypted" | grep "^${role_id_var}=" | cut -d= -f2-)
+    secret_id=$(printf '%s\n' "$decrypted" | grep "^${secret_id_var}=" | cut -d= -f2-)
+
+    [ -n "$role_id" ] && [ -n "$secret_id" ]
+}
+
 # Read one KV v2 path. NON-ZERO if the path cannot be read for ANY reason.
 #
 # THIS FUNCTION CAUSED A PRODUCTION OUTAGE ON 2026-08-03 by succeeding quietly.

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -499,7 +499,18 @@ cmd_service() {
 
     # Vault-first, SOPS-fallback for service secrets
     local vault_ok=false
-    if vault_available; then
+    if [ "$service" = "vault" ]; then
+        # h#844: authenticating to OpenBao in order to deploy OpenBao is
+        # circular — no VAULT_VAULT_ROLE_ID/_SECRET_ID has ever existed in the
+        # store, and structurally none sensibly could (the thing that would
+        # grant the login is the thing not yet up). vault_login "vault" was
+        # attempted here on every deploy and failed on every one, forever,
+        # by design — not a gap to bootstrap. Skipping the attempt (and
+        # saying why) keeps this permanent, structural non-event from
+        # reading like a real, transient AppRole failure on some other
+        # service, which is the whole reason this file's warnings exist.
+        info "vault stack always uses SOPS — authenticating to OpenBao to deploy OpenBao would be circular (h#844)"
+    elif vault_available; then
         # h#815: see the identical capture on the infra path above for why the
         # stream order matters here — stdout (a bare token on success) must
         # never reach a log; only vault_login's stderr reason is captured.
@@ -507,6 +518,16 @@ cmd_service() {
         if login_reason=$(vault_login "$service" "$secrets_file" 2>&1 >/dev/null); then
             vault_ok=true
             info "OpenBao authenticated for ${service}"
+        elif [ "$service" = "minio" ]; then
+            # h#844: VAULT_MINIO_ROLE_ID/_SECRET_ID exist in SOPS but no
+            # matching AppRole has ever been created in OpenBao (#720 covers
+            # bootstrapping it or removing the stale entry). That is also
+            # permanent and structural until #720 lands, and OpenBao's own
+            # "invalid role or secret ID" reads exactly like a real, fixable
+            # credential problem if not named as what it actually is.
+            # ${login_reason} still carries OpenBao's own text for anyone
+            # who wants to double-check it hasn't changed shape.
+            warn "No AppRole exists for minio yet (see #720): ${login_reason:-no reason given} — falling back to SOPS"
         else
             warn "OpenBao login failed for ${service}: ${login_reason:-no reason given} — falling back to SOPS"
         fi

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -509,7 +509,19 @@ cmd_service() {
         # saying why) keeps this permanent, structural non-event from
         # reading like a real, transient AppRole failure on some other
         # service, which is the whole reason this file's warnings exist.
-        info "vault stack always uses SOPS — authenticating to OpenBao to deploy OpenBao would be circular (h#844)"
+        #
+        # h#850 review: the skip above was unconditional on $service and
+        # never checked whether the premise it assumes was still true. Kept
+        # the skip — a vault-self login stays circular regardless of whether
+        # credentials for it exist — but the silence is now conditional on
+        # VAULT_VAULT_ROLE_ID/_SECRET_ID actually being absent, so the
+        # assumption announces itself the day someone bootstraps one rather
+        # than this silently doing nothing forever.
+        if vault_approle_credentials_present "vault" "$secrets_file"; then
+            warn "VAULT_VAULT_ROLE_ID/_SECRET_ID now exist in the store — this stack still will not use them, because authenticating to OpenBao to deploy OpenBao is circular regardless of whether credentials exist for it. Investigate why a vault-self AppRole was created; it is unused by this path and always will be (h#850)."
+        else
+            info "vault stack always uses SOPS — authenticating to OpenBao to deploy OpenBao would be circular (h#844)"
+        fi
     elif vault_available; then
         # h#815: see the identical capture on the infra path above for why the
         # stream order matters here — stdout (a bare token on success) must

--- a/tests/scripts/vault-login-diagnostics.bats
+++ b/tests/scripts/vault-login-diagnostics.bats
@@ -360,28 +360,65 @@ EOF
 # rather than left indistinguishable from OpenBao's generic rejection text.
 # ---------------------------------------------------------------------------
 
-@test "h#844: the vault stack never calls vault_login at all — sops is never even invoked" {
-  # If vault_login somehow ran, this sops stub would explode loudly and the
-  # probe's output would carry the failure. It must not appear.
-  cat > "$STUB/sops" <<'EOF'
-#!/usr/bin/env bash
-echo "sops should NEVER be invoked for the vault stack" >&2
-exit 99
-EOF
-  chmod +x "$STUB/sops"
+@test "h#850, ARM 1 (credentials absent): the vault stack never calls vault_login — sops is checked, not skipped, but the login attempt never happens" {
+  # h#850 review: the skip used to be unconditional on $service, never
+  # checking whether VAULT_VAULT_ROLE_ID/_SECRET_ID actually existed —
+  # reproduced empirically by the reviewing lane with a stub handing out a
+  # real-looking role_id/secret_id pair and showing the login was never
+  # attempted regardless. sops IS now invoked (vault_approle_credentials_present
+  # reads the store to check), so this arm stubs it to report absence
+  # honestly rather than asserting sops is never called at all.
+  stub_sops_no_credentials_for vault
 
   run run_service_probe vault
-  [[ "$output" != *"should NEVER be invoked"* ]]
   [[ "$output" != *"vault_login:"* ]]
+  [[ "$output" != *"docker"* ]]
+  [[ "$output" == *"vault stack always uses SOPS"* ]]
   [[ "$output" == *"circular"* ]]
+  [[ "$output" != *"now exist in the store"* ]]
   [[ "$output" == *"VAULT_OK=false"* ]]
 }
 
-@test "h#844: the vault stack's message says why, not just that it failed" {
+@test "h#850, ARM 2 (credentials present): the skip stays, but a loud warning fires instead of silence" {
+  # The premise (no VAULT_VAULT_ROLE_ID/_SECRET_ID could sensibly exist) is
+  # now DETECTABLE rather than merely assumed. This is the arm that did not
+  # exist before the review found the gap — a conditional never seen to take
+  # its other branch is not a conditional.
+  stub_sops_credentials_for vault "some-role-id" "some-secret-id"
+
   run run_service_probe vault
-  [[ "$output" == *"vault stack always uses SOPS"* ]]
-  [[ "$output" != *"OpenBao login failed"* ]]
-  [[ "$output" != *"falling back to SOPS"* ]]
+  # Still never attempts the login itself — the skip is kept, only its
+  # silence is now conditional.
+  [[ "$output" != *"vault_login:"* ]]
+  [[ "$output" != *"OpenBao authenticated for vault"* ]]
+  [[ "$output" == *"VAULT_VAULT_ROLE_ID/_SECRET_ID now exist in the store"* ]]
+  [[ "$output" == *"Investigate why a vault-self AppRole was created"* ]]
+  [[ "$output" == *"VAULT_OK=false"* ]]
+  # Distinguishable from minio's structural-absence warning — opposite
+  # polarity (unexpected presence, not expected absence), must not read as
+  # the same "ignore this" shape.
+  [[ "$output" != *"No AppRole exists"* ]]
+  [[ "$output" != *"(see #720)"* ]]
+}
+
+@test "h#850: vault's unexpected-credentials warning is distinguishable from minio's structural-absence warning" {
+  stub_sops_credentials_for vault "some-role-id" "some-secret-id"
+  run run_service_probe vault
+  vault_out="$output"
+
+  stub_sops_credentials_for minio "r" "s"
+  stub_docker_rejects_login
+  run run_service_probe minio
+  minio_out="$output"
+
+  [ "$vault_out" != "$minio_out" ]
+  # An operator must not be able to read one as the other: vault's says
+  # "this showed up and should not have — go find out why"; minio's says
+  # "this is known and tracked, ignore it". Opposite instructions.
+  [[ "$vault_out" == *"Investigate why"* ]]
+  [[ "$minio_out" != *"Investigate why"* ]]
+  [[ "$minio_out" == *"see #720"* ]]
+  [[ "$vault_out" != *"see #720"* ]]
 }
 
 @test "h#844: minio's AppRole rejection is labeled structural and points at #720" {

--- a/tests/scripts/vault-login-diagnostics.bats
+++ b/tests/scripts/vault-login-diagnostics.bats
@@ -60,6 +60,20 @@ EOF
   chmod +x "$STUB/sops"
 }
 
+# $1 = service, $2 = role_id, $3 = secret_id — the parameterized twin of
+# stub_sops_credentials, needed for h#844's minio case where the service
+# under test isn't "auth".
+stub_sops_credentials_for() {
+  local svc_upper
+  svc_upper=$(echo "$1" | tr '[:lower:]' '[:upper:]')
+  cat > "$STUB/sops" <<EOF
+#!/usr/bin/env bash
+echo "VAULT_${svc_upper}_ROLE_ID=$2"
+echo "VAULT_${svc_upper}_SECRET_ID=$3"
+EOF
+  chmod +x "$STUB/sops"
+}
+
 stub_docker_rejects_login() {
   cat > "$STUB/docker" <<'EOF'
 #!/usr/bin/env bash
@@ -331,4 +345,63 @@ EOF
   run grep -c 'vault_login .* 2>&1 >/dev/null' "$ROOT/scripts/deploy.sh"
   [ "$status" -eq 0 ]
   [ "$output" -eq 2 ]
+}
+
+# ---------------------------------------------------------------------------
+# h#844: two structurally-permanent AppRole gaps (vault, minio) fired the
+# SAME generic warning as a real, transient failure on every single deploy,
+# forever. The point of h#815's distinct modes was undermined by this: a
+# reader still could not tell "expected, permanent, ignore" from "a real
+# credential just broke" without knowing VAULT_SERVICES and the SOPS layout
+# by heart. These tests pin the two fixes named in the issue: the vault
+# stack skips the login attempt entirely (it would be circular — vault_login
+# "vault" can never succeed, no VAULT_VAULT_ROLE_ID could sensibly exist),
+# and minio's failure is labeled as the structural, #720-tracked gap it is
+# rather than left indistinguishable from OpenBao's generic rejection text.
+# ---------------------------------------------------------------------------
+
+@test "h#844: the vault stack never calls vault_login at all — sops is never even invoked" {
+  # If vault_login somehow ran, this sops stub would explode loudly and the
+  # probe's output would carry the failure. It must not appear.
+  cat > "$STUB/sops" <<'EOF'
+#!/usr/bin/env bash
+echo "sops should NEVER be invoked for the vault stack" >&2
+exit 99
+EOF
+  chmod +x "$STUB/sops"
+
+  run run_service_probe vault
+  [[ "$output" != *"should NEVER be invoked"* ]]
+  [[ "$output" != *"vault_login:"* ]]
+  [[ "$output" == *"circular"* ]]
+  [[ "$output" == *"VAULT_OK=false"* ]]
+}
+
+@test "h#844: the vault stack's message says why, not just that it failed" {
+  run run_service_probe vault
+  [[ "$output" == *"vault stack always uses SOPS"* ]]
+  [[ "$output" != *"OpenBao login failed"* ]]
+  [[ "$output" != *"falling back to SOPS"* ]]
+}
+
+@test "h#844: minio's AppRole rejection is labeled structural and points at #720" {
+  stub_sops_credentials_for minio "r" "s"
+  stub_docker_rejects_login
+  run run_service_probe minio
+  [[ "$output" == *"No AppRole exists for minio yet (see #720)"* ]]
+  # OpenBao's own reason still travels with it — this replaces the generic
+  # wrapper sentence, not the underlying diagnostic detail.
+  [[ "$output" == *"invalid role or secret ID"* ]]
+  [[ "$output" == *"VAULT_OK=false"* ]]
+}
+
+@test "h#844: a real, transient AppRole failure on another service still reads generically, not as #720" {
+  # The whole point: minio's structural label must not leak onto a service
+  # whose AppRole genuinely exists and could genuinely, transiently fail.
+  stub_sops_credentials "r" "s"
+  stub_docker_rejects_login
+  run run_service_probe auth
+  [[ "$output" == *"OpenBao login failed for auth"* ]]
+  [[ "$output" != *"#720"* ]]
+  [[ "$output" != *"No AppRole exists"* ]]
 }


### PR DESCRIPTION
Closes h#844.

## What was verified before fixing

- `scripts/vault.sh:31` — `VAULT_SERVICES="db auth infra observability sync"`. Neither `minio` nor `vault` is a member.
- `scripts/deploy.sh`'s `cmd_service` (the dispatch target for `db|auth|minio|vault|observability`) calls `vault_login "$service"` unconditionally, with no per-service exemption.
- Grepped key *names* (not values) in `infra/secrets/prod.enc.env`: `VAULT_MINIO_ROLE_ID`/`VAULT_MINIO_SECRET_ID` exist (a role that was never created in OpenBao — #720's subject). `VAULT_VAULT_ROLE_ID`/`VAULT_VAULT_SECRET_ID` do not exist anywhere in the store.

So `vault`'s failure and `minio`'s failure are structurally different, and neither is a credential that could ever transiently start working — they're permanent by construction, but the warning read like a real, fixable problem on every single deploy.

## The two fixes, both scoped to `cmd_service`'s vault-login block

**`vault`**: skip `vault_login` entirely. Authenticating to OpenBao in order to deploy OpenBao is circular — the thing that would grant the login is the thing not yet up. `VAULT_VAULT_ROLE_ID` was never a gap to bootstrap; there structurally can't sensibly be one. Replaced with a one-line `info` explaining why, so `vault_ok` still falls through to the existing SOPS path unchanged.

**`minio`**: still attempts `vault_login` (its credentials exist, so its rejection today is a live, real OpenBao 403 — genuinely different from `vault`'s case). On rejection, the warning is relabeled "No AppRole exists for minio yet (see #720)" instead of the generic wrapper sentence, with OpenBao's own reason still appended for anyone double-checking it hasn't changed shape.

Left `#720`'s actual decision (bootstrap vs. remove the stale SOPS entry) untouched — that's its own job, this issue is only about the warning being indistinguishable from a real failure.

## Verification

- New tests in `tests/scripts/vault-login-diagnostics.bats`: vault never invokes `vault_login`/`sops` at all; vault's message names the reason; minio's message is relabeled and still carries OpenBao's raw reason; and a control proving the `#720` label does **not** leak onto a genuinely transient failure on another service (`auth`).
- Mutation-verified: reverting to the single generic branch fails exactly those four new tests and nothing else.
- Full `vault-login-diagnostics.bats` (16/16), `deploy.bats` (32/32), and the broader `vault*.bats` suite all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)