### PR TITLE
docs: bring the 2026-07-31 handoff current — a week's verified state

### DIFF
--- a/docs/decisions/2026-07-31-handoff.md
+++ b/docs/decisions/2026-07-31-handoff.md
@@ -7,6 +7,118 @@ was checked. Where something was not checked, it says so rather than hedging.
 after that, so the sections marked **`Re-verified 2026-07-31 11:20 UTC`** supersede the
 06:21 figures where they disagree. Everything else still carries its original timestamp.
 
+**A week later, a second wave supersedes further: see "Re-verified 2026-08-07" below.**
+That section is the one to read first on a cold start — it carries what changed across
+both this repo and hill90-app in the intervening week, including two corrections of
+confident claims that turned out false. Everything above it that it doesn't mention is
+still standing, unedited, per this document's own closing rule.
+
+## Re-verified 2026-08-07 — a week on
+
+CLAUDE.md already carries the estate's current dated facts and is not repeated here —
+this section links it rather than restating it, and adds what CLAUDE.md doesn't carry:
+the reasoning behind each result, including the corrections.
+
+**The chat reply path is proven end to end at the API layer; `chat_threads` is still 0 in
+production.** Two facts, not one, and neither should be read as the other. hill90-app#607
+proved the outbound half (`POST /chat/threads` reachable, thread + first message committed
+before dispatch) against a real Postgres; hill90-app#608 proved the reply half —
+`chatCallbackHandler`'s auth (all four rejection paths genuinely exercised, mutation-verified
+to actually catch a broken token check), persistence, and the SSE-cursor mechanism — also
+against a real Postgres. **What's narrowed, and it's the one thing not proven**: the
+precondition (a pending agent-reply row) is created directly via SQL rather than by a real
+agentbox container completing an LLM call — agentbox's own system-prompt assembly and the
+actual dispatch→agentbox→callback round trip remain unexercised, stated plainly in #608's own
+report rather than glossed over. Separately, hill90-app#502 established that a normal
+(non-admin) user cannot exercise any of this today at all — `/agents/:id/start` is
+admin-gated, and that gate was traced and found load-bearing (the resource-limit fields on
+agent creation have no upper bound; the admin gate on start is the only thing standing
+between an arbitrary-resource agent row and a container). So: the machinery is proven at the
+API boundary; nothing has ever actually flowed through it in production, and a normal user
+structurally cannot make that happen today. `chat_threads` is 0 rows, not "0 recently."
+
+**Keycloak crashed twice in the past week — one root cause found, one honestly still open.**
+Hill90#859 originally concluded both crashes were unrecoverable because Keycloak's own logs
+"never reached Loki." **That conclusion was wrong**, and so was the premise under it: a Loki
+label query with no explicit time range defaults to roughly the last hour, so a low-volume
+container like Keycloak looks absent when it is merely quiet in whatever hour got queried —
+recorded as an instrument-blindness correction in CONTRIBUTING.md (h#860). With the real logs
+in hand:
+- **Episode 2 (2026-08-05, exit 1, 3 restarts) is fully explained and is not a fault.**
+  `docker inspect postgres` showed `RestartCount=0` at a start time 47 seconds after a
+  20:23:39 db-stack deploy — Postgres wasn't crashing, it was being *recreated* by our own
+  deploy automation. Five deploys landed inside one hour that evening, two of them failures;
+  each db-stack recreation dropped every connection, Keycloak's cluster-discovery thread
+  caught the resulting database error, and Keycloak shut itself down gracefully each time.
+  Designed behavior for a service whose database vanishes underneath it, not a defect.
+- **Episode 1 (2026-08-03 04:23–05:17 UTC, exit 2, 70 restarts) is characterized, not
+  explained, and that is the honest and final state of it, not a placeholder for more
+  digging.** Every one of the 70 restarts died at the identical point — mid server-image
+  rebuild, before Keycloak itself starts — with no diagnostic output; Postgres was confirmed
+  undisturbed throughout, ruling out a database story for this episode. Host-level Prometheus
+  metrics (verified to actually cover the window before being trusted, then compared against
+  the same clock window the day before as a baseline) rule out classic resource exhaustion —
+  memory, disk, inodes and swap are all unremarkable — but show a real, precisely-timed
+  signal: available memory steps up ~800MB at the loop's exact start second and back down
+  with a disk-I/O spike at its exact end, ~4.6x the baseline peak CPU in between. That shape
+  reads as *less* being allocated during the failures, not a resource exhausted and freed —
+  consistent with the rebuild dying before whatever normally claims that memory. Attribution
+  to a specific container stops here: cAdvisor has no per-container series on this host (see
+  next item), which is the actual boundary of what this instrument can prove, not a stopping
+  point chosen for convenience. Full evidence trail on Hill90#859.
+
+**cAdvisor's missing per-container metrics is no longer just untidy — it now has a named,
+concrete cost.** Hill90#855 diagnosed the cause (Docker's containerd-snapshotter removes the
+layerdb path cAdvisor reads); this week gave that gap its first real bill: it is the specific
+thing that stopped Keycloak episode 1's host-level CPU/I/O signal from being attributed to a
+container. Fixing it is no longer a tidiness argument — it is the difference between
+"something used more resources during this incident" and "this specific container did."
+
+**All six backup-restore targets are now proven, one with a caveat that isn't closed yet.**
+Hill90#801 restored all six into scratch resources and inspected real content, not empty
+shells — five fully, the sixth (Grafana's OAuth-identity data) via an unauthenticated health
+check and direct read-only SQLite inspection, because the admin credential needed for a full
+proof is the same one Hill90#832 tracks as exposed and unrotated. The restored OAuth subject
+UUIDs independently matched real `agents.created_by` values in hill90-app's own production
+data — a genuinely hard thing to fake, and the strongest evidence available without that
+credential. Closing the gap to the other five's rigor depends on #832.
+
+**The unenforced trust boundary hill90-app#614 documents is real, and the doc that denied it
+is fixed.** `WORKLOAD_PRINCIPAL_V2` is unset in production, so agent identity (`sub` in the
+knowledge-store JWT) is a reusable slug rather than a stable identifier — recreating an agent
+under a deleted agent's name inherits its former memories, and `agent_auth.py` has zero
+ownership checks to catch it. hill90-app#617 (merged) corrected
+`docs/architecture/trust-boundaries.md`, which had previously and wrongly claimed this
+boundary was enforced. hill90-app#618 holds an executable reproduction, not yet fixed by
+design — which of the three possible fixes to take is Jon's call, not a lane's, because a
+trust-boundary fix needs different review than a doc correction. Blast radius today, stated
+rather than left implicit: two agents exist in production, zero chat threads, so the actual
+exposure window is as narrow as it will ever be to fix this in.
+
+**The human-gated queue, stated honestly rather than left to be inferred from a rising issue
+count.** Hill90#862 is a full, evidence-cited sort of all 22 open Hill90 issues into three
+buckets — the response to Jon asking whether the estate is stuck. It isn't: of the 14 issues
+that need a human, most are fully diagnosed already, with root cause and fix both known —
+what's left in each is a production-authorization call, a credential only a human can mint,
+or an architecture decision, not more investigation. 2 issues turned out already resolved
+(their own PRs never auto-closed them — see below), and 6 are real, agent-doable remaining
+work. #862 is the current source of truth for this list; it is not reproduced here because it
+will go stale exactly the way this document warns against, and #862 itself carries the dates
+and evidence needed to re-verify rather than inherit it later.
+
+**A silent, systemic trap in this repo's own convention cost two issues real open time, and
+is now fixed.** This repo prefixes issue references with `h#` in prose (`h#844's fix`), which
+is fine everywhere except a PR body's own closing-keyword line — GitHub does not parse
+`h#NNN` as an issue reference at all, so `Closes h#844` silently closes nothing. A scan of
+every merged PR found it in 19 distinct cases; 17 were closed by hand anyway, but Hill90#786
+and Hill90#844 sat open for hours to days on nothing but this syntax, indistinguishable from
+real unfinished work — #844 specifically needed a full independent re-verification pass
+before it could safely be called resolved, which is the cost of not catching this sooner. A
+CI check (Hill90#864, not yet merged) now fails a PR body on this exact shape, while still
+allowing `h#NNN` in ordinary prose — positive-controlled against the repo's own real PR
+bodies, including a false positive the check found on itself when its own introducing PR
+quoted the bad pattern in backticks as evidence.
+
 ## The shape of the estate right now
 
 `Re-verified 2026-07-31 11:20 UTC.`
@@ -232,6 +344,11 @@ These are half the value and are recorded so nobody pays for them twice.
 
 ## Open decisions — Jon's, not a lane's
 
+**The current, evidence-cited version of this list is Hill90#862** (14 items, each
+re-verified live, not inherited from a stale comment). The list below predates it and is
+kept because it's a decision record, not a status tracker — but where the two disagree,
+#862 is newer and was checked more recently.
+
 1. **Repository visibility for hill90-app.** The current tree contains neither the tailnet
    address nor the SSH alias; the exposure is in history only, and the repository is still
    private, so a rewrite performed *before* first publication is effective while one after
@@ -259,7 +376,16 @@ These are half the value and are recorded so nobody pays for them twice.
    `Re-verified 2026-07-31 11:20 UTC`: still `Exited (0)`, volume still present.
 5. **Run Config VPS, to put the SSH hardening in force.** The drop-in is in this repository
    and `sshd -T` still reports `passwordauthentication yes`. Until it runs, the firewall is
-   the only thing standing between the setting and the internet.
+   the only thing standing between the setting and the internet. **`Re-verified 2026-08-07`:
+   the fix is ready and correct, still not applied.** PR #852 (merged) consolidated this with
+   Hill90#681, Hill90#786 and hill90-app#226; a live `--check --diff` dry-run against the real
+   host confirmed it edits the file that actually decides behavior today
+   (`50-cloud-init.conf`, not just `sshd_config`), uses `reload` not `restart` so an in-flight
+   session survives, and that the connection-safety gates it ships cannot be exercised in
+   `--check` mode at all — that boundary is a property of Ansible's check mode, not a gap in
+   the playbook. #852's body wrote "Closes h#786", which GitHub doesn't parse (see the h#864
+   entry above), so #681 and #786 both still show as open describing this identical remaining
+   step: dispatching `harden-ssh.yml` with `check: false` against production.
 6. **The `api.hill90.com` rate limit, as a specified number.** The UI carries the shared
    rate-limit middleware and the API carries none. Not an exposure — the API is meant to be
    public and authenticates its callers — but the asymmetry looks unintended. The proposal
