### PR TITLE
Reject automatic role grants

### DIFF
--- a/scripts/checks/check_retired_roles_ungranted.py
+++ b/scripts/checks/check_retired_roles_ungranted.py
@@ -39,7 +39,8 @@ The retired set is read from keycloak.sh REALM_ROLES_REMOVED rather than restate
 here, so this cannot cover fewer roles than the removal actually deletes.
 
 GRANT SITES CHECKED (static):
-  * MinIO policy names           — the union rule makes a policy name a grant
+  * MinIO policy names           — the union rule makes a policy name a grant;
+                                    automatic realm-role names grant every user
   * Grafana role_attribute_path  — names a role to hand out an org role
   * OpenBao admin-sso            — bound_claims name a role to hand out a policy
   * keycloak.sh REALM_ROLES      — a retired role must not also be created
@@ -83,8 +84,19 @@ def shell_list(path: Path, var: str) -> list[str]:
     return m.group(1).split() if m else []
 
 
+def shell_default(path: Path, var: str) -> str | None:
+    m = re.search(rf'^{var}="\$\{{{var}:-([^}}]+)\}}"', path.read_text(), re.M)
+    return m.group(1) if m else None
+
+
 def static_checks(retired: set[str]) -> list[str]:
     problems: list[str] = []
+    realm = shell_default(KEYCLOAK, "KC_REALM")
+    if not realm:
+        problems.append("could not determine KC_REALM's default; cannot check automatic realm-role grants")
+        automatic: set[str] = set()
+    else:
+        automatic = {"offline_access", "uma_authorization", f"default-roles-{realm}"}
 
     created = set(shell_list(KEYCLOAK, "REALM_ROLES"))
     both = sorted(retired & created)
@@ -98,26 +110,37 @@ def static_checks(retired: set[str]) -> list[str]:
         if "LEGACY" in m.group(1):
             continue
         created_pol |= {p for p in m.group(1).split() if not p.startswith("$")}
-    bad = sorted(retired & created_pol)
-    print(f"  {'MISS' if bad else 'ok  '}  MinIO policies created: {', '.join(sorted(created_pol))}")
-    for r in bad:
+    bad_retired = sorted(retired & created_pol)
+    print(f"  {'MISS' if bad_retired else 'ok  '}  MinIO policies created: {', '.join(sorted(created_pol))}")
+    for r in bad_retired:
         problems.append(f"minio.sh still creates a policy named {r}; MinIO grants the union of claim values that name a policy, so that is a grant")
+
+    bad_automatic = sorted(automatic & created_pol)
+    print(f"  {'MISS' if bad_automatic else 'ok  '}  MinIO automatic realm-role policies: {', '.join(bad_automatic) or 'none'}")
+    for role in bad_automatic:
+        problems.append(f"minio.sh creates policy {role}, an automatic realm role held by every realm member")
 
     gtxt = GRAFANA.read_text()
     arms = set(re.findall(r"realm_access\.roles\[\*\],\s*'([^']+)'", gtxt))
     bad = sorted(retired & arms)
-    print(f"  {'MISS' if bad else 'ok  '}  Grafana role_attribute_path: {', '.join(sorted(arms))}")
+    bad_automatic = sorted(automatic & arms)
+    print(f"  {'MISS' if bad or bad_automatic else 'ok  '}  Grafana role_attribute_path: {', '.join(sorted(arms))}")
     for r in bad:
         problems.append(f"Grafana's role_attribute_path grants an org role to {r}")
+    for role in bad_automatic:
+        problems.append(f"Grafana's role_attribute_path grants an org role to automatic role {role}, held by every realm member")
 
     vtxt = VAULT.read_text()
     claims: set[str] = set()
     for m in re.finditer(r'"realm_roles":\s*\[([^\]]*)\]', vtxt):
         claims |= {c.strip().strip('"\'') for c in m.group(1).split(",") if c.strip()}
     bad = sorted(retired & claims)
-    print(f"  {'MISS' if bad else 'ok  '}  OpenBao bound_claims: {', '.join(sorted(claims))}")
+    bad_automatic = sorted(automatic & claims)
+    print(f"  {'MISS' if bad or bad_automatic else 'ok  '}  OpenBao bound_claims: {', '.join(sorted(claims))}")
     for r in bad:
         problems.append(f"OpenBao's admin-sso role grants a vault policy to {r}")
+    for role in bad_automatic:
+        problems.append(f"OpenBao's admin-sso role grants a vault policy to automatic role {role}, held by every realm member")
 
     return problems
 

--- a/scripts/checks/check_retired_roles_ungranted.py
+++ b/scripts/checks/check_retired_roles_ungranted.py
@@ -89,6 +89,32 @@ def shell_default(path: Path, var: str) -> str | None:
     return m.group(1) if m else None
 
 
