### PR TITLE
fix(observability): promtail waits for loki to be healthy, not merely started

### DIFF
--- a/deploy/compose/prod/docker-compose.observability.yml
+++ b/deploy/compose/prod/docker-compose.observability.yml
@@ -246,8 +246,16 @@ services:
       - /var/lib/docker/containers:/var/lib/docker/containers:ro
       - promtail-positions:/var/lib/promtail
     command: -config.file=/etc/promtail/promtail.yml
+    # h#777: was the short list form (`- loki`), which Compose resolves to
+    # service_started — waits for loki's container to start, not for loki to
+    # actually be answering. Not a data-loss bug: promtail's push client
+    # retries a failed batch with backoff and does not drop it (verified live
+    # — see the PR). This closes the gap between what was declared and what
+    # it actually waited for, and cuts the failed-connection retry noise
+    # every startup/restart otherwise logs.
     depends_on:
-      - loki
+      loki:
+        condition: service_healthy
     healthcheck:
       test: ["CMD", "promtail", "--version"]
       interval: 30s


### PR DESCRIPTION
Closes #777.

## Correcting the issue's own wording

The issue describes promtail's `depends_on` as using `service_started`. It doesn't — that literal string never appears in the file. It uses Compose's **short list form** (`depends_on: - loki`), which Compose resolves to the `service_started` condition implicitly. The semantics the issue names are exactly right; the literal text is not, and a grep for `service_started` finds nothing and could read as "already fixed." Worth saying because this session already paid for a mis-described defect once today (h#831's stale container count) — real by consequence, mis-described by search string.

## Verified before touching anything

- `loki` genuinely has a healthcheck (`docker-compose.observability.yml:142`, `wget --spider http://localhost:3100/ready`), so `condition: service_healthy` is available, not aspirational.
- promtail's `depends_on` (line 249) is the **only** one anywhere in this file — confirmed directly. None of the other 8 services declare any ordering.
- One correction to the issue's count: it says "seven other services." Precisely enumerated here as **eight** (`prometheus, alertmanager, blackbox-exporter, loki, tempo, grafana, node-exporter, cadvisor`). Noting it rather than silently using either number.

## What actually goes wrong today — established before claiming a fix

Reproduced live: a real promtail 3.5.0 tailing a real log file, started before loki existed at all. It did **not** crash and did **not** drop anything — its push client logged `"error sending batch, will retry"` (promtail's default backoff-retry client) and kept the batch. Once loki became reachable, the retried batch was delivered (observed arriving in loki's own logs).

**This is a tidiness fix, stated as one, not a data-loss fix.** promtail's own client already tolerates loki starting after it. The fix closes the gap between what compose *declared* (wait) and what it actually *waited for* (nothing meaningful), and removes a startup window of retried-and-discarded connection-failure log noise on every deploy/restart — not a window where logs are lost.

## The denominator, decided per service

None of the other 8 services get a `depends_on` added here — each for the same reason, a self-healing access pattern ordering wouldn't improve:
- **prometheus** (and everything it scrapes: blackbox-exporter, node-exporter, cadvisor, and every service's `/metrics`) — pull-based. A target not yet up is simply absent from that scrape, retried next interval by design. That's what Prometheus scraping *is*.
- **alertmanager** — receives from prometheus's own notifier, which queues and retries regardless of start order.
- **tempo** — receives OTLP pushes from services outside this file (Keycloak, etc.); a push failing early is the identical shape promtail's own client already tolerates.
- **grafana** — this file's own existing comment already establishes this empirically for Keycloak ("Grafana boots fine with Keycloak stopped"); identical reasoning holds for its Prometheus/Loki/Tempo datasources — unreachable at boot fails that dashboard *query* later, not grafana's start.

Promtail isn't an exception to "ordering is not a substitute for retry logic" — its own client proves the retry logic works. It gets fixed anyway because it's the one service that **already declared** an ordering intent, incompletely. Completing an existing declaration correctly is a smaller, different decision than adding one to eight services that never made one.

## Positive control

`docker compose up loki promtail`, with the fix:
```
loki Started -> loki Waiting -> loki Healthy -> promtail Starting
```
Reverted to the prior short-form `depends_on`, reran the identical command:
```
loki Started -> promtail Starting
```
No Waiting/Healthy step — promtail starts the instant loki's container exists, exactly the gap this issue reports. Both runs against disposable networks/volumes/containers (`h777c` prefix), torn down after — never the shared stack.

## Verification

- `docker compose config` — valid.
- `check_md_links.py`, `check_argv_secrets.sh` — unaffected.
- `ops-health-observability-coverage.bats` — 4/4, unaffected (service-count/container-list assertions, doesn't touch `depends_on`).

## Note on CI

Pushing while Actions is still working through its queue after the outage — per instruction, not re-running anything if this queues; it'll clear on its own.