@@ -270,7 +396,11 @@ These are half the value and are recorded so nobody pays for them twice.
    report that the host is gone. A ping from the nightly backup cron to an outside service
    would cover the backup failing, the host dying, and the who-watches-the-watcher hole in
    Alertmanager, all at once. It was deliberately not built because it needs an account that
-   is Jon's to open.
+   is Jon's to open. **Still true, and distinct from a narrower fix that landed since**:
+   h#712 (closed) built a dead man's switch for a *scheduled GitHub Actions workflow that
+   stops firing entirely* — the class of gap that let `vault-sync-to-sops` fail silently for
+   days (Hill90#789/#799). That covers a workflow going quiet, not this item's host-level
+   heartbeat; this decision is unchanged and still open.
 
 ## The rule this cycle kept re-learning
 


### PR DESCRIPTION
CLAUDE.md names this document as the START HERE read for a cold session, and it was a week stale while tonight (and the days before it) produced a lot of measured fact — plus several corrections of confident claims that turned out false, which matter as much as the findings themselves.

New "Re-verified 2026-08-07" section, inserted right after the existing superseding note so it's the first thing a cold session reads, per the doc's own convention. Only records what was actually verified this week, each item cited:

- **Chat reply path**: proven end to end at the API layer (hill90-app#607 outbound, #608 reply/callback — auth, persistence, SSE cursor, mutation-verified). `chat_threads` is still 0 rows in production, and hill90-app#502 established a normal user structurally can't exercise this today at all — the admin gate on `/agents/:id/start` is load-bearing, not incidental.
- **Keycloak's two crashes**: episode 2 (2026-08-05) is fully explained as our own deploy burst — `docker inspect` showed Postgres was *recreated*, not crashed, 47s after a db-stack deploy, three times in an hour of our own deploys. Episode 1 (2026-08-03) is characterized, not explained — host Prometheus metrics rule out classic exhaustion but show a real signal (available memory steps ~800MB at the loop's exact start/end seconds) that can't be attributed to a specific container.
- **cAdvisor's per-container gap** (#855) now has a named cost, not just tidiness: it's the specific thing blocking episode 1's attribution.
- **All six backup-restore targets are proven** (#801), one (Grafana OAuth data) with a caveat depending on #832's credential rotation.
- **hill90-app#614's trust boundary is real**, the doc that denied it is fixed (#617 merged), the reproduction/fix choice is #618, Jon's call.
- **The human-gated queue**, linked via #862's full evidence-cited triage rather than reproduced — reproducing it here would just go stale the way this document itself warns against.

Also updated two "Open decisions" entries with direct evidence rather than leaving them silently stale (item 5, SSH hardening — the live dry-run and the h#-prefix trap that left #681/#786 both open on nothing but syntax; item 7 — a one-line disambiguation from h#712's narrower, already-closed workflow-level dead-man's-switch), and added a pointer at the top of that section to #862 as the fresher full list, without touching the historical entries.

`check_md_links.py` passes clean (64 files scanned).

Not merged — reporting back per instruction.