### PR TITLE
docs: record the Loki default-window instrument blindness from h#859

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -199,6 +199,7 @@ appeared **six times in one day wearing six different coats**:
 | `amtool check-config`: **SUCCESS** | Every notification then failed at *render* time — `default` is not an Alertmanager template function. A **green verdict** from an instrument that could not see the failure. |
 | an exact-match sweep for `blackbox` → *"container missing"* | The container is named `blackbox-exporter`. It was running the whole time. |
 | decoding a token from `admin-cli`: no `sub`, no `realm_access` → *"the user has no roles"* | **`admin-cli` issues a LIGHTWEIGHT access token.** The token is valid — it returned `200` from every admin endpoint — because Keycloak resolves permissions server-side from the session, not from claims. Fine for probing permissions; blind for inspecting claims. Use an authorization-code flow through a real client. |
+| `/loki/api/v1/label/container/values` with no `start`/`end` → *"keycloak, minio, portainer and postgres-exporter have no logs at all, Promtail must be broken for them"* (h#859) | **That endpoint defaults to roughly the last hour when no range is given.** All four are low-volume loggers — a startup burst, then long silence — so whichever hour happened to be queried, they were quiet in it. An explicit 7-day range returned real, continuous history for all four, including the exact lines needed to diagnose two live incidents. Promtail was never broken; the query was never given a range wide enough to see what was already there. |
 
 Three more from the tenant the same week: `ls -l` hiding a dotfile read as *"the file is
 absent"*; a `grep` for a compose warning whose quotes were backslash-escaped read as
@@ -211,6 +212,9 @@ know, and confirm it produces a result, before believing it when it produces non
   already known to be unfireable. If it stops finding those, it has gone blind.
 - Before reporting "no objects in the bucket", put one there and see it.
 - Before reporting a container missing, list all of them and read the names.
+- Before reporting a container has no logs in Loki, query with an explicit wide range —
+  `label/.../values` with no range silently defaults to about an hour, and a quiet
+  container looks identical to a broken shipper in that window.
 - `promtool test` cannot prove a rule can fire — the test author supplies the labels. Only
   the live series check can. Neither is sufficient alone.
 


### PR DESCRIPTION
## Summary

h#859 (the Keycloak crash-loop investigation) originally concluded promtail was silently failing to ship logs for four platform containers — keycloak, minio, portainer, postgres-exporter — based on querying `/loki/api/v1/label/container/values` with no `start`/`end` and finding them absent from the result.

**That conclusion was wrong.** Caught and independently confirmed: querying the same endpoint with an explicit 7-day range returns all four, with real, continuous history. The endpoint defaults to roughly the last hour when no range is given — proved directly by comparing the no-range result against explicit 1h/6h/7d ranges: the no-range and 1h results were byte-identical, 6h added `minio`, and 7d added all four plus a long tail of old scratch-container names, confirming full retention is genuinely there. All four are low-volume loggers (a startup burst, then long silence), so whichever hour happened to get queried, they were quiet in it. **Nothing was wrong with promtail or its config** — a scoped file-tailing alternative was prototyped and validated against a disposable scratch Loki during the investigation, then discarded once the real cause was found, since there was nothing to fix.

## Why this belongs in CONTRIBUTING.md, not promtail.yml

This is the exact defect family the "Verify the Instrument Before You Believe the Verdict" section already tracks: a blind instrument and a genuinely absent thing produce identical output, and only a positive control (querying with a range wide enough to see what's actually there) tells them apart. Recorded as a new row in that section's table, plus a matching bullet in the positive-control list, so the next person who reaches for that endpoint queries it with an explicit range first instead of re-diagnosing a shipping bug that isn't there.

## What this PR does NOT do

The actual Keycloak crash root causes — now recoverable from Loki with the corrected (wide-range) query — are written up as a comment on h#859, not here, since fixing the diagnosis didn't require touching promtail.

## Test plan
- [x] Re-ran the exact no-range vs 1h vs 6h vs 7d comparison against live Loki — documented in the h#859 comment
- [x] `git diff` is a 4-line addition to `CONTRIBUTING.md`, no code changed
- [x] Do NOT merge — reviewer to confirm

🤖 Generated with [Claude Code](https://claude.com/claude-code)