### PR TITLE
fix(auth): preflight first realm import — h#809

### DIFF
--- a/docs/runbooks/vps-rebuild.md
+++ b/docs/runbooks/vps-rebuild.md
@@ -229,11 +229,13 @@ make deploy-auth
 `HILL90_UI_CLIENT_SECRET` must already be set in the secrets store. This is
 the ONE step in the whole rebuild where `start --import-realm` actually
 imports (a fresh Keycloak has no existing realm), and an unset value here
-installs a public, unsubstituted placeholder as the client secret fronting
-`hill90.com` — see the Prerequisites section for the full mechanism (h#809,
-h#835) and the automated check that now catches it
-(`verify_realm_secrets_substituted` in `scripts/keycloak.sh`, wired into
-`keycloak.sh apply`, which `deploy.sh auth` calls automatically).
+would install a public, unsubstituted placeholder as the client secret fronting
+`hill90.com`. `deploy.sh auth` now queries Postgres **before** it stops or
+starts Keycloak: if the `platform` realm is absent, its first-import preflight
+refuses an absent or literal-placeholder value; if the realm already exists,
+the check passes without this value so routine auth deploys remain valid. The
+existing `verify_realm_secrets_substituted` check in `scripts/keycloak.sh`
+remains the post-import defence-in-depth verification (h#809, h#835).
 
 **Result:**
 - ✅ Keycloak running, realm `platform` imported

--- a/scripts/checks/preflight-first-realm-import-secret.sh
+++ b/scripts/checks/preflight-first-realm-import-secret.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Refuse a first Keycloak realm import without a real hill90-ui client secret.
+#
+# `start --import-realm` ignores existing realms, so HILL90_UI_CLIENT_SECRET is
+# legitimately absent on routine auth deploys.  The Keycloak database is the
+# authoritative distinction before deploy.sh stops or starts the container:
+# no `platform` realm means the next Keycloak start will import it.
+#
+# The script deliberately reports only state, never the secret value.
+# Usage: preflight-first-realm-import-secret.sh <db-user> <db-name> <realm>
+set -euo pipefail
+
+DB_USER="${1:?db user required}"
+DB_NAME="${2:?db name required}"
+REALM="${3:?realm required}"
+
+query() {
+    docker exec postgres psql -U "$DB_USER" -d "$DB_NAME" -tAc "$1" 2>/dev/null | tr -d '[:space:]'
+}
+
+# A fresh Keycloak database has no realm table.  Once the schema exists, ask
+# the database rather than inferring import state from whether a container is
+# currently running; routine deploys stop that container themselves.
+if ! realm_table_exists=$(query "SELECT EXISTS (SELECT 1 FROM pg_catalog.pg_tables WHERE schemaname = 'public' AND tablename = 'realm');"); then
+    echo "ERROR: could not determine whether Keycloak's realm table exists; refusing auth deploy before a possible first import." >&2
+    exit 2
+fi
+
+realm_exists=f
+if [ "$realm_table_exists" = t ]; then
+    if ! realm_exists=$(query "SELECT EXISTS (SELECT 1 FROM realm WHERE name = '${REALM}');"); then
+        echo "ERROR: could not determine whether realm '${REALM}' exists; refusing auth deploy before a possible first import." >&2
+        exit 2
+    fi
+fi
+
+if [ "$realm_exists" = t ]; then
+    echo "Keycloak realm '${REALM}' already exists; routine auth deploy does not need HILL90_UI_CLIENT_SECRET."
+    exit 0
+fi
+
+secret="${HILL90_UI_CLIENT_SECRET:-}"
+if [ -z "$secret" ]; then
+    echo "ERROR: HILL90_UI_CLIENT_SECRET is missing; refusing the first Keycloak realm import before it can install a public placeholder." >&2
+    exit 1
+fi
+
+if [ "$secret" = '${HILL90_UI_CLIENT_SECRET}' ]; then
+    echo "ERROR: HILL90_UI_CLIENT_SECRET is the literal placeholder; refusing the first Keycloak realm import." >&2
+    exit 1
+fi
+
+echo "First Keycloak realm import preflight passed; HILL90_UI_CLIENT_SECRET is present."

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -459,6 +459,16 @@ cmd_service() {
         if ! docker exec postgres psql -U "$guard_user" -tAc 'SELECT 1' >/dev/null 2>&1; then
             die "Cannot deploy auth: cannot query postgres as '${guard_user}'. Deploy it first: bash scripts/deploy.sh db ${env}"
         fi
+
+        # `start --import-realm` only imports on a fresh Keycloak database.
+        # HILL90_UI_CLIENT_SECRET is deliberately optional on routine auth
+        # deploys, but it must be real before that first import. Run this while
+        # the database still describes the pre-deploy state, before the later
+        # compose down/up can start Keycloak and consume the realm template.
+        if ! sops exec-env "$secrets_file" \
+            "bash '$SCRIPT_DIR/checks/preflight-first-realm-import-secret.sh' '$guard_user' keycloak platform"; then
+            die "Cannot deploy auth: first-realm-import secret preflight failed."
+        fi
     fi
 
     # One-time migration: remove old-project containers that would collide

--- a/tests/scripts/first-realm-import-secret.bats
+++ b/tests/scripts/first-realm-import-secret.bats
@@ -26,6 +26,68 @@ EOF
   chmod +x "$STUB/docker"
 }
 
+build_deploy_harness() {
+  CTL="$BATS_TEST_TMPDIR/deploy-path"
+  mkdir -p "$CTL/scripts/checks"
+  cp "${DEPLOY_SOURCE:-$ROOT/scripts/deploy.sh}" "$CTL/scripts/deploy.sh"
+  cp "$CHECK" "$CTL/scripts/checks/preflight-first-realm-import-secret.sh"
+
+  cat > "$CTL/scripts/backup.sh" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+  cat > "$CTL/scripts/keycloak.sh" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+  chmod +x "$CTL/scripts/backup.sh" "$CTL/scripts/keycloak.sh"
+
+  cat > "$STUB/sops" <<'EOF'
+#!/usr/bin/env bash
+if [ "$1" = exec-env ]; then
+  bash -c "$3"
+  exit $?
+fi
+exit 99
+EOF
+  chmod +x "$STUB/sops"
+
+cat > "$STUB/docker" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$*" == *"pg_catalog.pg_tables"* ]]; then
+  printf '%s\n' "${FAKE_REALM_SCHEMA:-f}"
+elif [[ "$*" == *"FROM realm"* ]]; then
+  printf '%s\n' "${FAKE_PLATFORM_REALM:-f}"
+elif [[ "$*" == *"SELECT 1"* ]]; then
+  printf '1\n'
+elif [ "$1" = compose ]; then
+  if [[ "$*" == *" up -d"* ]]; then
+    : > "$AUTH_COMPOSE_SENTINEL"
+  fi
+elif [ "$1" = inspect ] && [[ "$*" == *"--format="* ]]; then
+  printf 'healthy\n'
+fi
+EOF
+  chmod +x "$STUB/docker"
+
+  cat > "$CTL/harness.sh" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$CTL/scripts"
+ensure_age_key() { :; }
+require_file() { :; }
+secret_value() { printf 'hill90'; }
+die() { printf 'DIE: %s\\n' "\$*" >&2; exit 97; }
+warn() { printf 'WARN: %s\\n' "\$*" >&2; }
+info() { :; }
+vault_available() { return 1; }
+vault_approle_credentials_present() { return 1; }
+cmd_verify() { :; }
+prune_builder_cache() { :; }
+EOF
+  sed -n '/^cmd_service() {/,/^}/p' "$CTL/scripts/deploy.sh" >> "$CTL/harness.sh"
+}
+
 @test "FIRST IMPORT: an absent HILL90_UI_CLIENT_SECRET refuses before import" {
   run env -u HILL90_UI_CLIENT_SECRET FAKE_REALM_SCHEMA=f \
     bash "$CHECK" hill90 keycloak platform
@@ -59,12 +121,38 @@ EOF
   [[ "$output" == *"already exists"* ]]
 }
 
-@test "deploy auth runs the first-import preflight before compose can start Keycloak" {
-  run bash -c '
-    preflight=$(grep -n "preflight-first-realm-import-secret.sh" scripts/deploy.sh | head -n1 | cut -d: -f1)
-    compose=$(awk -v after="$preflight" "NR > after && /docker compose -p.*up -d/ { print NR; exit }" scripts/deploy.sh)
-    test -n "$preflight" && test -n "$compose" && test "$preflight" -lt "$compose"
-  '
+@test "DEPLOY PATH: a failed first-import preflight aborts before compose can start Keycloak" {
+  build_deploy_harness
+  sentinel="$BATS_TEST_TMPDIR/auth-compose-started"
+
+  run env -u HILL90_UI_CLIENT_SECRET FAKE_REALM_SCHEMA=f \
+    AUTH_COMPOSE_SENTINEL="$sentinel" bash -c "source '$CTL/harness.sh'; cmd_service auth prod"
+
+  [ "$status" -eq 97 ]
+  [[ "$output" == *"first-realm-import secret preflight failed"* ]]
+  [ ! -e "$sentinel" ]
+}
+
+@test "DEPLOY PATH: an existing realm permits progress to the auth compose-start sentinel" {
+  build_deploy_harness
+  sentinel="$BATS_TEST_TMPDIR/auth-compose-started"
+
+  run env -u HILL90_UI_CLIENT_SECRET FAKE_REALM_SCHEMA=t FAKE_PLATFORM_REALM=t \
+    AUTH_COMPOSE_SENTINEL="$sentinel" bash -c "source '$CTL/harness.sh'; cmd_service auth prod"
 
   [ "$status" -eq 0 ]
+  [ -e "$sentinel" ]
+}
+
+@test "MUTATION CONTROL: bypassing the deploy-path preflight reaches compose on a missing secret" {
+  mutated="$BATS_TEST_TMPDIR/deploy-without-preflight.sh"
+  sed '/if ! sops exec-env "\$secrets_file" \\/,/^        fi$/d' "$ROOT/scripts/deploy.sh" > "$mutated"
+  DEPLOY_SOURCE="$mutated" build_deploy_harness
+  sentinel="$BATS_TEST_TMPDIR/auth-compose-started"
+
+  run env -u HILL90_UI_CLIENT_SECRET FAKE_REALM_SCHEMA=f \
+    AUTH_COMPOSE_SENTINEL="$sentinel" bash -c "source '$CTL/harness.sh'; cmd_service auth prod"
+
+  [ "$status" -eq 0 ]
+  [ -e "$sentinel" ]
 }

--- a/tests/scripts/first-realm-import-secret.bats
+++ b/tests/scripts/first-realm-import-secret.bats
@@ -1,0 +1,70 @@
+#!/usr/bin/env bats
+
+# Regression coverage for h#809. The production preflight queries Postgres to
+# distinguish a first Keycloak realm import from a routine auth deploy; these
+# tests replace Docker with a tiny deterministic stand-in and use only dummy
+# secret values.
+
+setup() {
+  ROOT="$BATS_TEST_DIRNAME/../.."
+  CHECK="$ROOT/scripts/checks/preflight-first-realm-import-secret.sh"
+  STUB="$BATS_TEST_TMPDIR/bin"
+  mkdir -p "$STUB"
+  PATH="$STUB:$PATH"
+
+  cat > "$STUB/docker" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$*" == *"pg_catalog.pg_tables"* ]]; then
+  printf '%s\n' "${FAKE_REALM_SCHEMA:-f}"
+elif [[ "$*" == *"FROM realm"* ]]; then
+  printf '%s\n' "${FAKE_PLATFORM_REALM:-f}"
+else
+  printf 'unexpected docker invocation: %s\n' "$*" >&2
+  exit 99
+fi
+EOF
+  chmod +x "$STUB/docker"
+}
+
+@test "FIRST IMPORT: an absent HILL90_UI_CLIENT_SECRET refuses before import" {
+  run env -u HILL90_UI_CLIENT_SECRET FAKE_REALM_SCHEMA=f \
+    bash "$CHECK" hill90 keycloak platform
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"HILL90_UI_CLIENT_SECRET is missing"* ]]
+}
+
+@test "FIRST IMPORT: the literal realm-template placeholder refuses" {
+  run env HILL90_UI_CLIENT_SECRET='${HILL90_UI_CLIENT_SECRET}' FAKE_REALM_SCHEMA=f \
+    bash "$CHECK" hill90 keycloak platform
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"literal placeholder"* ]]
+}
+
+@test "FIRST IMPORT: a nonempty synthetic secret permits import" {
+  run env HILL90_UI_CLIENT_SECRET='synthetic-ui-secret-0123456789' FAKE_REALM_SCHEMA=f \
+    bash "$CHECK" hill90 keycloak platform
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"preflight passed"* ]]
+  [[ "$output" != *"synthetic-ui-secret-0123456789"* ]]
+}
+
+@test "ROUTINE DEPLOY: an existing platform realm permits an absent secret" {
+  run env -u HILL90_UI_CLIENT_SECRET FAKE_REALM_SCHEMA=t FAKE_PLATFORM_REALM=t \
+    bash "$CHECK" hill90 keycloak platform
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"already exists"* ]]
+}
+
+@test "deploy auth runs the first-import preflight before compose can start Keycloak" {
+  run bash -c '
+    preflight=$(grep -n "preflight-first-realm-import-secret.sh" scripts/deploy.sh | head -n1 | cut -d: -f1)
+    compose=$(awk -v after="$preflight" "NR > after && /docker compose -p.*up -d/ { print NR; exit }" scripts/deploy.sh)
+    test -n "$preflight" && test -n "$compose" && test "$preflight" -lt "$compose"
+  '
+
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary

References #809. Adds a pre-import guard to the real `scripts/deploy.sh auth` path used after the rebuild/config workflow chain. It queries the Keycloak database before any auth compose stop/start:

- missing `platform` realm: refuses an absent or literal-placeholder `HILL90_UI_CLIENT_SECRET`;
- existing `platform` realm: passes without that value, preserving routine auth deploys;
- query uncertainty: refuses rather than assuming the import is safe.

The existing post-import Keycloak check remains defence in depth. No alert-count or alert-series files were changed.

## Test evidence

- Red before the original implementation: `bats tests/scripts/first-realm-import-secret.bats` failed all four semantic cases because the preflight was absent (exit 127).
- Behavioral deploy-path proof: a stubbed `cmd_service auth` with a first-import secret failure exits 97 **before** the auth compose-start sentinel; an existing `platform` realm with the value absent reaches that sentinel.
- Mutation-verified: deleting the `sops exec-env` preflight block from an in-memory copy makes the required-failure behavioral assertion red; the mutant reaches `Deploying auth service...` instead.
- `bats tests/scripts/first-realm-import-secret.bats tests/scripts/deploy.bats` — 39/39 passing.
- `bash -n` and `shellcheck --severity=error` passed for the guard and deploy script.
- `python3 scripts/checks/check_checks_are_wired.py` passed and confirms this check has a real script caller.
- Relevant workflow YAML parsed successfully. `actionlint` is not installed locally.

## Boundary

This does not dispatch workflows or contact production. It validates only presence/non-placeholder form in Hill90; it does not read, print, or cross-repository-compare secret values.