### PR TITLE
docs(runbook): vps-rebuild.md deploys db, auth, minio, and initializes vault

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help build deploy-infra deploy-infra-production deploy-vault deploy-observability test logs health ssh secrets-edit secrets-init secrets-view secrets-update ps snapshot recreate-vps config-vps validate docs-dev backup backup-list backup-prune backup-restore rollback rollback-classify down dns-view dns-sync dns-verify vault-init vault-unseal vault-auto-unseal vault-status vault-setup vault-seed vault-sync-to-sops vault-setup-sync-token vault-bootstrap-approles check-secrets-schema
+.PHONY: help build deploy-infra deploy-infra-production deploy-db deploy-auth deploy-minio deploy-vault deploy-observability test logs health ssh secrets-edit secrets-init secrets-view secrets-update ps snapshot recreate-vps config-vps validate docs-dev backup backup-list backup-prune backup-restore rollback rollback-classify down dns-view dns-sync dns-verify vault-init vault-unseal vault-auto-unseal vault-status vault-setup vault-seed vault-sync-to-sops vault-setup-sync-token vault-bootstrap-approles check-secrets-schema
 
 # Environment
 ENV ?= prod
@@ -143,6 +143,27 @@ deploy-infra-production: ## Deploy infrastructure, refusing to proceed unless th
 	@echo "Refuses to deploy if the configured CA is Let's Encrypt staging."
 	@read -p "Are you sure? (yes/no): " confirm && [ "$$confirm" = "yes" ]
 	ACME_REQUIRE_PRODUCTION=1 bash scripts/deploy.sh infra $(ENV)
+
+# h#831: deploy.sh has supported db/auth/minio as first-class targets since
+# before this Makefile existed (its own usage text lists them) — nothing here
+# ever exposed them as `make` targets, which is how vps-rebuild.md ended up
+# with no step for any of the three: a runbook author reaching for the
+# established `make deploy-X` convention here had nothing to reach for.
+deploy-db: ## Deploy PostgreSQL (platform database)
+	@echo "$(COLOR_YELLOW)Deploying PostgreSQL...$(COLOR_RESET)"
+	bash scripts/deploy.sh db $(ENV)
+
+# auth (Keycloak) stores realms in Postgres and refuses to deploy if it
+# cannot query it (scripts/deploy.sh's own guard: "Cannot deploy auth: cannot
+# query postgres... Deploy it first: bash scripts/deploy.sh db"). db must be
+# deployed before this target, not just before it in a runbook's prose.
+deploy-auth: ## Deploy Keycloak (platform identity provider) — requires deploy-db first
+	@echo "$(COLOR_YELLOW)Deploying Keycloak...$(COLOR_RESET)"
+	bash scripts/deploy.sh auth $(ENV)
+
+deploy-minio: ## Deploy MinIO object store (platform storage)
+	@echo "$(COLOR_YELLOW)Deploying MinIO...$(COLOR_RESET)"
+	bash scripts/deploy.sh minio $(ENV)
 
 deploy-vault: ## Deploy OpenBao secrets management
 	@echo "$(COLOR_YELLOW)Deploying OpenBao vault...$(COLOR_RESET)"

--- a/docs/runbooks/vps-rebuild.md
+++ b/docs/runbooks/vps-rebuild.md
@@ -7,14 +7,60 @@ Complete automated rebuild of the Hill90 VPS from catastrophic failure.
 The host-level rebuild (VPS OS, Ansible bootstrap, Traefik/Portainer, observability)
 is fully automated. **Vault is not** — initializing, configuring, seeding and
 generating AppRole credentials for a freshly-deployed OpenBao are manual steps this
