### PR TITLE
Make ambiguous tmux delivery non-resendable

### DIFF
--- a/scripts/supervisor/README.md
+++ b/scripts/supervisor/README.md
@@ -14,6 +14,15 @@ task database or normal result transport.
   nonce, tmux server/session identity, harness, command, and repository path.
 - A lane has at most one nonterminal task. The prompt contains the stable task
   ID and the commands that accept and complete that task.
+- Delivery is ambiguous the instant a send is attempted, not just when it
+  fails: `assign` persists `delivery_pending` before the physical tmux send,
+  and that task id cannot be automatically resent while it stays in that
+  state, whether the send raised or the ledger's own post-send write failed.
+  Nothing infers delivery from echoed pane text. A human resolves the
+  ambiguity with `hill90-supervisor reconcile --task <id> --outcome
+  {delivered,failed}` after inspecting the pane directly; `reconcile` is
+  deliberately not caller-verified because the pane it is reconciling may be
+  the very thing that is stuck.
 - Completion results are immutable, limited to 64 KiB, hashed, and published
   with a deterministic `completion:<task-id>` event in the same database
   transaction as the terminal task transition.
@@ -51,6 +60,9 @@ hill90-supervisor assign --lane infra-worker --task gh.jonhill90.Hill90.issue.42
 
 hill90-supervisor tick
 hill90-supervisor status
