### PR TITLE
fix(observability): close two selector blind spots in check_alert_series.py

### DIFF
--- a/scripts/checks/check_alert_series.py
+++ b/scripts/checks/check_alert_series.py
@@ -50,6 +50,46 @@ is stale already exists on every single run, for free. So: if a selector
 that is ALSO in the allowlist comes back with real series, that is now a
 hard failure, not a silently-ignored `ok`. Zero lag, no new bookkeeping, no
 date to remember to update.
+
+h#855 REVIEW — TWO BLIND SPOTS THIS SCRIPT COULD NOT SEE, closed here.
+Both were proven with a synthetic rule against the live production
+Prometheus before either fix was written — see the PR body, not just this
+comment, for the actual output.
+
+1. A selector inside absent(...) was checked with the SAME "0 series = this
+   rule cannot fire" rule as everything else. That is backwards for this one
+   construct: 0 series is exactly what an absent()-wrapped selector is
+   DESIGNED to detect — it is the rule's own firing condition, not evidence
+   the rule is broken. The real alerts.yml has six such rules today
+   (LokiIngestionStalled/SignalMissing, BackupNotSucceeding*,
+   ScheduledWorkflow*) — four of the six currently pass only because the
+   underlying metric happens to have series RIGHT NOW; the moment any one of
+   them genuinely went absent (a real incident, or a workflow that has never
+   fired), the old code would have reported "this rule cannot fire" — false,
+   and exactly backwards during the one moment it would matter.
+   is_absent_wrapped() below detects the ONE shape this file's own rules
+   actually use — `absent(` or `absent_over_time(` directly preceding the
+   selector — not a general PromQL parse. A 0-series result for such a
+   selector is no longer added to `missing`; it is reported as its own
+   category and does not fail the check, because the wrapper is itself the
+   author's declaration that absence is a real, meaningful state — the same
+   role an allowlist entry plays for every other selector, without needing
+   one written by hand for each of the six.
+
+2. A label referenced only via `by (label)` / `without (label)` /
+   `on (label)` / `ignoring (label)` / `group_left(label)` /
+   `group_right(label)`, or only inside a `{{ $labels.label }}` annotation
+   template, was invisible to selector extraction: STRIP deletes the
+   by/without/on/ignoring/group_left/group_right clause's contents before
+   metric names are ever looked for, and annotations are never read at all.
+   So a rule could group or annotate by a label that not one live series of
+   its own metric actually carries, and this script would report the bare
+   metric as `ok` — exactly the HighMemoryUsage shape cited above, just
+   reached through aggregation instead of an explicit `{name="x"}` matcher.
+   Closed by extracting every such label per rule and, for each metric
+   selector already found in that same rule, checking `<metric>{<label>!=""}`
+   through the IDENTICAL query/allowlist/report pipeline every other
+   selector already goes through — not a second mechanism.
 """
 import json
 import re
@@ -91,6 +131,26 @@ STRIP = [
 
 SELECTOR = re.compile(r"(?<![\w:.])([a-zA-Z_:][\w:]*)\s*(\{[^}]*\})?")
 
+# h#855: the exact shape this file's own rules use — the selector is the
+# function's direct argument. Not a general PromQL parse (nested calls, a
+# nested rate()/sum() between absent( and the metric, would not match) —
+# proportionate to what actually exists in alerts.yml today, same spirit as
+# the rest of this script's regex-based extraction rather than a real parser.
+ABSENT_WRAPPER = re.compile(r"\babsent(?:_over_time)?\s*\(\s*$")
+
+# h#855: labels referenced for grouping or joining, which STRIP deletes
+# wholesale before selectors_in() ever runs. Captured separately, from the
+# UNSTRIPPED expression text.
+GROUPING_CLAUSE = re.compile(
+    r"\b(?:by|without|on|ignoring|group_left|group_right)\s*\(([^)]*)\)"
+)
+
+# h#855: {{ $labels.name }}-style references in annotation templates. Go
+# template whitespace trimming ({{- and -}}) is not special-cased — none of
+# this file's annotations use it, and the label name itself is unaffected
+# either way.
+ANNOTATION_LABEL = re.compile(r"\$labels\.(\w+)")
+
 
 def prometheus_query(expr):
     """Instant query via the container, so no published port is needed and no
@@ -112,16 +172,22 @@ def prometheus_query(expr):
 
 
 def selectors_in(expr):
-    """Every metric selector in a PromQL expression, label matchers included.
+    """Every metric selector in a PromQL expression, label matchers included,
+    tagged with whether it is the direct argument of absent()/absent_over_time().
 
     The label matchers are the reason this keeps the braces: a rule can name a
     real metric and still match nothing because of one wrong label.
