### PR TITLE
fix(observability): drop the stale tempo-append-failures allowlist entry

### DIFF
--- a/scripts/checks/alert-series-allowlist.txt
+++ b/scripts/checks/alert-series-allowlist.txt
@@ -7,7 +7,6 @@
 #
 # Format:  <metric-name-or-full-selector>    # why it can legitimately be absent
 
-tempo_distributor_ingester_append_failures_total  # Lazily created: Tempo exposes this counter only after the first append failure. Verified 2026-07-31 — after the 09:45 restart /metrics carried tempo_distributor_ingester_appends_total (248 successes) and no failures line at all, while before the restart the series existed with value 30. Absence means "no failures since start", which is the healthy state.
 
 loki_request_duration_seconds_count{route="loki_api_v1_push", status_code!~"2.."}  # Lazily created per status code. THIS IS NOT THE LokiIngestionErrors BUG: status_code is a real label on this metric, carrying observed values 200, 204, 503 and "success" across routes, and a 503 has genuinely been recorded on route="ready". The ingest route has only ever returned 204 on this deployment, so the non-2xx series has not been created yet; it appears the moment a push is rejected. Contrast the rule this replaced, whose `status` label does not exist on its metric under any condition. Verified 2026-07-31.
 


### PR DESCRIPTION
`check_alert_series.py` failed the observability deploy (run 31136345907,
step "Prove every alert rule matches a live series") with one STALE
ALLOWLIST ENTRY. The line claimed
`tempo_distributor_ingester_append_failures_total` can legitimately be
absent because Tempo creates the counter lazily, so absence means "no
failures since start". That was true when written (2026-07-31). It is
not true now.

Verified against the live production Prometheus, not inferred:

  count(tempo_distributor_ingester_append_failures_total)  -> 1 series
  tempo_distributor_ingester_append_failures_total         -> 10
  increase(...[1h])                                        -> 0

Positive control for the instrument, run in the same session: a
deliberately fake metric returns [] from the same query path, so the
query does distinguish present from absent.

The counter existing is not itself a problem — the 10 failures are
historical (increase over the last hour is 0) and TempoIngestionErrors
is correctly not firing. What is a problem is a standing claim the data
contradicts: while the entry is present the rule is exempted from the
does-this-selector-match-anything check, which is the one thing that
check exists to catch.

Before/after on the VPS against the real Prometheus:

  BEFORE exit=1   (1 STALE ALLOWLIST ENTRY)
  AFTER  exit=0   (34 selectors checked, every selector matches a live
                   series, or is declared absent with a reason)

The VPS checkout was restored afterwards and is clean.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>