### PR TITLE
docs: move PRD.md and SPEC.md into docs/product/ (closes #797)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,11 @@ nothing. It is a **platform**: it hosts tenants but is not the application.
   what this platform offers a tenant;
   [`tenant-checkout-hazard.md`](docs/decisions/tenant-checkout-hazard.md) records
   why the tenant needs its own checkout guard and why its risk is the smaller one.
+- [`docs/product/`](docs/product/) — [`PRD.md`](docs/product/PRD.md) and
+  [`SPEC.md`](docs/product/SPEC.md), the requirements and inventory for the
+  2026-07-26 app/infra strip. Both are historical records of a decision that
+  was carried out, not a description of Hill90 today — read the banner at the
+  top of each before citing anything below it.
 - [`CONTRIBUTING.md`](CONTRIBUTING.md) — conventions and the deploy rules.
 - Published pages: [docs.hill90.com](https://docs.hill90.com).
 
@@ -44,7 +49,7 @@ platform/observability/ Prometheus, Alertmanager, blackbox, Loki, Tempo, Grafana
 infra/secrets/          SOPS-encrypted stores; age private keys are gitignored
 scripts/                deploy.sh, backup.sh, _common.sh, checks/
 ansible/                VPS bootstrap
-docs/                   runbooks, reference, architecture, decisions
+docs/                   runbooks, reference, architecture, decisions, product
 ```
 
 ## Invariants — do not break these without an explicit decision

--- a/docs/product/PRD.md
+++ b/docs/product/PRD.md
@@ -4,10 +4,10 @@
 > strip, not a description of Hill90 today.** The split it argues for happened, and
 > the tenant it produced now runs against this platform — so the *cost/benefit
 > argument* below is settled and the *architecture* it describes is superseded by
-> [docs/decisions/app-tenancy-on-the-vps.md](docs/decisions/app-tenancy-on-the-vps.md),
+> [docs/decisions/app-tenancy-on-the-vps.md](../decisions/app-tenancy-on-the-vps.md),
 > which defines the contract this platform actually offers a tenant. Its reasoning
 > about Keycloak and Postgres was wrong and is corrected in
-> [docs/decisions/platform-primitives.md](docs/decisions/platform-primitives.md).
+> [docs/decisions/platform-primitives.md](../decisions/platform-primitives.md).
 > Kept as the record of a decision that was carried out.
 
 **Status:** implemented 2026-07-26

--- a/docs/product/SPEC.md
+++ b/docs/product/SPEC.md
@@ -3,10 +3,10 @@
 > **Historical: this specifies the 2026-07-26 app/infra strip as planned, not the
 > estate as it stands.** The strip was executed; what the platform offers a tenant
 > now is defined in
-> [docs/decisions/app-tenancy-on-the-vps.md](docs/decisions/app-tenancy-on-the-vps.md).
+> [docs/decisions/app-tenancy-on-the-vps.md](../decisions/app-tenancy-on-the-vps.md).
 > Its classification of Keycloak and Postgres as application dependencies was
 > wrong — see
-> [docs/decisions/platform-primitives.md](docs/decisions/platform-primitives.md).
+> [docs/decisions/platform-primitives.md](../decisions/platform-primitives.md).
 > Kept because it records what was specified and therefore what was done.
 
 **Status:** implemented 2026-07-26


### PR DESCRIPTION
Closes #797.

**Should they even survive the move?** Both carry a "Historical / superseded" banner, but each says explicitly: *"Kept as the record of a decision that was carried out."* That's this repo's own decision-records-preserve pattern, not a stale status tracker — deleting them would destroy the record of what was decided and why, which is the opposite of what a dead doc looks like. So: move, not delete.

**Placement:** `docs/product/PRD.md` and `docs/product/SPEC.md`, matching hill90-app#612 tonight — PRD/SPEC for hill90-app went into `docs/product/` specifically because dropping them at `docs/` top level reads as an unnamed fifth category next to `architecture/`, `decisions/`, `reference/`, `runbooks/`.

**References fixed:** each file has two links to `docs/decisions/*.md` that were root-relative (correct while the files lived at repo root); rewritten to `../decisions/*.md` for their new location. SPEC.md's companion link to `PRD.md` needed no change — both moved into the same directory together. Grepped the whole repo (CLAUDE.md, README.md, CONTRIBUTING.md, `.github/`, `scripts/`, `tests/`) for any other inbound reference to either filename and found none.

**Verification:** `python3 scripts/checks/check_md_links.py` → `Markdown link check passed: no missing local links found (64 files scanned)` — up from 62, since PRD.md/SPEC.md sat outside the checker's scan roots at repo-root level and are now inside `docs/`, which it does scan.

**docs.hill90.com:** cloned `hill90-docs` (the repo that actually authors that published site, confirmed separately during #814 tonight) and grepped it for `PRD`/`SPEC` — zero hits. The site's `homelab/*.mdx` pages are hand-authored, not generated from these files, so no published URL changes and no redirect is needed.

**CLAUDE.md:** added a `docs/product/` entry under "Where to look" (with the historical-banner caveat stated up front) and added `product` to the `docs/` layout line.

Not merged — reporting back per instruction.