### PR TITLE
fix(ssh): narrow, reproducible re-apply of the sshd/firewall hardening #545 already wrote (h#786)

### DIFF
--- a/.github/workflows/harden-ssh.yml
+++ b/.github/workflows/harden-ssh.yml
@@ -1,0 +1,95 @@
+name: Harden SSH (Firewall + sshd only)
+
+# h#681 / h#786: a narrow re-apply of infra/ansible/playbooks/02-firewall.yml
+# and 04-ssh-lockdown.yml ONLY, against the already-known TAILSCALE_IP.
+#
+# Deliberately NOT config-vps.yml / bootstrap.yml (01-08, 11-12): per h#681's
+# own blast-radius accounting, 03-tailscale reconfigures the only access path
+# this estate has and 05-docker bounces every container on the host for the
+# length of a restart. Neither is wanted to re-apply a firewall rule and an
+# sshd drop-in that have been correct in this repo since #545 and have simply
+# never been run — Config VPS last executed 2026-02-02, months before #545
+# existed.
+#
+# `check` defaults to true: a dry run (`ansible-playbook --check --diff`)
+# reports what would change, including the CURRENT effective `sshd -T` /
+# `firewall-cmd --list-services` output, without changing anything. Applying
+# requires an explicit `check: false` — this is a hard-to-reverse change to
+# sshd on the only production host, over SSH, and should not be one click
+# away from the default.
+on:
+  workflow_dispatch:
+    inputs:
+      check:
+        description: 'Dry run only (--check --diff, changes nothing). Set to false to actually apply.'
+        required: true
+        type: boolean
+        default: true
+
+concurrency:
+  group: deploy-prod
+  cancel-in-progress: false
+
+jobs:
+  harden-ssh:
+    name: Re-apply firewall + SSH hardening
+    runs-on: ubuntu-latest
+    environment: production
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Tailscale
+        uses: tailscale/github-action@v2
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:github-actions
+
+      - name: Setup SSH key
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.VPS_SSH_PRIVATE_KEY }}" > ~/.ssh/remote.hill90.com
+          chmod 600 ~/.ssh/remote.hill90.com
+
+      - name: Setup SOPS/age for secrets
+        run: |
+          curl -L -o /tmp/sops https://github.com/getsops/sops/releases/download/v3.9.0/sops-v3.9.0.linux.amd64
+          chmod +x /tmp/sops
+          sudo mv /tmp/sops /usr/local/bin/sops
+
+          mkdir -p ~/.config/sops/age
+          echo "${{ secrets.SOPS_AGE_KEY }}" > ~/.config/sops/age/keys.txt
+          chmod 600 ~/.config/sops/age/keys.txt
+
+      - name: Install Ansible
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ansible
+
+      - name: Re-apply firewall + SSH hardening (dry run)
+        if: ${{ inputs.check }}
+        env:
+          SOPS_AGE_KEY_FILE: /home/runner/.config/sops/age/keys.txt
+        run: make harden-ssh-check
+
+      - name: Re-apply firewall + SSH hardening (APPLY — sshd will reload)
+        if: ${{ !inputs.check }}
+        env:
+          SOPS_AGE_KEY_FILE: /home/runner/.config/sops/age/keys.txt
+        run: |
+          echo "::warning::Applying — sshd will RELOAD if anything changed. This does not drop existing sessions, but verify access from a second run of this workflow (with check: true) before assuming the previous run's session-based access is unaffected."
+          make harden-ssh
+
+      - name: Summary
+        if: success()
+        run: |
+          if [ "${{ inputs.check }}" = "true" ]; then
+            echo "✅ Dry run complete — nothing was changed. Re-run with check: false to apply."
+          else
+            echo "✅ Firewall + SSH hardening re-applied and verified against sshd -T."
+            echo "Verify access from a fresh session before relying on this being done."
+          fi

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help build deploy-infra deploy-infra-production deploy-vault deploy-observability test logs health ssh secrets-edit secrets-init secrets-view secrets-update ps snapshot recreate-vps config-vps validate docs-dev backup backup-list backup-prune backup-restore rollback rollback-classify down dns-view dns-sync dns-verify vault-init vault-unseal vault-auto-unseal vault-status vault-setup vault-seed vault-sync-to-sops vault-setup-sync-token vault-bootstrap-approles check-secrets-schema
+.PHONY: help build deploy-infra deploy-infra-production deploy-vault deploy-observability test logs health ssh secrets-edit secrets-init secrets-view secrets-update ps snapshot recreate-vps config-vps harden-ssh harden-ssh-check validate docs-dev backup backup-list backup-prune backup-restore rollback rollback-classify down dns-view dns-sync dns-verify vault-init vault-unseal vault-auto-unseal vault-status vault-setup vault-seed vault-sync-to-sops vault-setup-sync-token vault-bootstrap-approles check-secrets-schema
 
 # Environment
 ENV ?= prod
@@ -91,10 +91,12 @@ config-vps: ## Configure VPS OS only (no containers deployed)
 	bash scripts/vps.sh config $(VPS_IP)
 	@echo ""
 	@echo "$(COLOR_GREEN)✓ VPS configured!$(COLOR_RESET)"
-	@echo ""
-	@echo "$(COLOR_YELLOW)Next: Deploy infrastructure and services$(COLOR_RESET)"
-	@echo "  make deploy-infra    # Traefik, Portainer"
-	@echo ""
+
+harden-ssh-check: ## Dry run of harden-ssh — reports what would change, changes nothing
+	bash scripts/vps.sh harden-ssh --check
+
+harden-ssh: ## Re-apply firewall + SSH hardening only (02+04), against the known TAILSCALE_IP — h#681/h#786
+	bash scripts/vps.sh harden-ssh
 
 # ============================================================================
 # Development

--- a/infra/ansible/playbooks/02-firewall.yml
+++ b/infra/ansible/playbooks/02-firewall.yml
@@ -62,6 +62,7 @@
   command: firewall-cmd --zone=public --list-services
   register: fw_public
   changed_when: false