+
+    Returns a list of (selector, is_absent_wrapped) tuples, in first-seen
+    order, deduplicated on the selector text alone (the same selector text
+    always carries the same wrapped-ness within one expression).
     """
     text = expr
     for pattern in STRIP:
         text = pattern.sub(" ", text)
 
     found = []
+    seen = set()
     for m in SELECTOR.finditer(text):
         name, labels = m.group(1), m.group(2) or ""
         # A '(' after the identifier makes it a function call. Skip whitespace
@@ -133,9 +199,26 @@ def selectors_in(expr):
         if name in KEYWORDS or name.isdigit():
             continue
         sel = name + labels
-        if sel not in found:
-            found.append(sel)
+        wrapped = bool(ABSENT_WRAPPER.search(text[:m.start()]))
+        if sel not in seen:
+            seen.add(sel)
+            found.append((sel, wrapped))
     return found
+
+
+def grouping_and_annotation_labels(rule):
+    """h#855: labels a rule groups/joins on, or names in an annotation
+    template, that selectors_in() cannot see because STRIP deletes the
+    grouping clause and annotations are a different YAML field entirely."""
+    labels = set()
+    for m in GROUPING_CLAUSE.finditer(rule.get("expr", "")):
+        for part in m.group(1).split(","):
+            part = part.strip()
+            if part:
+                labels.add(part)
+    annotations_blob = " ".join(str(v) for v in (rule.get("annotations") or {}).values())
+    labels.update(ANNOTATION_LABEL.findall(annotations_blob))
+    return labels
 
 
 def main():
@@ -162,14 +245,33 @@ def main():
         print("A check that cannot run must not report success. Exiting 1.")
         return 1
 
-    missing, stale_allowlist, checked = [], [], 0
+    missing, stale_allowlist, absent_ok, checked = [], [], [], 0
     for group in doc.get("groups", []):
         for rule in group.get("rules", []):
             name = rule.get("alert")
             if not name:
                 continue
             print(f"{name}")
-            for sel in selectors_in(rule["expr"]):
+
+            rule_selectors = selectors_in(rule["expr"])
+
+            # h#855: labels referenced only via grouping/join clauses or an
+            # annotation template. Checked against every plain-metric
+            # selector this same rule already names — `<metric>{<label>!=""}`
+            # — reusing the identical query/allowlist/report path below
+            # rather than a second mechanism. Base metric name only (no
+            # existing braces): the question is "does this metric EVER carry
+            # a non-empty value for this label", independent of whatever
+            # other matcher the rule's own selector already applies.
+            grouping_labels = grouping_and_annotation_labels(rule)
+            if grouping_labels:
+                base_metrics = {sel.split("{")[0] for sel, _wrapped in rule_selectors}
+                for label in sorted(grouping_labels):
+                    for metric in sorted(base_metrics):
+                        synthetic = f'{metric}{{{label}!=""}}'
+                        rule_selectors.append((synthetic, False))
+
+            for sel, is_absent in rule_selectors:
                 base = sel.split("{")[0]
                 is_allowlisted = base in allowed or sel in allowed
                 res, err = prometheus_query(sel)
@@ -195,6 +297,23 @@ def main():
                               f"the line — the reason it was added no longer "
                               f"applies.")
                         stale_allowlist.append((name, sel))
+                elif is_absent:
+                    # h#855: 0 series for the direct argument of absent()/
+                    # absent_over_time() is the rule's own firing condition,
+                    # not evidence it is broken — the exact inversion the
+                    # old code got wrong. Not a failure. Not silently "ok"
+                    # either: still worth a human noticing which selectors
+                    # are currently in this state, since it is also what a
+                    # genuinely dead selector looks like on every run, not
+                    # just the one where it matters.
+                    print(f"    ~  {sel}   0 series — inside absent()/"
+                          f"absent_over_time(): this IS the rule's firing "
+                          f"condition, not a broken selector. If this has "
+                          f"NEVER had series, that is still worth checking "
+                          f"by hand — this line only proves the shape is "
+                          f"correctly designed, not that the name is "
+                          f"correctly spelled.")
+                    absent_ok.append((name, sel))
                 elif is_allowlisted:
                     why = allowed.get(sel) or allowed.get(base)
                     print(f"    -  {sel}   0 series — declared absent: {why}")
@@ -205,6 +324,10 @@ def main():
 
     print("-" * 70)
     print(f"{checked} selectors checked")
+    if absent_ok:
+        print(f"({len(absent_ok)} of those are absent()-wrapped selectors "
+              f"with 0 series — expected, not counted as failures; see '~' "
+              f"lines above)")
     if missing:
         print(f"\n{len(missing)} SELECTOR(S) MATCH NOTHING:\n")
         for rule, sel, why in missing:

--- a/tests/checks/test_check_alert_series_selector_blind_spots.py
+++ b/tests/checks/test_check_alert_series_selector_blind_spots.py
@@ -1,0 +1,133 @@
+"""Tests for the two selector-extraction blind spots closed in check_alert_series.py
+(h#855, follow-up to the cAdvisor/containerd-snapshotter diagnosis).
+
+Both were proven against the live production Prometheus with a synthetic rule
+before either fix was written (see the PR body). This is the regression form
+of that same proof, run against a stubbed `docker` like
+test_check_alert_series_stale_allowlist.py already does — not by importing
+internals, so a refactor of the query plumbing does not silently stop testing
+the actual CLI behavior.
+
+1. A selector that is the direct argument of absent()/absent_over_time() was
+   checked with the SAME "0 series = broken rule" logic as everything else.
+   That is backwards: 0 series is exactly what such a selector is DESIGNED to
+   detect. FixtureAbsentInversion below has 0 series for its wrapped selector
+   and must still exit 0.
+
+2. A label referenced only via by()/without()/on()/ignoring()/group_left()/
+   group_right() — or only inside a `{{ $labels.x }}` annotation template —
+   was invisible to selector extraction, so a rule could group by a label no
+   live series of its own metric carries and still report `ok`. This is the
+   historical HighMemoryUsage shape, reached through aggregation instead of
+   an explicit {name="x"} matcher. FixtureGroupingHidesDeadLabel groups by a
+   label ("phantom") the metric never carries, and must fail.
+   FixtureGroupingHealthyLabel groups by a label ("job") the metric DOES
+   carry, and must still pass — proving the fix discriminates rather than
+   failing every grouping clause.
+"""
+from __future__ import annotations
+
+import json
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "checks" / "check_alert_series.py"
+
+ALERTS_YML = """\
+groups:
+  - name: fixture
+    rules:
+      - alert: FixtureAbsentInversion
+        expr: absent(totally_fake_metric_h855{})
+      - alert: FixtureGroupingHidesDeadLabel
+        expr: sum by (phantom) (fixture_metric_h855)
+      - alert: FixtureGroupingHealthyLabel
+        expr: sum by (job) (fixture_metric_h855)
+"""
+
+
+def _series(labels_list):
+    return json.dumps({
+        "status": "success",
+        "data": {"resultType": "vector", "result": [
+            {"metric": dict(labels, __name__="fixture_metric_h855"), "value": [0, "1"]}
+            for labels in labels_list
+        ]},
+    })
+
+
+EMPTY = json.dumps({"status": "success", "data": {"resultType": "vector", "result": []}})
+
+
+def _make_docker_stub(stub_dir: Path):
+    """fixture_metric_h855 exists with a `job` label but never a `phantom`
+    label — so a query for {phantom!=""} must return empty while {job!=""}
+    and the bare metric both return real series. totally_fake_metric_h855
+    never has series under any query, by construction."""
+    fixture_body = _series([{"job": "fixture-job", "instance": "x"}])
+    script = f"""#!/usr/bin/env bash
+url="${{*: -1}}"
+case "$url" in
+  *totally_fake_metric_h855*) echo '{EMPTY}' ;;
+  *phantom*) echo '{EMPTY}' ;;
+  *fixture_metric_h855*) echo '{fixture_body}' ;;
+  *) echo '{EMPTY}' ;;
+esac
+"""
+    docker = stub_dir / "docker"
+    docker.write_text(script)
+    docker.chmod(docker.stat().st_mode | stat.S_IEXEC)
+
+
+def run_check(tmp_path: Path):
+    fake_root = tmp_path / "repo"
+    (fake_root / "platform" / "observability" / "prometheus").mkdir(parents=True)
+    (fake_root / "scripts" / "checks").mkdir(parents=True)
+    (fake_root / "platform" / "observability" / "prometheus" / "alerts.yml").write_text(ALERTS_YML)
+    (fake_root / "scripts" / "checks" / "alert-series-allowlist.txt").write_text("")
+    script_copy = fake_root / "scripts" / "checks" / "check_alert_series.py"
+    script_copy.write_text(SCRIPT.read_text())
+
+    stub_dir = tmp_path / "bin"
+    stub_dir.mkdir()
+    _make_docker_stub(stub_dir)
+
+    env = dict(os.environ)
+    env["PATH"] = f"{stub_dir}:{env['PATH']}"
+
+    return subprocess.run(
+        ["python3", "scripts/checks/check_alert_series.py"],
+        cwd=fake_root, capture_output=True, text=True, env=env,
+    )
+
+
+class TestAbsentWrapperInversion:
+    def test_zero_series_inside_absent_does_not_fail(self, tmp_path):
+        result = run_check(tmp_path)
+        assert "FixtureAbsentInversion" in result.stdout
+        assert "this IS the rule's firing condition" in result.stdout
+        missing_section = (
+            result.stdout.split("SELECTOR(S) MATCH NOTHING")[1]
+            if "SELECTOR(S) MATCH NOTHING" in result.stdout else ""
+        )
+        assert "FixtureAbsentInversion" not in missing_section
+
+
+class TestGroupingLabelBlindSpot:
+    def test_grouping_by_dead_label_fails(self, tmp_path):
+        result = run_check(tmp_path)
+        assert 'fixture_metric_h855{phantom!=""}' in result.stdout
+        assert 'NO fixture_metric_h855{phantom!=""}' in result.stdout
+
+    def test_grouping_by_live_label_passes(self, tmp_path):
+        result = run_check(tmp_path)
+        assert 'ok fixture_metric_h855{job!=""}' in result.stdout
+
+    def test_overall_exit_is_1_because_of_the_dead_label_only(self, tmp_path):
+        result = run_check(tmp_path)
+        assert result.returncode == 1
+        assert "1 SELECTOR(S) MATCH NOTHING" in result.stdout
+        assert 'FixtureGroupingHidesDeadLabel: fixture_metric_h855{phantom!=""}' in result.stdout


### PR DESCRIPTION
## Summary

Follow-up to #855. cAdvisor emits zero Docker container series because the host's containerd-snapshotter storage driver has no overlayfs layerdb — so `container_memory_usage_bytes` exists (40 series) but never carries a `name` label. That raised the natural next question: **can `check_alert_series.py` see this shape at all** — a rule matching a live *metric* but a dead *label value*? It could not, for two separate reasons, each proven against live production Prometheus with a synthetic rule before either fix was written.

### Blind spot 1 — `absent()`/`absent_over_time()` inversion
A selector that is the direct argument of `absent(...)` was checked with the same "0 series = broken rule" logic as every other selector. That's backwards for this one construct — 0 series is exactly the designed firing condition. Six real rules in `alerts.yml` use this shape (`LokiIngestionStalled`/`SignalMissing`, `BackupNotSucceeding*`, `ScheduledWorkflow*`); four of the six only "passed" before this fix because the underlying metric happens to have series right now. The moment one genuinely went absent, the old code would report the rule as broken — exactly backwards at the one moment it matters.

### Blind spot 2 — grouping/join/annotation labels invisible to extraction
A label referenced only via `by()`/`without()`/`on()`/`ignoring()`/`group_left()`/`group_right()`, or only inside a `{{ $labels.x }}` annotation template, was never seen: `STRIP` deletes the grouping clause's contents before metric names are matched, and annotations are a separate YAML field `selectors_in()` never reads. This is the historical `HighMemoryUsage` shape (fixed by renaming to `HostMemoryHigh`, per the file's own docstring), reached through aggregation instead of an explicit `{name="x"}` matcher — and the check script's blind spot to that *shape* was never closed.

## Proof (before/after, live production Prometheus, three synthetic rules)

| Rule | Before | After |
|---|---|---|
| `PROOF_AbsentInversion` (`absent(fake_metric)`) | **incorrectly failed** — "0 SERIES — this rule cannot fire" | correctly reported as `~` (firing condition, not a failure) |
| `PROOF_ByGroupingHidesLabel` (`sum by (name) (container_memory_usage_bytes)`) | **incorrectly passed** — "ok 40 series" | correctly caught — `NO container_memory_usage_bytes{name!=""} 0 SERIES` |
| `PROOF_GenuinelyHealthyGrouping` (`sum by (mountpoint) (node_filesystem_avail_bytes)`, negative control) | n/a | passes both base and synthetic checks — proves the fix discriminates rather than failing every grouping clause |

Then re-ran the fixed script against the **real** `alerts.yml` on the VPS: 55 selectors checked (up from 34, from the new synthetic checks), **exit 0, no regressions** — all six real `absent()`-wrapped rules behave correctly, no existing grouping/annotation label produces a new false positive, and stale-allowlist detection is unchanged (an allowlisted selector with real series is still reported STALE before the absent-exemption branch is reached).

Read-only throughout: instant Prometheus queries only, nothing enabled/written/restarted.

## Test plan
- [x] `tests/checks/test_check_alert_series_selector_blind_spots.py` (new, 4 tests) — stubs `docker` like the existing `test_check_alert_series_stale_allowlist.py` convention, not internals
- [x] `python3 -m pytest tests/checks/test_check_alert_series_selector_blind_spots.py tests/checks/test_check_alert_series_stale_allowlist.py -v` — 7/7 pass
- [x] `python3 -m py_compile scripts/checks/check_alert_series.py`
- [x] Fixed script run against real production `alerts.yml` on the VPS — exit 0, 55/55 selectors matching or declared absent
- [x] Do NOT merge — reviewer to confirm before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)