+
+# Only after inspecting a task stuck in delivery_pending directly:
+hill90-supervisor reconcile --task gh.jonhill90.Hill90.issue.42 --outcome delivered
 ```
 
 Workers run the task-bound `accept` and `complete` commands included in their

--- a/scripts/supervisor/adapter.py
+++ b/scripts/supervisor/adapter.py
@@ -94,6 +94,12 @@ class TmuxAdapter:
     def assign_task(self, *, lane, task_id, summary):
         with self.ledger.operation_lock():
             record = self._verified_lane(lane)
+            existing = self.ledger.get_task(task_id)
+            if existing is not None and existing["status"] == "delivery_pending":
+                raise RuntimeError(
+                    f"delivery already attempted for task {task_id} and is unconfirmed; "
+                    "reconcile the task before it can be assigned again"
+                )
             state = classify_capture(record["harness"], self.transport.capture(record["pane_id"], lines=25))
             if state != "idle":
                 raise RuntimeError(f"lane is {state}; assignment not sent")
@@ -114,11 +120,15 @@ class TmuxAdapter:
                 f"At completion write {result_file} and run: "
                 f"hill90-supervisor complete --task {task_id} --result-file {result_file}"
             )
+            # Persist the ambiguous, non-resendable state before the physical
+            # send. If send_literal raises, or the ledger write below fails,
+            # the task is left here rather than silently eligible for retry -
+            # see assign_task's guard above and mark_delivered's own allowed
+            # source state. Nothing after this point trusts echoed pane text
+            # to decide whether the send actually reached the harness.
+            self.ledger.mark_delivery_pending(task_id, pane_nonce=record["nonce"])
             self.transport.send_literal(record["pane_id"], prompt)
-            post_state = classify_capture(record["harness"], self.transport.capture(record["pane_id"], lines=25))
-            if post_state == "active":
-                return self.ledger.mark_delivered(task_id, pane_nonce=record["nonce"])
-            raise RuntimeError(f"task prompt was not accepted; lane is {post_state}")
+            return self.ledger.mark_delivered(task_id, pane_nonce=record["nonce"])
 
     def observe_lane(self, lane):
         record = self._verified_lane(lane)

--- a/scripts/supervisor/cli.py
+++ b/scripts/supervisor/cli.py
@@ -47,6 +47,10 @@ def parser():
         if name == "complete":
             command.add_argument("--result-file", type=Path, required=True)
 
+    reconcile = sub.add_parser("reconcile")
+    reconcile.add_argument("--task", required=True)
+    reconcile.add_argument("--outcome", choices=("delivered", "failed"), required=True)
+
     observe = sub.add_parser("observe")
     observe.add_argument("--lane", action="append")
 
@@ -117,6 +121,16 @@ def main(argv=None):
             raise ValueError("unknown task")
         _verify_caller(adapter, ledger, task["lane"])
         value = ledger.complete(args.task, args.result_file.read_bytes())
+    elif args.command == "reconcile":
+        # Deliberately not caller-verified: this is the human-operator path
+        # for an ambiguous delivery, run from outside the (possibly stuck or
+        # unresponsive) pane after inspecting it directly. It never infers
+        # its answer from tmux capture.
+        task = ledger.get_task(args.task)
+        if task is None:
+            raise ValueError("unknown task")
+        lane = ledger.get_lane(task["lane"])
+        value = ledger.reconcile_delivery(args.task, pane_nonce=lane["nonce"], outcome=args.outcome)
     elif args.command == "observe":
         lanes = args.lane or [item["lane"] for item in ledger.list_lanes() if item["lane"] != "architecture"]
         value = [event for lane in lanes if (event := adapter.observe_lane(lane)) is not None]

--- a/scripts/supervisor/cli.py
+++ b/scripts/supervisor/cli.py
@@ -122,15 +122,17 @@ def main(argv=None):
         _verify_caller(adapter, ledger, task["lane"])
         value = ledger.complete(args.task, args.result_file.read_bytes())
     elif args.command == "reconcile":
-        # Deliberately not caller-verified: this is the human-operator path
-        # for an ambiguous delivery, run from outside the (possibly stuck or
-        # unresponsive) pane after inspecting it directly. It never infers
-        # its answer from tmux capture.
+        # Deliberately not caller-verified and deliberately not the lane's
+        # *current* nonce: this is the human-operator path for an ambiguous
+        # delivery, run from outside the (possibly stuck, dead, or since
+        # re-registered) pane after inspecting it directly. Authentication
+        # uses the task's own recorded pane_nonce from send time - see
+        # Ledger._reconcile_transition. It never infers its answer from tmux
+        # capture.
         task = ledger.get_task(args.task)
         if task is None:
             raise ValueError("unknown task")
-        lane = ledger.get_lane(task["lane"])
-        value = ledger.reconcile_delivery(args.task, pane_nonce=lane["nonce"], outcome=args.outcome)
+        value = ledger.reconcile_delivery(args.task, pane_nonce=task["pane_nonce"], outcome=args.outcome)
     elif args.command == "observe":
         lanes = args.lane or [item["lane"] for item in ledger.list_lanes() if item["lane"] != "architecture"]
         value = [event for lane in lanes if (event := adapter.observe_lane(lane)) is not None]

--- a/scripts/supervisor/core.py
+++ b/scripts/supervisor/core.py
@@ -27,7 +27,7 @@ MAX_RESULT_BYTES = 64 * 1024
 
 
 class Ledger:
-    def __init__(self, root: Path | str, *, clock=None):
+    def __init__(self, root: Path | str, *, clock=None, _migration_failpoint=None):
         self.root = Path(root)
         self.clock = clock or (lambda: int(time.time()))
         self.results_dir = self.root / "results"
@@ -47,11 +47,12 @@ class Ledger:
         os.chmod(self.lock_path, 0o600)
         self._lock_depth = 0
         self._initialize()
+        self._migrate_tasks_table(failpoint=_migration_failpoint)
 
-    def _connect(self):
+    def _connect(self, *, foreign_keys=True):
         connection = sqlite3.connect(self.db_path, timeout=30, isolation_level=None)
         connection.row_factory = sqlite3.Row
-        connection.execute("PRAGMA foreign_keys = ON")
+        connection.execute(f"PRAGMA foreign_keys = {'ON' if foreign_keys else 'OFF'}")
         connection.execute("PRAGMA journal_mode = WAL")
         connection.execute("PRAGMA synchronous = FULL")
         return connection
@@ -121,6 +122,7 @@ class Ledger:
                     result_sha256 TEXT,
                     created_at INTEGER NOT NULL,
                     updated_at INTEGER NOT NULL,
+                    delivery_attempted_at INTEGER,
                     delivered_at INTEGER,
                     accepted_at INTEGER,
                     completed_at INTEGER
@@ -168,6 +170,99 @@ class Ledger:
                 """
             )
         os.chmod(self.db_path, 0o600)
+
+    _TASKS_SCHEMA_MARKERS = ("delivery_pending", "delivery_attempted_at")
+
+    def _migrate_tasks_table(self, *, failpoint=None):
+        """Widen an existing `tasks` table to the current schema in place.
+
+        `CREATE TABLE IF NOT EXISTS` in `_initialize` never touches a table
+        that already exists, so a ledger created before `delivery_pending`
+        and `delivery_attempted_at` existed keeps its old CHECK constraint
+        and column set forever unless this runs. SQLite has no
+        `ALTER TABLE ... ALTER COLUMN` / `DROP CONSTRAINT`, so the only way
+        to widen a CHECK constraint is to rebuild the table.
+
+        Every row and the `one_open_task_per_lane` index are preserved. The
+        rebuild is one transaction: any failure mid-migration rolls back to
+        the original table, unmodified. Foreign key enforcement is turned
+        off only around this rebuild (it cannot be toggled mid-transaction)
+        because `events.task_id REFERENCES tasks(id)` would otherwise block
+        dropping the original table while rows still reference it; the
+        table this rebuild produces is named `tasks` again by the time this
+        returns, so that reference is satisfied exactly as before.
+        """
+        with self._locked():
+            with contextlib.closing(self._connect()) as probe:
+                existing = probe.execute(
+                    "SELECT sql FROM sqlite_master WHERE type='table' AND name='tasks'"
+                ).fetchone()
+                if existing is None:
+                    return
+                if all(marker in existing["sql"] for marker in self._TASKS_SCHEMA_MARKERS):
+                    return
+                columns = {info["name"] for info in probe.execute("PRAGMA table_info(tasks)").fetchall()}
+            attempted_column = "delivery_attempted_at" if "delivery_attempted_at" in columns else "NULL"
+
+            connection = self._connect(foreign_keys=False)
+            try:
+                connection.execute("BEGIN IMMEDIATE")
+                try:
+                    connection.execute(
+                        """
+                        CREATE TABLE tasks_migrated (
+                            id TEXT PRIMARY KEY,
+                            lane TEXT NOT NULL REFERENCES lanes(lane),
+                            pane_nonce TEXT NOT NULL,
+                            summary TEXT NOT NULL,
+                            status TEXT NOT NULL CHECK (
+                                status IN ('created', 'delivery_pending', 'delivered', 'accepted',
+                                           'running', 'complete', 'failed', 'cancelled')
+                            ),
+                            result_path TEXT,
+                            result_sha256 TEXT,
+                            created_at INTEGER NOT NULL,
+                            updated_at INTEGER NOT NULL,
+                            delivery_attempted_at INTEGER,
+                            delivered_at INTEGER,
+                            accepted_at INTEGER,
+                            completed_at INTEGER
+                        )
+                        """
+                    )
+                    self._fail(failpoint, "after_create")
+                    connection.execute(
+                        f"""
+                        INSERT INTO tasks_migrated (
+                            id, lane, pane_nonce, summary, status, result_path, result_sha256,
+                            created_at, updated_at, delivery_attempted_at, delivered_at,
+                            accepted_at, completed_at
+                        )
+                        SELECT id, lane, pane_nonce, summary, status, result_path, result_sha256,
+                               created_at, updated_at, {attempted_column}, delivered_at,
+                               accepted_at, completed_at
+                        FROM tasks
+                        """
+                    )
+                    self._fail(failpoint, "after_copy")
+                    connection.execute("DROP TABLE tasks")
+                    self._fail(failpoint, "after_drop")
+                    connection.execute("ALTER TABLE tasks_migrated RENAME TO tasks")
+                    self._fail(failpoint, "after_rename")
+                    connection.execute(
+                        """
+                        CREATE UNIQUE INDEX IF NOT EXISTS one_open_task_per_lane
+                            ON tasks(lane)
+                            WHERE status NOT IN ('complete', 'failed', 'cancelled')
+                        """
+                    )
+                except BaseException:
+                    connection.rollback()
+                    raise
+                else:
+                    connection.commit()
+            finally:
+                connection.close()
 
     @staticmethod
     def _dict(row):
@@ -375,13 +470,45 @@ class Ledger:
 
         A task in this state has had delivery attempted but not confirmed. It
         is deliberately not "delivered": nothing here trusts that the send
-        reached the pane, only that an attempt is now on record and cannot be
-        silently repeated.
+        reached the pane, only that an attempt is now on record (in
+        `delivery_attempted_at`, not `delivered_at`) and cannot be silently
+        repeated. `delivered_at` stays null until delivery is genuinely
+        confirmed.
         """
-        return self._transition(task_id, pane_nonce, ("created",), "delivery_pending", "delivered_at")
+        return self._transition(task_id, pane_nonce, ("created",), "delivery_pending", "delivery_attempted_at")
 
     def mark_delivered(self, task_id, *, pane_nonce):
         return self._transition(task_id, pane_nonce, ("delivery_pending",), "delivered", "delivered_at")
+
+    def _reconcile_transition(self, task_id, pane_nonce, target, timestamp_column):
+        """Resolve a `delivery_pending` task without requiring the current lane.
+
+        Unlike `_transition`, this does not check the *lane's* current
+        nonce. Reconciliation exists precisely for the case where the pane
+        that received the ambiguous send is gone and its lane has since
+        been re-registered with a new nonce - requiring the current
+        incarnation here would make every stuck delivery permanently
+        unreconcilable. Authentication instead comes from the task's own
+        `pane_nonce`, recorded at send time: a caller who does not know it
+        cannot reconcile the wrong task by guessing.
+        """
+        now = int(self.clock())
+        with self._locked(), self._transaction() as connection:
+            row = connection.execute("SELECT * FROM tasks WHERE id = ?", (task_id,)).fetchone()
+            if row is None:
+                raise ValueError("unknown task")
+            if row["pane_nonce"] != pane_nonce:
+                raise ValueError("pane incarnation does not match task")
+            if row["status"] == target:
+                return self._dict(row)
+            if row["status"] != "delivery_pending":
+                raise ValueError(f"cannot reconcile a {row['status']} task")
+            connection.execute(
+                f"UPDATE tasks SET status = ?, updated_at = ?, {timestamp_column} = ? WHERE id = ?",
+                (target, now, now, task_id),
+            )
+            row = connection.execute("SELECT * FROM tasks WHERE id = ?", (task_id,)).fetchone()
+        return self._dict(row)
 
     def reconcile_delivery(self, task_id, *, pane_nonce, outcome):
         """Resolve an ambiguous delivery by explicit human decision.
@@ -390,12 +517,14 @@ class Ledger:
         adapter's own post-send confirmation. It exists for the case where
         that confirmation itself failed or the operator inspected the pane
         directly and reached a conclusion the ledger cannot infer on its own
-        from echoed terminal text.
+        from echoed terminal text. It authenticates against the task's own
+        recorded pane_nonce, not the lane's current one - see
+        `_reconcile_transition`.
         """
         if outcome == "delivered":
-            return self._transition(task_id, pane_nonce, ("delivery_pending",), "delivered", "delivered_at")
+            return self._reconcile_transition(task_id, pane_nonce, "delivered", "delivered_at")
         if outcome == "failed":
-            return self._transition(task_id, pane_nonce, ("delivery_pending",), "failed", "completed_at")
+            return self._reconcile_transition(task_id, pane_nonce, "failed", "completed_at")
         raise ValueError("reconciliation outcome must be 'delivered' or 'failed'")
 
     def accept(self, task_id, *, pane_nonce):

--- a/scripts/supervisor/core.py
+++ b/scripts/supervisor/core.py
@@ -114,8 +114,8 @@ class Ledger:
                     pane_nonce TEXT NOT NULL,
                     summary TEXT NOT NULL,
                     status TEXT NOT NULL CHECK (
-                        status IN ('created', 'delivered', 'accepted', 'running',
-                                   'complete', 'failed', 'cancelled')
+                        status IN ('created', 'delivery_pending', 'delivered', 'accepted',
+                                   'running', 'complete', 'failed', 'cancelled')
                     ),
                     result_path TEXT,
                     result_sha256 TEXT,
@@ -370,8 +370,33 @@ class Ledger:
             row = connection.execute("SELECT * FROM tasks WHERE id = ?", (task_id,)).fetchone()
         return self._dict(row)
 
+    def mark_delivery_pending(self, task_id, *, pane_nonce):
+        """Persist an ambiguous, non-resendable state before the physical send.
+
+        A task in this state has had delivery attempted but not confirmed. It
+        is deliberately not "delivered": nothing here trusts that the send
+        reached the pane, only that an attempt is now on record and cannot be
+        silently repeated.
+        """
+        return self._transition(task_id, pane_nonce, ("created",), "delivery_pending", "delivered_at")
+
     def mark_delivered(self, task_id, *, pane_nonce):
-        return self._transition(task_id, pane_nonce, ("created",), "delivered", "delivered_at")
+        return self._transition(task_id, pane_nonce, ("delivery_pending",), "delivered", "delivered_at")
+
+    def reconcile_delivery(self, task_id, *, pane_nonce, outcome):
+        """Resolve an ambiguous delivery by explicit human decision.
+
+        This is the only path out of `delivery_pending` other than the
+        adapter's own post-send confirmation. It exists for the case where
+        that confirmation itself failed or the operator inspected the pane
+        directly and reached a conclusion the ledger cannot infer on its own
+        from echoed terminal text.
+        """
+        if outcome == "delivered":
+            return self._transition(task_id, pane_nonce, ("delivery_pending",), "delivered", "delivered_at")
+        if outcome == "failed":
+            return self._transition(task_id, pane_nonce, ("delivery_pending",), "failed", "completed_at")
+        raise ValueError("reconciliation outcome must be 'delivered' or 'failed'")
 
     def accept(self, task_id, *, pane_nonce):
         return self._transition(task_id, pane_nonce, ("delivered",), "accepted", "accepted_at")

--- a/scripts/supervisor/tests/test_adapter.py
+++ b/scripts/supervisor/tests/test_adapter.py
@@ -120,6 +120,38 @@ class AdapterTest(unittest.TestCase):
             self.adapter.assign_task(lane="architecture", task_id="wrong-pane", summary="Must not send")
         self.assertEqual([], self.transport.sends)
 
+    def test_ambiguous_send_persists_delivery_pending_and_blocks_automatic_resend(self):
+        def failing_send(target, payload):
+            self.transport.sends.append((target, payload))
+            raise RuntimeError("tmux send-keys timed out")
+
+        self.transport.send_literal = failing_send
+        with self.assertRaisesRegex(RuntimeError, "timed out"):
+            self.adapter.assign_task(lane="architecture", task_id="flaky-task", summary="Ambiguous delivery")
+
+        task = self.ledger.get_task("flaky-task")
+        self.assertEqual("delivery_pending", task["status"])
+        self.assertEqual(1, len(self.transport.sends))
+
+        # A never-attempted task simply has no ledger row at all.
+        self.assertIsNone(self.ledger.get_task("never-attempted"))
+
+        # The same task id cannot be silently resent while unconfirmed.
+        with self.assertRaisesRegex(RuntimeError, "reconcile"):
+            self.adapter.assign_task(lane="architecture", task_id="flaky-task", summary="Ambiguous delivery")
+        self.assertEqual(1, len(self.transport.sends))
+
+        # A human, not echoed pane text, resolves the ambiguity.
+        reconciled = self.ledger.reconcile_delivery("flaky-task", pane_nonce="nonce-19", outcome="failed")
+        self.assertEqual("failed", reconciled["status"])
+
+    def test_successful_send_does_not_infer_delivery_from_echoed_prompt_text(self):
+        # Even though the pane echoes the sent prompt back into its own capture,
+        # assign_task must not use that capture to decide the task was delivered.
+        self.transport.panes["%19"]["after_send"] = "flaky terminal chrome, no active/idle marker\n"
+        task = self.adapter.assign_task(lane="architecture", task_id="quiet-task", summary="No echo needed")
+        self.assertEqual("delivered", task["status"])
+
     def test_one_hundred_unchanged_observations_send_nothing(self):
         for _ in range(100):
             self.assertIsNone(self.adapter.observe_lane("architecture"))

--- a/scripts/supervisor/tests/test_cli.py
+++ b/scripts/supervisor/tests/test_cli.py
@@ -60,6 +60,28 @@ class CliTest(unittest.TestCase):
             self.assertEqual([], adapter.observed)
             self.assertFalse(adapter.notified)
 
+    def test_reconcile_resolves_an_ambiguous_delivery_without_pane_capture(self):
+        with tempfile.TemporaryDirectory() as root:
+            ledger = Ledger(Path(root))
+            ledger.register_lane(
+                lane="architecture", pane_id="%19", nonce="nonce-19", harness="codex", repo="/repo",
+                server_id="server", session_id="$1", command="codex",
+            )
+            ledger.assign(task_id="flaky-task", lane="architecture", pane_nonce="nonce-19", summary="Ambiguous")
+            ledger.mark_delivery_pending("flaky-task", pane_nonce="nonce-19")
+
+            output = io.StringIO()
+            with contextlib.redirect_stdout(output):
+                self.assertEqual(
+                    0,
+                    cli.main(
+                        ["--state-dir", root, "reconcile", "--task", "flaky-task", "--outcome", "delivered"]
+                    ),
+                )
+            value = json.loads(output.getvalue())
+            self.assertEqual("delivered", value["status"])
+            self.assertEqual("delivered", ledger.get_task("flaky-task")["status"])
+
     def test_tick_without_the_canonical_sensor_is_also_gated(self):
         with tempfile.TemporaryDirectory() as root:
             ledger = Ledger(Path(root))

--- a/scripts/supervisor/tests/test_cli.py
+++ b/scripts/supervisor/tests/test_cli.py
@@ -82,6 +82,36 @@ class CliTest(unittest.TestCase):
             self.assertEqual("delivered", value["status"])
             self.assertEqual("delivered", ledger.get_task("flaky-task")["status"])
 
+    def test_reconcile_survives_lane_re_registration_after_a_dead_pane(self):
+        with tempfile.TemporaryDirectory() as root:
+            ledger = Ledger(Path(root))
+            ledger.register_lane(
+                lane="architecture", pane_id="%19", nonce="nonce-dead", harness="codex", repo="/repo",
+                server_id="server", session_id="$1", command="codex",
+            )
+            ledger.assign(task_id="flaky-task", lane="architecture", pane_nonce="nonce-dead", summary="Ambiguous")
+            ledger.mark_delivery_pending("flaky-task", pane_nonce="nonce-dead")
+
+            # The pane died and was re-registered under a new tmux pane and nonce
+            # before a human got to reconcile the stuck delivery.
+            ledger.register_lane(
+                lane="architecture", pane_id="%25", nonce="nonce-reborn", harness="codex", repo="/repo",
+                server_id="server", session_id="$1", command="codex",
+            )
+            self.assertEqual("nonce-reborn", ledger.get_lane("architecture")["nonce"])
+
+            output = io.StringIO()
+            with contextlib.redirect_stdout(output):
+                self.assertEqual(
+                    0,
+                    cli.main(
+                        ["--state-dir", root, "reconcile", "--task", "flaky-task", "--outcome", "delivered"]
+                    ),
+                )
+            value = json.loads(output.getvalue())
+            self.assertEqual("delivered", value["status"])
+            self.assertEqual("delivered", ledger.get_task("flaky-task")["status"])
+
     def test_tick_without_the_canonical_sensor_is_also_gated(self):
         with tempfile.TemporaryDirectory() as root:
             ledger = Ledger(Path(root))

--- a/scripts/supervisor/tests/test_core.py
+++ b/scripts/supervisor/tests/test_core.py
@@ -1,5 +1,6 @@
 import hashlib
 import concurrent.futures
+import sqlite3
 import sys
 import tempfile
 import unittest
@@ -10,6 +11,114 @@ SUPERVISOR_DIR = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(SUPERVISOR_DIR))
 
 from core import Ledger  # noqa: E402
+
+
+# The exact schema `_initialize` wrote at 3af0b431, before `delivery_pending`
+# or `delivery_attempted_at` existed. `CREATE TABLE IF NOT EXISTS` never
+# rewrites a table that already exists this way, so any ledger created under
+# that commit needs `_migrate_tasks_table` to reach the current schema.
+PRE_PR_SCHEMA_SCRIPT = """
+CREATE TABLE lanes (
+    lane TEXT PRIMARY KEY,
+    pane_id TEXT NOT NULL,
+    nonce TEXT NOT NULL,
+    harness TEXT NOT NULL CHECK (harness IN ('codex', 'claude')),
+    repo TEXT NOT NULL,
+    server_id TEXT NOT NULL,
+    session_id TEXT NOT NULL,
+    command TEXT NOT NULL,
+    updated_at INTEGER NOT NULL
+);
+
+CREATE TABLE tasks (
+    id TEXT PRIMARY KEY,
+    lane TEXT NOT NULL REFERENCES lanes(lane),
+    pane_nonce TEXT NOT NULL,
+    summary TEXT NOT NULL,
+    status TEXT NOT NULL CHECK (
+        status IN ('created', 'delivered', 'accepted', 'running',
+                   'complete', 'failed', 'cancelled')
+    ),
+    result_path TEXT,
+    result_sha256 TEXT,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL,
+    delivered_at INTEGER,
+    accepted_at INTEGER,
+    completed_at INTEGER
+);
+
+CREATE UNIQUE INDEX one_open_task_per_lane
+    ON tasks(lane)
+    WHERE status NOT IN ('complete', 'failed', 'cancelled');
+
+CREATE TABLE source_tasks (
+    id TEXT PRIMARY KEY,
+    source_kind TEXT NOT NULL CHECK (source_kind IN ('issue', 'pull')),
+    source_url TEXT NOT NULL UNIQUE,
+    source_ref TEXT NOT NULL,
+    summary TEXT NOT NULL,
+    source_state TEXT NOT NULL,
+    status TEXT NOT NULL CHECK (
+        status IN ('created', 'delivered', 'accepted', 'running',
+                   'complete', 'failed', 'cancelled')
+    ),
+    evidence_json TEXT NOT NULL,
+    status_marker TEXT,
+    updated_at INTEGER NOT NULL
+);
+
+CREATE TABLE events (
+    key TEXT PRIMARY KEY,
+    type TEXT NOT NULL,
+    task_id TEXT REFERENCES tasks(id),
+    status TEXT NOT NULL CHECK (status IN ('pending', 'notified', 'acked')),
+    payload_path TEXT,
+    created_at INTEGER NOT NULL,
+    notified_at INTEGER,
+    retry_at INTEGER,
+    acked_at INTEGER
+);
+
+CREATE TABLE components (
+    name TEXT PRIMARY KEY,
+    healthy INTEGER NOT NULL,
+    error TEXT,
+    snapshot_sha256 TEXT,
+    updated_at INTEGER NOT NULL
+);
+"""
+
+
+def _seed_pre_pr_database(root: Path):
+    """Build a ledger.sqlite3 with exactly the 3af0b431 schema and one row."""
+    root.mkdir(parents=True, exist_ok=True)
+    db_path = root / "ledger.sqlite3"
+    connection = sqlite3.connect(db_path)
+    try:
+        connection.execute("PRAGMA foreign_keys = ON")
+        connection.executescript(PRE_PR_SCHEMA_SCRIPT)
+        connection.execute(
+            """
+            INSERT INTO lanes(lane, pane_id, nonce, harness, repo, server_id, session_id, command, updated_at)
+            VALUES ('app-review', '%22', 'nonce-22-a', 'codex', '/repo/app', 'server-a', '$4', 'codex', 1000)
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO tasks(id, lane, pane_nonce, summary, status, created_at, updated_at)
+            VALUES ('review-870', 'app-review', 'nonce-22-a', 'Review PR 870 without editing', 'created', 1000, 1000)
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO events(key, type, task_id, status, created_at)
+            VALUES ('attention:review-870', 'attention', 'review-870', 'pending', 1000)
+            """
+        )
+        connection.commit()
+    finally:
+        connection.close()
 
 
 class MutableClock:
@@ -201,6 +310,236 @@ class LedgerTest(unittest.TestCase):
         self.assertEqual(1, sum("outstanding task" in outcome for outcome in outcomes))
         open_tasks = [task for task in self.ledger.list_tasks() if task["status"] not in ("complete", "failed", "cancelled")]
         self.assertEqual(1, len(open_tasks))
+
+
+class TaskTableMigrationTest(unittest.TestCase):
+    """Blocker 1: `CREATE TABLE IF NOT EXISTS` does not migrate an existing DB."""
+
+    def setUp(self):
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tempdir.cleanup)
+        self.root = Path(self.tempdir.name)
+        _seed_pre_pr_database(self.root)
+
+    def _raw_tasks_sql(self):
+        connection = sqlite3.connect(self.root / "ledger.sqlite3")
+        try:
+            return connection.execute(
+                "SELECT sql FROM sqlite_master WHERE type='table' AND name='tasks'"
+            ).fetchone()[0]
+        finally:
+            connection.close()
+
+    def _raw_task_row(self, task_id="review-870"):
+        connection = sqlite3.connect(self.root / "ledger.sqlite3")
+        connection.row_factory = sqlite3.Row
+        try:
+            row = connection.execute("SELECT * FROM tasks WHERE id = ?", (task_id,)).fetchone()
+            return dict(row) if row else None
+        finally:
+            connection.close()
+
+    def test_reproduction_old_check_constraint_rejects_delivery_pending_directly(self):
+        """Before any migration exists, writing delivery_pending to the raw
+        pre-PR schema must fail - this is the bug the migration fixes."""
+        connection = sqlite3.connect(self.root / "ledger.sqlite3")
+        try:
+            with self.assertRaises(sqlite3.IntegrityError):
+                connection.execute("UPDATE tasks SET status = 'delivery_pending' WHERE id = 'review-870'")
+        finally:
+            connection.close()
+
+    def test_opening_pre_pr_database_migrates_schema_and_preserves_every_row(self):
+        before = self._raw_task_row()
+        self.assertEqual("created", before["status"])
+        self.assertNotIn("delivery_attempted_at", before)
+
+        ledger = Ledger(self.root, clock=lambda: 2_000)
+
+        migrated_sql = self._raw_tasks_sql()
+        self.assertIn("delivery_pending", migrated_sql)
+        self.assertIn("delivery_attempted_at", migrated_sql)
+
+        after = ledger.get_task("review-870")
+        self.assertEqual(before["id"], after["id"])
+        self.assertEqual(before["lane"], after["lane"])
+        self.assertEqual(before["pane_nonce"], after["pane_nonce"])
+        self.assertEqual(before["summary"], after["summary"])
+        self.assertEqual(before["status"], after["status"])
+        self.assertEqual(before["created_at"], after["created_at"])
+        self.assertIsNone(after["delivery_attempted_at"])
+
+        # Every other table, and the lane row the task's FK depends on, survives untouched.
+        self.assertEqual(1, len(ledger.list_lanes()))
+        self.assertEqual(1, len(ledger.list_tasks()))
+        self.assertEqual(1, len(ledger.list_events()))
+
+        # The FK from events to tasks is intact and still enforced by name.
+        connection = sqlite3.connect(self.root / "ledger.sqlite3")
+        try:
+            connection.execute("PRAGMA foreign_keys = ON")
+            with self.assertRaises(sqlite3.IntegrityError):
+                connection.execute(
+                    "INSERT INTO events(key, type, task_id, status, created_at) "
+                    "VALUES ('bad', 'attention', 'does-not-exist', 'pending', 2000)"
+                )
+                connection.commit()
+        finally:
+            connection.close()
+
+        # The whole point: mark_delivery_pending now works against the migrated schema.
+        pending = ledger.mark_delivery_pending("review-870", pane_nonce="nonce-22-a")
+        self.assertEqual("delivery_pending", pending["status"])
+
+        # The one_open_task_per_lane index survived: a second open task on the same lane still fails.
+        with self.assertRaisesRegex(ValueError, "outstanding task"):
+            ledger.assign(task_id="review-871", lane="app-review", pane_nonce="nonce-22-a", summary="Second task")
+
+    def test_migration_failure_rolls_back_leaving_original_table_and_rows_intact(self):
+        for failpoint in ("after_create", "after_copy", "after_drop", "after_rename"):
+            with self.subTest(failpoint=failpoint):
+                root = Path(tempfile.mkdtemp())
+                self.addCleanup(lambda r=root: __import__("shutil").rmtree(r, ignore_errors=True))
+                _seed_pre_pr_database(root)
+
+                with self.assertRaisesRegex(RuntimeError, failpoint):
+                    Ledger(root, clock=lambda: 2_000, _migration_failpoint=failpoint)
+
+                # Rolled back: the table is exactly as it was before the attempt.
+                connection = sqlite3.connect(root / "ledger.sqlite3")
+                connection.row_factory = sqlite3.Row
+                try:
+                    sql = connection.execute(
+                        "SELECT sql FROM sqlite_master WHERE type='table' AND name='tasks'"
+                    ).fetchone()["sql"]
+                    self.assertNotIn("delivery_pending", sql, f"schema leaked past rollback at {failpoint}")
+                    row = dict(connection.execute("SELECT * FROM tasks WHERE id='review-870'").fetchone())
+                    self.assertEqual("created", row["status"])
+                    self.assertEqual(1, connection.execute("SELECT COUNT(*) FROM tasks").fetchone()[0])
+                    self.assertEqual(1, connection.execute("SELECT COUNT(*) FROM events").fetchone()[0])
+                finally:
+                    connection.close()
+
+                # And migration recovers cleanly on the very next open.
+                recovered = Ledger(root, clock=lambda: 3_000)
+                self.assertIn("delivery_pending", self._migrated_sql(root))
+                after = recovered.get_task("review-870")
+                self.assertEqual("created", after["status"])
+                pending = recovered.mark_delivery_pending("review-870", pane_nonce="nonce-22-a")
+                self.assertEqual("delivery_pending", pending["status"])
+
+    @staticmethod
+    def _migrated_sql(root):
+        connection = sqlite3.connect(root / "ledger.sqlite3")
+        try:
+            return connection.execute(
+                "SELECT sql FROM sqlite_master WHERE type='table' AND name='tasks'"
+            ).fetchone()[0]
+        finally:
+            connection.close()
+
+    def test_fresh_ledger_never_triggers_a_migration_rebuild(self):
+        """A brand-new state directory has the current schema from CREATE TABLE
+        IF NOT EXISTS alone; `_migrate_tasks_table` must be a no-op for it."""
+        fresh_root = Path(tempfile.mkdtemp())
+        self.addCleanup(lambda: __import__("shutil").rmtree(fresh_root, ignore_errors=True))
+        ledger = Ledger(fresh_root, clock=lambda: 1_000)
+        ledger.register_lane(
+            lane="app-review", pane_id="%1", nonce="n", harness="codex", repo="/r",
+            server_id="s", session_id="$1", command="codex",
+        )
+        task = ledger.assign(task_id="t1", lane="app-review", pane_nonce="n", summary="Do the thing")
+        self.assertEqual("created", task["status"])
+        pending = ledger.mark_delivery_pending("t1", pane_nonce="n")
+        self.assertEqual("delivery_pending", pending["status"])
+
+
+class DeliveryTimestampTest(unittest.TestCase):
+    """Correctness defect: mark_delivery_pending must not write delivered_at."""
+
+    def setUp(self):
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tempdir.cleanup)
+        self.clock = MutableClock()
+        self.ledger = Ledger(Path(self.tempdir.name), clock=self.clock)
+        self.ledger.register_lane(
+            lane="app-review", pane_id="%22", nonce="nonce-22-a", harness="codex", repo="/repo/app",
+            server_id="server-a", session_id="$4", command="codex",
+        )
+        self.ledger.assign(
+            task_id="review-870", lane="app-review", pane_nonce="nonce-22-a",
+            summary="Review PR 870 without editing",
+        )
+
+    def test_mark_delivery_pending_sets_delivery_attempted_at_not_delivered_at(self):
+        self.clock.value = 1_500
+        pending = self.ledger.mark_delivery_pending("review-870", pane_nonce="nonce-22-a")
+        self.assertEqual(1_500, pending["delivery_attempted_at"])
+        self.assertIsNone(pending["delivered_at"])
+
+    def test_confirmed_delivery_sets_delivered_at_and_keeps_attempt_timestamp(self):
+        self.clock.value = 1_500
+        self.ledger.mark_delivery_pending("review-870", pane_nonce="nonce-22-a")
+        self.clock.value = 1_600
+        delivered = self.ledger.mark_delivered("review-870", pane_nonce="nonce-22-a")
+        self.assertEqual(1_500, delivered["delivery_attempted_at"])
+        self.assertEqual(1_600, delivered["delivered_at"])
+
+    def test_failed_reconciliation_leaves_delivered_at_null_but_retains_attempt_timestamp(self):
+        self.clock.value = 1_500
+        self.ledger.mark_delivery_pending("review-870", pane_nonce="nonce-22-a")
+        self.clock.value = 1_700
+        retired = self.ledger.reconcile_delivery("review-870", pane_nonce="nonce-22-a", outcome="failed")
+        self.assertEqual("failed", retired["status"])
+        self.assertIsNone(retired["delivered_at"])
+        self.assertEqual(1_500, retired["delivery_attempted_at"])
+        self.assertEqual(1_700, retired["completed_at"])
+
+
+class ReconcileAfterReRegistrationTest(unittest.TestCase):
+    """Blocker 2: reconcile must survive a re-registered lane."""
+
+    def setUp(self):
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tempdir.cleanup)
+        self.clock = MutableClock()
+        self.ledger = Ledger(Path(self.tempdir.name), clock=self.clock)
+        self.ledger.register_lane(
+            lane="app-review", pane_id="%22", nonce="nonce-dead", harness="codex", repo="/repo/app",
+            server_id="server-a", session_id="$4", command="codex",
+        )
+        self.ledger.assign(
+            task_id="review-870", lane="app-review", pane_nonce="nonce-dead",
+            summary="Review PR 870 without editing",
+        )
+        self.ledger.mark_delivery_pending("review-870", pane_nonce="nonce-dead")
+
+    def test_reproduction_reconciling_with_the_lanes_current_nonce_wedges(self):
+        """Reproduces the reported bug: passing the LANE's current (new)
+        nonce - the CLI's old behavior - fails against the task's own
+        pane_nonce recorded at send time."""
+        self.ledger.register_lane(
+            lane="app-review", pane_id="%23", nonce="nonce-reborn", harness="codex", repo="/repo/app",
+            server_id="server-a", session_id="$4", command="codex",
+        )
+        current_lane_nonce = self.ledger.get_lane("app-review")["nonce"]
+        self.assertEqual("nonce-reborn", current_lane_nonce)
+        with self.assertRaisesRegex(ValueError, "pane incarnation does not match task"):
+            self.ledger.reconcile_delivery("review-870", pane_nonce=current_lane_nonce, outcome="delivered")
+
+    def test_reconcile_with_task_pane_nonce_succeeds_after_lane_re_registration(self):
+        self.ledger.register_lane(
+            lane="app-review", pane_id="%23", nonce="nonce-reborn", harness="codex", repo="/repo/app",
+            server_id="server-a", session_id="$4", command="codex",
+        )
+        task_pane_nonce = self.ledger.get_task("review-870")["pane_nonce"]
+        self.assertEqual("nonce-dead", task_pane_nonce)
+        reconciled = self.ledger.reconcile_delivery("review-870", pane_nonce=task_pane_nonce, outcome="delivered")
+        self.assertEqual("delivered", reconciled["status"])
+
+    def test_reconcile_still_rejects_a_wrong_task_nonce(self):
+        with self.assertRaisesRegex(ValueError, "pane incarnation does not match task"):
+            self.ledger.reconcile_delivery("review-870", pane_nonce="some-guessed-nonce", outcome="delivered")
 
 
 if __name__ == "__main__":

--- a/scripts/supervisor/tests/test_core.py
+++ b/scripts/supervisor/tests/test_core.py
@@ -51,11 +51,44 @@ class LedgerTest(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "outstanding task"):
             self.assign("review-871")
 
+        self.ledger.mark_delivery_pending("review-870", pane_nonce="nonce-22-a")
         self.ledger.mark_delivered("review-870", pane_nonce="nonce-22-a")
         accepted = self.ledger.accept("review-870", pane_nonce="nonce-22-a")
         self.assertEqual("accepted", accepted["status"])
         with self.assertRaisesRegex(ValueError, "pane incarnation"):
             self.ledger.accept("review-870", pane_nonce="reused-pane")
+
+    def test_delivery_pending_persists_before_send_and_blocks_direct_delivered(self):
+        self.assign()
+        with self.assertRaisesRegex(ValueError, "cannot transition"):
+            self.ledger.mark_delivered("review-870", pane_nonce="nonce-22-a")
+
+        pending = self.ledger.mark_delivery_pending("review-870", pane_nonce="nonce-22-a")
+        self.assertEqual("delivery_pending", pending["status"])
+        # Once ambiguous, it stays ambiguous until a transition names an outcome;
+        # a second delivery attempt cannot be represented as a fresh "created" task.
+        with self.assertRaisesRegex(ValueError, "outstanding task"):
+            self.assign("review-871")
+
+        delivered = self.ledger.mark_delivered("review-870", pane_nonce="nonce-22-a")
+        self.assertEqual("delivered", delivered["status"])
+
+    def test_reconcile_delivery_confirms_or_retires_an_ambiguous_task(self):
+        self.assign()
+        self.ledger.mark_delivery_pending("review-870", pane_nonce="nonce-22-a")
+        with self.assertRaisesRegex(ValueError, "outcome"):
+            self.ledger.reconcile_delivery("review-870", pane_nonce="nonce-22-a", outcome="bogus")
+
+        confirmed = self.ledger.reconcile_delivery("review-870", pane_nonce="nonce-22-a", outcome="delivered")
+        self.assertEqual("delivered", confirmed["status"])
+
+        self.ledger.cancel_open_task("app-review")
+        self.assign("review-871")
+        self.ledger.mark_delivery_pending("review-871", pane_nonce="nonce-22-a")
+        retired = self.ledger.reconcile_delivery("review-871", pane_nonce="nonce-22-a", outcome="failed")
+        self.assertEqual("failed", retired["status"])
+        # A retired ambiguous task frees the lane for a genuinely new assignment.
+        self.assign("review-872")
 
     def test_completion_is_immutable_idempotent_and_event_is_exactly_once(self):
         self.assign()
@@ -88,6 +121,7 @@ class LedgerTest(unittest.TestCase):
 
     def test_idle_attention_is_level_triggered_until_task_disposition(self):
         self.assign()
+        self.ledger.mark_delivery_pending("review-870", pane_nonce="nonce-22-a")
         self.ledger.mark_delivered("review-870", pane_nonce="nonce-22-a")
         self.ledger.accept("review-870", pane_nonce="nonce-22-a")
         event = self.ledger.observe_idle("app-review", pane_nonce="nonce-22-a")


### PR DESCRIPTION
## Objective

Formalizes the first safety fix identified from the uncommitted prototype draft in `/private/tmp/hill90-supervisor-ledger` (not touched by this PR — its diff was inspected read-only for context only): a tmux send that may have succeeded but whose acknowledgement failed must never be silently resent.

Refs jonhill90/agent-dotfiles#17. Targets this prototype branch per that issue, not `Hill90` main — the durable core moves to `agent-dotfiles` only after lifecycle safety is independently accepted (per #16's disposition).

## What changed

- `Ledger` gains a `delivery_pending` status, persisted **before** the physical tmux send (`mark_delivery_pending`, `created` → `delivery_pending`).
- `mark_delivered` now only transitions `delivery_pending` → `delivered` — never directly from `created`.
- `TmuxAdapter.assign_task` no longer infers delivery from a post-send capture of echoed pane text. It persists `delivery_pending`, sends, and only then marks `delivered`. If the send raises, or the ledger write fails, the task is left in `delivery_pending` and `assign_task` refuses to retry that task id automatically.
- New `Ledger.reconcile_delivery(task_id, pane_nonce=..., outcome="delivered"|"failed")` and `hill90-supervisor reconcile --task <id> --outcome {delivered,failed}` give a human — not the pane's own scrollback — the only way to resolve a stuck ambiguous delivery. Deliberately not caller-verified: the pane being reconciled may itself be unresponsive.
- Never-attempted (no ledger row) and attempted-but-unconfirmed (`delivery_pending`) are now distinct and both visible via `hill90-supervisor status`.
- README documents the new contract clause and command.

## Explicitly out of scope for this slice

GitHub assignment gating, ownership-safe completion, attention events, token caps, harness registry, repo moves — untouched.

## Review fixes (this update)

Independent review of the above found two blockers and one correctness defect. Each was reproduced against the pre-fix code first (see Verification), then fixed:

1. **Existing ledger DBs never migrated (blocker).** `_initialize` uses `CREATE TABLE IF NOT EXISTS`, which never rewrites a table that already exists — so a `ledger.sqlite3` created before this PR kept its old `status` CHECK constraint permanently, and the very first `mark_delivery_pending` against it raised a raw `sqlite3.IntegrityError`. Added `Ledger._migrate_tasks_table`: on open, if the existing `tasks` table is missing the current schema markers, it is rebuilt in one transaction — new table, copy every row, drop the old table, rename the new one back to `tasks`, recreate the `one_open_task_per_lane` index. Foreign keys are disabled only around this rebuild (toggling mid-transaction is a no-op in SQLite, and `events.task_id REFERENCES tasks(id)` would otherwise block dropping the original table while rows reference it); the rebuilt table is named `tasks` again by commit time, so that reference is exactly as before. A failure at any checkpoint rolls back to the untouched original table — proven for all four checkpoints, with no row loss and a clean retry on the next open.
2. **Reconcile wedged after a re-registered lane (blocker).** The CLI passed the *lane's current* nonce into `reconcile_delivery`, which required it to equal the *task's own* `pane_nonce` recorded at send time — impossible once a dead pane's lane is re-registered with a new nonce, permanently wedging reconciliation for exactly the ambiguous-delivery case this feature exists to resolve. `reconcile_delivery` now authenticates against the task's own recorded `pane_nonce` via a dedicated `_reconcile_transition` that does not check the lane's current incarnation at all. Ordinary transitions (`mark_delivered`, `accept`, `mark_delivery_pending`) are unchanged and still ownership-safe via the existing `_transition`/`_verify_lane_nonce`. A wrong task nonce is still rejected. (Full harness-registry/incarnation versioning is out of scope here — left for slice #3.)
3. **`mark_delivery_pending` wrote `delivered_at` (correctness defect).** A merely-attempted delivery was indistinguishable, by timestamp, from a genuinely confirmed one. Added `delivery_attempted_at` (included in the migration); `mark_delivery_pending` now writes only that column. `delivered_at` is set solely by `mark_delivered` or `reconcile_delivery(outcome="delivered")`. A failed reconciliation leaves `delivered_at` null while retaining `delivery_attempted_at`.

## Verification

Schema change is additive and rollback-safe: one new CHECK-constraint status value, one new nullable column, both applied via a transactional in-place migration for pre-existing databases — no destructive migration, no schema removal, no row loss (proven directly for the migration, not asserted).

```
$ python3 -m unittest discover -s scripts/supervisor/tests -v
Ran 47 tests in 0.428s
OK