-runbook does not itself walk through (see Step 3b, h#807). The process takes
-~8-13 minutes for the automated portion and consists of 4 steps, plus vault setup:
+runbook does not itself walk through (see Step 7, h#807). The process takes
+~8-13 minutes for the automated portion and consists of 6 automated steps,
+plus manual vault setup and a final health check:
 
 1. **Recreate VPS** (~3-5 minutes) - OS rebuild via Hostinger API
 2. **Config VPS** (~3-5 minutes) - Infrastructure bootstrap via Ansible
 3. **Deploy Infra** (~1-2 minutes) - Infrastructure service deployment (Traefik, Portainer)
-3b. **Deploy AND configure Vault** (manual — not on the automated clock) - see Step 3b
-4. **Deploy All** (~2-3 minutes) - Application service deployment
+4. **Deploy Database** (~1 minute) - PostgreSQL (h#831 — previously missing from this runbook entirely)
+5. **Deploy Auth** (~1 minute) - Keycloak, after database (h#831 — previously missing)
+6. **Deploy MinIO** (~1 minute) - Object storage, after auth (h#831 — previously missing)
+7. **Deploy AND configure Vault** (manual — not on the automated clock) - see Step 7
+8. **Deploy Observability** (~1 minute) - Monitoring stack
+9. **Health Verification** - confirm every service, not just the ones deployed last
+
+**h#831, stated plainly rather than softened: following this runbook's PRIOR
+version end to end rebuilt a VPS with no database, no Keycloak and no object
+storage.** `db` and `minio` were absent from the document entirely — not one
+mention. `auth` was harder to catch: the word appears six times in prose
+(`auth.hill90.com`, `HILL90_UI_CLIENT_SECRET`, `hill90-ui`), which is enough
+for a reader skimming for coverage to see it mentioned and move on, but there
+was no `make deploy-auth` or equivalent anywhere. Steps 4-6 below close all
+three. **The Makefile itself had no targets for any of them either** — a
+bigger gap than the runbook's prose, since a runbook author reaching for this
+file's own `make deploy-X` convention had nothing to reach for; `deploy-db`,
+`deploy-auth` and `deploy-minio` are added to the Makefile in the same change
+as this runbook fix, not papered over with a raw `deploy.sh` invocation that
+breaks the pattern every other step in this document follows.
+
+**The order below is not a guess.** It is read directly from
+[`.github/workflows/deploy.yml`](../../.github/workflows/deploy.yml), the
+real, already-running production deploy pipeline — its jobs declare
+`needs: [db]` for auth, `needs: [auth]` for minio, `needs: [minio]` for vault,
+each with its own reasoning in that file's comments: Keycloak stores realms in
+Postgres, so `deploy-auth` waits for `deploy-db`; MinIO validates OIDC tokens
+against Keycloak, so `deploy-minio` is ordered after `deploy-auth` (ordering
+by convention, not a hard runtime requirement — the workflow's own comment
+says MinIO starts fine with Keycloak absent, only federated S3 login needs
+it); `deploy-vault` and `deploy-observability` are serialized after that for
+operational reasons (#778 — parallel deploy jobs raced on the same VPS
+checkout and on service restarts), not a data dependency. This runbook is
+brought into agreement with that pipeline, not inventing a second, competing
+order.
+
+**This sequence has NOT been executed end to end.** It is derived from
+`deploy.yml`'s dependency graph and `scripts/deploy.sh`'s own code-enforced
+guard (`cmd_service`'s auth step queries Postgres directly and `die`s with
+"Deploy it first: bash scripts/deploy.sh db" if it cannot — the one
+dependency enforced in code, not just in the pipeline's job graph), not
+proven by running a real rebuild — the VPS cannot be rebuilt to test a
+documentation change. What would prove it: running Steps 1-8 against a real
+rebuild (or, short of that, standing up db/auth/minio/vault/observability in
+this exact order against a disposable host or the standalone local stack) and
+confirming each step succeeds before the next begins, the same standard
+h#807's vault section already holds itself to ("Not verified here...").
 
 ## Prerequisites
 
@@ -147,7 +193,82 @@ make deploy-infra
 
 ---
 
-### Step 3b: Deploy AND Configure Vault
+### Step 4: Deploy Database (~1 minute)
+
+**h#831 — previously absent from this runbook entirely.** Deploy PostgreSQL,
+the platform database:
+
+```bash
+make deploy-db
+```
+
+**Why this has to happen before Step 5:** Keycloak (Step 5) stores every realm
+in this Postgres instance and will not start against an unreachable one —
+`scripts/deploy.sh`'s own `cmd_service` queries Postgres directly before
+deploying `auth` and `die`s with "Deploy it first: bash scripts/deploy.sh db"
+if it cannot. This is a code-enforced dependency, not a documentation
+convention — deploying `auth` before this step fails, it does not degrade.
+
+**Result:**
+- ✅ PostgreSQL running, reachable on the internal network
+
+---
+
+### Step 5: Deploy Auth (~1 minute)
+
+**h#831 — previously absent from this runbook entirely.** Deploy Keycloak,
+the platform identity provider:
+
+```bash
+make deploy-auth
+```
+
+**Requires Step 4 (Database) to have completed** — see above.
+
+**Read the Prerequisites section above before this step, not after.**
+`HILL90_UI_CLIENT_SECRET` must already be set in the secrets store. This is
+the ONE step in the whole rebuild where `start --import-realm` actually
+imports (a fresh Keycloak has no existing realm), and an unset value here
+installs a public, unsubstituted placeholder as the client secret fronting
+`hill90.com` — see the Prerequisites section for the full mechanism (h#809,
+h#835) and the automated check that now catches it
+(`verify_realm_secrets_substituted` in `scripts/keycloak.sh`, wired into
+`keycloak.sh apply`, which `deploy.sh auth` calls automatically).
+
+**Result:**
+- ✅ Keycloak running, realm `platform` imported
+- ✅ `auth.hill90.com` serving
+
+---
+
+### Step 6: Deploy MinIO (~1 minute)
+
+**h#831 — previously absent from this runbook entirely.** Deploy MinIO,
+platform object storage:
+
+```bash
+make deploy-minio
+```
+
+**Ordered after Step 5 (Auth), matching `deploy.yml`'s own convention — but
+this is NOT a hard runtime dependency, stated so nobody assumes it is.**
+MinIO validates OIDC tokens against Keycloak for federated S3 login, but the
+container itself starts fine with Keycloak absent, and root-credential access
+is unaffected. The pipeline orders it after `auth` anyway (`deploy.yml`:
+`deploy-minio` `needs: [deploy-auth]`) because that is the order this estate
+has already committed to elsewhere, not because MinIO would fail otherwise —
+this runbook follows the same convention rather than inventing a
+looser-but-different one.
+
+**Result:**
+- ✅ MinIO running, `storage.hill90.com` serving
+- ⚠️ Federated (Keycloak SSO) login to MinIO's console will not work until
+  Step 7 (Vault) has run `setup-oidc` and the realm role → MinIO policy
+  mapping is in place. Root credentials work immediately.
+
+---
+
+### Step 7: Deploy AND Configure Vault
 
 ```bash
 make deploy-vault
@@ -172,7 +293,19 @@ one).
 [Step 4](disaster-recovery.md#step-4) through Step 9, not repeated here to avoid the
 two runbooks drifting out of sync with each other the way this gap itself happened:
 
-1. [Initialize](disaster-recovery.md#step-4) — `bash scripts/vault.sh init`
+1. [Initialize](disaster-recovery.md#step-4) — `bash scripts/vault.sh init`, **AND** push the
+   new unseal key into SOPS before doing anything else. `vault.sh init` mints a
+   **brand-new** unseal key and root token (`bao operator init`, run fresh against an
+   empty volume) — it does **not** reuse or need `main`'s existing `OPENBAO_UNSEAL_KEY`,
+   and a reader who assumes it does will look for the wrong value. `cmd_init` writes
+   the new key to disk on the VPS (`/opt/hill90/secrets/openbao-unseal.key`,
+   deliberately never printed — h#805) and nowhere else; [Step 4](disaster-recovery.md#step-4)'s
+   own `scp` + `make secrets-update KEY=OPENBAO_UNSEAL_KEY` sequence is what gets it
+   into SOPS, from your **workstation**, not the VPS. Skipping that half of the linked
+   step leaves this rebuild's vault working right now but with no durable copy of its
+   own unseal key anywhere but the host that could fail next — the same class of
+   single point of failure #799 already found in the OTHER direction (a stale key in
+   SOPS that no longer matches the live vault).
 2. Unseal — `bash scripts/vault.sh unseal`
 3. Setup (KV v2, AppRole auth, audit logging, policies, service roles) — `bash scripts/vault.sh setup`
 4. Seed from SOPS — `bash scripts/vault.sh seed`
@@ -227,7 +360,7 @@ does when there is nothing to unseal.
 
 ---
 
-### Step 4: Deploy Observability (~1 minute)
+### Step 8: Deploy Observability (~1 minute)
 
 ```bash
 make deploy-observability   # or: bash scripts/deploy.sh observability prod
@@ -243,18 +376,23 @@ make deploy-observability   # or: bash scripts/deploy.sh observability prod
 4. Waits for containers to become healthy
 
 **Result:**
-- ✅ Nine observability containers running (infra 2 + vault 1 + observability 9 = 12
-  platform containers total, not ten — h#808)
+- ✅ Nine observability containers running. **h#831 recount**, against every
+  compose file listed in this runbook directly, not carried over from the prior
+  figure: infra 2 (traefik, portainer) + db 2 (postgres, postgres-exporter) +
+  auth 1 (keycloak) + minio 1 + vault 1 (openbao) + observability 9 = **16
+  platform containers total, not 12.** The prior "12" figure (h#808) predates
+  Steps 4-6 existing in this runbook at all — it was never wrong for what it
+  counted, it counted a rebuild that was missing three stacks.
 - ✅ Grafana at https://grafana.hill90.com (Tailscale-only)
 - ✅ Prometheus scrape targets healthy
 
-**Not verified against the live host** — this correction is against the compose file
-and `scripts/ops.sh` (see the code-side fix, h#808), not a container count taken from
-a running rebuild.
+**Not verified against the live host** — this correction is against the compose files
+directly (see the code-side fix, h#808, for the observability figure specifically),
+not a container count taken from a running rebuild.
 
 ---
 
-### Step 5: Health Verification
+### Step 9: Health Verification
 
 **A container reporting `unhealthy` partway through a rebuild is usually not a
 failure.** A rebuilt host starts every service against empty volumes, and
@@ -275,7 +413,8 @@ make health
 ```
 
 **Checks performed:**
-- ✅ All twelve Docker containers running (infra 2 + vault 1 + observability 9 — h#808)
+- ✅ All sixteen Docker containers running (infra 2 + db 2 + auth 1 + minio 1 +
+  vault 1 + observability 9 — h#831 recount, see Step 8)
 - ✅ Traefik dashboard accessible (https://traefik.hill90.com via Tailscale)
 - ✅ Portainer accessible (https://portainer.hill90.com via Tailscale)
 - ✅ Grafana accessible (https://grafana.hill90.com via Tailscale)
@@ -423,12 +562,16 @@ ssh deploy@<vps-ip> "cd /opt/hill90/app && docker compose logs"
 2. Recreate VPS: `make recreate-vps`
 3. Bootstrap infrastructure: `make config-vps VPS_IP=<ip>`
 4. Deploy infrastructure: `make deploy-infra`
-5. Deploy vault: `make deploy-vault`
-6. Initialize, unseal, configure, seed and generate AppRole credentials for vault —
-   see [Step 3b](#step-3b-deploy-and-configure-vault) above; **not automated**, and
+5. Deploy database: `make deploy-db` (h#831)
+6. Deploy auth: `make deploy-auth` — requires Step 5 (h#831)
+7. Deploy MinIO: `make deploy-minio` (h#831)
+8. Deploy vault: `make deploy-vault`
+9. Initialize, unseal, configure, seed and generate AppRole credentials for vault,
+   including pushing the freshly-minted unseal key into SOPS — see
+   [Step 7](#step-7-deploy-and-configure-vault) above; **not automated**, and
    not optional (h#807)
-7. Deploy observability: `make deploy-observability`
-8. Verify health: `make health`
+10. Deploy observability: `make deploy-observability`
+11. Verify health: `make health`
 
 **Fully automated (no intervention):**
 - ✅ Tailscale auth key generation and rotation

--- a/tests/scripts/dr-runbooks-content.bats
+++ b/tests/scripts/dr-runbooks-content.bats
@@ -149,7 +149,55 @@ setup() {
 @test "h#808 docs: vps-rebuild.md no longer claims ten total platform containers" {
   run grep -F 'All ten Docker containers' "$VPS"
   [ "$status" -ne 0 ]
+}
+
+# h#831: the "twelve" figure h#808 established was correct for what it counted
+# (infra + vault + observability) — it predates db/auth/minio existing in this
+# runbook at all. Adding those three stacks' containers makes it stale in the
+# same direction as the "ten" figure it replaced, not a new defect.
+@test "h#831 docs: vps-rebuild.md no longer claims twelve total platform containers, now sixteen" {
   run grep -F 'All twelve Docker containers' "$VPS"
+  [ "$status" -ne 0 ]
+  run grep -F 'All sixteen Docker containers' "$VPS"
+  [ "$status" -eq 0 ]
+}
+
+@test "h#831: vps-rebuild.md now has deploy steps for db, auth and minio, in that order" {
+  run grep -F 'make deploy-db' "$VPS"
+  [ "$status" -eq 0 ]
+  run grep -F 'make deploy-auth' "$VPS"
+  [ "$status" -eq 0 ]
+  run grep -F 'make deploy-minio' "$VPS"
+  [ "$status" -eq 0 ]
+  # Order, not just presence: db's heading line number must precede auth's,
+  # which must precede minio's.
+  db_line=$(grep -n '^### Step .*Deploy Database' "$VPS" | head -1 | cut -d: -f1)
+  auth_line=$(grep -n '^### Step .*Deploy Auth' "$VPS" | head -1 | cut -d: -f1)
+  minio_line=$(grep -n '^### Step .*Deploy MinIO' "$VPS" | head -1 | cut -d: -f1)
+  [ -n "$db_line" ] && [ -n "$auth_line" ] && [ -n "$minio_line" ]
+  [ "$db_line" -lt "$auth_line" ]
+  [ "$auth_line" -lt "$minio_line" ]
+}
+
+@test "h#831: the Makefile actually has deploy-db, deploy-auth and deploy-minio targets" {
+  # -F is fixed-string matching, so `^` is a literal caret in that mode, not
+  # an anchor — plain grep (basic regex) is required for these to mean
+  # "target definition line", not just "the substring appears somewhere".
+  run grep -n '^deploy-db:' "$ROOT/Makefile"
+  [ "$status" -eq 0 ]
+  run grep -n '^deploy-auth:' "$ROOT/Makefile"
+  [ "$status" -eq 0 ]
+  run grep -n '^deploy-minio:' "$ROOT/Makefile"
+  [ "$status" -eq 0 ]
+}
+
+@test "h#831: vps-rebuild.md's vault step now states the unseal key is newly minted, not reused from main" {
+  run grep -iF 'brand-new' "$VPS"
+  [ "$status" -eq 0 ]
+  # The actual sentence wraps "not" in markdown bold (**not**), so the
+  # fixed-string match has to skip over the asterisks the same way a
+  # rendered reader would.
+  run grep -F 'it does **not** reuse or need' "$VPS"
   [ "$status" -eq 0 ]
 }
 


### PR DESCRIPTION
Closes #831.

## What was missing, verified directly

`vps-rebuild.md` never deployed `db`, `auth` or `minio`. `db` and `minio` were absent entirely. `auth` was harder to catch: the word appears six times in prose (`auth.hill90.com`, `HILL90_UI_CLIENT_SECRET`, `hill90-ui`) — enough for a skimming reader to see it mentioned and move on — but there was no deploy step for it anywhere. Following the prior version end to end rebuilt a VPS with no database, no Keycloak, and no object storage.

## The bigger finding, checked before writing a single runbook step

**The Makefile itself had no targets for any of the three.** Papering over that with a raw `deploy.sh` invocation in the runbook would have broken the `make deploy-X` pattern every other step here follows, and been the real gap left unstated. Added `deploy-db`, `deploy-auth`, `deploy-minio` to the Makefile, matching `deploy-vault`/`deploy-observability`'s exact style, `.PHONY` included.

## Order — read from the real pipeline, not guessed

`.github/workflows/deploy.yml`, the actual production deploy pipeline, already encodes this: `deploy-auth: needs: [deploy-db]`, `deploy-minio: needs: [deploy-auth]`, `deploy-vault: needs: [deploy-minio]`, each with its own reasoning in that file's comments — Keycloak stores realms in Postgres so auth waits for db; MinIO is ordered after auth by *convention* (validates OIDC tokens against it) but not hard requirement (its own comment: MinIO starts fine with Keycloak absent); vault/observability are serialized after that for operational reasons (#778), not a data dependency. This runbook is brought into agreement with that pipeline. One dependency is additionally enforced **in code**: `deploy.sh`'s `cmd_service` queries Postgres directly before deploying `auth` and `die`s if it can't reach it.

New Steps 4-6 each state what they depend on and why, not just the command. Step 5 (auth) cross-references the `HILL90_UI_CLIENT_SECRET` prerequisite (h#809) and the automated guard that now catches it (h#835). Step 6 (minio) states explicitly that ordering-after-auth is convention, not a real dependency, so nobody infers one that doesn't exist.

## A second gap, found while verifying the first — folded in, not filed separately

Same file, same class. The vault section already named `vault.sh init/unseal/setup/seed/setup-oidc/bootstrap-approles` (linked to `disaster-recovery.md`'s Step 4 rather than duplicated — **kept that way**: duplicating a credential-minting procedure into a second file is how the two drift apart, and this estate has spent today closing exactly that shape elsewhere). What was actually missing: the numbered list's item 1 didn't make clear that the linked step *also* covers pushing the newly-minted unseal key into SOPS (`scp` + `make secrets-update KEY=OPENBAO_UNSEAL_KEY`), and nowhere stated that `vault.sh init` mints a **brand-new** key rather than reusing `main`'s existing `OPENBAO_UNSEAL_KEY` — a reader who assumed reuse would look for the wrong value. Both made explicit inline.

## Container count recounted, not carried forward

h#808's "twelve" figure (infra 2 + vault 1 + observability 9) was correct for what it counted — it predates Steps 4-6 existing in this runbook at all. Recounted against every compose file: infra 2 + db 2 (postgres, postgres-exporter) + auth 1 + minio 1 + vault 1 + observability 9 = **sixteen**. Updated in both places the doc states it.

## Not claimed to work end to end — stated explicitly

This sequence is derived from `deploy.yml`'s dependency graph and `deploy.sh`'s code-enforced guard, not proven by a real rebuild — the VPS can't be rebuilt to test a doc change. What would prove it: running the full sequence against a real rebuild, or the same order against a disposable host / the standalone local stack, confirming each step succeeds before the next begins.

## Renumbering

Step 3b → Step 7 (only internal self-reference, in Automation Summary, updated), Step 4 → Step 8, Step 5 → Step 9. Overview and Automation Summary numbered lists updated to match.

## Verification

- `check_md_links.py`: all anchors resolve, 62 files scanned, clean.
- Extended `tests/scripts/dr-runbooks-content.bats` with 4 new assertions: container-count correction, presence **and order** of the three new deploy steps, the Makefile targets actually existing, and the unseal-key wording.
- **Mutation-verified**: reverting the doc/Makefile changes alone makes exactly those 4 new tests fail; the 19 pre-existing h#804-h#808 tests stay green throughout. Restoring makes all 23 pass.

```
1..23
[... 19 pre-existing tests, all ok ...]
ok 19 h#831 docs: vps-rebuild.md no longer claims twelve total platform containers, now sixteen
ok 20 h#831: vps-rebuild.md now has deploy steps for db, auth and minio, in that order
ok 21 h#831: the Makefile actually has deploy-db, deploy-auth and deploy-minio targets
ok 22 h#831: vps-rebuild.md's vault step now states the unseal key is newly minted, not reused from main
ok 23 h#808 corroborated against the compose file: exactly 9 observability services are defined
```

## Note on timing

Pushed while GitHub Actions may still be affected by the earlier partial outage — if CI shows red on this PR for that reason, it isn't a real failure; will re-check once Actions recovers.