+  check_mode: no
 
 # The assertion that would have caught this. A firewall rule nobody reads is the
 # same class as a config file nobody reads: 04-ssh-lockdown.yml exists precisely

--- a/infra/ansible/playbooks/04-ssh-lockdown.yml
+++ b/infra/ansible/playbooks/04-ssh-lockdown.yml
@@ -381,6 +381,109 @@
     success_msg: "SSH hardening verified against sshd -T (password auth off, root login off, key auth on)"
 
 # ---------------------------------------------------------------------------
+# GATE 3: sshd -T agreeing with intent is an assertion, not a connection
+# (h#852 review)
+# ---------------------------------------------------------------------------
+#
+# GATE 2, above, proves an authenticated connection works BEFORE this play
+# touches sshd — but nothing after the reload proves one still works AFTER.
+# The assert immediately above this compares `sshd -T`'s reported
+# configuration against what was intended; it never opens a socket. That is
+# a real gap specifically here, because this is the one change in this
+# playbook whose failure mode is losing the access needed to fix it — every
+# other assert in this file is checking a state that, if wrong, is at worst
+# inconvenient, not a lockout.
+#
+# Same method as GATE 2 and the same reason: there is no real private key on
+# this host to test with, so this generates a second throwaway keypair,
+# appends it to the SAME authorized_keys the reload just changed sshd's
+# handling of, and attempts a real authenticated connection over loopback —
+# proving the MECHANISM survives the reload, not just that the config text
+# reads as expected. A listening port is not this proof: `wait_for: port=22`
+# would pass whether or not authentication itself still works, which is
+# exactly the property this reload changes.
+#
+# block/rescue/always, identical reasoning to GATE 2: the throwaway key must
+# be removed whether the probe succeeds, fails, or the play is interrupted.
+- name: Prove an authenticated SSH connection still works AFTER the reload
+  block:
+    - name: Generate a second throwaway keypair to probe post-reload sshd
+      command: >
+        ssh-keygen -t ed25519 -N '' -q
+        -f /tmp/.hill90-ssh-postreload-gate-{{ ansible_date_time.epoch }}
+        -C hill90-ssh-postreload-gate-probe
+      register: postreload_gate_keygen
+      changed_when: false
+
+    - name: Read the post-reload probe's public key
+      slurp:
+        src: "/tmp/.hill90-ssh-postreload-gate-{{ ansible_date_time.epoch }}.pub"
+      register: postreload_gate_pubkey_raw
+
+    - name: Append the post-reload probe's public key to the deploy user's authorized_keys
+      lineinfile:
+        path: "{{ deploy_home }}/.ssh/authorized_keys"
+        line: "{{ (postreload_gate_pubkey_raw.content | b64decode).strip() }}"
+        create: no
+
+    - name: Attempt a FRESH authenticated SSH connection as the deploy user, over loopback, after the reload
+      command: >
+        ssh -i /tmp/.hill90-ssh-postreload-gate-{{ ansible_date_time.epoch }}
+        -o BatchMode=yes -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
+        -o ConnectTimeout=5 -o PreferredAuthentications=publickey
+        {{ deploy_user }}@127.0.0.1 true
+      register: postreload_gate_connection
+      changed_when: false
+      failed_when: false
+
+  always:
+    - name: Remove the post-reload probe's line from authorized_keys
+      lineinfile:
+        path: "{{ deploy_home }}/.ssh/authorized_keys"
+        line: "{{ (postreload_gate_pubkey_raw.content | b64decode).strip() }}"
+        state: absent
+      when: postreload_gate_pubkey_raw is defined and postreload_gate_pubkey_raw.content is defined
+
+    - name: Remove the post-reload probe keypair files
+      file:
+        path: "/tmp/.hill90-ssh-postreload-gate-{{ ansible_date_time.epoch }}{{ item }}"
+        state: absent
+      loop:
+        - ""
+        - ".pub"
+
+- name: Fail the play if the post-reload connection did not actually authenticate
+  assert:
+    that:
+      - postreload_gate_connection.rc == 0
+    fail_msg: |
+      sshd -T reports the intended configuration (verified above), but a
+      FRESH authenticated connection as {{ deploy_user }} — using a new
+      throwaway key appended after the reload, over loopback — failed (exit
+      {{ postreload_gate_connection.rc | default('?') }}).
+
+      This is the failure this gate exists to catch before anyone
+      disconnects: the effective configuration reading correctly is not the
+      same claim as a new connection actually succeeding against it. Do NOT
+      close your current session. Investigate from THIS session — likely
+      causes: an interaction between the corrected cloud-init drop-in and
+      the 00- hardening drop-in that "sshd -t" validated as syntactically
+      fine but that behaves differently than intended, or a reload that did
+      not actually take effect despite systemd reporting success.
+
+      stderr from the post-reload probe connection:
+      {{ postreload_gate_connection.stderr | default('(no output)') }}
+    success_msg: "Verified: a FRESH authenticated SSH connection as {{ deploy_user }} succeeds AFTER the reload — the mechanism survived the change, not just the config text"
+
+# Human verification stays required alongside the machine gate above, not
+# instead of it — they are different assurances. The gate proves the
+# mechanism works for a key ansible controls, generated and destroyed within
+# this same play run; it cannot prove YOUR session, from YOUR terminal, with
+# YOUR actual key, still works. Keep this session open regardless of the
+# gate passing, and verify access from a second, fresh session before
+# disconnecting the first.
+
+# ---------------------------------------------------------------------------
 # NOTE ON fail2ban
 # ---------------------------------------------------------------------------
 #

--- a/infra/ansible/playbooks/04-ssh-lockdown.yml
+++ b/infra/ansible/playbooks/04-ssh-lockdown.yml
@@ -30,6 +30,21 @@
 #
 # Every change is then verified against `sshd -T`. An assertion nobody checks is
 # how the previous version survived a full rebuild.
