### PR TITLE
ci: fail a PR whose closing keyword is followed by h#NNN instead of #NNN

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,15 @@ jobs:
       - name: Validate markdown links
         run: python3 scripts/checks/check_md_links.py
 
+      # h#786/h#844: found by scanning merged PRs after two issues sat open
+      # for hours on nothing but "Closes h#NNN" — GitHub does not parse the
+      # h# prefix as a closing keyword. Reads the real PR body via env, never
+      # interpolated into the shell.
+      - name: Assert the PR body doesn't defeat auto-close with an h# prefix
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: python3 scripts/checks/check_pr_body_h_prefix.py
+
       # h#758 (found by h#736's fix): wired only to its own bats control
       # since it was written. Genuinely hermetic — it counts rules in
       # platform/observability/prometheus/alerts.yml against the sentence in

--- a/scripts/checks/check_pr_body_h_prefix.py
+++ b/scripts/checks/check_pr_body_h_prefix.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""A PR body closing keyword followed by 'h#NNN' never closes the issue.
+
+    PR_BODY="$body" python3 scripts/checks/check_pr_body_h_prefix.py
+
+WHY. This repo's own convention prefixes issue references with 'h#' in prose
+(e.g. "h#844's fix"), which reads fine and is fine — GitHub just doesn't
+parse "h#123" as an issue reference at all, closing keyword or not; it wants
+a bare "#123" (or "owner/repo#123"). That's harmless everywhere except one
+place: a PR body's own closing-keyword line ("Closes h#844"), where a human
+reading it sees a closed issue and GitHub silently does nothing. Nobody
+notices, because both the check runner and the PR author read the same text
+and see intent, not GitHub's literal parser.
+
+This is not hypothetical — a live scan of every merged PR (2026-08-07) found
+it in 20 merged PRs total; 18 were later closed by hand and 2 (h#786, h#844)
+sat open for hours to days on nothing but this, indistinguishable in the
+issue tracker from real unfinished work. h#844 in particular needed a full
+independent re-verification pass to confirm nothing was actually left to do
+before it could safely be called resolved — exactly the cost this check
+exists to stop paying repeatedly.
+
+Deliberately narrow: this does NOT ban 'h#NNN' in prose, which is this
+repo's normal and correct way to reference an issue outside a closing
+line — only 'h#NNN' sitting directly after a GitHub closing keyword
+(close/closes/closed, fix/fixes/fixed, resolve/resolves/resolved), where the
+'h#' silently defeats the auto-close GitHub would otherwise perform on plain
+'#NNN'. A check that flagged every 'h#NNN' anywhere would be wrong on its
+own terms — it would make people stop writing 'h#NNN' in prose, where nothing
+is broken, to dodge a check that was never actually about prose.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+
+# GitHub's own closing-keyword set: close/closes/closed, fix/fixes/fixed,
+# resolve/resolves/resolved. Keyword, optional colon, then either same-line
+# whitespace or a single newline (not a blank-line paragraph break) before
+# 'h#NNN'. The single-newline-not-double distinction matters: it is what
+# keeps a markdown heading like "## What this fixes" followed, paragraphs
+# later, by unrelated prose that happens to mention "h#NNN" from being
+# flagged as a closing-keyword usage it never was.
+PATTERN = re.compile(
+    r"\b(close[sd]?|fix(?:e[sd])?|resolve[sd]?)\b:?(?:[ \t]+|\n(?!\n))h#(\d+)",
+    re.IGNORECASE,
+)
+
+
+def main() -> int:
+    body = os.environ.get("PR_BODY", "")
+
+    matches = list(PATTERN.finditer(body))
+
+    if not matches:
+        print(
+            f"PR body h#-prefix check passed: no closing keyword followed by "
+            f"'h#NNN' found ({len(body)} chars scanned)."
+        )
+        return 0
+
+    print("PR body h#-prefix check FAILED.")
+    print()
+    print(
+        "GitHub does not parse 'h#NNN' as an issue reference — only '#NNN' "
+        "(or 'owner/repo#NNN') closes an issue. The following closing-keyword "
+        "usage will silently fail to close its issue:"
+    )
+    print()
+    for m in matches:
+        keyword, issue_num = m.group(1), m.group(2)
+        snippet = body[m.start() : m.end()].replace("\n", "\\n")
+        print(f"  {snippet!r} -> write '{keyword} #{issue_num}' instead")
+    print()
+    print(
+        "'h#NNN' in prose elsewhere in the body (not right after a closing "
+        "keyword) is fine and unaffected by this check."
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/checks/check_pr_body_h_prefix.py
+++ b/scripts/checks/check_pr_body_h_prefix.py
@@ -28,6 +28,14 @@ line — only 'h#NNN' sitting directly after a GitHub closing keyword
 '#NNN'. A check that flagged every 'h#NNN' anywhere would be wrong on its
 own terms — it would make people stop writing 'h#NNN' in prose, where nothing
 is broken, to dodge a check that was never actually about prose.
+
+A PR body has to be able to DISCUSS the bad pattern without being accused of
+using it — this check's own introducing PR (h#864) quoted "Closes h#844" in
+backticks as its own positive-control evidence and failed its own CI on
+itself, a better positive control than anything either of us wrote by hand.
+So fenced code blocks (```...```) and inline code spans (`...`) are blanked
+out before matching — a quoted or fenced example of the defect is not the
+defect.
 """
 
 from __future__ import annotations
@@ -48,11 +56,30 @@ PATTERN = re.compile(
     re.IGNORECASE,
 )
 
+# Fenced blocks first (so a stray single backtick inside one can't be misread
+# as the start of an inline span once the fence itself is blanked), then
+# inline spans. Blanked with same-length whitespace, not removed, so a
+# keyword right before a fence and 'h#NNN' right after it can never end up
+# adjacent to each other by the deletion itself.
+FENCE_RE = re.compile(r"```.*?```", re.DOTALL)
+INLINE_CODE_RE = re.compile(r"`[^`\n]+`")
+
+
+def _blank(match: re.Match[str]) -> str:
+    return " " * len(match.group(0))
+
+
+def _strip_code(text: str) -> str:
+    text = FENCE_RE.sub(_blank, text)
+    text = INLINE_CODE_RE.sub(_blank, text)
+    return text
+
 
 def main() -> int:
     body = os.environ.get("PR_BODY", "")
+    scannable = _strip_code(body)
 
-    matches = list(PATTERN.finditer(body))
+    matches = list(PATTERN.finditer(scannable))
 
     if not matches:
         print(

--- a/tests/checks/test_pr_body_h_prefix.py
+++ b/tests/checks/test_pr_body_h_prefix.py
@@ -1,0 +1,85 @@
+"""Tests for scripts/checks/check_pr_body_h_prefix.py
+
+Positive-controlled per this repo's own convention: show the check failing
+on the exact defect it exists to catch, and show it passing on both the
+correct syntax and on the prose usage it must NOT flag, since a check that
+banned 'h#NNN' outright would make people stop using this repo's own
+convention in the one place it is fine.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "checks" / "check_pr_body_h_prefix.py"
+
+
+def _run(body: str) -> subprocess.CompletedProcess[str]:
+    env = dict(os.environ, PR_BODY=body)
+    return subprocess.run(
+        ["python3", str(SCRIPT)], capture_output=True, text=True, env=env
+    )
+
+
+def test_the_actual_defect_closes_h_prefix_fails():
+    """THE ASSERTION THAT MATTERS: this is the exact live defect (h#786, h#844)."""
+    result = _run("Closes h#844.\n\n## What was verified\n...")
+    assert result.returncode == 1
+    assert "FAILED" in result.stdout
+    assert "'Closes h#844'" in result.stdout
+    assert "write 'Closes #844' instead" in result.stdout
+
+
+def test_correct_syntax_passes():
+    """CONTROL: the fix for the defect above must itself be accepted."""
+    result = _run("Closes #844.\n\n## What was verified\n...")
+    assert result.returncode == 0
+    assert "passed" in result.stdout
+
+
+def test_h_prefix_in_prose_without_a_closing_keyword_passes():
+    """CONTROL: this repo's own normal convention must not be banned.
+
+    A check that flagged every 'h#NNN' anywhere would make people stop using
+    this repo's own convention in prose, where nothing is broken.
+    """
+    result = _run(
+        "Split out of #791. h#844's fix touches the same block as h#850's "
+        "own review comment. See h#720 for the related minio decision."
+    )
+    assert result.returncode == 0
+    assert "passed" in result.stdout
+
+
+def test_other_closing_keyword_variants_are_all_caught():
+    for text in [
+        "Closed h#1.",
+        "Fix h#2.",
+        "Fixes h#3.",
+        "Fixed h#4.",
+        "Resolve h#5.",
+        "Resolves h#6.",
+        "Resolved h#7.",
+        "Close: h#8.",
+    ]:
+        result = _run(text)
+        assert result.returncode == 1, f"expected failure for {text!r}"
+
+
+def test_closing_keyword_across_a_paragraph_break_is_not_a_false_positive():
+    """A heading that happens to contain a keyword must not reach across a
+    blank line to an unrelated 'h#NNN' mention many lines later."""
+    result = _run(
+        "Closes #746.\n\n## What this fixes\n\nh#746's top-ranked finding was..."
+    )
+    assert result.returncode == 0
+    assert "passed" in result.stdout
+
+
+def test_empty_body_passes():
+    result = _run("")
+    assert result.returncode == 0
+    assert "passed" in result.stdout

--- a/tests/checks/test_pr_body_h_prefix.py
+++ b/tests/checks/test_pr_body_h_prefix.py
@@ -83,3 +83,59 @@ def test_empty_body_passes():
     result = _run("")
     assert result.returncode == 0
     assert "passed" in result.stdout
+
+
+def test_quoted_defect_inside_inline_backticks_passes():
+    """CONTROL: discussing the bad pattern is not using it."""
+    result = _run("This check fails on `Closes h#123` in a PR body.")
+    assert result.returncode == 0
+    assert "passed" in result.stdout
+
+
+def test_quoted_defect_inside_a_fenced_block_passes():
+    """CONTROL: same as above, fenced instead of inline."""
+    body = (
+        "Positive control:\n\n"
+        "```\n"
+        "Closes h#123\n"
+        "```\n\n"
+        "That's the failing case."
+    )
+    result = _run(body)
+    assert result.returncode == 0
+    assert "passed" in result.stdout
+
+
+def test_bare_unquoted_defect_still_fails_even_with_code_stripping():
+    """THE ARM THAT KEEPS THE CHECK HONEST: code-stripping must not become
+    an escape hatch. A real, unquoted, un-fenced 'Closes h#NNN' still fails."""
+    result = _run("Closes h#844.\n\nSome unrelated body text.")
+    assert result.returncode == 1
+    assert "FAILED" in result.stdout
+    assert "'Closes h#844'" in result.stdout
+
+
+def test_self_referential_case_prose_explanation_plus_backtick_quote_passes():
+    """REGRESSION: this is h#864's own PR body shape — the exact false
+    positive CI caught on itself. A body that explains the h#-prefix trap in
+    prose AND quotes the bad pattern in backticks as evidence must pass."""
+    body = (
+        "GitHub does not parse 'h#NNN' as an issue reference — only '#NNN' "
+        "closes an issue.\n\n"
+        "## Positive control\n\n"
+        "```\n"
+        "=== FAILING: the actual live defect shape ===\n"
+        "PR body h#-prefix check FAILED.\n\n"
+        "  'Closes h#844' -> write 'Closes #844' instead\n"
+        "exit: 1\n\n"
+        "=== PASSING: correct syntax ===\n"
+        "PR body h#-prefix check passed: no closing keyword followed by "
+        "'h#NNN' found (12 chars scanned).\n"
+        "exit: 0\n"
+        "```\n\n"
+        "This repo prefixes issue references with 'h#' in prose "
+        "(e.g. \"h#844's fix\"), which reads fine and is fine."
+    )
+    result = _run(body)
+    assert result.returncode == 0
+    assert "passed" in result.stdout


### PR DESCRIPTION
## The full extent (found first, before fixing anything)

Scanned every merged PR body for a GitHub closing keyword (`close`/`closes`/`closed`, `fix`/`fixes`/`fixed`, `resolve`/`resolves`/`resolved`) immediately followed by `h#NNN` instead of `#NNN` — the pattern that left #786 and #844 sitting open tonight on nothing but syntax.

**20 hits across 19 distinct merged PRs**: #852(→h#786), #850(→h#844), #843(→h#841), #842(→h#811), #840(→h#839), #837(→h#836), #833 & #830(→h#804, twice), #828(→h#748), #827(→h#749), #826(→h#746), #824(→h#751), #823(→h#750), #822(→h#747), #821(→h#752), #820(→h#787), #819(→h#753), #818(→h#816), #817(→h#815), #723(→h#712).

Cross-referenced against current issue state (`gh issue view --json state` on all 19 referenced issues): **17 were closed by hand anyway** — someone noticed and closed them manually, so the syntax slip cost nothing in those cases. Only **#786 and #844** were still open purely on this, which is why tonight's audit caught them and not the rest.

**Did not close anything** — the instruction going in was that an issue left open by this trap might *also* have real remaining work, and #844 needed a full independent re-verification pass before it could safely be called resolved. #786 does have real remaining work (Jon's apply decision); #844 turned out fully resolved (see #844's own comment thread). Both already handled separately tonight, not by this PR.

One thing worth flagging precisely: **#681 is not a casualty of this defect.** It's open on the same underlying sshd-hardening work as #786 and gets mentioned in #852's body ("Same root cause as h#681"), but never as a closing-keyword target in any merged PR — it stays open on real, undispatched work, not a syntax slip.

## The fix

`scripts/checks/check_pr_body_h_prefix.py` reads the PR body from the `PR_BODY` env var (set from `github.event.pull_request.body` in `ci.yml`, never interpolated into a shell string — no injection surface) and fails if a closing keyword is immediately followed by `h#NNN`.

Deliberately narrow, and proven narrow: `h#NNN` in prose elsewhere in the body — this repo's own normal, correct convention — is untouched. A check that banned the prefix outright would be wrong on its own terms and would just train people off a convention that isn't broken anywhere except this one spot.

## Positive control

```
=== FAILING: the actual live defect shape ===
PR body h#-prefix check FAILED.

GitHub does not parse 'h#NNN' as an issue reference — only '#NNN' (or 'owner/repo#NNN') closes an issue. The following closing-keyword usage will silently fail to close its issue:

  'Closes h#844' -> write 'Closes #844' instead

'h#NNN' in prose elsewhere in the body (not right after a closing keyword) is fine and unaffected by this check.
exit: 1

=== PASSING: correct syntax ===
PR body h#-prefix check passed: no closing keyword followed by 'h#NNN' found (12 chars scanned).
exit: 0

=== PASSING: h# in prose, no closing keyword ===
PR body h#-prefix check passed: no closing keyword followed by 'h#NNN' found (47 chars scanned).
exit: 0
```

`tests/checks/test_pr_body_h_prefix.py` — 6/6 pass, including the paragraph-break case (a markdown heading containing "fixes" must not reach across a blank line to an unrelated `h#NNN` mention many lines later — this was a real false positive during development, caught and fixed before it shipped).

Wired into `ci.yml`'s existing `pull_request` job; `check_checks_are_wired.py` confirms it as `ok ... workflow` (REAL, not orphaned or test-only).

Not merged — reporting back per instruction.