+def source_without_comments(text: str) -> str:
+    """Remove comments while preserving # characters inside quoted strings."""
+    lines: list[str] = []
+    for line in text.splitlines():
+        quote: str | None = None
+        escaped = False
+        for index, char in enumerate(line):
+            if escaped:
+                escaped = False
+                continue
+            if char == "\\" and quote != "'":
+                escaped = True
+                continue
+            if quote:
+                if char == quote:
+                    quote = None
+                continue
+            if char in "'\"":
+                quote = char
+            elif char == "#":
+                line = line[:index]
+                break
+        lines.append(line)
+    return "\n".join(lines)
+
+
 def static_checks(retired: set[str]) -> list[str]:
     problems: list[str] = []
     realm = shell_default(KEYCLOAK, "KC_REALM")
@@ -104,9 +130,9 @@ def static_checks(retired: set[str]) -> list[str]:
     for r in both:
         problems.append(f"keycloak.sh lists {r} in REALM_ROLES and in REALM_ROLES_REMOVED — it would be created and deleted every run")
 
-    minio_txt = MINIO.read_text()
+    minio_txt = source_without_comments(MINIO.read_text())
     created_pol = set()
-    for m in re.finditer(r"for policy in ([^;]+); do", minio_txt):
+    for m in re.finditer(r"for\s+policy\s+in\s+([^;\n]+)\s*;\s*do\b", minio_txt):
         if "LEGACY" in m.group(1):
             continue
         created_pol |= {p for p in m.group(1).split() if not p.startswith("$")}
@@ -120,7 +146,7 @@ def static_checks(retired: set[str]) -> list[str]:
     for role in bad_automatic:
         problems.append(f"minio.sh creates policy {role}, an automatic realm role held by every realm member")
 
-    gtxt = GRAFANA.read_text()
+    gtxt = source_without_comments(GRAFANA.read_text())
     arms = set(re.findall(r"realm_access\.roles\[\*\],\s*'([^']+)'", gtxt))
     bad = sorted(retired & arms)
     bad_automatic = sorted(automatic & arms)
@@ -130,7 +156,7 @@ def static_checks(retired: set[str]) -> list[str]:
     for role in bad_automatic:
         problems.append(f"Grafana's role_attribute_path grants an org role to automatic role {role}, held by every realm member")
 
-    vtxt = VAULT.read_text()
+    vtxt = source_without_comments(VAULT.read_text())
     claims: set[str] = set()
     for m in re.finditer(r'"realm_roles":\s*\[([^\]]*)\]', vtxt):
         claims |= {c.strip().strip('"\'') for c in m.group(1).split(",") if c.strip()}

--- a/tests/scripts/retired-roles-ungranted-control.bats
+++ b/tests/scripts/retired-roles-ungranted-control.bats
@@ -64,6 +64,27 @@ setup() {
   [[ "$output" == *"every realm member"* ]]
 }
 