+#
+# h#786 addendum: this fix was correct and has been in `main` since #545
+# (2026-07-26) — it was simply never RUN. `Config VPS` last executed
+# 2026-02-02, months before #545 existed, and nothing has invoked it since
+# (h#681). Confirmed live 2026-08-05/06: `00-hill90-hardening.conf` is absent
+# from `/etc/ssh/sshd_config.d/` on the running host, `sshd -T` still reports
+# `passwordauthentication yes`. Applying this (unchanged) fix is `make
+# harden-ssh` / `infra/ansible/playbooks/ssh-harden.yml` — a narrow re-run of
+# just this file and 02-firewall.yml, not the full bootstrap, because
+# bootstrap's other plays (03-tailscale, 05-docker) have a blast radius this
+# fix does not need. That review also asked whether sorting BEFORE cloud-init's
+# drop-in is a fix that works "by construction" or by luck of filename
+# ordering — see the task immediately below "SSH hardening, written where it
+# wins" for the answer: 50-cloud-init.conf's own PasswordAuthentication line is
+# now corrected directly, so this keyword no longer depends on ordering at all.
 
 # ---------------------------------------------------------------------------
 # GATE: refuse to lock the door until we have proven there is a key that
@@ -217,6 +232,25 @@
 # ---------------------------------------------------------------------------
 # SSH hardening, written where it wins
 # ---------------------------------------------------------------------------
+#
+# h#786 review: the 00- drop-in below wins by lexical sort order ahead of
+# cloud-init's 50-cloud-init.conf — correct, but a fix that works because
+# "00" sorts before "50" is a fix that works by luck of filename ordering,
+# not by construction. The task immediately below instead corrects
+# 50-cloud-init.conf's OWN content directly, so PasswordAuthentication is
+# right at its actual source and there is no ordering dependency left for
+# this specific keyword at all. The 00- drop-in stays — it is still the
+# only place PermitRootLogin, KbdInteractiveAuthentication and the rest are
+# set, none of which cloud-init's drop-in touches — this is a correction to
+# the one setting that actually conflicted, not a replacement for it.
+- name: Correct PasswordAuthentication directly in cloud-init's own drop-in, at its source
+  lineinfile:
+    path: /etc/ssh/sshd_config.d/50-cloud-init.conf
+    regexp: '^\s*PasswordAuthentication\s+'
+    line: 'PasswordAuthentication no'
+    create: no
+  failed_when: false   # the file may not exist on every image; absence is not an error, it just means there is nothing here to correct
+  register: cloud_init_dropin_corrected
 
 - name: Deploy SSH hardening drop-in (sorts before cloud-init's)
   copy:
@@ -245,14 +279,19 @@
 
 # `sshd -t` validates the FULL effective configuration, includes and all, which
 # is the only way to know the drop-in composes correctly with what is already
-# there. It runs BEFORE any restart, and a bad file is removed rather than left
-# in place — otherwise the next restart by anything at all would fail, and the
+# there. It runs BEFORE any reload, and a bad file is removed rather than left
+# in place — otherwise the next reload by anything at all would fail, and the
 # only route in is the tailnet.
+#
+# check_mode: no — this is a read-only validation of whatever is ALREADY on
+# disk. Under `--check` it still runs, so a dry-run reports the current,
+# real syntax state rather than being skipped as "would validate something".
 - name: Validate the effective sshd configuration
   command: /usr/sbin/sshd -t
   register: sshd_validate
   changed_when: false
   failed_when: false
+  check_mode: no
 
 - name: Remove the drop-in if it produced an invalid configuration
   file:
@@ -264,17 +303,30 @@
   fail:
     msg: |
       The SSH hardening drop-in produced an invalid sshd configuration and has
-      been removed. sshd was NOT restarted, so access is unaffected.
+      been removed. sshd was NOT reloaded, so access is unaffected.
 
       sshd -t said:
       {{ sshd_validate.stderr | default('(no output)') }}
   when: sshd_validate.rc != 0
 
-- name: Restart sshd to apply the drop-in
+# RELOAD, not restart. None of the keywords this play sets — PasswordAuthentication,
+# PermitRootLogin, PubkeyAuthentication, KbdInteractiveAuthentication,
+# PermitEmptyPasswords, MaxAuthTries, ClientAliveInterval/CountMax — require a
+# full restart; sshd re-reads its config on SIGHUP (systemd `reloaded`) without
+# dropping already-established sessions. A restart would drop the very
+# connection this playbook is running over if it happens to be a plain-sshd one
+# rather than Tailscale SSH.
+#
+# OPERATOR NOTE, belongs here and not just in a PR description: after this task
+# runs, keep your current session open and verify access from a SECOND, fresh
+# session before disconnecting the first. A reload that produced an effective
+# configuration nobody can authenticate against would otherwise be discovered
+# only by losing access.
+- name: Reload sshd to apply the drop-in and the corrected cloud-init file
   systemd:
     name: sshd
-    state: restarted
-  when: sshd_dropin.changed
+    state: reloaded
+  when: sshd_dropin.changed or cloud_init_dropin_corrected.changed | default(false)
 
 # Stop cloud-init reasserting PasswordAuthentication on rebuild. The 00- drop-in
 # already wins, but leaving cloud-init writing the opposite value means the host
@@ -304,6 +356,7 @@
   command: /usr/sbin/sshd -T
   register: sshd_effective
   changed_when: false
+  check_mode: no
 
 - name: Assert SSH hardening actually applied
   assert:

--- a/infra/ansible/playbooks/ssh-harden.yml
+++ b/infra/ansible/playbooks/ssh-harden.yml
@@ -1,0 +1,53 @@
+---
+# Narrow re-apply of firewall + SSH hardening, without the rest of bootstrap.
+#
+# h#681 / h#786: 04-ssh-lockdown.yml already writes the drop-in that beats
+# cloud-init's PasswordAuthentication override, validates it with `sshd -t`,
+# and asserts the result against `sshd -T` — the fix has been correct in this
+# repo since #545 (2026-07-26). It has never taken effect on the running host
+# because the only thing that invokes it is bootstrap.yml, and the only thing
+# that invokes bootstrap.yml is `make config-vps` / Config VPS — which nobody
+# has run since 2026-02-02, months before the fix existed. This is not a
+# config bug; it is a pipeline that was never re-triggered after the fix
+# landed.
+#
+# bootstrap.yml (01-08, 11-12) is the wrong tool for re-applying just this:
+# per h#681's own blast-radius accounting, 03-tailscale reconfigures the only
+# access path this estate has (557 interactive + 189 pipeline sessions in 24h,
+# 0 accepted plain sshd logins) and 05-docker bounces every container in the
+# estate, platform and tenant, for the length of a restart. Neither is wanted
+# to fix a firewall rule and an sshd drop-in.
+#
+# This playbook imports ONLY 02 (firewall) and 04 (ssh-lockdown), in that
+# order — 02 must run first because it is what turns public ssh ON (matching
+# the base image's default), and 04 is what turns it back off and restricts
+# to the tailnet; running 04 without 02 having run at least once would still
+# leave firewalld in whatever state it was already in for the ssh service,
+# which 04's own "Remove public SSH access" task handles regardless, but the
+# ORDER in the two files assumes 02 ran first and this preserves that.
+#
+# Connects as deploy_user, NOT root: `ansible_user: root` in inventory/hosts.yml
+# is correct only for a bare, unconfigured host. This host has already been
+# bootstrapped once — sshd -T already reports permitrootlogin no, verified live
+# — so a root connection is refused before any task here would even run.
+# deploy_user's key-based access and passwordless sudo were verified live
+# before this file was written, not assumed.
+#
+# Does NOT deploy containers, does NOT touch Tailscale, does NOT auto-trigger
+# deploy-infra. Re-run is safe: both imported task files are idempotent
+# (firewalld state, a copy: task, and an assert), matching bootstrap.yml's own
+# design.
+- name: Re-apply firewall and SSH hardening only
+  hosts: vps
+  become: yes
+  gather_facts: yes
+
+  vars_files:
+    - ../inventory/group_vars/all.yml
+
+  tasks:
+    - name: "02 - Firewall"
+      import_tasks: 02-firewall.yml
+
+    - name: "04 - SSH Lockdown"
+      import_tasks: 04-ssh-lockdown.yml

--- a/scripts/vps.sh
+++ b/scripts/vps.sh
@@ -20,6 +20,9 @@ Usage: vps.sh <command> [args]
 Commands:
   recreate              Rebuild VPS via API (DESTRUCTIVE, auto-rotates Tailscale key)
   config   <vps_ip>     Configure VPS OS via Ansible (no containers)
+  harden-ssh [--check]  Re-apply firewall + SSH hardening only (02+04), against
+                         the already-known TAILSCALE_IP — see h#681/h#786.
+                         --check reports what would change without changing it.
   help                  Show this help message
 EOF
 }
