### PR TITLE
Reject empty alert rule sets

### DIFF
--- a/scripts/checks/check_alert_series.py
+++ b/scripts/checks/check_alert_series.py
@@ -256,6 +256,11 @@ def main():
         print(f"CANNOT REACH PROMETHEUS: {err}")
         print("A check that cannot run must not report success. Exiting 1.")
         return 1
+    if not probe:
+        print("Prometheus up query returned no live series; refusing vacuous success")
+        print("A reachable endpoint without an up series cannot prove the")
+        print("subsequent selector results came from a live Prometheus. Exiting 1.")
+        return 1
 
     missing, stale_allowlist, absent_ok, checked = [], [], [], 0
     for group in doc.get("groups", []):

--- a/scripts/checks/check_alert_series.py
+++ b/scripts/checks/check_alert_series.py
@@ -224,6 +224,12 @@ def grouping_and_annotation_labels(rule):
 def main():
     raw = RULES.read_text()
     doc = yaml.safe_load(raw)
+    alert_rule_count = sum(
+        1
+        for group in doc.get("groups", [])
+        for rule in group.get("rules", [])
+        if rule.get("alert")
+    )
 
     allowed = {}
     if ALLOWLIST.exists():
@@ -238,6 +244,12 @@ def main():
     if allowed:
         print(f"declared absent ({ALLOWLIST.name}): {len(allowed)} selector(s)")
     print()
+
+    if not alert_rule_count:
+        print("rules file contains no alert rules; refusing vacuous success")
+        print("Recording rules are valid Prometheus input, but this check only")
+        print("verifies alert rules can match live series. Exiting 1.")
+        return 1
 
     probe, err = prometheus_query("up")
     if err:

--- a/tests/checks/test_check_alert_series_empty_alert_set.py
+++ b/tests/checks/test_check_alert_series_empty_alert_set.py
@@ -1,0 +1,64 @@
+"""Regression test for #775: a live check must not vacuously pass no alerts.
+
+Prometheus accepts recording rules, but this checker deliberately inspects alert
+rules only. A recording-rule-only file must therefore fail even when the
+Prometheus connectivity probe has a real ``up`` series.
+"""
+from __future__ import annotations
+
+import json
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "checks" / "check_alert_series.py"
+
+
+def test_recording_rule_only_file_refuses_vacuous_success(tmp_path: Path):
+    fake_root = tmp_path / "repo"
+    rules_dir = fake_root / "platform" / "observability" / "prometheus"
+    checks_dir = fake_root / "scripts" / "checks"
+    rules_dir.mkdir(parents=True)
+    checks_dir.mkdir(parents=True)
+    (rules_dir / "alerts.yml").write_text(
+        """\
+groups:
+  - name: fixture
+    rules:
+      - record: fixture_recording_rule_775
+        expr: vector(1)
+"""
+    )
+    (checks_dir / "alert-series-allowlist.txt").write_text("")
+    (checks_dir / "check_alert_series.py").write_text(SCRIPT.read_text())
+
+    up_response = json.dumps({
+        "status": "success",
+        "data": {"resultType": "vector", "result": [{
+            "metric": {"__name__": "up", "job": "prometheus"},
+            "value": [0, "1"],
+        }]},
+    })
+    stub_dir = tmp_path / "bin"
+    stub_dir.mkdir()
+    docker = stub_dir / "docker"
+    docker.write_text(f"""#!/usr/bin/env bash
+case "${{*: -1}}" in
+  *query=up*) echo '{up_response}' ;;
+  *) echo '{{"status":"success","data":{{"resultType":"vector","result":[]}}}}' ;;
+esac
+""")
+    docker.chmod(docker.stat().st_mode | stat.S_IEXEC)
+
+    env = dict(os.environ)
+    env["PATH"] = f"{stub_dir}:{env['PATH']}"
+    result = subprocess.run(
+        ["python3", "scripts/checks/check_alert_series.py"],
+        cwd=fake_root, capture_output=True, text=True, env=env,
+    )
+
+    assert result.returncode == 1, result.stdout
+    assert "rules file contains no alert rules" in result.stdout
+    assert "0 selectors checked" not in result.stdout