+@test "valid MinIO loop whitespace still detects an automatic realm-role policy" {
+  sed -i.bak 's/for policy in platform-admin platform-viewer; do/for policy in platform-admin platform-viewer offline_access;  do/' \
+    "$CTL/scripts/minio.sh"
+  rm -f "$CTL/scripts/minio.sh.bak"
+
+  run bash -n "$CTL/scripts/minio.sh"
+  [ "$status" -eq 0 ]
+
+  run python3 "$CHECK"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"offline_access"* ]]
+}
+
+@test "a harmless MinIO comment is not treated as an automatic realm-role policy" {
+  printf '\n# for policy in offline_access; do\n' >> "$CTL/scripts/minio.sh"
+
+  run python3 "$CHECK"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"PASS"* ]]
+}
+
 @test "pointing Grafana back at a retired role turns it red" {
   sed -i.bak "s/'platform-editor'/'editor'/" \
     "$CTL/deploy/compose/prod/docker-compose.observability.yml"
@@ -84,6 +105,15 @@ setup() {
   [[ "$output" == *"Grafana's role_attribute_path grants an org role to automatic role offline_access"* ]]
 }
 
+@test "a harmless Grafana comment is not treated as an automatic realm-role grant" {
+  printf "\n# contains(realm_access.roles[*], 'offline_access')\n" >> \
+    "$CTL/deploy/compose/prod/docker-compose.observability.yml"
+
+  run python3 "$CHECK"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"PASS"* ]]
+}
+
 @test "pointing OpenBao's bound claim back at a retired role turns it red" {
   sed -i.bak 's/"realm_roles": \["platform-admin"\]/"realm_roles": ["admin"]/' "$CTL/scripts/vault.sh"
   rm -f "$CTL/scripts/vault.sh.bak"
@@ -100,6 +130,14 @@ setup() {
   run python3 "$CHECK"
   [ "$status" -eq 1 ]
   [[ "$output" == *"OpenBao's admin-sso role grants a vault policy to automatic role uma_authorization"* ]]
+}
+
+@test "a harmless OpenBao comment is not treated as an automatic realm-role grant" {
+  printf '\n# "realm_roles": ["uma_authorization"]\n' >> "$CTL/scripts/vault.sh"
+
+  run python3 "$CHECK"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"PASS"* ]]
 }
 
 @test "listing a retired role in REALM_ROLES as well turns it red" {

--- a/tests/scripts/retired-roles-ungranted-control.bats
+++ b/tests/scripts/retired-roles-ungranted-control.bats
@@ -53,6 +53,17 @@ setup() {
   [[ "$output" == *"union"* ]]
 }
 
+@test "an automatic realm-role MinIO policy turns the static check red before deploy" {
+  sed -i.bak 's/for policy in platform-admin platform-viewer; do/for policy in platform-admin platform-viewer offline_access; do/' \
+    "$CTL/scripts/minio.sh"
+  rm -f "$CTL/scripts/minio.sh.bak"
+
+  run python3 "$CHECK"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"offline_access"* ]]
+  [[ "$output" == *"every realm member"* ]]
+}
+
 @test "pointing Grafana back at a retired role turns it red" {
   sed -i.bak "s/'platform-editor'/'editor'/" \
     "$CTL/deploy/compose/prod/docker-compose.observability.yml"
@@ -63,6 +74,16 @@ setup() {
   [[ "$output" == *"Grafana's role_attribute_path grants an org role to editor"* ]]
 }
 
+@test "pointing Grafana at an automatic realm role turns it red" {
+  sed -i.bak "s/'platform-editor'/'offline_access'/" \
+    "$CTL/deploy/compose/prod/docker-compose.observability.yml"
+  rm -f "$CTL/deploy/compose/prod/docker-compose.observability.yml.bak"
+
+  run python3 "$CHECK"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Grafana's role_attribute_path grants an org role to automatic role offline_access"* ]]
+}
+
 @test "pointing OpenBao's bound claim back at a retired role turns it red" {
   sed -i.bak 's/"realm_roles": \["platform-admin"\]/"realm_roles": ["admin"]/' "$CTL/scripts/vault.sh"
   rm -f "$CTL/scripts/vault.sh.bak"
@@ -70,6 +91,15 @@ setup() {
   run python3 "$CHECK"
   [ "$status" -eq 1 ]
   [[ "$output" == *"OpenBao's admin-sso role grants a vault policy to admin"* ]]
+}
+
+@test "pointing OpenBao at an automatic realm role turns it red" {
+  sed -i.bak 's/"realm_roles": \["platform-admin"\]/"realm_roles": ["uma_authorization"]/' "$CTL/scripts/vault.sh"
+  rm -f "$CTL/scripts/vault.sh.bak"
+
+  run python3 "$CHECK"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"OpenBao's admin-sso role grants a vault policy to automatic role uma_authorization"* ]]
 }
 
 @test "listing a retired role in REALM_ROLES as well turns it red" {


### PR DESCRIPTION
## Summary

Refs #776. Extend the static retired-role grant check to fail before deploy when an automatic Keycloak realm role is used as a MinIO policy name, Grafana role-mapping arm, or OpenBao bound claim.

The automatic set is derived from `keycloak.sh`'s `KC_REALM` default: `offline_access`, `uma_authorization`, and `default-roles-$KC_REALM`.

The source extractor now ignores comments (while preserving quoted `#` characters), and the MinIO loop parser accepts valid shell whitespace around `; do`.

## Verification

Red before the parser correction:

- `bats -f "valid MinIO loop whitespace|harmless MinIO comment|harmless Grafana comment|harmless OpenBao comment" tests/scripts/retired-roles-ungranted-control.bats` — all four controls failed.

Green after:

- `bats tests/scripts/retired-roles-ungranted-control.bats` — 22/22 (the original 18 plus four permanent parser controls).
- `python3 scripts/checks/check_retired_roles_ungranted.py`
- `python3 scripts/checks/check_checks_are_wired.py`
- `python3 -m py_compile scripts/checks/check_retired_roles_ungranted.py`
- `bash -n scripts/minio.sh scripts/vault.sh scripts/keycloak.sh`
- `git diff --check`

Evidence:

- On the #868 parent, injecting each automatic role into MinIO, Grafana, or OpenBao exits 0, so these controls fail the parent.
- Mutation probes: restoring the old MinIO matcher exits 0 for the whitespace grant; bypassing comment filtering exits 1 for a harmless comment.