@@ -327,6 +330,93 @@ cmd_config() {
 }
 
 # ---------------------------------------------------------------------------
+# Narrow re-apply of firewall + SSH hardening only — h#681 / h#786
+# ---------------------------------------------------------------------------
+
+# Re-applies infra/ansible/playbooks/ssh-harden.yml (02-firewall + 04-ssh-lockdown
+# ONLY — see that file's own header for why bootstrap.yml is the wrong tool for
+# this). Unlike cmd_config, this takes NO vps_ip argument: it targets an
+# ALREADY-BOOTSTRAPPED host by its known TAILSCALE_IP, which is the only address
+# that still answers once 04 has taken effect — a bare host with no Tailscale IP
+# recorded yet has nothing for this command to re-harden.
+#
+# Connects as deploy_user, not root: root login is refused by design once 04 has
+# taken effect even once, and the whole reason this command exists is hosts where
+# it may already have partially taken effect. Verified live before this was
+# written, not assumed: `deploy` has key-based access and passwordless sudo on
+# the current production host.
+cmd_harden_ssh() {
+    local mode="apply"
+    case "${1:-}" in
+        --check|--dry-run) mode="check" ;;
+        "") : ;;
+        *) die "Unknown option '$1'. Usage: vps.sh harden-ssh [--check]" ;;
+    esac
+
+    local ansible_flags=()
+    if [ "$mode" = "check" ]; then
+        ansible_flags=(--check --diff)
+        echo -e "${CYAN}═══════════════════════════════════════════════════════════════${NC}"
+        echo -e "${CYAN}  DRY RUN — Firewall + SSH Hardening (02 + 04 only), no changes  ${NC}"
+        echo -e "${CYAN}═══════════════════════════════════════════════════════════════${NC}"
+        echo -e "${YELLOW}--check --diff: reports what would change without changing it.${NC}"
+        echo -e "${YELLOW}Read-only diagnostics (sshd -t, sshd -T, firewall-cmd --list-services)${NC}"
+        echo -e "${YELLOW}still run for real, so this reports the CURRENT effective state too.${NC}"
+    else
+        echo -e "${CYAN}═══════════════════════════════════════════════════════════════${NC}"
+        echo -e "${CYAN}       Re-apply Firewall + SSH Hardening (02 + 04 only)         ${NC}"
+        echo -e "${CYAN}═══════════════════════════════════════════════════════════════${NC}"
+    fi
+    echo ""
+
+    if [[ -z "${TAILSCALE_AUTH_KEY:-}" ]]; then
+        load_secrets
+    fi
+
+    local tailscale_ip
+    tailscale_ip=$(cd "$PROJECT_ROOT" && sops -d --extract '["TAILSCALE_IP"]' infra/secrets/prod.enc.env 2>/dev/null || echo "")
+    [ -n "$tailscale_ip" ] \
+        || die "No TAILSCALE_IP recorded in the store. This command re-hardens an already-bootstrapped host; a host that has never completed 'make config-vps' has nothing here to re-apply — run that first."
+
+    echo -e "${BLUE}Target (Tailscale IP):${NC} $tailscale_ip"
+    echo -e "${BLUE}Connecting as:${NC} deploy (root login is refused once hardening has taken effect)"
+    if [ "$mode" = "apply" ]; then
+        echo -e "${YELLOW}This RELOADS sshd if anything changed. Keep this session open and verify${NC}"
+        echo -e "${YELLOW}access from a SECOND, fresh session before disconnecting this one.${NC}"
+    fi
+    echo ""
+
+    cd "$PROJECT_ROOT/infra/ansible"
+    if ansible-playbook -i "inventory/hosts.yml" \
+                     "${ansible_flags[@]}" \
+                     -e "ansible_host=$tailscale_ip" \
+                     -e "ansible_user=deploy" \
+                     -e "ansible_become=yes" \
+                     -e "ansible_ssh_private_key_file=~/.ssh/remote.hill90.com" \
+                     -e "ansible_ssh_common_args='-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'" \
+                     playbooks/ssh-harden.yml; then
+        echo ""
+        if [ "$mode" = "check" ]; then
+            success "   ✓ Dry run complete — nothing was changed. Re-run without --check to apply."
+        else
+            success "   ✓ Firewall + SSH hardening re-applied and verified against sshd -T"
+        fi
+    else
+        echo ""
+        if [ "$mode" = "check" ]; then
+            echo -e "${YELLOW}   Dry run reported a failure — see ansible output above. Nothing was changed.${NC}"
+            echo -e "${YELLOW}   A failed assert here can just mean the host is currently in the broken${NC}"
+            echo -e "${YELLOW}   state this fix addresses — that is what a dry run against a broken host${NC}"
+            echo -e "${YELLOW}   is expected to show.${NC}"
+        else
+            echo -e "${RED}   ✗ Re-apply failed — see ansible output above${NC}"
+            echo -e "${YELLOW}   Re-run is safe: both imported task files are idempotent.${NC}"
+        fi
+        exit 1
+    fi
+}
+
+# ---------------------------------------------------------------------------
 # Main dispatcher
 # ---------------------------------------------------------------------------
 