--- a/tests/checks/test_check_alert_series_empty_alert_set.py
+++ b/tests/checks/test_check_alert_series_empty_alert_set.py
@@ -62,3 +62,51 @@ esac
     assert result.returncode == 1, result.stdout
     assert "rules file contains no alert rules" in result.stdout
     assert "0 selectors checked" not in result.stdout
+
+
+def test_empty_successful_up_probe_refuses_vacuous_success(tmp_path: Path):
+    """A reachable Prometheus with no live series is not a healthy proof.
+
+    ``absent()`` correctly permits its *selector* to have no series, but that
+    exception must not turn an empty successful ``up`` probe into a green live
+    check.  Before #867's follow-up guard, this fixture printed the
+    absent-wrapper exception and exited 0.
+    """
+    fake_root = tmp_path / "repo"
+    rules_dir = fake_root / "platform" / "observability" / "prometheus"
+    checks_dir = fake_root / "scripts" / "checks"
+    rules_dir.mkdir(parents=True)
+    checks_dir.mkdir(parents=True)
+    (rules_dir / "alerts.yml").write_text(
+        """\
+groups:
+  - name: fixture
+    rules:
+      - alert: FixtureAbsent
+        expr: absent(fixture_metric_867)
+"""
+    )
+    (checks_dir / "alert-series-allowlist.txt").write_text("")
+    (checks_dir / "check_alert_series.py").write_text(SCRIPT.read_text())
+
+    empty_response = json.dumps({
+        "status": "success",
+        "data": {"resultType": "vector", "result": []},
+    })
+    stub_dir = tmp_path / "bin"
+    stub_dir.mkdir()
+    docker = stub_dir / "docker"
+    docker.write_text(f"""#!/usr/bin/env bash
+echo '{empty_response}'
+""")
+    docker.chmod(docker.stat().st_mode | stat.S_IEXEC)
+
+    env = dict(os.environ)
+    env["PATH"] = f"{stub_dir}:{env['PATH']}"
+    result = subprocess.run(
+        ["python3", "scripts/checks/check_alert_series.py"],
+        cwd=fake_root, capture_output=True, text=True, env=env,
+    )
+
+    assert result.returncode == 1, result.stdout
+    assert "up query returned no live series" in result.stdout

--- a/tests/checks/test_check_alert_series_selector_blind_spots.py
+++ b/tests/checks/test_check_alert_series_selector_blind_spots.py
@@ -71,6 +71,10 @@ def _make_docker_stub(stub_dir: Path):
     script = f"""#!/usr/bin/env bash
 url="${{*: -1}}"
 case "$url" in
+  # The checker first probes `up` to establish that this represents live
+  # Prometheus data. Every selector-specific assertion below assumes that
+  # precondition, so this fixture must provide it explicitly.
+  *query=up*) echo '{fixture_body}' ;;
   *totally_fake_metric_h855*) echo '{EMPTY}' ;;
   *phantom*) echo '{EMPTY}' ;;
   *fixture_metric_h855*) echo '{fixture_body}' ;;


### PR DESCRIPTION
## Summary

Refs #775. Fail `check_alert_series.py` when either:

- `alerts.yml` contains no alert rules, including a valid recording-rule-only file that previously printed `0 selectors checked` and exited 0; or
- Prometheus accepts the `up` query but returns no series, which previously allowed an all-`absent(...)`/allowlisted selector set to pass without evidence of live data.

## Verification

- New failing-first regression: an empty successful `up` response plus an `absent(...)` alert exited 0 before the fix; after the guard it exits 1 before selector exceptions can create a green result.
- Parent control for the original empty-alert defect: PR parent with a recording-rule-only file and a real synthetic `up` series exits 0 and prints `0 selectors checked`; the retained test now fails that state and passes with this PR.
- `python3 -m pytest -q tests/checks/test_check_alert_series_empty_alert_set.py tests/checks/test_check_alert_series_selector_blind_spots.py tests/checks/test_check_alert_series_stale_allowlist.py` — 9 passed.
- `python3 -m pytest -q tests/checks/` — passed.
- `python3 -m py_compile scripts/checks/check_alert_series.py` and `git diff --check` — passed.

The selector blind-spot test stub now supplies a real `up` series, because the check correctly requires that live-data precondition before reaching its selector-specific assertions.