$ python3 -m py_compile scripts/supervisor/*.py scripts/supervisor/tests/*.py
(no output — success)

$ shellcheck --severity=error scripts/supervisor/*.sh
(no output — success)

$ plutil -lint scripts/supervisor/com.hill90.supervisor.plist
com.hill90.supervisor.plist: OK

$ bats tests/scripts/supervisor-service.bats
1..2
ok 1 v5's singleton guard covers v4's awake companion LaunchAgent
ok 2 rollback has an explicit drain check before restarting v4
```

Failing-test-first evidence, original slice: the new/updated tests (`test_ambiguous_send_persists_delivery_pending_and_blocks_automatic_resend`, `test_successful_send_does_not_infer_delivery_from_echoed_prompt_text`, `test_delivery_pending_persists_before_send_and_blocks_direct_delivered`, `test_reconcile_delivery_confirms_or_retires_an_ambiguous_task`, `test_reconcile_resolves_an_ambiguous_delivery_without_pane_capture`) were run against the unmodified base commit first and failed with 2 failures / 5 errors, then passed after the implementation.

Failing-test-first evidence, this update: the new/changed tests for all three review findings (`TaskTableMigrationTest`, `DeliveryTimestampTest`, `ReconcileAfterReRegistrationTest`, plus `test_reconcile_survives_lane_re_registration_after_a_dead_pane` in `test_cli.py`) were run against this branch's pre-fix commit (`5561cd20`) first — 3 failures / 8 errors across all three findings — then passed after the fix (47/47 green). The dirty prototype worktree at `/private/tmp/hill90-supervisor-ledger` was not touched; its diff stat is unchanged from before this update.

No service install/start, no real lane prompt, no production action, no issue closure, no merge performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