@@ -342,6 +432,7 @@ main() {
     case "$cmd" in
         recreate)       cmd_recreate "$@" ;;
         config)         cmd_config "$@" ;;
+        harden-ssh)     cmd_harden_ssh "$@" ;;
         help|--help|-h) usage ;;
         *)
             echo "Unknown command: $cmd"

--- a/tests/scripts/ssh-hardening.bats
+++ b/tests/scripts/ssh-hardening.bats
@@ -14,9 +14,28 @@ ROLE=infra/ansible/playbooks/04-ssh-lockdown.yml
   # A value written into sshd_config is read AFTER the Include and loses.
   run grep -F 'dest: /etc/ssh/sshd_config.d/00-hill90-hardening.conf' "$ROLE"
   [ "$status" -eq 0 ]
-  # No lineinfile against the main config file.
-  run bash -c "grep -A3 'lineinfile:' $ROLE | grep -F 'path: /etc/ssh/sshd_config'"
+  # No lineinfile against the MAIN config file specifically — anchored to
+  # end-of-line so this does not also match a legitimate lineinfile against
+  # a *drop-in* (sshd_config.d/50-cloud-init.conf), which h#786 deliberately
+  # added and is a different file entirely from the main config.
+  run bash -c "grep -A3 'lineinfile:' $ROLE | grep -E 'path: /etc/ssh/sshd_config\$'"
   [ "$status" -ne 0 ]
+}
+
+@test "h#786: cloud-init's own drop-in is corrected at its source, not just out-ranked by sort order" {
+  # The 00- drop-in winning by lexical order is real but was flagged in
+  # review as a fix that works by luck of filename ordering rather than by
+  # construction. This pins the stronger fix alongside it: a lineinfile task
+  # that corrects PasswordAuthentication directly inside
+  # /etc/ssh/sshd_config.d/50-cloud-init.conf, so this keyword no longer
+  # depends on which file sorts first at all.
+  run bash -c "grep -A6 'name: Correct PasswordAuthentication directly in cloud' $ROLE | grep -F 'path: /etc/ssh/sshd_config.d/50-cloud-init.conf'"
+  [ "$status" -eq 0 ]
+  run bash -c "grep -A6 'name: Correct PasswordAuthentication directly in cloud' $ROLE | grep -F 'line: '\''PasswordAuthentication no'\'''"
+  [ "$status" -eq 0 ]
+  # Absence of the file must not be an error — not every image ships it.
+  run bash -c "grep -A8 'name: Correct PasswordAuthentication directly in cloud' $ROLE | grep -F 'failed_when: false'"
+  [ "$status" -eq 0 ]
 }
 
 @test "the drop-in name sorts before cloud-init's" {
@@ -47,13 +66,29 @@ ROLE=infra/ansible/playbooks/04-ssh-lockdown.yml
   [ "$status" -eq 0 ]
 }
 
