### PR TITLE
docs(claude.md): sess.roles was a misdiagnosis, not an open defect (Hill90#847)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,13 +187,46 @@ cannot be granted by accident.
 > a defect in the running system — but be exact about provenance: proofs 3 to 5 were
 > made **with `curl`, not from the page**.
 >
-> **Open defect: `sess.roles` returned `null`** on a second login while the token's
-> own claims were correct. Authorisation is enforced in the api from the token, so
-> nothing is unsafe, but a UI reading `session.roles` would render an
-> empty-permissions view. Possibly related: `app-ui` logs four
-> `[profile-proxy] Error: SyntaxError: Unexpected end of JSON input` failures —
-> `JSON.parse` on an empty body — `Verified 2026-07-30 02:07 UTC`. Not proven to be
-> the same fault; recorded as the leading candidate.
+> **`sess.roles = null`, formerly recorded here as an open defect, was a
+> misdiagnosis — resolved same day, in the same commit that fixed the real bug
+> this paragraph used to name as its leading candidate.** hill90-app **#59**
+> (`292a4bf`, 2026-07-30) established both, from a single investigation:
+>
+> - **`session.roles` (bare) was never a defect and was never going to hold
+>   anything.** Roles live at `session.user.roles` — `services/ui/src/auth.ts`
+>   assigns `session.user.roles = token.roles`, and
+>   `types/next-auth.d.ts` declares `roles` only under `Session.user`, never at
+>   `Session` top level, so `session.roles` does not even typecheck. The
+>   original `02:07 UTC` report compared two of the reporter's own scripts —
+>   one read `sess.roles ?? sess.user?.roles` (prints the real value), the
+>   other read only `sess.roles` (prints `undefined`, logged as `null`) — and
+>   read the difference between the scripts as a difference between logins.
+>   Reproduced against production, three consecutive fresh logins as
+>   `testuser01`, identically: `session.user.roles` correct
+>   (`["user"]`), `session.roles` absent. A permanent regression test,
+>   `services/ui/src/__tests__/session-roles-contract.test.ts`, pins both
+>   directions — roles present at `session.user.roles`, absent at
+>   `session.roles` — and is mutation-verified: adding `session.roles =
+>   token.roles` turns it red. **Re-verified against the CURRENT tree**,
+>   `Verified 2026-08-07`: `auth.ts:138`, the type declaration, and the test
+>   all still read exactly as the commit describes; the test still passes;
+>   `grep`ing `services/ui/src` for a bare `session.roles`/`sess.roles` read
+>   finds none.
+> - **The real bug this paragraph pointed at — `app-ui`'s four
+>   `[profile-proxy] Error: SyntaxError: Unexpected end of JSON input` failures
+>   — was genuinely real, and unrelated.** `JSON.parse` on an empty body,
+>   introduced when `GET /profile/avatar` started answering `204` (#32). Fixed
+>   the same day, later, in the same commit: both
+>   `services/ui/src/app/api/profile/route.ts` and
+>   `.../api/profile/[...path]/route.ts` now handle a bodiless response, a
+>   dedicated regression test (`profile-proxy-empty-body.test.ts`) pins it, and
+>   it has been deployed for a week (`hill90/ui` at `f538b1f096bb`, `Verified
+>   2026-08-06`).
+>
+> Net: **no open defect remains on either half.** `sess.roles = null` is not
+> live code returning null — it is a property that was never populated,
+> correctly, by design; nothing reads it. The `02:07 UTC` timestamp on the
+> original report is kept above for provenance, not as a still-open finding.
 
 **Postgres: `app-postgres` goes.** The app consumes the platform's Postgres. The
 complication is real and is not the Keycloak steps repeated: this platform's


### PR DESCRIPTION
Closes Hill90#847.

## What the issue asked for, and what I found instead

The issue asked me to correct CLAUDE.md's stale "leading candidate" framing (profile-proxy fixed, sess.roles still open, candidate eliminated) — and separately, to establish whether `sess.roles` is still returning null, from code if possible, from a live login only if it genuinely can't be determined otherwise.

**It can be determined from code, and the answer is stronger than "still open, no candidate": `sess.roles` was never a real defect at all.** hill90-app **#59** (`292a4bf`, 2026-07-30) — the same commit the issue already verified fixed profile-proxy — is a single investigation that resolved BOTH halves of the caveat block, not just one:

> *"sess.roles IS NOT A DEFECT, and it is not intermittent. […] The field is absent, so reading it yields undefined. auth.ts assigns session.user.roles = token.roles; types/next-auth.d.ts declares roles under Session.user only, so session.roles does not even typecheck; and no ui source reads it. The original report was mine and it compared two of my own scripts: one read `sess.roles ?? sess.user?.roles` and printed `["user"]`, the other read only `sess.roles` and printed `null`. I reported the difference between my scripts as a difference between logins."*

That's a misdiagnosis, corrected same-day, by the same person who filed the original report, pinned by a permanent regression test (`session-roles-contract.test.ts`, mutation-verified: adding `session.roles = token.roles` turns it red).

## Re-verified against the CURRENT tree, not just cited from a week-old commit

- `services/ui/src/auth.ts:138` — `session.user.roles = token.roles`, unchanged.
- `services/ui/src/types/next-auth.d.ts` — `roles?: string[]` declared only inside `Session.user`, never at `Session` top level.
- `services/ui/src/__tests__/session-roles-contract.test.ts` — still present, still passes:
  ```
  ✓ src/__tests__/session-roles-contract.test.ts (3 tests) 198ms
  ```
- `services/ui/src/__tests__/profile-proxy-empty-body.test.ts` — also re-run, still passes (7/7).
- `grep -rnE "\bsession\.roles\b|\bsess\.roles\b" services/ui/src --include="*.ts" --include="*.tsx"` (excluding tests) — zero matches. No UI source reads the bare property today.

## The edit

Replaced the "possibly related... leading candidate" framing with: `session.roles` was never populated by design (not a runtime null returned by broken code — a property that plain doesn't exist, confirmed by the type declaration itself), the real profile-proxy bug was genuine but unrelated, and both were resolved in the same commit. Kept the original `02:07 UTC` timestamp on the source report for provenance rather than letting it inherit today's date, per the issue's own instruction. Recorded the eliminated candidate explicitly rather than silently deleting it, since — per the issue — that itself is information worth keeping: the next reader shouldn't have to rediscover that this specific candidate was already ruled out.

**Not merging** — report only, per instruction.