-@test "the config is validated before sshd is restarted" {
-  # Writing a bad drop-in and restarting would break the only route in.
+@test "the config is validated before sshd is reloaded" {
+  # Writing a bad drop-in and reloading would break the only route in.
   run bash -c "
     v=\$(grep -n 'sshd -t' $ROLE | head -1 | cut -d: -f1)
-    r=\$(grep -n 'name: Restart sshd' $ROLE | head -1 | cut -d: -f1)
+    r=\$(grep -n 'name: Reload sshd' $ROLE | head -1 | cut -d: -f1)
     [ -n \"\$v\" ] && [ -n \"\$r\" ] && [ \"\$v\" -lt \"\$r\" ]
   "
+  [ "$status" -eq 0 ]
+}
+
+@test "h#786: sshd is reloaded, not restarted — none of these keywords need a full restart" {
+  # A restart would drop the very connection this playbook might be running
+  # over, if it happens to be a plain-sshd session rather than Tailscale SSH.
+  # Reload (SIGHUP) re-reads config without dropping established sessions,
+  # and every keyword this role sets supports it.
+  run grep -F 'name: Reload sshd to apply the drop-in' "$ROLE"
+  [ "$status" -eq 0 ]
+  run bash -c "grep -A3 'name: Reload sshd to apply the drop-in' $ROLE | grep -F 'state: reloaded'"
+  [ "$status" -eq 0 ]
+  run bash -c "grep -A3 'name: Reload sshd to apply the drop-in' $ROLE | grep -F 'state: restarted'"
+  [ "$status" -ne 0 ]
+  # The operator note belongs in the file, not only in a PR description.
+  run grep -iF 'keep your current session open' "$ROLE"
   [ "$status" -eq 0 ]
 }
 
@@ -109,7 +144,7 @@ ROLE=infra/ansible/playbooks/04-ssh-lockdown.yml
     gate=\$(grep -n 'name: Refuse to proceed without a usable key' $ROLE | head -1 | cut -d: -f1)
     firewall=\$(grep -n 'name: Lock SSH to Tailscale network only' $ROLE | head -1 | cut -d: -f1)
     dropin=\$(grep -n 'name: Deploy SSH hardening drop-in' $ROLE | head -1 | cut -d: -f1)
-    restart=\$(grep -n 'name: Restart sshd to apply the drop-in' $ROLE | head -1 | cut -d: -f1)
+    restart=\$(grep -n 'name: Reload sshd to apply the drop-in' $ROLE | head -1 | cut -d: -f1)
     [ -n \"\$gate\" ] && [ -n \"\$firewall\" ] && [ -n \"\$dropin\" ] && [ -n \"\$restart\" ] \
       && [ \"\$gate\" -lt \"\$firewall\" ] && [ \"\$gate\" -lt \"\$dropin\" ] && [ \"\$gate\" -lt \"\$restart\" ]
   "

--- a/tests/scripts/ssh-hardening.bats
+++ b/tests/scripts/ssh-hardening.bats
@@ -271,3 +271,79 @@ ROLE=infra/ansible/playbooks/04-ssh-lockdown.yml
   run bash -c "grep -A25 'name: Refuse to proceed unless the probe connection actually authenticated' $ROLE | grep -iF 'StrictModes'"
   [ "$status" -eq 0 ]
 }
+
+# ---------------------------------------------------------------------------
+# GATE 3 (h#852 review of h#786): sshd -T reading correctly is an assertion,
+# not a connection. GATE 2 proves an authenticated connection works BEFORE
+# the reload; nothing previously proved one still worked AFTER it.
+# ---------------------------------------------------------------------------
+
+@test "GATE 3 exists and runs AFTER both the reload and the sshd -T assert" {
+  run bash -c "
+    reload=\$(grep -n 'name: Reload sshd to apply the drop-in' $ROLE | head -1 | cut -d: -f1)
+    effective_assert=\$(grep -n 'name: Assert SSH hardening actually applied' $ROLE | head -1 | cut -d: -f1)
+    gate3=\$(grep -n 'name: Prove an authenticated SSH connection still works AFTER the reload' $ROLE | head -1 | cut -d: -f1)
+    refuse3=\$(grep -n 'name: Fail the play if the post-reload connection did not actually authenticate' $ROLE | head -1 | cut -d: -f1)
+    [ -n \"\$reload\" ] && [ -n \"\$effective_assert\" ] && [ -n \"\$gate3\" ] && [ -n \"\$refuse3\" ] \
+      && [ \"\$reload\" -lt \"\$gate3\" ] && [ \"\$effective_assert\" -lt \"\$gate3\" ] && [ \"\$gate3\" -lt \"\$refuse3\" ]
+  "
+  [ "$status" -eq 0 ]
+}
+
+@test "GATE 3 attempts a REAL fresh ssh connection, not a port check" {
+  run bash -c "grep -A45 'name: Prove an authenticated SSH connection still works AFTER the reload' $ROLE | grep -E '^\s+ssh -i '"
+  [ "$status" -eq 0 ]
+  run bash -c "grep -A45 'name: Prove an authenticated SSH connection still works AFTER the reload' $ROLE | grep -F 'BatchMode=yes'"
+  [ "$status" -eq 0 ]
+  # A listening-port check would prove nothing about whether auth still
+  # works — the exact property the reload changes. Must not be the method.
+  run bash -c "grep -A45 'name: Prove an authenticated SSH connection still works AFTER the reload' $ROLE | grep -iF 'wait_for'"
+  [ "$status" -ne 0 ]
+}
+
+@test "GATE 3 targets loopback, over a SECOND throwaway key distinct from GATE 2's" {
+  run bash -c "grep -A45 'name: Prove an authenticated SSH connection still works AFTER the reload' $ROLE | grep -F '127.0.0.1'"
+  [ "$status" -eq 0 ]
+  run bash -c "grep -A10 'name: Generate a second throwaway keypair to probe post-reload sshd' $ROLE | grep -F 'ssh-keygen -t ed25519'"
+  [ "$status" -eq 0 ]
+  # Distinct temp filename from GATE 2's probe, so a re-run cannot collide
+  # with or accidentally reuse GATE 2's already-cleaned-up files.
+  run grep -F 'hill90-ssh-postreload-gate' "$ROLE"
+  [ "$status" -eq 0 ]
+}
+
+@test "GATE 3 cleans up its probe key unconditionally, via block/always" {
+  run bash -c "grep -A60 'name: Prove an authenticated SSH connection still works AFTER the reload' $ROLE | grep -m1 '^  block:'"
+  [ "$status" -eq 0 ]
+  run bash -c "grep -A60 'name: Prove an authenticated SSH connection still works AFTER the reload' $ROLE | grep -m1 '^  always:'"
+  [ "$status" -eq 0 ]
+  run bash -c "grep -A70 'name: Prove an authenticated SSH connection still works AFTER the reload' $ROLE | grep -c 'name: Remove the post-reload probe'"
+  [ "$output" -ge 2 ]
+}
+
+@test "GATE 3 refuses on the fresh connection's own exit code" {
+  run bash -c "grep -A5 'name: Fail the play if the post-reload connection did not actually authenticate' $ROLE | grep -F 'postreload_gate_connection.rc == 0'"
+  [ "$status" -eq 0 ]
+}
+
+@test "GATE 3's failure message tells the operator not to close the current session" {
+  # The sentence wraps across two lines in the YAML block scalar, same trap
+  # noted elsewhere in this file (see the CLAUDE.md rules — a fixed-string
+  # match against a wrapped sentence silently matches nothing), so this
+  # joins lines with tr before grepping rather than matching the whole
+  # sentence as one grep line.
+  run bash -c "grep -A25 'name: Fail the play if the post-reload connection did not actually authenticate' $ROLE | tr '\n' ' ' | tr -s ' ' | grep -iF 'Do NOT close your current session'"
+  [ "$status" -eq 0 ]
+}
+
+@test "the human second-session instruction is kept alongside GATE 3, not replaced by it" {
+  run bash -c "grep -A25 'name: Fail the play if the post-reload connection did not actually authenticate' $ROLE | grep -iF 'different assurances'"
+  [ "$status" -eq 0 ]
+  # The ORIGINAL h#786 operator note, pre-dating this gate, must survive
+  # unedited — this gate is additive, not a replacement for the human check.
+  run grep -iF 'keep your current session open' "$ROLE"
+  [ "$status" -eq 0 ]
+  # And GATE 3's own reinforcement of the same instruction is present too.
+  run grep -iF 'keep this session open' "$ROLE"
+  [ "$status" -eq 0 ]
+}

--- a/tests/scripts/vps.bats
+++ b/tests/scripts/vps.bats
@@ -25,3 +25,126 @@
   [ "$status" -eq 1 ]
   [[ "$output" == *"required"* ]] || [[ "$output" == *"Usage"* ]]
 }
+
+# ---------------------------------------------------------------------------
+# h#681 / h#786: harden-ssh — narrow re-apply of firewall + SSH hardening
+# only, without the rest of bootstrap.yml's blast radius (03-tailscale,
+# 05-docker). cmd_harden_ssh is stubbed here, not run for real — sops and
+# ansible-playbook are replaced with recording stubs so these tests prove
+# the COMMAND'S OWN LOGIC (which flags reach ansible-playbook, which mode
+# is reported) without ever touching a real secrets store or a real host.
+# ---------------------------------------------------------------------------
+
+setup_harden_ssh_stubs() {
+  STUB="$BATS_TEST_TMPDIR/bin"
+  mkdir -p "$STUB"
+  PATH="$STUB:$PATH"
+
+  cat > "$STUB/sops" <<'EOF'
+#!/usr/bin/env bash
+echo "203.0.113.10"
+EOF
+  chmod +x "$STUB/sops"
+
+  cat > "$STUB/ansible-playbook" <<EOF
+#!/usr/bin/env bash
+echo "\$@" > "$BATS_TEST_TMPDIR/ansible-playbook.args"
+exit 0
+EOF
+  chmod +x "$STUB/ansible-playbook"
+
+  # load_secrets is skipped entirely when this is already set — cmd_harden_ssh
+  # only needs the second, direct `sops --extract TAILSCALE_IP` call, which
+  # the stub above answers regardless of which secrets file is asked for.
+  export TAILSCALE_AUTH_KEY=stub-not-a-real-key
+}
+
+@test "vps.sh help mentions harden-ssh and --check" {
+  run bash scripts/vps.sh help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"harden-ssh"* ]]
+  [[ "$output" == *"--check"* ]]
+}
+
+@test "harden-ssh rejects an unknown option before touching secrets or the network" {
+  # No stubs installed on purpose — if this reached load_secrets/sops/ansible
+  # at all, it would fail on a missing age key or real sops, not on this
+  # assertion. Failing fast on option parsing means it does neither.
+  run bash scripts/vps.sh harden-ssh --bogus
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Unknown option"* ]]
+  [[ "$output" == *"--check"* ]]
+}
+
+@test "harden-ssh (apply mode) invokes ansible-playbook WITHOUT --check" {
+  setup_harden_ssh_stubs
+  run bash scripts/vps.sh harden-ssh
+  [ "$status" -eq 0 ]
+  [ -f "$BATS_TEST_TMPDIR/ansible-playbook.args" ]
+  run cat "$BATS_TEST_TMPDIR/ansible-playbook.args"
+  [[ "$output" != *"--check"* ]]
+  [[ "$output" == *"playbooks/ssh-harden.yml"* ]]
+  [[ "$output" == *"ansible_user=deploy"* ]]
+}
+
+@test "harden-ssh --check invokes ansible-playbook WITH --check --diff, same playbook" {
+  setup_harden_ssh_stubs
+  run bash scripts/vps.sh harden-ssh --check
+  [ "$status" -eq 0 ]
+  [ -f "$BATS_TEST_TMPDIR/ansible-playbook.args" ]
+  run cat "$BATS_TEST_TMPDIR/ansible-playbook.args"
+  [[ "$output" == *"--check"* ]]
+  [[ "$output" == *"--diff"* ]]
+  [[ "$output" == *"playbooks/ssh-harden.yml"* ]]
+}
+
+@test "harden-ssh --dry-run is accepted as a synonym for --check" {
+  setup_harden_ssh_stubs
+  run bash scripts/vps.sh harden-ssh --dry-run
+  [ "$status" -eq 0 ]
+  run cat "$BATS_TEST_TMPDIR/ansible-playbook.args"
+  [[ "$output" == *"--check"* ]]
+}
+
+@test "harden-ssh (apply mode) warns to keep the session open before reloading" {
+  setup_harden_ssh_stubs
+  run bash scripts/vps.sh harden-ssh
+  [[ "$output" == *"Keep this session open"* ]]
+}
+
+@test "harden-ssh --check does NOT print the keep-this-session-open warning — nothing is being reloaded" {
+  setup_harden_ssh_stubs
+  run bash scripts/vps.sh harden-ssh --check
+  [[ "$output" != *"Keep this session open"* ]]
+}
+
+@test "harden-ssh connects as deploy, never root — root login is refused on an already-hardened host" {
+  setup_harden_ssh_stubs
+  run bash scripts/vps.sh harden-ssh
+  run cat "$BATS_TEST_TMPDIR/ansible-playbook.args"
+  [[ "$output" == *"ansible_user=deploy"* ]]
+  [[ "$output" != *"ansible_user=root"* ]]
+}
+
+@test "harden-ssh refuses cleanly when no TAILSCALE_IP is recorded — never calls ansible-playbook" {
+  STUB="$BATS_TEST_TMPDIR/bin"
+  mkdir -p "$STUB"
+  PATH="$STUB:$PATH"
+  cat > "$STUB/sops" <<'EOF'
+#!/usr/bin/env bash
+echo ""
+EOF
+  chmod +x "$STUB/sops"
+  cat > "$STUB/ansible-playbook" <<EOF
+#!/usr/bin/env bash
+echo "SHOULD NOT HAVE BEEN CALLED" > "$BATS_TEST_TMPDIR/ansible-playbook.called"
+exit 0
+EOF
+  chmod +x "$STUB/ansible-playbook"
+  export TAILSCALE_AUTH_KEY=stub-not-a-real-key
+
+  run bash scripts/vps.sh harden-ssh
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"No TAILSCALE_IP recorded"* ]]
+  [ ! -f "$BATS_TEST_TMPDIR/ansible-playbook.called" ]
+}


### PR DESCRIPTION
Closes h#786. Same root cause as h#681 (not a duplicate fix — confirmed before writing anything: the existing `04-ssh-lockdown.yml` fix from #545 is correct and has simply never run against this host).

## The finding, verified live

```
sudo sshd -T | grep passwordauth   ->  passwordauthentication yes
/etc/ssh/sshd_config:64            ->  PasswordAuthentication no
/etc/ssh/sshd_config.d/50-cloud-init.conf:1  ->  PasswordAuthentication yes   <- wins
```

`00-hill90-hardening.conf` (the drop-in `04-ssh-lockdown.yml` writes to beat cloud-init) is **absent from the live host**. `Config VPS` last executed 2026-02-02, months before #545 (2026-07-26). Nothing has invoked `bootstrap.yml` — the only thing that runs playbook 04 — since.

**Not currently exploitable**: `76.13.26.69:22` is closed/filtered externally, with `100.88.29.112:22` (Tailscale) open as the reachability control proving the test itself works. One external vantage point is not proof for every vantage point, and a config that disagrees with itself is broken regardless of what currently bounds it.

## What this ships — code only, nothing applied to the live host

- **`infra/ansible/playbooks/ssh-harden.yml`** — imports ONLY `02-firewall.yml` + `04-ssh-lockdown.yml`, not the full bootstrap. `03-tailscale` reconfigures the only access path and `05-docker` bounces every container on the host; neither is wanted here. Connects as `deploy_user`, not `root` — root login is already refused on this host (verified live), so `ansible_user: root` (inventory's default) would be refused before any task ran.
- **`scripts/vps.sh harden-ssh [--check]`**, **`make harden-ssh`** / **`make harden-ssh-check`** — targets the already-known `TAILSCALE_IP`, no `vps_ip` argument. `--check` passes `--check --diff` through to `ansible-playbook`: a dry run reporting what would change, including the **current** effective `sshd -T` / `firewall-cmd --list-services` output (forced to run under `--check` via `check_mode: no` on those two read-only tasks), without changing anything.
- **`.github/workflows/harden-ssh.yml`** — `workflow_dispatch` only, `check` input defaults to `true`. Applying requires an explicit `check: false`. No `vps_ip`, no DNS step, no auto-triggered `deploy-infra` — this touches sshd and firewalld only.

## The root-cause fix, not just the sort-order one

Flagged in review: "`00-` sorts before `50-cloud-init.conf`" works by luck of filename ordering, not by construction. `04-ssh-lockdown.yml` now **also** corrects `50-cloud-init.conf`'s own `PasswordAuthentication` line directly via `lineinfile`, so this keyword no longer depends on which file sorts first at all. The `00-` drop-in stays — it's still the only place `PermitRootLogin`, `KbdInteractiveAuthentication`, etc. are set, none of which cloud-init's drop-in touches.

## Reload, not restart

None of the keywords this play sets need a full sshd restart. Reload (SIGHUP) re-reads config without dropping established sessions. Stated in the playbook itself, not just here: **keep your current session open and verify access from a second, fresh session before disconnecting the first.**

## Verification

- Both playbooks pass `ansible-playbook --syntax-check`.
- `tests/scripts/ssh-hardening.bats`: 24/24 — 2 new tests (cloud-init correction, reload-not-restart) plus 3 existing tests updated for the renamed reload task. Mutation-verified: reverting either change fails exactly its own test, nothing else.
- `tests/scripts/vps.bats`: 13/13 — 9 new tests for `cmd_harden_ssh` against stubbed `sops`/`ansible-playbook`: proves `--check` reaches `ansible-playbook` as `--check --diff` and apply mode does not (mutation-verified), connects as `deploy` never `root`, refuses cleanly with no `TAILSCALE_IP` recorded before ever calling `ansible-playbook`, session-open warning appears only in apply mode.
- `tests/scripts/cloudflare.bats` (existing `config-vps.yml` coverage): 25/25, unaffected.

## Not done this session, deliberately

No `ansible-playbook` invocation against the live host, no sshd reload, no dispatch of the new workflow. Applying this is a hard-to-reverse change to sshd on the only production host, over SSH — needs an explicit go-ahead, not an implied one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)